### PR TITLE
Change "Learn More" Anchor Link

### DIFF
--- a/src/pages/AccountSettings/tabs/Access/Access.js
+++ b/src/pages/AccountSettings/tabs/Access/Access.js
@@ -32,7 +32,7 @@ function Access({ provider }) {
             data-testid="tokens-docs-link"
             rel="noreferrer"
             target="_blank"
-            href="https://docs.codecov.io/reference#authorization"
+            href="https://docs.codecov.io/reference/authorization"
             className="text-ds-blue"
           >
             learn more


### PR DESCRIPTION
# Description
This PR is to update the `learn more` anchor link. Currently, the anchor takes the user to https://docs.codecov.io/reference#authorization but it should be taking the user to https://docs.codecov.io/reference/authorization. Very simple change