### PR TITLE
Revert "Bump postcss from 8.4.8 to 8.4.12"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -70,7 +70,7 @@
         "jest-junit": "^13.0.0",
         "lint-staged": "^12.3.6",
         "msw": "^0.39.0",
-        "postcss": "^8.4.12",
+        "postcss": "^8.4.8",
         "prettier": "^2.5.1",
         "react-is": "^17.0.2",
         "react-test-renderer": "^17.0.2",
@@ -29297,19 +29297,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.12",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.12.tgz",
-      "integrity": "sha512-lg6eITwYe9v6Hr5CncVbK70SoioNQIq81nsaG86ev5hAidQvmOeETBqs7jm43K2F5/Ley3ytDtriImV6TpNiSg==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        }
-      ],
+      "version": "8.4.8",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.8.tgz",
+      "integrity": "sha512-2tXEqGxrjvAO6U+CJzDL2Fk2kPHTv1jQsYkSoMeOis2SsYaXRO2COxTdQp99cYvif9JTXaAk9lYGc3VhJt7JPQ==",
       "dependencies": {
         "nanoid": "^3.3.1",
         "picocolors": "^1.0.0",
@@ -29317,6 +29307,10 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
       }
     },
     "node_modules/postcss-attribute-case-insensitive": {
@@ -60738,9 +60732,9 @@
       "dev": true
     },
     "postcss": {
-      "version": "8.4.12",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.12.tgz",
-      "integrity": "sha512-lg6eITwYe9v6Hr5CncVbK70SoioNQIq81nsaG86ev5hAidQvmOeETBqs7jm43K2F5/Ley3ytDtriImV6TpNiSg==",
+      "version": "8.4.8",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.8.tgz",
+      "integrity": "sha512-2tXEqGxrjvAO6U+CJzDL2Fk2kPHTv1jQsYkSoMeOis2SsYaXRO2COxTdQp99cYvif9JTXaAk9lYGc3VhJt7JPQ==",
       "requires": {
         "nanoid": "^3.3.1",
         "picocolors": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "jest-junit": "^13.0.0",
     "lint-staged": "^12.3.6",
     "msw": "^0.39.0",
-    "postcss": "^8.4.12",
+    "postcss": "^8.4.8",
     "prettier": "^2.5.1",
     "react-is": "^17.0.2",
     "react-test-renderer": "^17.0.2",


### PR DESCRIPTION
Reverts codecov/gazebo#1221 - failed main pipeline, https://app.circleci.com/pipelines/github/codecov/gazebo/4352/workflows/f2d03453-1573-4bf3-88a8-6b495b1f9dd6