### PR TITLE
Added initial layout

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -11,6 +11,8 @@ import { ReactQueryDevtools } from 'react-query/devtools'
 
 const AccountSettings = lazy(() => import('./pages/AccountSettings'))
 const HomePage = lazy(() => import('./pages/HomePage'))
+const CommitPage = lazy(() => import('./pages/CommitPage'))
+
 const OwnerPage = lazy(() => import('./pages/OwnerPage'))
 const FullLayout = lazy(() => import('./layouts/FullLayout'))
 
@@ -62,6 +64,11 @@ function App() {
               <Route path="/:provider/:owner/:repo/" exact>
                 <BaseLayout>
                   <FullLayout>Repo page</FullLayout>
+                </BaseLayout>
+              </Route>
+              <Route path="/:provider/:owner/:repo/commit/:commit" exact>
+                <BaseLayout>
+                  <CommitPage />
                 </BaseLayout>
               </Route>
               <Route path="/">

--- a/src/pages/CommitPage/CommitPage.js
+++ b/src/pages/CommitPage/CommitPage.js
@@ -1,0 +1,28 @@
+function CommitPage() {
+  return (
+    <div className="flex flex-col">
+      <span className="w-full border-b border-ds-gray-secondary pb-3">
+        Febg/repo-test/Commits/jsdfhjksd
+      </span>
+      <span className="mt-4 text-lg font-semibold text-ds-gray-octonary">
+        Update Graphql mutation
+      </span>
+      <div className="flex mt-1 text-ds-gray-">
+        2 hours ago Pierce-m authored commit
+        <a className="ml-1.5" href="somethinf">
+          jsdfhjksd
+        </a>
+      </div>
+      <hr className="mt-6" />
+      <div className="flex flex-col md:flex-row mt-8">
+        <div className="flex w-full mr-8 md:max-w-md flex-col">
+          <div className="h-44 bg-ds-gray-octonary"></div>
+          <div className="h-44 mt-2 md:mt-8 bg-ds-gray-octonary"></div>
+        </div>
+        <div className="h-96 w-full mt-2 md:mt-0 bg-ds-gray-secondary"></div>
+      </div>
+    </div>
+  )
+}
+
+export default CommitPage

--- a/src/pages/CommitPage/index.js
+++ b/src/pages/CommitPage/index.js
@@ -1,0 +1,1 @@
+export { default } from './CommitPage'


### PR DESCRIPTION
# Description

This PR adds the initial layout of the Commit Details page! for now everything is hardcoded

- Pending talk to @kylemann about re arranging the `Responsive` view

# Screenshots
<img width="1079" alt="Screen Shot 2021-06-08 at 11 55 45 AM" src="https://user-images.githubusercontent.com/54366973/121226870-a076a100-c850-11eb-9e2e-d19176442338.png">
