### PR TITLE
add a case where the payment method is null but the plan is pro

### DIFF
--- a/src/pages/AccountSettings/tabs/BillingAndUsers/BillingAndUsers.js
+++ b/src/pages/AccountSettings/tabs/BillingAndUsers/BillingAndUsers.js
@@ -26,7 +26,7 @@ function BillingAndUsers({ provider, owner }) {
       <div className="block md:flex flex-wrap justify-between">
         {accountDetails.plan ? (
           <>
-            <div className="sm:mr-4 sm:flex-initial flex-1">
+            <div className="sm:mr-4 sm:flex-initial flex-1 max-w-sm">
               <CurrentPlanCard accountDetails={accountDetails} />
               {shouldRenderBillingDetails && (
                 <>

--- a/src/pages/AccountSettings/tabs/BillingAndUsers/PaymentCard/CardInformation.js
+++ b/src/pages/AccountSettings/tabs/BillingAndUsers/PaymentCard/CardInformation.js
@@ -1,0 +1,86 @@
+import PropTypes from 'prop-types'
+import { format, fromUnixTime } from 'date-fns'
+
+import Button from 'old_ui/Button'
+import { subscriptionDetailType } from 'services/account'
+
+import amexLogo from './assets/amex.png'
+import discoverLogo from './assets/discover.jpg'
+import mastercardLogo from './assets/mastercard.png'
+import visaLogo from './assets/visa.png'
+
+const cardBrand = {
+  amex: {
+    logo: amexLogo,
+    name: 'American Express',
+  },
+  discover: {
+    logo: discoverLogo,
+    name: 'Discover',
+  },
+  mastercard: {
+    logo: mastercardLogo,
+    name: 'MasterCard',
+  },
+  visa: {
+    logo: visaLogo,
+    name: 'Visa',
+  },
+  fallback: {
+    logo: visaLogo,
+    name: 'Credit card',
+  },
+}
+
+function getNextBilling(subscriptionDetail) {
+  const isCancelled = subscriptionDetail.cancelAtPeriodEnd
+
+  if (isCancelled) return null
+
+  const periodEnd = fromUnixTime(subscriptionDetail.currentPeriodEnd)
+  return format(periodEnd, 'do MMMM, yyyy')
+}
+
+function CardInformation({ subscriptionDetail, openForm, card }) {
+  const typeCard = cardBrand[card.brand] ?? cardBrand.fallback
+  const nextBilling = getNextBilling(subscriptionDetail)
+
+  return (
+    <>
+      <div className="flex mt-6">
+        <div className="w-12 mr-6">
+          <img className="w-full" alt="credit card logo" src={typeCard.logo} />
+        </div>
+        <div>
+          <b className="tracking-widest">
+            ****&nbsp;&nbsp;****&nbsp;&nbsp;****&nbsp;&nbsp;{card.last4}
+          </b>
+          <p className="text-gray-500">
+            {typeCard.name} - Expires {card.expMonth}/{card.expYear}
+          </p>
+        </div>
+      </div>
+      {nextBilling && (
+        <p className="text-gray-500 my-4 text-sm">
+          Next billing on <span className="text-gray-900">{nextBilling}</span>.
+        </p>
+      )}
+      <Button color="pink" variant="outline" onClick={openForm}>
+        Edit card
+      </Button>
+    </>
+  )
+}
+
+CardInformation.propTypes = {
+  subscriptionDetail: subscriptionDetailType,
+  card: PropTypes.shape({
+    brand: PropTypes.string.isRequired,
+    last4: PropTypes.string.isRequired,
+    expMonth: PropTypes.number.isRequired,
+    expYear: PropTypes.number.isRequired,
+  }).isRequired,
+  openForm: PropTypes.func.isRequired,
+}
+
+export default CardInformation

--- a/src/pages/AccountSettings/tabs/BillingAndUsers/PaymentCard/PaymentCard.js
+++ b/src/pages/AccountSettings/tabs/BillingAndUsers/PaymentCard/PaymentCard.js
@@ -1,57 +1,26 @@
 import { useState } from 'react'
 import PropTypes from 'prop-types'
-import { format, fromUnixTime } from 'date-fns'
 
 import Card from 'old_ui/Card'
 import Button from 'old_ui/Button'
 import { subscriptionDetailType } from 'services/account'
 
-import amexLogo from './assets/amex.png'
-import discoverLogo from './assets/discover.jpg'
-import mastercardLogo from './assets/mastercard.png'
-import visaLogo from './assets/visa.png'
 import CreditCardForm from './CreditCardForm'
+import CardInformation from './CardInformation'
 
-const cardBrand = {
-  amex: {
-    logo: amexLogo,
-    name: 'American Express',
-  },
-  discover: {
-    logo: discoverLogo,
-    name: 'Discover',
-  },
-  mastercard: {
-    logo: mastercardLogo,
-    name: 'MasterCard',
-  },
-  visa: {
-    logo: visaLogo,
-    name: 'Visa',
-  },
-  fallback: {
-    logo: visaLogo,
-    name: 'Credit card',
-  },
-}
-
-function getNextBilling(subscriptionDetail) {
-  const isCancelled = subscriptionDetail.cancelAtPeriodEnd
-
-  if (isCancelled) return null
-
-  const periodEnd = fromUnixTime(subscriptionDetail.currentPeriodEnd)
-  return format(periodEnd, 'do MMMM, yyyy')
-}
+const proPlans = [
+  'users-pr-inappm',
+  'users-pr-inappy',
+  'users-inappm',
+  'users-inappy',
+]
 
 function PaymentCard({ subscriptionDetail, provider, owner }) {
-  const card = subscriptionDetail?.defaultPaymentMethod?.card
+  const isPayingCustomer = proPlans.includes(subscriptionDetail?.plan?.value)
   const [isFormOpen, setIsFormOpen] = useState(false)
+  const card = subscriptionDetail?.defaultPaymentMethod?.card
 
-  if (!card) return null
-
-  const typeCard = cardBrand[card.brand] ?? cardBrand.fallback
-  const nextBilling = getNextBilling(subscriptionDetail)
+  if (!card && !isPayingCustomer) return null
 
   return (
     <Card className="p-6 mb-4">
@@ -62,38 +31,19 @@ function PaymentCard({ subscriptionDetail, provider, owner }) {
           owner={owner}
           closeForm={() => setIsFormOpen(false)}
         />
+      ) : card ? (
+        <CardInformation
+          card={card}
+          subscriptionDetail={subscriptionDetail}
+          openForm={() => setIsFormOpen(true)}
+        />
       ) : (
         <>
-          <div className="flex mt-6">
-            <div className="w-12 mr-6">
-              <img
-                className="w-full"
-                alt="credit card logo"
-                src={typeCard.logo}
-              />
-            </div>
-            <div>
-              <b className="tracking-widest">
-                ****&nbsp;&nbsp;****&nbsp;&nbsp;****&nbsp;&nbsp;{card.last4}
-              </b>
-              <p className="text-gray-500">
-                {typeCard.name} - Expires {card.expMonth}/{card.expYear}
-              </p>
-            </div>
-          </div>
-          {nextBilling && (
-            <p className="text-gray-500 my-4 text-sm">
-              Next billing on{' '}
-              <span className="text-gray-900">{nextBilling}</span>.
-            </p>
-          )}
-          <Button
-            color="pink"
-            variant="outline"
-            onClick={() => setIsFormOpen(true)}
-          >
-            Edit card
-          </Button>
+          <p className="my-4 text-gray-500">
+            No credit card set. Please contact support if you think it’s an
+            error or set it yourself.
+          </p>
+          <Button onClick={() => setIsFormOpen(true)}>Set card</Button>
         </>
       )}
     </Card>

--- a/src/pages/AccountSettings/tabs/BillingAndUsers/PaymentCard/PaymentCard.spec.js
+++ b/src/pages/AccountSettings/tabs/BillingAndUsers/PaymentCard/PaymentCard.spec.js
@@ -15,6 +15,9 @@ const subscriptionDetail = {
       last4: '1234',
     },
   },
+  plan: {
+    value: 'users-pr-inappy',
+  },
   currentPeriodEnd: 1606851492,
   cancelAtPeriodEnd: false,
 }
@@ -64,7 +67,23 @@ describe('PaymentCard', () => {
     })
   })
 
-  describe('when the user doesnt have any cards', () => {
+  describe('when the user doesnt have a card but is on a free plan', () => {
+    beforeEach(() => {
+      setup({
+        ...subscriptionDetail,
+        defaultPaymentMethod: null,
+        plan: {
+          value: 'users-free',
+        },
+      })
+    })
+
+    it('renders nothing', () => {
+      expect(wrapper.container).toBeEmptyDOMElement()
+    })
+  })
+
+  describe('when the user doesnt have any cards but has a paid plan', () => {
     beforeEach(() => {
       setup({
         ...subscriptionDetail,
@@ -72,8 +91,32 @@ describe('PaymentCard', () => {
       })
     })
 
-    it('renders nothing', () => {
-      expect(wrapper.container).toBeEmptyDOMElement()
+    it('renders an error message', () => {
+      expect(
+        screen.getByText(
+          /No credit card set. Please contact support if you think it’s an error or set it yourself./
+        )
+      ).toBeInTheDocument()
+    })
+
+    describe('when the user clicks on Set card', () => {
+      beforeEach(() => {
+        useUpdateCard.mockReturnValue({
+          mutate: () => null,
+          isLoading: false,
+        })
+        userEvent.click(screen.getByRole('button', { name: /set card/i }))
+      })
+
+      it('doesnt render the card anymore', () => {
+        expect(screen.queryByText(/Visa/)).not.toBeInTheDocument()
+      })
+
+      it('renders the form', () => {
+        expect(
+          screen.getByRole('button', { name: /save/i })
+        ).toBeInTheDocument()
+      })
     })
   })
 


### PR DESCRIPTION
# Description

The customer can be on a paid-plan; but the credit card could be wrongly set on the Stripe Data; which would not render the card at all. This PR adds an extra case of logic to render an empty state if the user is on a paid plan but the card is not set.

# Notable change

I created a new component that will take care of rendering the card information, so the top level component `PaymentCard` can control the logic of what is being rendered: the form, the card data or the empty state.

# Screenshots

![Screenshot 2021-05-04 at 12 18 46](https://user-images.githubusercontent.com/13302836/116990477-6f480580-acd3-11eb-9691-d391f4b13734.png)
