### PR TITLE
Fixes the site margins to be uniform and more inline with pavillion

### DIFF
--- a/src/layouts/BaseLayout/BaseLayout.js
+++ b/src/layouts/BaseLayout/BaseLayout.js
@@ -23,7 +23,7 @@ function BaseLayout({ children }) {
     <>
       <Header />
       <Suspense fallback={fullPageLoader}>
-        <main className="container flex-grow mt-6 mb-10 md:p-0">
+        <main className="container flex-grow mt-4 mb-8 md:p-0">
           <ErrorBoundary sentryScopes={[['layout', 'base']]}>
             <NetworkErrorBoundary>{children}</NetworkErrorBoundary>
           </ErrorBoundary>


### PR DESCRIPTION
# Description
I noticed the white space above and below the content was incorrect so I updated the base layout to be more inline with the designs.