### PR TITLE
fix purge path in tailwind

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -7,8 +7,8 @@ module.exports = {
   },
   purge: {
     content: [
-      './src/components/**/*.js',
-      './src/components/**.js',
+      './src/**/*.js',
+      './src/*.js',
       './public/*.html',
     ],
   },


### PR DESCRIPTION
# Description

The purge paths were wrong because of the refactor from https://github.com/codecov/gazebo/pull/100
