### PR TITLE
Banner Persistance Domain Bug Fix

### DIFF
--- a/src/services/redirects/hooks.js
+++ b/src/services/redirects/hooks.js
@@ -12,6 +12,7 @@ export function useLegacyRedirects({ cookieName, selectedOldUI, pathname }) {
       Cookie.set(cookieName, 'old', {
         expires: 90,
         path: pathname,
+        domain: '.codecov.io',
       })
     }
   }, [cookieName, selectedOldUI, pathname])

--- a/src/services/redirects/hooks.spec.js
+++ b/src/services/redirects/hooks.spec.js
@@ -3,27 +3,35 @@ import { useLegacyRedirects } from './hooks'
 import Cookie from 'js-cookie'
 
 describe('useLegacyRedirects', () => {
-  function setup({ cookieName, selectedOldUI, location }) {
+  let getSpy
+  function setup({ cookieName, selectedOldUI, pathname }) {
     renderHook(() =>
-      useLegacyRedirects({ cookieName, selectedOldUI, location })
+      useLegacyRedirects({ cookieName, selectedOldUI, pathname })
     )
   }
 
   describe('when the old UI is selected', () => {
     let props
     beforeEach(() => {
+      getSpy = jest.spyOn(Cookie, 'set')
       props = {
         cookieName: 'cookie-monster',
         selectedOldUI: true,
-        location: {
-          pathname: 'gh/codecov/',
-        },
+        pathname: '/gh/codecov/',
       }
       setup(props)
     })
 
+    afterEach(() => {
+      getSpy.mockRestore()
+    })
+
     it('sets the cookie with old name, expiration of 90 days and path of pathname', () => {
-      expect(Cookie.get(props.cookieName)).toBe('old')
+      expect(getSpy).toHaveBeenCalledWith('cookie-monster', 'old', {
+        domain: '.codecov.io',
+        expires: 90,
+        path: '/gh/codecov/',
+      })
     })
   })
 
@@ -32,9 +40,7 @@ describe('useLegacyRedirects', () => {
       const props = {
         cookieName: 'cookie-monster',
         selectedOldUI: false,
-        location: {
-          pathname: 'gh/codecov/123',
-        },
+        pathname: '/gh/codecov/123',
       }
       delete global.window.location
       global.window = Object.create(window)


### PR DESCRIPTION
# Description
This PR is to fix a bug with banner persistence. Basically, the banner persist by setting up a cookie that should be available by legacy, `codecov.io` and gazebo, `app.codecov.io`. The cookie domain should be `.codecov.io` to be available for both legacy and gazebo. Currently, the cookie is defaulted to be set to the domain the page is in, so gazebo sets it to `app.codecov.io`. 

# Notable Changes
- Explicitly set the domain to `.codecov.io`
- Adjusts necessary test
