### PR TITLE
There was no space inbetween Questions? and the Fresh desk link.

### DIFF
--- a/src/pages/AccountSettings/tabs/BillingAndUsers/LegacyUser/LegacyUser.js
+++ b/src/pages/AccountSettings/tabs/BillingAndUsers/LegacyUser/LegacyUser.js
@@ -51,7 +51,7 @@ function LegacyUser({ accountDetails, provider, owner }) {
             Upgrade to per user pricing
           </Button>
           <p className="mt-4 text-gray-900">
-            Questions?
+            Questions?{' '}
             <a
               className="underline hover:text-blue-600"
               target="_blank"


### PR DESCRIPTION
# Description
Fixes a grammatical error.

# Screenshots
<img width="629" alt="Screen Shot 2021-03-12 at 2 07 45 PM" src="https://user-images.githubusercontent.com/1530868/110980601-6292db00-833c-11eb-8404-a40361246888.png">

