### PR TITLE
Disable netlify deploys for dependabot.

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,2 +1,5 @@
+[build]
+  ignore = "git log -1 --pretty=%B | grep dependabot"
+
 [context.deploy-preview]
   environment = { REACT_APP_API_URL = "https://stage-api.codecov.dev", REACT_APP_STRIPE_KEY="pk_test_d3lcWjpwF96baLX9ShZfMcq4", REACT_APP_BASE_URL="https://stage-web.codecov.dev" }


### PR DESCRIPTION
# Description
Try skipping dependabot preview builds. Instead relying on circle ci npm build asserting things are fine.

Grabbed from https://www.netlify.com/blog/2020/04/27/ignore-unnecessary-builds-to-optimize-your-build-times/



# Notable Changes
If this works I'm going to add the same config to codecov-client
