### PR TITLE
mock the timezone in development

### DIFF
--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -1,5 +1,17 @@
+/* eslint-disable no-extend-native */
+
 // jest-dom adds custom jest matchers for asserting on DOM nodes.
 // allows you to do things like:
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
 import '@testing-library/jest-dom'
+
+// mock the timezone to always be GMT (https://stackoverflow.com/a/313792880)
+const getTimezoneOffset = Date.prototype.getTimezoneOffset
+beforeAll(() => {
+  Date.prototype.getTimezoneOffset = () => 0
+})
+
+afterAll(() => {
+  Date.prototype.getTimezoneOffset = getTimezoneOffset
+})


### PR DESCRIPTION
# Description

We have some flaky tests because of the timezone in which the tests are ran, as a certain date can be a different day depending on where you are, the assertion on the copy could be wrong.

Mocking the date object to always run on the same timezone (GMT) should fix it

