### PR TITLE
fix generation of the release map for source map on sentry

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,9 +31,9 @@
   },
   "scripts": {
     "start": "craco start",
-    "build": "export REACT_APP_SENTRY_RELEASE=$(git rev-parse --short HEAD); craco build",
+    "build": "export REACT_APP_SENTRY_RELEASE=$(git rev-parse --short=7 HEAD); craco build",
     "test": "craco test",
-    "sentry": "export REACT_APP_SENTRY_RELEASE=$(git rev-parse --short HEAD); craco build && node scripts/sentry.js",
+    "sentry": "export REACT_APP_SENTRY_RELEASE=$(git rev-parse --short=7 HEAD); craco build && node scripts/sentry.js",
     "test:ci": "craco test --collectCoverage --runInBand --reporters=default --reporters=jest-junit",
     "eject": "craco eject",
     "lint": "npx eslint --no-ignore --max-warnings=0 -c .eslintrc.json 'src/**/*.{js,jsx,ts,tsx,json}'",


### PR DESCRIPTION
# Description

The Sentry release is different on the tag we upload from the tag we push the error in production. I think it's because Netlify builder has some different git settings; giving a different number from our own CI when calling `git rev-parse --short`. CircleCI gives 9 character and Netlify 10.

Because of the mismatch, the error on Sentry doesn't have the proper source map

By specifying the number of character I want in the short sha of the commit, they should match nicely.