### PR TITLE
safe config from window

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -86,7 +86,7 @@
     ></noscript>
     <% } %>
     <script type="text/javascript">
-      window.configEnv = {}
+      window.configEnv = window.configEnv || {}
     </script>
     <!--
       This HTML file is a template.


### PR DESCRIPTION
# Description

The configEnv from window was behind overwritten by the index.html so I made it set to an empty object only if it's not defined