### PR TITLE
make avatar safer if the user doesnt have a username

### DIFF
--- a/src/old_ui/Avatar/Avatar.js
+++ b/src/old_ui/Avatar/Avatar.js
@@ -1,11 +1,13 @@
 import BBAvatar from './BBAvatar'
 import PropTypes from 'prop-types'
 
+import get from 'lodash/get'
+
 function Avatar({ username, alt, className, avatarUrl }) {
   return (
     <>
       {avatarUrl && <img className={className} src={avatarUrl} alt={alt} />}
-      {!avatarUrl && <BBAvatar text={username[0]} />}
+      {!avatarUrl && <BBAvatar text={get(username, 0, '?')} />}
     </>
   )
 }


### PR DESCRIPTION
# Description

Very few users in the database do not have a username; which crashes the UI if we want the avatar on one of those user. (https://sentry.io/organizations/codecov/issues/2358261408/?project=5514400&query=is%3Aunresolved for Yalochat on Bitbucket)

I made it safer to access the first letter of a username, falling back to `?` if there is no username:

<img width="777" alt="Screenshot 2021-04-23 at 13 57 37" src="https://user-images.githubusercontent.com/13302836/115867932-f972ad00-a43b-11eb-94e2-07d1874ed36c.png">
