### PR TITLE
load stripe only in the account settings page

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,12 +1,9 @@
 import { lazy } from 'react'
 import { QueryClient, QueryClientProvider } from 'react-query'
 import { BrowserRouter, Switch, Route, Redirect } from 'react-router-dom'
-import { Elements } from '@stripe/react-stripe-js'
-import { loadStripe } from '@stripe/stripe-js'
 
 import { ToastNotificationProvider } from 'services/toastNotification'
 import BaseLayout from 'layouts/BaseLayout'
-import config from 'config'
 import { ReactQueryDevtools } from 'react-query/devtools'
 // Not lazy loading because the page is very small and is accessed often
 
@@ -29,89 +26,85 @@ const queryClient = new QueryClient({
   },
 })
 
-const stripePromise = loadStripe(config.STRIPE_KEY)
-
 function App() {
   return (
-    <Elements stripe={stripePromise}>
-      <ToastNotificationProvider>
-        <QueryClientProvider client={queryClient}>
-          <ReactQueryDevtools initialIsOpen={false} />
-          <BrowserRouter>
-            <Switch>
-              <Route path="/login/:provider">
-                <BaseLayout>
-                  <LoginPage />
-                </BaseLayout>
-              </Route>
-              <Route path="/login">
-                <BaseLayout>
-                  <LoginPage />
-                </BaseLayout>
-              </Route>
-              <Route path="/account/:provider/:owner/">
-                <BaseLayout>
-                  <AccountSettings />
-                </BaseLayout>
-              </Route>
-              <Route path="/analytics/:provider/:owner/" exact>
-                <BaseLayout>
-                  <AnalyticsPage />
-                </BaseLayout>
-              </Route>
-              <Route path="/:provider/+" exact>
-                <BaseLayout>
-                  <HomePage />
-                </BaseLayout>
-              </Route>
-              <Route path="/:provider/" exact>
-                <BaseLayout>
-                  <HomePage active={true} />
-                </BaseLayout>
-              </Route>
-              <Route path="/:provider/:owner/" exact>
-                <BaseLayout>
-                  <OwnerPage active={true} />
-                </BaseLayout>
-              </Route>
-              <Route path="/:provider/:owner/+" exact>
-                <BaseLayout>
-                  <OwnerPage />
-                </BaseLayout>
-              </Route>
-              <Route path="/:provider/:owner/:repo/" exact>
-                <BaseLayout>
-                  <FullLayout>Repo page</FullLayout>
-                </BaseLayout>
-              </Route>
-              <Route path="/:provider/:owner/:repo/commit/:commit/:path+" exact>
-                <BaseLayout>
-                  <CommitPage />
-                </BaseLayout>
-              </Route>
-              <Route path="/:provider/:owner/:repo/commit/:commit/" exact>
-                <BaseLayout>
-                  <CommitPage />
-                </BaseLayout>
-              </Route>
-              <Route path="/:provider/:owner/:repo/tree/*" exact>
-                <BaseLayout>
-                  <p>Tree</p>
-                </BaseLayout>
-              </Route>
-              <Route path="/:provider/:owner/:repo/blob/:ref/*" exact>
-                <BaseLayout>
-                  <FileViewPage />
-                </BaseLayout>
-              </Route>
-              <Route path="/">
-                <Redirect to="/gh" />
-              </Route>
-            </Switch>
-          </BrowserRouter>
-        </QueryClientProvider>
-      </ToastNotificationProvider>
-    </Elements>
+    <ToastNotificationProvider>
+      <QueryClientProvider client={queryClient}>
+        <ReactQueryDevtools initialIsOpen={false} />
+        <BrowserRouter>
+          <Switch>
+            <Route path="/login/:provider">
+              <BaseLayout>
+                <LoginPage />
+              </BaseLayout>
+            </Route>
+            <Route path="/login">
+              <BaseLayout>
+                <LoginPage />
+              </BaseLayout>
+            </Route>
+            <Route path="/account/:provider/:owner/">
+              <BaseLayout>
+                <AccountSettings />
+              </BaseLayout>
+            </Route>
+            <Route path="/analytics/:provider/:owner/" exact>
+              <BaseLayout>
+                <AnalyticsPage />
+              </BaseLayout>
+            </Route>
+            <Route path="/:provider/+" exact>
+              <BaseLayout>
+                <HomePage />
+              </BaseLayout>
+            </Route>
+            <Route path="/:provider/" exact>
+              <BaseLayout>
+                <HomePage active={true} />
+              </BaseLayout>
+            </Route>
+            <Route path="/:provider/:owner/" exact>
+              <BaseLayout>
+                <OwnerPage active={true} />
+              </BaseLayout>
+            </Route>
+            <Route path="/:provider/:owner/+" exact>
+              <BaseLayout>
+                <OwnerPage />
+              </BaseLayout>
+            </Route>
+            <Route path="/:provider/:owner/:repo/" exact>
+              <BaseLayout>
+                <FullLayout>Repo page</FullLayout>
+              </BaseLayout>
+            </Route>
+            <Route path="/:provider/:owner/:repo/commit/:commit/:path+" exact>
+              <BaseLayout>
+                <CommitPage />
+              </BaseLayout>
+            </Route>
+            <Route path="/:provider/:owner/:repo/commit/:commit/" exact>
+              <BaseLayout>
+                <CommitPage />
+              </BaseLayout>
+            </Route>
+            <Route path="/:provider/:owner/:repo/tree/*" exact>
+              <BaseLayout>
+                <p>Tree</p>
+              </BaseLayout>
+            </Route>
+            <Route path="/:provider/:owner/:repo/blob/:ref/*" exact>
+              <BaseLayout>
+                <FileViewPage />
+              </BaseLayout>
+            </Route>
+            <Route path="/">
+              <Redirect to="/gh" />
+            </Route>
+          </Switch>
+        </BrowserRouter>
+      </QueryClientProvider>
+    </ToastNotificationProvider>
   )
 }
 

