### PR TITLE
Circle to ignore dependabot branches for running the storybook job.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,7 +91,7 @@ workflows:
       - storybook:
           filters:
             branches:
-              ignore: /dependabot/
+              ignore: /^dependabot*/
           requires:
             - install
       - test:


### PR DESCRIPTION
# Description
Config update
