### PR TITLE
Change authorization from frontedn to Bearer

### DIFF
--- a/src/shared/api/helpers.js
+++ b/src/shared/api/helpers.js
@@ -22,7 +22,7 @@ export function getHeaders(provider) {
 
   const authorizationHeader = token
     ? {
-        Authorization: `frontend ${token}`,
+        Authorization: `Bearer ${token}`,
       }
     : {}
 


### PR DESCRIPTION
# Description
Pierce noticed we were using the old semantic Authorization header, updating to the correct new one.