--- a/src/pages/AccountSettings/AccountSettings.js
+++ b/src/pages/AccountSettings/AccountSettings.js
@@ -1,8 +1,11 @@
 import { Suspense, lazy } from 'react'
 import { useParams, Switch, Route, Redirect } from 'react-router-dom'
+import { Elements } from '@stripe/react-stripe-js'
+import { loadStripe } from '@stripe/stripe-js'
 
 import LogoSpinner from 'old_ui/LogoSpinner'
 import SidebarLayout from 'layouts/SidebarLayout'
+import config from 'config'
 
 import SideMenuAccount from './SideMenuAccount'
 import Header from './shared/Header'
@@ -17,6 +20,8 @@ const YAMLTab = lazy(() => import('./tabs/YAML'))
 const AccessTab = lazy(() => import('./tabs/Access'))
 const NotFound = lazy(() => import('../NotFound'))
 
+const stripePromise = loadStripe(config.STRIPE_KEY)
+
 function AccountSettings() {
   const { provider, owner } = useParams()
 
@@ -27,7 +32,7 @@ function AccountSettings() {
   )
 
   return (
-    <>
+    <Elements stripe={stripePromise}>
       <Header />
       <SidebarLayout sidebar={<SideMenuAccount />}>
         <Suspense fallback={tabLoading}>
@@ -65,7 +70,7 @@ function AccountSettings() {
           </Switch>
         </Suspense>
       </SidebarLayout>
-    </>
+    </Elements>
   )
 }
 


### PR DESCRIPTION
# Description

Stripe script was taking a lot of resources, so I moved the initialization to be only on the AccountSettings page.

On production
<img width="1440" alt="Screenshot 2021-09-24 at 10 51 18" src="https://user-images.githubusercontent.com/87858901/134646753-d18c6f53-2a77-4a56-8222-f9435346c1e2.png">

After this change (note that on Preview deploy, netlify injects some debug script, so the number will be higher)
<img width="1440" alt="Screenshot 2021-09-24 at 10 51 15" src="https://user-images.githubusercontent.com/87858901/134646762-4b7ec8c4-cc7e-4e6f-a5dd-34d02a9d148d.png">
