### PR TITLE
Old toggle active state broke with the tailwind upgrade

### DIFF
--- a/src/old_ui/Toggle/Toggle.js
+++ b/src/old_ui/Toggle/Toggle.js
@@ -11,7 +11,7 @@ function checkClass(show, classes) {
 
 const ToggleClasses = {
   button:
-    'bg-gray-200 relative inline-flex flex-shrink-0 h-6 w-11 border-2 border-transparent rounded-full cursor-pointer transition-colors ease-in-out duration-200 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-50',
+    'relative inline-flex flex-shrink-0 h-6 w-11 border-2 border-transparent rounded-full cursor-pointer transition-colors ease-in-out duration-200 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-50',
   circle:
     'pointer-events-none translate-x-0 inline-block h-5 w-5 rounded-full bg-white shadow transform ring-0 transition ease-in-out duration-200',
   label: checkClass,


### PR DESCRIPTION
# Description
The new tailwind compiler's priority changed
 slightly with the new version, we were setting bg twice previously, this prevents a conflict when active is true.

# Code Example

# Notable Changes

# Screenshot
![Screen Shot 2022-03-17 at 8 19 28 PM](https://user-images.githubusercontent.com/87824812/158909443-d74b897b-4928-4400-9e87-b1715d0b5691.png)

![Image from iOS](https://user-images.githubusercontent.com/87824812/158909311-7beb2c92-934a-40a9-864b-78f90c64aa8c.png)


# Link to Sample Entry

https://5fa9228f77839a00217f8a45-odcourvcnd.chromatic.com/?path=/story/old-ui-components-toggle--normal-toggle