### PR TITLE
use avatar component in context switcher

### DIFF
--- a/src/ui/ContextSwitcher/ContextSwitcher.js
+++ b/src/ui/ContextSwitcher/ContextSwitcher.js
@@ -2,13 +2,15 @@ import PropTypes from 'prop-types'
 import cs from 'classnames'
 import Icon from 'ui/Icon'
 import { Menu, MenuList, MenuButton, MenuLink } from '@reach/menu-button'
-import './ContextSwitcher.css'
+
 import AppLink from 'shared/AppLink'
+import Avatar from 'ui/Avatar'
+
+import './ContextSwitcher.css'
 
 const styles = {
   button: 'flex items-center text-xl font-semibold',
   image: 'w-6 h-6 rounded-full',
-  imageButton: 'w-6 h-6 border-2 border-ds-gray-secondary rounded-full',
   switchContext: 'px-4 py-2 border-b border-ds-gray-secondary font-semibold',
 }
 
@@ -30,7 +32,7 @@ function ContextSwitcher({ activeContext, contexts }) {
         options={{ owner: owner.username }}
         key={owner.username}
       >
-        <img alt="logo" src={owner.avatarUrl} className={styles.image} />
+        <Avatar user={owner} bordered />
         <div className={cs('mx-2', { 'font-semibold': isActiveContext })}>
           {owner.username}
         </div>
@@ -41,11 +43,7 @@ function ContextSwitcher({ activeContext, contexts }) {
   return (
     <Menu>
       <MenuButton className={styles.button}>
-        <img
-          alt="logo"
-          src={currentContext.owner.avatarUrl}
-          className={styles.imageButton}
-        />
+        <Avatar user={currentContext.owner} bordered />
         <div className="ml-2 mr-1">{currentContext.owner.username}</div>
         <span aria-hidden="true">
           <Icon variant="solid" name="chevron-down" />


### PR DESCRIPTION
# Description

The Context Switcher wasn't using the Avatar Component; so it was breaking for the not found bitbucket avatar:

<img width="1440" alt="Screenshot 2021-06-03 at 10 10 25" src="https://user-images.githubusercontent.com/13302836/120612815-ddf4bc00-c455-11eb-827b-2f19615a1355.png">

Using the Avatar Component, it will properly fallback on the letter component

<img width="743" alt="Screenshot 2021-06-03 at 10 30 19" src="https://user-images.githubusercontent.com/13302836/120613651-b6522380-c456-11eb-8450-f756523d543c.png">
