### PR TITLE
Remove un nessisary dependencies from fossa

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23863,7 +23863,8 @@
     "y18n": {
       "version": "5.0.5",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.5.tgz",
-      "integrity": "sha512-hsRUr4FFrvhhRH12wOdfs38Gy7k2FFzB9qgN9v3aLykRq0dRcdcpz5C9FxdS2NuhOrI/628b/KSTJ3rwHysYSg=="
+      "integrity": "sha512-hsRUr4FFrvhhRH12wOdfs38Gy7k2FFzB9qgN9v3aLykRq0dRcdcpz5C9FxdS2NuhOrI/628b/KSTJ3rwHysYSg==",
+      "dev": true
     },
     "yallist": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -11,8 +11,6 @@
     "classnames": "^2.2.6",
     "date-fns": "^2.19.0",
     "downshift": "^6.1.0",
-    "elliptic": "^6.5.4",
-    "immer": "^8.0.1",
     "js-cookie": "^2.2.1",
     "lodash": "^4.17.21",
     "prop-types": "^15.7.2",
@@ -27,7 +25,6 @@
     "react-use": "^17.2.1",
     "web-vitals": "^1.1.1",
     "websocket-extensions": "^0.1.4",
-    "y18n": "^5.0.5",
     "yup": "^0.32.9"
   },
   "scripts": {


### PR DESCRIPTION
# Description
Removed locking in some sub dependency packages to let dependencies decide what version (still passing npm audit). These were originally added to appease fossa before the dependencies resolved the issues.

