### PR TITLE
Dorian/fix link context switcher

### DIFF
--- a/src/pages/AccountSettings/shared/Header/Header.js
+++ b/src/pages/AccountSettings/shared/Header/Header.js
@@ -13,6 +13,7 @@ function Header() {
         <TabNavigation
           tabs={[
             { pageName: 'owner', children: 'Repos' },
+            { pageName: 'analytics', children: 'Analytics' },
             { pageName: 'accountAdmin', children: 'Settings' },
           ]}
         />

--- a/src/pages/OwnerPage/OwnerPage.js
+++ b/src/pages/OwnerPage/OwnerPage.js
@@ -16,6 +16,7 @@ function OwnerPage() {
         <TabNavigation
           tabs={[
             { pageName: 'ownerInternal', children: 'Repos' },
+            { pageName: 'analytics', children: 'Analytics' },
             { pageName: 'accountAdmin', children: 'Settings' },
           ]}
         />

--- a/src/services/navigation/useNavLinks.js
+++ b/src/services/navigation/useNavLinks.js
@@ -38,6 +38,11 @@ function useNavLinks() {
         `/${provider}/${owner}`,
       isExternalLink: false,
     },
+    analytics: {
+      path: ({ provider = p, owner = o } = { provider: p, owner: o }) =>
+        `/analytics/${provider}/${owner}`,
+      isExternalLink: true,
+    },
     repo: {
       path: (
         { provider = p, owner = o, repo = r } = {

--- a/src/services/navigation/useNavLinks.spec.js
+++ b/src/services/navigation/useNavLinks.spec.js
@@ -115,6 +115,26 @@ describe('useNavLinks', () => {
     })
   })
 
+  describe('analytics', () => {
+    beforeAll(() => {
+      setup(['/gl/doggo/squirrel-locator'])
+    })
+
+    it('Returns the correct link with nothing passed', () => {
+      expect(hookData.result.current.analytics.path()).toBe(
+        '/analytics/gl/doggo'
+      )
+    })
+    it('can override the params', () => {
+      expect(hookData.result.current.analytics.path({ provider: 'bb' })).toBe(
+        '/analytics/bb/doggo'
+      )
+      expect(hookData.result.current.analytics.path({ owner: 'cat' })).toBe(
+        '/analytics/gl/cat'
+      )
+    })
+  })
+
   describe('repo link', () => {
     beforeAll(() => {
       setup(['/gl/doggo/squirrel-locator'])


### PR DESCRIPTION
# Description

Couple of improvement on the Header:
 - Fix the link in the context switcher to be external link and force refresh the page
 - Add analytics tab

<img width="526" alt="Screenshot 2021-04-29 at 14 53 07" src="https://user-images.githubusercontent.com/13302836/116553622-9fba2900-a8fa-11eb-83e8-1ce84988d92a.png">
