### PR TITLE
Testing something out.

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -4,7 +4,7 @@ codecov:
 coverage:
   precision: 2
   round: down
-  range: "70...100"
+  range: '70...100'
 
   status:
     project: yes
@@ -12,19 +12,8 @@ coverage:
     changes: no
 
 comment:
-  layout: "reach, diff, flags, files, footer"
+  layout: 'reach, diff, flags, files, footer'
   behavior: default
   require_changes: no
   require_base: no
   require_head: yes
-
-ignore:
-  - ./src/**/*.stories.js
-  - ./src/setupTests.js
-  - ./src/setupProxy.js
-  - ./src/reportWebVitals.js
-  - ./scripts/*
-  - ./src/index.js
-  - ./src/sentry.js
-  - ./src/mocks/*.js
-  - ./src/**/mocks.js

--- a/package.json
+++ b/package.json
@@ -114,6 +114,18 @@
   "jest": {
     "transformIgnorePatterns": [
       "<rootDir>/node_modules/(?!d3)/"
+    ],
+    "coveragePathIgnorePatterns": [
+      "/node_modules/",
+      "<rootDir>/src/**/*.stories.js",
+      "<rootDir>/src/setupTests.js",
+      "<rootDir>/src/setupProxy.js",
+      "<rootDir>/src/reportWebVitals.js",
+      "<rootDir>/scripts/*",
+      "<rootDir>/src/index.js",
+      "<rootDir>/src/sentry.js",
+      "<rootDir>/src/mocks/*.js",
+      "<rootDir>/src/**/mocks.js"
     ]
   },
   "msw": {


### PR DESCRIPTION
# Description
I noticed while reading jest docs that they have a doverage ignore folder, moving the ignore list to jest will make jest coverage reports locally (`npm run test -- --coverage`) match Codecov results.
