### PR TITLE
set a stale time of 30s

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -17,7 +17,6 @@ const queryClient = new QueryClient({
     queries: {
       suspense: true,
       retry: false,
-      refetchOnWindowFocus: false,
       staleTime: 30000, // 30s
     },
   },


### PR DESCRIPTION
# Description

Make the stale time of React-Query 30 secondes. That will prevent re-render loop when a children is using the same data that is defined by a parent component.