### PR TITLE
Update header codecov logo to go to provider instead of root.

### DIFF
--- a/src/layouts/Header/DesktopMenu.js
+++ b/src/layouts/Header/DesktopMenu.js
@@ -6,19 +6,19 @@ import ServerStatus from './ServerStatus'
 import Dropdown from './Dropdown'
 import { MainNavLink } from './NavLink'
 import { useMainNav } from 'services/header'
-import { useStaticNavLinks } from 'services/navigation'
+import { useNavLinks } from 'services/navigation'
 import { ReactComponent as CodecovIcon } from 'assets/svg/codecov.svg'
 
 function DesktopMenu() {
   const main = useMainNav()
-  const { root } = useStaticNavLinks()
+  const { provider } = useNavLinks()
 
   return (
     <>
       <div data-testid="desktop-menu" className="flex items-center">
         <AppLink
-          to={root.path()}
-          useRouter={!root.isExternalLink}
+          to={provider.path()}
+          useRouter={!provider.isExternalLink}
           tabIndex="0"
           className="mx-2 md:mx-0 flex-shrink-0"
         >


### PR DESCRIPTION
# Description
Joe noticed we're not linking to the correct location vs legacy when you click on the umbrella in the header. 
