### PR TITLE
set enviroment for sentry in the config

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -1,3 +1,4 @@
 REACT_APP_API_URL=https://api.codecov.io
 REACT_APP_BASE_URL=https://codecov.io
 REACT_APP_MARKETING_BASE_URL=https://about.codecov.io
+REACT_APP_SENTRY_ENVIRONMENT=production

--- a/src/config.js
+++ b/src/config.js
@@ -4,6 +4,7 @@ const defaultConfig = {
   API_URL: '',
   STRIPE_KEY: '',
   IS_ENTERPRISE: false,
+  SENTRY_ENVIRONMENT: 'staging',
 }
 
 function removeReactAppPrefix(obj) {

--- a/src/sentry.js
+++ b/src/sentry.js
@@ -6,6 +6,7 @@ Sentry.init({
   dsn: config.SENTRY_DSN,
   debug: config.node_env !== 'production',
   release: config.SENTRY_RELEASE,
+  environment: config.SENTRY_ENVIRONMENT,
   ...declutterConfig(),
 })
 


### PR DESCRIPTION
# Description

Currently, all the error we receive on Sentry as marked as production environment, even if they are from the preview environment:

- https://sentry.io/organizations/codecov/issues/2419784340/?environment=production&project=5514400&query=is%3Aunresolved
- https://sentry.io/organizations/codecov/issues/2419656919

This PR attemps to fix it by giving to Sentry the right environment from the config.