### PR TITLE
forward marketing link to the login link

### DIFF
--- a/src/layouts/Header/DesktopMenu.spec.js
+++ b/src/layouts/Header/DesktopMenu.spec.js
@@ -98,7 +98,7 @@ describe('LoginPrompt', () => {
         label: 'Log in',
         to: 'https://stage-web.codecov.dev/login/?to=http%3A%2F%2Flocalhost%2F',
       },
-      { label: 'Sign up', to: 'https://about.codecov.io/sign-up/?' },
+      { label: 'Sign up', to: 'https://about.codecov.io/sign-up/' },
     ]
 
     expectedLinks.forEach((expectedLink) => {

--- a/src/services/navigation/useNavLinks.js
+++ b/src/services/navigation/useNavLinks.js
@@ -4,7 +4,22 @@ import { useParams, useLocation } from 'react-router-dom'
 
 import config from 'config'
 
+function forwardMarketingTag(search) {
+  const queryParams = qs.parse(search, {
+    ignoreQueryPrefix: true,
+  })
+  return pick(queryParams, [
+    'utm_source',
+    'utm_medium',
+    'utm_campaign',
+    'utm_term',
+    'utm_content',
+    'utm_department',
+  ])
+}
+
 function useNavLinks() {
+  const { search } = useLocation()
   const { provider: p, owner: o, repo: r, id: i } = useParams()
 
   return {
@@ -21,10 +36,21 @@ function useNavLinks() {
           {
             to,
             private: privateScope,
+            ...forwardMarketingTag(search),
           },
           { addQueryPrefix: true }
         )
         return `${config.BASE_URL}/login/${provider}${query}`
+      },
+      isExternalLink: true,
+    },
+    signUp: {
+      text: 'Sign Up',
+      path: () => {
+        const params = qs.stringify(forwardMarketingTag(search), {
+          addQueryPrefix: true,
+        })
+        return `${config.MARKETING_BASE_URL}/sign-up/${params}`
       },
       isExternalLink: true,
     },
@@ -183,32 +209,10 @@ function useNavLinks() {
   }
 }
 
-function forwardMarketingTag(search) {
-  const queryParams = qs.parse(search, {
-    ignoreQueryPrefix: true,
-  })
-  const onlyMarketingParams = pick(queryParams, [
-    'utm_source',
-    'utm_medium',
-    'utm_campaign',
-    'utm_term',
-    'utm_content',
-  ])
-  return qs.stringify(onlyMarketingParams)
-}
-
 // Seperate function which doesn't unessisarily use the router.
 function useStaticNavLinks() {
-  const { search } = useLocation()
-
   return {
     root: { path: () => `${config.MARKETING_BASE_URL}`, isExternalLink: true },
-    signUp: {
-      text: 'Sign Up',
-      path: () =>
-        `${config.MARKETING_BASE_URL}/sign-up/?${forwardMarketingTag(search)}`,
-      isExternalLink: true,
-    },
     demo: {
       text: 'Demo',
       path: () => `${config.MARKETING_BASE_URL}/demo`,

--- a/src/services/navigation/useNavLinks.spec.js
+++ b/src/services/navigation/useNavLinks.spec.js
@@ -82,6 +82,19 @@ describe('useNavLinks', () => {
         `${config.BASE_URL}/login/gl?to=htts%3A%2F%2Fapp.codecov.io%2Fgh%2Fcodecov`
       )
     })
+
+    it('forwards the utm tags', () => {
+      setup([
+        '/gh?utm_source=a&utm_medium=b&utm_campaign=c&utm_term=d&utm_content=e&not=f',
+      ])
+      expect(
+        hookData.result.current.signIn.path({
+          to: 'htts://app.codecov.io/gh/codecov',
+        })
+      ).toBe(
+        `${config.BASE_URL}/login/gh?to=htts%3A%2F%2Fapp.codecov.io%2Fgh%2Fcodecov&utm_source=a&utm_medium=b&utm_campaign=c&utm_term=d&utm_content=e`
+      )
+    })
   })
 
   describe('owner link', () => {
@@ -444,6 +457,23 @@ describe('useNavLinks', () => {
       ).toBe('/gl/doggo/watch/tree/ref/src/view')
     })
   })
+
+  describe('signup forward the marketing link', () => {
+    beforeEach(() => {
+      setup([
+        '/gh?utm_source=a&utm_medium=b&utm_campaign=c&utm_term=d&utm_content=e&not=f',
+      ])
+    })
+
+    it('returns the correct url', () => {
+      expect(
+        hookData.result.current.signUp.path({ pathname: 'random/path/name' })
+      ).toBe(
+        config.MARKETING_BASE_URL +
+          '/sign-up/?utm_source=a&utm_medium=b&utm_campaign=c&utm_term=d&utm_content=e'
+      )
+    })
+  })
 })
 
 describe('useStaticNavLinks', () => {
@@ -481,32 +511,6 @@ describe('useStaticNavLinks', () => {
     it('returns the correct url', () => {
       expect(links.legacyUI.path({ pathname: 'random/path/name' })).toBe(
         config.BASE_URL + 'random/path/name'
-      )
-    })
-  })
-
-  describe('signup forward the marketing link', () => {
-    let signupLink
-    beforeEach(() => {
-      const hookData = renderHook(() => useStaticNavLinks(), {
-        wrapper: (props) => (
-          <MemoryRouter
-            initialEntries={[
-              '/gh?utm_source=a&utm_medium=b&utm_campaign=c&utm_term=d&utm_content=e&not=f',
-            ]}
-            initialIndex={0}
-          >
-            <Route path="/:provider">{props.children}</Route>
-          </MemoryRouter>
-        ),
-      })
-      signupLink = hookData.result.current.signUp
-    })
-
-    it('returns the correct url', () => {
-      expect(signupLink.path({ pathname: 'random/path/name' })).toBe(
-        config.MARKETING_BASE_URL +
-          '/sign-up/?utm_source=a&utm_medium=b&utm_campaign=c&utm_term=d&utm_content=e'
       )
     })
   })


### PR DESCRIPTION
# Description

[https://codecovio.atlassian.net/browse/CODE-651](https://codecovio.atlassian.net/browse/CODE-651)

We need to forward the UTM_* attribute from the current page to the sign-up/log-in links. They will be used by the API when sending signup/login segment events