### PR TITLE
Disable refetching on focus by default (Can be opted in)

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -16,6 +16,7 @@ const queryCache = new QueryCache({
     queries: {
       suspense: true,
       retry: false,
+      refetchOnWindowFocus: false,
     },
   },
 })
@@ -24,43 +25,43 @@ const stripePromise = loadStripe(config.STRIPE_KEY)
 
 function App() {
   return (
-  <Elements stripe={stripePromise}>
-    <ToastNotificationProvider>
-      <ReactQueryCacheProvider queryCache={queryCache}>
-        <BrowserRouter>
-          <Switch>
-            <Route path="/account/:provider/:owner/">
-              <BaseLayout>
-                <AccountSettings />
-              </BaseLayout>
-            </Route>
-            <Route path="/:provider/" exact>
-              <BaseLayout>
-                <FullLayout>List of organizations</FullLayout>
-              </BaseLayout>
-            </Route>
-            <Route path="/:provider/:owner/" exact>
-              <BaseLayout>
-                <FullLayout>List of repos</FullLayout>
-              </BaseLayout>
-            </Route>
-            <Route path="/:provider/:owner/:repo/" exact>
-              <BaseLayout>
-                <FullLayout>Repo page</FullLayout>
-              </BaseLayout>
-            </Route>
-            <Route path="/">
-              <BaseLayout>
-                <FullLayout>
-                  <p>Home page</p>
-                </FullLayout>
-              </BaseLayout>
-            </Route>
-          </Switch>
-        </BrowserRouter>
-      </ReactQueryCacheProvider>
-    </ToastNotificationProvider>
-  </Elements>
+    <Elements stripe={stripePromise}>
+      <ToastNotificationProvider>
+        <ReactQueryCacheProvider queryCache={queryCache}>
+          <BrowserRouter>
+            <Switch>
+              <Route path="/account/:provider/:owner/">
+                <BaseLayout>
+                  <AccountSettings />
+                </BaseLayout>
+              </Route>
+              <Route path="/:provider/" exact>
+                <BaseLayout>
+                  <FullLayout>List of organizations</FullLayout>
+                </BaseLayout>
+              </Route>
+              <Route path="/:provider/:owner/" exact>
+                <BaseLayout>
+                  <FullLayout>List of repos</FullLayout>
+                </BaseLayout>
+              </Route>
+              <Route path="/:provider/:owner/:repo/" exact>
+                <BaseLayout>
+                  <FullLayout>Repo page</FullLayout>
+                </BaseLayout>
+              </Route>
+              <Route path="/">
+                <BaseLayout>
+                  <FullLayout>
+                    <p>Home page</p>
+                  </FullLayout>
+                </BaseLayout>
+              </Route>
+            </Switch>
+          </BrowserRouter>
+        </ReactQueryCacheProvider>
+      </ToastNotificationProvider>
+    </Elements>
   )
 }
 


### PR DESCRIPTION
# Description
All api's were being re-called when ever you refocused on the window. This is a great feature but not needed for `/profile` or `/user`. This can be re enabled on a per call basis 

# Notable Changes
The app will call the server less. I want to have a team discussion on this, but disabling for the moment


