### PR TITLE
Fix billing upgrade path for legacy users

### DIFF
--- a/src/pages/AccountSettings/tabs/BillingAndUsers/LegacyUser/LegacyUser.js
+++ b/src/pages/AccountSettings/tabs/BillingAndUsers/LegacyUser/LegacyUser.js
@@ -23,7 +23,16 @@ function LegacyUser({ accountDetails, provider, owner }) {
         <p className="mt-4 text-gray-500">
           You’re on a legacy per repository plan, these plans are no longer
           supported by Codecov, if you need help managing your plan please reach
-          out to support.
+          out to{' '}
+          <a
+            className="underline hover:text-blue-600"
+            target="_blank"
+            rel="noreferrer"
+            href="https://codecov.freshdesk.com/support/home"
+          >
+            support
+          </a>
+          .
         </p>
         <p className="mt-4 text-gray-900 text-xl bold">
           {accountDetails.nbActivePrivateRepos}/


### PR DESCRIPTION
# Description
This was navigating to `.../account/gh/terrysmithdc/billing/billing/upgrade` instead of `.../account/gh/terrysmithdc/billing/upgrade`


Also added a support link in the plan description.

![Screen Shot 2021-02-10 at 5 37 02 PM](https://user-images.githubusercontent.com/1530868/107575824-b6d45f00-6bc6-11eb-9fc2-72c3e5171235.png)
