### PR TITLE
Remove last pr and last seen from user management page

### DIFF
--- a/src/pages/AccountSettings/tabs/BillingAndUsers/UserManagement/UserManagement.js
+++ b/src/pages/AccountSettings/tabs/BillingAndUsers/UserManagement/UserManagement.js
@@ -3,8 +3,6 @@ import PropTypes from 'prop-types'
 import { FormControls } from './FormControls'
 import { FormPaginate } from './FormPaginate'
 
-import { DateItem } from './DateItem'
-
 import Card from 'old_ui/Card'
 import Toggle from 'old_ui/Toggle'
 import User from 'old_ui/User'
@@ -24,8 +22,7 @@ const UserManagementClasses = {
   title: 'text-2xl font-bold',
   results: 'shadow divide-y divide-gray-200 divide-solid p-6',
   userTable: 'grid grid-cols-5 lg:gap-2 my-6',
-  user: ({ lastseen, latestPrivatePrDate }) =>
-    lastseen || latestPrivatePrDate ? 'col-span-3' : 'col-span-4',
+  user: 'col-span-4',
   ctaWrapper: 'flex items-center justify-end',
   cta: 'w-full truncate',
 }
@@ -75,33 +72,6 @@ function UserManagement({ provider, owner }) {
     data: { planAutoActivate },
   } = useAccountDetails({ owner, provider })
 
