### PR TITLE
Add schedule details whenever there is scheduled information

### DIFF
--- a/src/pages/AccountSettings/tabs/BillingAndUsers/CurrentPlanCard/CurrentPlanCard.js
+++ b/src/pages/AccountSettings/tabs/BillingAndUsers/CurrentPlanCard/CurrentPlanCard.js
@@ -5,6 +5,7 @@ import { isFreePlan } from 'shared/utils/billing'
 import ActionsBilling from './ActionsBilling'
 import BenefitList from '../../../shared/BenefitList'
 import Usage from './Usage'
+import ScheduledPlanDetails from './ScheduledPlanDetails'
 import A from 'ui/A'
 
 function CurrentPlanCard({ accountDetails }) {
@@ -26,6 +27,11 @@ function CurrentPlanCard({ accountDetails }) {
       </div>
       <hr className="my-6" />
       <Usage accountDetails={accountDetails} isBasicPlan={isBasicPlan} />
+      {accountDetails?.scheduleDetail?.scheduledPhase && (
+        <ScheduledPlanDetails
+          scheduledPhase={accountDetails?.scheduleDetail?.scheduledPhase}
+        />
+      )}
       <div className="flex flex-col items-center mt-1">
         <ActionsBilling
           accountDetails={accountDetails}

--- a/src/pages/AccountSettings/tabs/BillingAndUsers/CurrentPlanCard/CurrentPlanCard.spec.js
+++ b/src/pages/AccountSettings/tabs/BillingAndUsers/CurrentPlanCard/CurrentPlanCard.spec.js
@@ -106,6 +106,41 @@ describe('CurrentPlanCard', () => {
     })
   })
 
+  describe('when the subscription has scheduled information', () => {
+    beforeEach(() => {
+      setup({
+        ...proAccountDetails,
+        scheduleDetail: {
+          id: 'sub_sched_sch1K77Y5GlVGuVgOrkJrLjRnne',
+          scheduledPhase: {
+            plan: 'Annual',
+            quantity: 14,
+            startDate: 191276319264,
+          },
+        },
+      })
+    })
+
+    it('renders scheduled details', () => {
+      expect(screen.getByText(/\Scheduled Details/)).toBeInTheDocument()
+    })
+  })
+
+  describe('when the subscription doesn not have scheduled information', () => {
+    beforeEach(() => {
+      setup({
+        ...proAccountDetails,
+        scheduleDetail: {
+          id: null,
+        },
+      })
+    })
+
+    it('renders doesn not render scheduled details', () => {
+      expect(screen.queryByText(/\Scheduled Details/)).not.toBeInTheDocument()
+    })
+  })
+
   describe('when the user is using github marketplace', () => {
     beforeEach(() => {
       setup({

--- a/src/pages/AccountSettings/tabs/BillingAndUsers/CurrentPlanCard/ScheduledPlanDetails/ScheduledPlanDetails.js
+++ b/src/pages/AccountSettings/tabs/BillingAndUsers/CurrentPlanCard/ScheduledPlanDetails/ScheduledPlanDetails.js
@@ -1,0 +1,32 @@
+import PropType from 'prop-types'
+import { format, fromUnixTime } from 'date-fns'
+
+function getScheduleStart(scheduledPhase) {
+  const scheduleStart = fromUnixTime(scheduledPhase?.startDate)
+  return format(scheduleStart, 'MMMM do yyyy, h:m aaaa')
+}
+
+function ScheduledPlanDetails({ scheduledPhase }) {
+  const { plan, quantity } = scheduledPhase
+  const scheduleStart = getScheduleStart(scheduledPhase)
+
+  return (
+    <div className="flex flex-col gap-0.5">
+      <h2 className="font-semibold">Scheduled Details</h2>
+      <span>Start Date: {scheduleStart}</span>
+      <span className="capitalize">Plan: {plan}</span>
+      <span>Seats: {quantity}</span>
+      <hr className="my-6" />
+    </div>
+  )
+}
+
+ScheduledPlanDetails.propTypes = {
+  scheduledPhase: PropType.shape({
+    quantity: PropType.number.isRequired,
+    plan: PropType.string.isRequired,
+    startDate: PropType.number.isRequired,
+  }),
+}
+
+export default ScheduledPlanDetails

--- a/src/pages/AccountSettings/tabs/BillingAndUsers/CurrentPlanCard/ScheduledPlanDetails/ScheduledPlanDetails.spec.js
+++ b/src/pages/AccountSettings/tabs/BillingAndUsers/CurrentPlanCard/ScheduledPlanDetails/ScheduledPlanDetails.spec.js
@@ -1,0 +1,42 @@
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+
+import ScheduledPlanDetails from './ScheduledPlanDetails'
+import { QueryClientProvider, QueryClient } from 'react-query'
+
+const queryClient = new QueryClient()
+
+describe('ScheduledPlanDetails', () => {
+  function setup(scheduledPhase) {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <ScheduledPlanDetails scheduledPhase={scheduledPhase} />
+      </QueryClientProvider>,
+      {
+        wrapper: MemoryRouter,
+      }
+    )
+  }
+
+  describe('when rendering with a pro plan', () => {
+    beforeEach(() => {
+      setup({
+        plan: 'annual',
+        quantity: 14,
+        startDate: 1642105987,
+      })
+    })
+
+    it('renders plan', () => {
+      expect(screen.getByText(/annual/)).toBeInTheDocument()
+    })
+
+    it('renders quantity', () => {
+      expect(screen.getByText(/14/)).toBeInTheDocument()
+    })
+
+    it('renders start date in human readable', () => {
+      expect(screen.getByText(/January 13th 2022/)).toBeInTheDocument()
+    })
+  })
+})

--- a/src/pages/AccountSettings/tabs/BillingAndUsers/CurrentPlanCard/ScheduledPlanDetails/index.js
+++ b/src/pages/AccountSettings/tabs/BillingAndUsers/CurrentPlanCard/ScheduledPlanDetails/index.js
@@ -1,0 +1,1 @@
+export { default } from './ScheduledPlanDetails'


### PR DESCRIPTION
# Description
This PR is to account for the UI implementation details whenever a user has scheduled information for the future. If a client downgrades their plan or number of seats, these changes are scheduled to happen in the future by the backend; these changes surface these scheduled details to the client.

More info here, https://github.com/codecov/codecov-api/pull/890

# Notable Changes
- Added `ScheduledPlanDetails` component to render if there if a subscription has a schedule
- Added tests + adjusted `CurrentPlanCard` to render this new component

# Screenshots
![Screen Shot 2022-01-13 at 12 47 42 PM](https://user-images.githubusercontent.com/82913673/149406803-a3745c63-ceaa-439c-a7a9-53918a45cfaf.png)

# Link to Sample Entry
N/A since the backend changes aren't merged

# Notes
This can't be merged till the API ticket above is merged ^