### PR TITLE
Fix fileviewer breadcrumb

### DIFF
--- a/src/pages/FileView/FileView.js
+++ b/src/pages/FileView/FileView.js
@@ -42,7 +42,7 @@ function FileView() {
         paths={[
           { pageName: 'owner', text: owner },
           { pageName: 'repo', text: repo },
-          ...treePaths,
+          treePaths[treePaths.length - 1],
         ]}
       />
       <div className="border-t border-solid border-ds-gray-tertiary mt-4 py-6">

--- a/src/pages/FileView/FileView.spec.js
+++ b/src/pages/FileView/FileView.spec.js
@@ -54,7 +54,7 @@ describe('FileView', () => {
     })
 
     it('renders the breadcrumb', () => {
-      expect(screen.getAllByText('src').length).toBe(2)
+      expect(screen.getAllByText('src').length).toBe(1)
       expect(screen.getAllByText('index2.py').length).toBe(3)
     })
   })


### PR DESCRIPTION
# Description

The top Breadcrumb of the Fileviewer should only render the last segment of the file src path!