### PR TITLE
Fix render loop on admin tab

### DIFF
--- a/src/pages/AccountSettings/AccountSettings.js
+++ b/src/pages/AccountSettings/AccountSettings.js
@@ -4,15 +4,12 @@ import uniqueId from 'lodash/uniqueId'
 
 import LogoSpinner from 'ui/LogoSpinner'
 import SidebarLayout from 'layouts/SidebarLayout'
-import { useUser } from 'services/user'
 
 import SideMenu from './SideMenu'
 import routes from './routes'
 
 function AccountSettings() {
-  const { data: user } = useUser()
   const { provider, owner } = useParams()
-  const isPersonalSettings = user.username.toLowerCase() === owner.toLowerCase()
 
   const tabLoading = (
     <div className="h-full w-full flex items-center justify-center">
@@ -21,9 +18,7 @@ function AccountSettings() {
   )
 
   return (
-    <SidebarLayout
-      sidebar={<SideMenu isPersonalSettings={isPersonalSettings} />}
-    >
+    <SidebarLayout sidebar={<SideMenu />}>
       <Suspense fallback={tabLoading}>
         <Switch>
           {routes.map(({ path, exact, Component, redirect }) => (
@@ -31,13 +26,7 @@ function AccountSettings() {
               {redirect && (
                 <Redirect path={path} to={redirect({ provider, owner })} />
               )}
-              {Component && (
-                <Component
-                  provider={provider}
-                  owner={owner}
-                  isPersonalSettings={isPersonalSettings}
-                />
-              )}
+              {Component && <Component provider={provider} owner={owner} />}
             </Route>
           ))}
         </Switch>

--- a/src/pages/AccountSettings/SideMenu.js
+++ b/src/pages/AccountSettings/SideMenu.js
@@ -1,13 +1,17 @@
-import PropTypes from 'prop-types'
-import { NavLink } from 'react-router-dom'
+import { NavLink, useParams } from 'react-router-dom'
 import uniqueId from 'lodash/uniqueId'
 
 import { useNavLinks } from 'services/navigation'
+import { useUser } from 'services/user'
 import Icon from 'ui/Icon'
 import AppLink from 'ui/AppLink'
 
-function SideMenu({ isPersonalSettings }) {
+function SideMenu() {
+  const { owner } = useParams()
   const { accountAdmin, yamlTab, accessTab, billingAndUsers } = useNavLinks()
+  const { data: user } = useUser()
+  const isPersonalSettings = user.username.toLowerCase() === owner.toLowerCase()
+
   const personalLinks = [
     {
       props: {
@@ -65,10 +69,6 @@ function SideMenu({ isPersonalSettings }) {
       </section>
     </aside>
   )
-}
-
-SideMenu.propTypes = {
-  isPersonalSettings: PropTypes.bool.isRequired,
 }
 
 export default SideMenu

--- a/src/pages/AccountSettings/tabs/Admin/Admin.js
+++ b/src/pages/AccountSettings/tabs/Admin/Admin.js
@@ -8,8 +8,10 @@ import ManageAdminCard from './ManageAdminCard'
 import GithubIntegrationCard from './GithubIntegrationCard'
 import DeletionCard from './DeletionCard'
 
-function Admin({ isPersonalSettings, provider, owner }) {
+function Admin({ provider, owner }) {
   const { data: user } = useUser({ provider })
+  const isPersonalSettings = user.username.toLowerCase() === owner.toLowerCase()
+
   return (
     <div>
       {isPersonalSettings ? (
@@ -35,9 +37,7 @@ function Admin({ isPersonalSettings, provider, owner }) {
 }
 
 Admin.propTypes = {
-  isPersonalSettings: PropTypes.bool.isRequired,
   provider: PropTypes.string.isRequired,
   owner: PropTypes.string.isRequired,
 }
-
 export default Admin

--- a/src/pages/AccountSettings/tabs/Admin/Admin.spec.js
+++ b/src/pages/AccountSettings/tabs/Admin/Admin.spec.js
@@ -17,7 +17,7 @@ describe('AdminTab', () => {
   }
 
   function setup(over = {}) {
-    useUser.mockReturnValue({ data: {} })
+    useUser.mockReturnValue({ data: { username: 'terry' } })
     const props = {
       ...defaultProps,
       ...over,
@@ -27,9 +27,7 @@ describe('AdminTab', () => {
 
   describe('when rendered for user', () => {
     beforeEach(() => {
-      setup({
-        isPersonalSettings: true,
-      })
+      setup({ owner: 'terry' })
     })
 
     it('renders the NameEmailCard', () => {
@@ -55,9 +53,7 @@ describe('AdminTab', () => {
 
   describe('when rendered for organization', () => {
     beforeEach(() => {
-      setup({
-        isPersonalSettings: false,
-      })
+      setup()
     })
 
     it('renders the ManageAdminCard', () => {


### PR DESCRIPTION
# Description
Move isPersonalSetting calculation to components that actually care (less passing props, stops infinite loop)

# Notable Changes
The cause was passing a prop that computed a value based on a hook the child component was using. This type of bug is difficult to cat in tests...