### PR TITLE
Enable camel case linting

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -16,7 +16,8 @@
       {
         "ignore": ["children", "context", "className"]
       }
-    ]
+    ],
+    "camelcase": ["error", { "properties": "always" }]
   },
   "overrides": [
     // UI Rules
@@ -78,7 +79,8 @@
         "max-nested-callbacks": "off",
         "max-statements": "off",
         "complexity": "off",
-        "react/display-name": "off"
+        "react/display-name": "off",
+        "camelcase": "off"
       }
     },
     // Story Rules

--- a/src/pages/AccountSettings/tabs/Admin/ManageAdminCard/AdminList.js
+++ b/src/pages/AccountSettings/tabs/Admin/ManageAdminCard/AdminList.js
@@ -20,8 +20,10 @@ function useAdminsAndRevoke({ provider, owner }) {
 
   function setAdminStatus(user, isAdmin) {
     const body = {
+      /* eslint-disable camelcase */
       targetUser: user.username,
       is_admin: isAdmin,
+      /* eslint-enable camelcase */
     }
     mutate(body)
   }

--- a/src/pages/AccountSettings/tabs/CancelPlan/barecancel.js
+++ b/src/pages/AccountSettings/tabs/CancelPlan/barecancel.js
@@ -21,11 +21,13 @@ function useBarecancel(accountDetails, cancelPlan) {
     // update the object of barecancel to account for the change
     // of stripeCustomerId or the cancelPlan callback
     window.barecancel.params = {
+      /* eslint-disable camelcase */
       access_token_id: config.BAREMETRICS_TOKEN, // Cancellation API public key
       customer_oid: stripeCustomerId,
       comment_required: true,
       test_mode: config.NODE_ENV !== 'production',
       callback_send: cancelPlan,
+      /* eslint-enable camelcase */
     }
   }, [stripeCustomerId, cancelPlan])
 }

--- a/src/services/account/hooks.js
+++ b/src/services/account/hooks.js
@@ -130,7 +130,11 @@ export function useUpdateCard({ provider, owner }) {
           return Api.patch({
             provider,
             path,
-            body: { payment_method: result.paymentMethod.id },
+            body: {
+              /* eslint-disable camelcase */
+              payment_method: result.paymentMethod.id,
+              /* eslint-enable camelcase */
+            },
           })
         })
     },
@@ -183,7 +187,9 @@ export function useAutoActivate({ provider, owner, opts = {} }) {
     (activate) => {
       const path = getPathAccountDetails({ provider, owner })
       const body = {
+        /* eslint-disable camelcase */
         plan_auto_activate: activate,
+        /* eslint-enable camelcase */
       }
 
       return Api.patch({


### PR DESCRIPTION
# Description
I noticed on another PR that we're missing an eslint rule. This enables the rule and sets up appropriate ignores when we need to use snake case (apis)

# Notable Changes
I've enabled camel casing however for the body of put/post/delete requests we do need to use snake case for our endpoints. We do have a utility method for camel case to snake case objects however @dorianamouroux  made the argument a while ago we shouldn't always snake case all keys of the body, so at the moment I'm going with disabling and re enabling the rule for just body responses. 

The rule is totally disabled for spec tests for mock rest responses.

# Code example
```js
const body = {
    /* eslint-disable camelcase */
    ...
    /* eslint-enable camelcase */
}
```

