### PR TITLE
Segment Adjust Object

### DIFF
--- a/src/services/tracking/segment.js
+++ b/src/services/tracking/segment.js
@@ -14,45 +14,50 @@ export const segmentUser = {
 }
 
 function identifyUser(user) {
-  return window?.analytics?.identify(user.ownerid, {
-    userId: user.ownerid,
-    traits: {
+  return window?.analytics?.identify(
+    user.ownerid,
+    {
       ...user,
     },
-    integrations: {
-      Salesforce: true,
-      Marketo: false,
-    },
-    context: {
-      externalIds: [
-        {
-          id: user.service_id,
-          type: user.service + '_id',
-          collections: 'users',
-          encoding: 'none',
-        },
-      ],
-    },
-  })
+    {
+      integrations: {
+        Salesforce: true,
+        Marketo: false,
+      },
+      context: {
+        externalIds: [
+          {
+            id: user.service_id,
+            type: user.service + '_id',
+            collections: 'users',
+            encoding: 'none',
+          },
+        ],
+      },
+    }
+  )
 }
 
 function identifyFromAnalytics(id, type) {
-  return window?.analytics?.identify({
-    integrations: {
-      Salesforce: false,
-      Marketo: false,
-    },
-    context: {
-      externalIds: [
-        {
-          id,
-          type,
-          collection: 'users',
-          encoding: 'none',
-        },
-      ],
-    },
-  })
+  return window?.analytics?.identify(
+    {},
+    {
+      integrations: {
+        Salesforce: false,
+        Marketo: false,
+      },
+      context: {
+        externalIds: [
+          {
+            id,
+            type,
+            collection: 'users',
+            encoding: 'none',
+          },
+        ],
+      },
+    }
+  )
 }
 
 export function identifySegmentUser(user) {
@@ -98,8 +103,6 @@ export function pageSegmentEvent({ event, path, url }) {
 
 export function identifySegmentEvent({ id, data }) {
   return window?.analytics?.identify(id, {
-    traits: {
-      ...data,
-    },
+    ...data,
   })
 }

--- a/src/services/tracking/segment.spec.js
+++ b/src/services/tracking/segment.spec.js
@@ -48,22 +48,9 @@ describe('identifySegmentUser', () => {
       expect(
         window.analytics.identify.mock.instances[0].identify
       ).toHaveBeenCalled()
-      expect(window.analytics.identify).toBeCalledWith(1, {
-        context: {
-          externalIds: [
-            {
-              collections: 'users',
-              encoding: 'none',
-              id: '123',
-              type: 'github_id',
-            },
-          ],
-        },
-        integrations: {
-          Marketo: false,
-          Salesforce: true,
-        },
-        traits: {
+      expect(window.analytics.identify).toBeCalledWith(
+        1,
+        {
           email: 'tedlasso@test.com',
           guest: false,
           name: 'Test User',
@@ -74,8 +61,23 @@ describe('identifySegmentUser', () => {
           staff: true,
           username: 'test_user',
         },
-        userId: 1,
-      })
+        {
+          context: {
+            externalIds: [
+              {
+                collections: 'users',
+                encoding: 'none',
+                id: '123',
+                type: 'github_id',
+              },
+            ],
+          },
+          integrations: {
+            Marketo: false,
+            Salesforce: true,
+          },
+        }
+      )
     })
   })
 
@@ -105,24 +107,12 @@ describe('identifySegmentUser', () => {
 
     it('hook should make 3 different identify calls', () => {
       expect(window.analytics.identify.mock.instances).toHaveLength(3)
+      // console.log(expect(window.analytics.identify.mock.instances[2].identify).toBeCalledWith(1))
       expect(
         window.analytics.identify.mock.instances[0].identify
-      ).toBeCalledWith(1, {
-        context: {
-          externalIds: [
-            {
-              collections: 'users',
-              encoding: 'none',
-              id: '123',
-              type: 'github_id',
-            },
-          ],
-        },
-        integrations: {
-          Marketo: false,
-          Salesforce: true,
-        },
-        traits: {
+      ).toBeCalledWith(
+        1,
+        {
           email: 'tedlasso@test.com',
           guest: false,
           name: 'Test User',
@@ -133,44 +123,65 @@ describe('identifySegmentUser', () => {
           staff: true,
           username: 'test_user',
         },
-        userId: 1,
-      })
+        {
+          context: {
+            externalIds: [
+              {
+                collections: 'users',
+                encoding: 'none',
+                id: '123',
+                type: 'github_id',
+              },
+            ],
+          },
+          integrations: {
+            Marketo: false,
+            Salesforce: true,
+          },
+        }
+      )
       expect(
         window.analytics.identify.mock.instances[1].identify
-      ).toBeCalledWith({
-        context: {
-          externalIds: [
-            {
-              collection: 'users',
-              encoding: 'none',
-              id: '123',
-              type: 'ga_client_id',
-            },
-          ],
-        },
-        integrations: {
-          Marketo: false,
-          Salesforce: false,
-        },
-      })
+      ).toBeCalledWith(
+        {},
+        {
+          context: {
+            externalIds: [
+              {
+                collection: 'users',
+                encoding: 'none',
+                id: '123',
+                type: 'ga_client_id',
+              },
+            ],
+          },
+          integrations: {
+            Marketo: false,
+            Salesforce: false,
+          },
+        }
+      )
       expect(
         window.analytics.identify.mock.instances[2].identify
-      ).toBeCalledWith({
-        context: {
-          externalIds: [
-            {
-              collection: 'users',
-              encoding: 'none',
-              id: '456',
-              type: 'marketo_cookie',
-            },
-          ],
-        },
-        integrations: {
-          Marketo: false,
-          Salesforce: false,
-        },
-      })
+      ).toBeCalledWith(
+        {},
+        {
+          context: {
+            externalIds: [
+              {
+                collection: 'users',
+                encoding: 'none',
+                id: '456',
+                type: 'marketo_cookie',
+              },
+            ],
+          },
+          integrations: {
+            Marketo: false,
+            Salesforce: false,
+          },
+        }
+      )
     })
   })
 
@@ -291,9 +302,7 @@ describe('identifySegmentEvent', () => {
 
       expect(window.analytics.identify).toHaveBeenCalled()
       expect(window.analytics.identify).toHaveBeenCalledWith(id, {
-        traits: {
-          ...data,
-        },
+        ...data,
       })
     })
   })


### PR DESCRIPTION
# Description
This PR is to change the object signature we're getting on Segment. Previously we were nesting the `traits` object with a custom made traits object in our code, so we extracted that logic here. 

# Screenshots
Unnested Object 
<img width="443" alt="Screen Shot 2021-12-20 at 1 56 33 PM" src="https://user-images.githubusercontent.com/82913673/146831701-e509025d-99d6-4373-8385-4c725af853c7.png">


# Notable Changes
- Got rid of `traits` object as it is implicitly called when calling the `identify` method
- Adjusted the tests
