### PR TITLE
CE-3115 Add sending credentials to requests.

### DIFF
--- a/src/shared/api/api.js
+++ b/src/shared/api/api.js
@@ -19,6 +19,7 @@ function _fetch({
   return fetch(uri, {
     headers,
     method,
+    credentials: 'include',
     body: body ? JSON.stringify(body) : null,
   }).then(async (res) => {
     let data = null


### PR DESCRIPTION
# Description
Adds credentials to API requests. Required to enable impersonation. Followed from the docs here: https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch#parameters

# Code Example

# Notable Changes

# Screenshots
