### PR TITLE
[CODE-1044]-remove-opacity-for-non-selected-code

### DIFF
--- a/src/shared/FileViewer/Line.js
+++ b/src/shared/FileViewer/Line.js
@@ -55,11 +55,7 @@ function Line({
       >
         {number}
       </td>
-      <td
-        className={cs('pl-2 break-all', {
-          'opacity-50': lineState === LINE_STATE.BLANK,
-        })}
-      >
+      <td className="pl-2 break-all">
         {line.map((token, key) => (
           <span key={key} {...getTokenProps({ token, key })} />
         ))}


### PR DESCRIPTION
# Description
"When you toggle covered/uncovered on the file viewer it adds/removes line coverage highlight and state is toggled off reduces opacity of text. This can make it challenging for some lines to viewed read and has proven to be more of a distraction for users (vs intention of a more focused code review)"

# Notable Changes
removed opacity of blank lines 

# Screenshots
<img width="1185" alt="Screen Shot 2022-03-15 at 5 20 49 PM" src="https://user-images.githubusercontent.com/91732700/158426045-4fd14714-d843-472c-a9fc-a6acee1e2914.png">
<img width="1185" alt="Screen Shot 2022-03-15 at 5 20 53 PM" src="https://user-images.githubusercontent.com/91732700/158426060-4a00d985-4558-4094-b56d-8326928e2817.png">


# Link to Sample Entry
