### PR TITLE
fix coverage for when no flags are selected

### DIFF
--- a/src/pages/FileView/FileView.js
+++ b/src/pages/FileView/FileView.js
@@ -52,7 +52,7 @@ function FileView() {
           flagNames={data.flagNames}
           coverage={data.coverage}
           content={data.content}
-          totals={data.totals?.coverage}
+          totals={data.totals}
           treePaths={treePaths}
           title={treePaths[treePaths.length - 1].text}
         />


### PR DESCRIPTION
# Description

[https://codecovio.atlassian.net/browse/CODE-731](https://codecovio.atlassian.net/browse/CODE-731)

The totals for when flags are not selected were always zero.