### PR TITLE
remove video and add the new link to inactive repo title

### DIFF
--- a/src/pages/RepoPage/new/New.js
+++ b/src/pages/RepoPage/new/New.js
@@ -109,23 +109,13 @@ function New({ data }) {
           {' '}
           🎉 Confirming completion
         </h2>
-        <p className="text-base border-b border-ds-gray-tertiary pb-8">
+        <p className="text-base">
           These steps should be added to the CI configuration. Codecov jobs
           occur after the test runner ran and output coverage report. Once
           uploader runs it will return a link where you can view your reports on
           Codecov.
         </p>
       </Fragment>
-
-      <div>
-        <p className="font-semibold mt-8 text-base">
-          Interested in a setup demo?{' '}
-          <span className="font-normal text-base">
-            Check out this walkthrough:
-          </span>
-        </p>
-        <div className="mt-4">Video here</div>
-      </div>
     </div>
   )
 }

--- a/src/shared/ListRepo/ReposTable/RepoTitleLink.js
+++ b/src/shared/ListRepo/ReposTable/RepoTitleLink.js
@@ -3,16 +3,20 @@ import PropTypes from 'prop-types'
 
 import AppLink from 'shared/AppLink'
 
-function RepoTitleLink({ repo, showRepoOwner }) {
+function RepoTitleLink({ repo, showRepoOwner, active, newRepoSetupLink }) {
   const options = {
     owner: repo.author.username,
     repo: repo.name,
   }
 
+  const handlePageName = () => {
+    return active ? 'repo' : newRepoSetupLink ? 'new' : 'repo'
+  }
+
   return (
     <div className="flex items-center">
       <AppLink
-        pageName="repo"
+        pageName={handlePageName()}
         options={options}
         className="flex text-ds-gray-quinary items-center hover:underline"
       >
@@ -54,6 +58,8 @@ RepoTitleLink.propTypes = {
     name: PropTypes.string,
   }),
   showRepoOwner: PropTypes.bool.isRequired,
+  active: PropTypes.bool.isRequired,
+  newRepoSetupLink: PropTypes.bool.isRequired,
 }
 
 export default RepoTitleLink

--- a/src/shared/ListRepo/ReposTable/ReposTable.js
+++ b/src/shared/ListRepo/ReposTable/ReposTable.js
@@ -43,7 +43,13 @@ const tableInactive = [
   },
 ]
 
-function transformRepoToTable(repos, owner, searchValue, newRepoSetupLink) {
+function transformRepoToTable(
+  repos,
+  owner,
+  searchValue,
+  newRepoSetupLink,
+  active
+) {
   // if there are no repos show empty message
   if (repos.length <= 0) {
     return [
@@ -59,7 +65,14 @@ function transformRepoToTable(repos, owner, searchValue, newRepoSetupLink) {
   const showRepoOwner = !owner
 
   return repos.map((repo) => ({
-    title: <RepoTitleLink repo={repo} showRepoOwner={showRepoOwner} />,
+    title: (
+      <RepoTitleLink
+        repo={repo}
+        showRepoOwner={showRepoOwner}
+        active={active}
+        newRepoSetupLink={newRepoSetupLink}
+      />
+    ),
     lastUpdated: (
       <span className="w-full text-right text-ds-gray-quinary">
         {repo.latestCommitAt
@@ -115,7 +128,8 @@ function ReposTable({
     data.repos,
     owner,
     searchValue,
-    newRepoSetupLink
+    newRepoSetupLink,
+    active
   )
 
   return (


### PR DESCRIPTION
# Description
removing the video section in the new page
also added a redirect when click on the title of the inactive repo to the new page 

we would also use useContext here but that's addressed in another [PR](https://github.com/codecov/gazebo/pull/1003) , once that is merged we can fix it here as well.