### PR TITLE
make invoice detail not break if no active subscription

### DIFF
--- a/src/pages/AccountSettings/tabs/InvoiceDetail/InvoiceDetail.spec.js
+++ b/src/pages/AccountSettings/tabs/InvoiceDetail/InvoiceDetail.spec.js
@@ -78,7 +78,7 @@ const subscriptionDetail = {
 }
 
 describe('InvoiceDetail', () => {
-  function setup(invoiceOver = {}, url = '') {
+  function setup(invoiceOver = {}, url = '', subscriptionOver = {}) {
     useInvoice.mockReturnValue({
       data: {
         ...invoice,
@@ -87,7 +87,10 @@ describe('InvoiceDetail', () => {
     })
     useAccountDetails.mockReturnValue({
       data: {
-        subscriptionDetail,
+        subscriptionDetail: {
+          ...subscriptionOver,
+          ...subscriptionDetail,
+        },
       },
     })
     render(
@@ -188,6 +191,18 @@ describe('InvoiceDetail', () => {
 
     it('prompts the user for printing', () => {
       expect(window.print).toHaveBeenCalled()
+    })
+  })
+
+  describe('when there are no subscriptionDetail', () => {
+    beforeEach(() => {
+      setup({}, '/invoice/123', {
+        subscriptionDetail: null,
+      })
+    })
+
+    it('renders the total', () => {
+      expect(screen.queryAllByText(/\$625\.51/i)[1]).toBeInTheDocument()
     })
   })
 })

--- a/src/pages/AccountSettings/tabs/InvoiceDetail/sections/InvoiceFooter.js
+++ b/src/pages/AccountSettings/tabs/InvoiceDetail/sections/InvoiceFooter.js
@@ -1,6 +1,11 @@
 import PropTypes from 'prop-types'
 
-function generateAddressInfo(billingDetails) {
+function generateAddressInfo(accountDetails) {
+  const billingDetails =
+    accountDetails.subscriptionDetail?.defaultPaymentMethod?.billingDetails
+
+  if (!billingDetails) return []
+
   // merge all the billingDetails without empty value in a the following:
   // ['Donald Duck',
   // '180 Broadway',
@@ -21,10 +26,7 @@ function generateAddressInfo(billingDetails) {
 }
 
 function InvoiceFooter({ invoice, accountDetails }) {
-  const {
-    billingDetails,
-  } = accountDetails.subscriptionDetail.defaultPaymentMethod
-  const addressInfo = generateAddressInfo(billingDetails)
+  const addressInfo = generateAddressInfo(accountDetails)
 
   return (
     <div className="flex">


### PR DESCRIPTION
# Description

[Sentry bug](https://sentry.io/organizations/codecov/issues/2283936237/?project=5514400&query=is%3Aunresolved)
[Jira ticket](https://codecovio.atlassian.net/browse/CE-3239)

Make the computing of the address in invoice detail safer.
