### PR TITLE
fix extra margin under the navbar

### DIFF
--- a/src/layouts/BaseLayout/BaseLayout.js
+++ b/src/layouts/BaseLayout/BaseLayout.js
@@ -22,7 +22,7 @@ function BaseLayout({ children }) {
     <>
       <Header />
       <Suspense fallback={fullPageLoader}>
-        <main className="container flex-grow mt-20 mb-10 px-4 pb-4 md:p-0">
+        <main className="container flex-grow mt-6 mb-10 md:p-0">
           <ErrorBoundary sentryScopes={[['layout', 'base']]}>
             <NetworkErrorBoundary>{children}</NetworkErrorBoundary>
           </ErrorBoundary>


### PR DESCRIPTION
# Description

Too much margin under the new navbar

# Screenshots

Before
<img width="1440" alt="Screenshot 2021-05-19 at 15 29 58" src="https://user-images.githubusercontent.com/13302836/118821020-1e313780-b8b7-11eb-879a-0fd5438a866a.png">

After
<img width="1440" alt="Screenshot 2021-05-19 at 15 30 01" src="https://user-images.githubusercontent.com/13302836/118821024-1ec9ce00-b8b7-11eb-8145-9ece10f63669.png">
