### PR TITLE
Handle empty repo tables

### DIFF
--- a/src/pages/HomePage/ReposTable/ReposTable.js
+++ b/src/pages/HomePage/ReposTable/ReposTable.js
@@ -39,7 +39,20 @@ const tableInactive = [
   },
 ]
 
-function transformRepoToTable(repos, owner) {
+function transformRepoToTable(repos, owner, searchValue) {
+  // if there are no repos show empty message
+  if (repos.length <= 0) {
+    return [
+      {
+        title: (
+          <span className="text-sm">
+            {searchValue ? 'no results found' : 'no repos detected'}
+          </span>
+        ),
+      },
+    ]
+  }
+
   // if we have an owner, then we don't need to show it on the repo title
   const showRepoOwner = !owner
 
@@ -76,7 +89,7 @@ function ReposTable({ active, searchValue, owner }) {
     owner,
   })
 
-  const dataTable = transformRepoToTable(data.repos, owner)
+  const dataTable = transformRepoToTable(data.repos, owner, searchValue)
 
   return (
     <Table data={dataTable} columns={active ? tableActive : tableInactive} />

--- a/src/pages/HomePage/ReposTable/ReposTable.spec.js
+++ b/src/pages/HomePage/ReposTable/ReposTable.spec.js
@@ -159,4 +159,33 @@ describe('ReposTable', () => {
       expect(notActiveRepos.length).toBe(3)
     })
   })
+  describe('when rendered empty repos', () => {
+    beforeEach(() => {
+      setup(
+        {
+          active: true,
+        },
+        []
+      )
+    })
+    it('renders no repos detected', () => {
+      const buttons = screen.getAllByText(/no repos detected/)
+      expect(buttons.length).toBe(1)
+    })
+  })
+  describe('when rendered empty search', () => {
+    beforeEach(() => {
+      setup(
+        {
+          active: true,
+          searchValue: 'something',
+        },
+        []
+      )
+    })
+    it('renders no results found', () => {
+      const buttons = screen.getAllByText(/no results found/)
+      expect(buttons.length).toBe(1)
+    })
+  })
 })


### PR DESCRIPTION
# Description

Handles empty repo tables as well as empty search results in the repo table

# Screenshots
<img width="1373" alt="Screen Shot 2021-05-24 at 4 22 31 PM" src="https://user-images.githubusercontent.com/54366973/119347223-47cdd280-bcac-11eb-8889-937f3bc2ccab.png">
<img width="1375" alt="Screen Shot 2021-05-24 at 4 22 23 PM" src="https://user-images.githubusercontent.com/54366973/119347230-4ac8c300-bcac-11eb-8118-9263f77869cc.png">