-  const Lastseen = (lastseen) => (
-    <DateItem testId="last-seen" label="Last seen:" date={lastseen} />
-  )
-  const LastPrivatePr = (latestPrivatePrDate) => (
-    <DateItem testId="last-pr" label="Last pr:" date={latestPrivatePrDate} />
-  )
-
-  const getLatestActivity = (lastPrivatePr, lastseen) => {
-    if (lastPrivatePr && lastseen) {
-      const lastPrivatePrDate = new Date(lastPrivatePr)
-      const lastseenDate = new Date(lastseen)
-      return lastPrivatePrDate > lastseenDate
-        ? LastPrivatePr(lastPrivatePr)
-        : Lastseen(lastseen)
-    }
-    return lastPrivatePr ? LastPrivatePr(lastPrivatePr) : Lastseen(lastseen)
-  }
-
-  const renderLastestActivity = (user) => {
-    const lastPrivatePr = user.latestPrivatePrDate
-    const lastseen = user.lastseen
-    if (!lastPrivatePr && !lastseen) {
-      return null
-    }
-    return getLatestActivity(lastPrivatePr, lastseen)
-  }
-
   return (
     <article className={UserManagementClasses.root}>
       <FormControls
@@ -135,13 +105,12 @@ function UserManagement({ provider, owner }) {
                 className={UserManagementClasses.userTable}
               >
                 <User
-                  className={UserManagementClasses.user(user)}
+                  className={UserManagementClasses.user}
                   username={user.username}
                   name={user.name}
                   avatarUrl={getOwnerImg(provider, user.username)}
                   pills={createPills(user)}
                 />
-                {renderLastestActivity(user)}
                 <div className={UserManagementClasses.ctaWrapper}>
                   <Button
                     className={UserManagementClasses.cta}

--- a/src/pages/AccountSettings/tabs/BillingAndUsers/UserManagement/UserManagement.spec.js
+++ b/src/pages/AccountSettings/tabs/BillingAndUsers/UserManagement/UserManagement.spec.js
@@ -2,8 +2,6 @@ import { render, screen, waitFor } from '@testing-library/react'
 import user from '@testing-library/user-event'
 import { QueryClient, QueryClientProvider } from 'react-query'
 import { MemoryRouter } from 'react-router-dom'
-import formatDistance from 'date-fns/formatDistance'
-import parseISO from 'date-fns/parseISO'
 
 import { useUsers, useUpdateUser } from 'services/users'
 import { useAccountDetails, useAutoActivate } from 'services/account'
@@ -42,12 +40,6 @@ const defaultQuery = {
   search: '',
   page: 1,
   pageSize: 50,
-}
-
-function assertFromToday(date) {
-  // Due to last seen/past pr being based on the current date
-  // we need to asset the expected date format is rendered vs hard coding the expect.
-  return formatDistance(parseISO(date), new Date(), 'MM/dd/yyyy')
 }
 
 describe('UserManagerment', () => {
@@ -180,132 +172,6 @@ describe('UserManagerment', () => {
         const studentLabel = screen.getByText(/dazzle@dota.com/)
         expect(studentLabel).toBeInTheDocument()
       })
-    })
-
-    describe('Last seen', () => {
-      beforeEach(() => {
-        const mockUseUsersValue = {
-          isSuccess: true,
-          data: {
-            totalPages: 1,
-            results: [{ username: 'kumar', lastseen: '2021-01-20T05:03:56Z' }],
-          },
-        }
-        setup({ mockUseUsersValue })
-      })
-      it('renders correct date', () => {
-        const placeholder = screen.getByText(/kumar/)
-        expect(placeholder).toBeInTheDocument()
-
-        const lastSeen = screen.getByText(
-          assertFromToday('2021-01-20T05:03:56Z')
-        )
-        expect(lastSeen).toBeInTheDocument()
-      })
-      it('takes precedence over last PR', () => {
-        const mockUseUsersValue = {
-          isSuccess: true,
-          data: {
-            totalPages: 1,
-            results: [
-              {
-                username: 'kumar',
-                lastseen: '2021-01-20T05:03:51Z',
-                latestPrivatePrDate: '2021-03-20T05:02:56Z',
-              },
-            ],
-          },
-        }
-        setup({ mockUseUsersValue })
-
-        const lastSeen = screen.getByText(
-          assertFromToday('2021-03-20T05:02:56Z')
-        )
-        expect(lastSeen).toBeInTheDocument()
-      })
-    })
-
-    describe('No last seen', () => {
-      beforeEach(() => {
-        const mockUseUsersValue = {
-          isSuccess: true,
-          data: {
-            totalPages: 1,
-            results: [{ username: 'kumar' }],
-          },
-        }
-        setup({ mockUseUsersValue })
-      })
-      it('not rendered', () => {
-        const placeholder = screen.getByText(/kumar/)
-        expect(placeholder).toBeInTheDocument()
-
-        const lastSeen = screen.queryByTestId('last-seen')
-        expect(lastSeen).not.toBeInTheDocument()
-      })
-    })
-
-    describe('Last pr', () => {
-      beforeEach(() => {
-        const mockUseUsersValue = {
-          isSuccess: true,
-          data: {
-            totalPages: 1,
-            results: [
-              {
-                username: 'kumar',
-                latestPrivatePrDate: '2021-01-20T05:03:56Z',
-              },
-            ],
-          },
-        }
-        setup({ mockUseUsersValue })
-      })
-      it('renders correct date', () => {
-        const placeholder = screen.getByText(/kumar/)
-        expect(placeholder).toBeInTheDocument()
-
-        const lastPr = screen.getByText(assertFromToday('2021-01-20T05:03:56Z'))
-        expect(lastPr).toBeInTheDocument()
-      })
-      it('takes precedence over lastseen', () => {
-        const mockUseUsersValue = {
-          isSuccess: true,
-          data: {
-            totalPages: 1,
-            results: [
-              {
-                username: 'kumar',
-                latestPrivatePrDate: '2021-03-20T05:03:56Z',
-                lastseen: '2021-01-20T05:02:56Z',
-              },
-            ],
-          },
-        }
-        setup({ mockUseUsersValue })
-        const lastPr = screen.getByText(assertFromToday('2021-03-20T05:03:56Z'))
-        expect(lastPr).toBeInTheDocument()
-      })
-    })
-  })
-
-  describe('No last pr', () => {
-    beforeEach(() => {
-      const mockUseUsersValue = {
-        isSuccess: true,
-        data: {
-          totalPages: 1,
-          results: [{ username: 'kumar' }],
-        },
-      }
-      setup({ mockUseUsersValue })
-    })
-    it('not rendered', () => {
-      const placeholder = screen.getByText(/kumar/)
-      expect(placeholder).toBeInTheDocument()
-
-      const lastPr = screen.queryByTestId('last-pr')
-      expect(lastPr).not.toBeInTheDocument()
     })
   })
 


### PR DESCRIPTION
# Description
Removes "Last Pr" and "Last seen" from the user management page as specified in https://codecovio.atlassian.net/browse/CODE-324 .  Will also be removing this from `api` once this is merged!