### PR TITLE
Code 1037 truncate the commit sch name to one line

### DIFF
--- a/src/pages/CommitPage/Header/TruncatedMessage.js
+++ b/src/pages/CommitPage/Header/TruncatedMessage.js
@@ -2,7 +2,12 @@ import { sanitize } from 'dompurify'
 import PropTypes from 'prop-types'
 import { useState } from 'react'
 
-import { TruncateEnum } from 'shared/utils/commit'
+import A from 'ui/A'
+
+const TruncateEnum = Object.freeze({
+  EXPAND: 'see more...',
+  COLLAPSE: 'see less...',
+})
 
 function TruncatedMessage({ message }) {
   const [truncateLabel, setTruncateLabel] = useState(TruncateEnum.EXPAND)
@@ -17,12 +22,11 @@ function TruncatedMessage({ message }) {
 
   return (
     <div>
-      <pre className="text-lg font-semibold break-all whitespace-pre-wrap inline font-default">
+      <pre className="text-lg font-semibold break-all whitespace-pre-wrap inline font-sans">
         {sanitize(truncatedMsg)}{' '}
       </pre>
       {isLongMessage && (
-        <button
-          className="text-ds-blue-darker"
+        <A
           onClick={() =>
             setTruncateLabel(
               truncateLabel === TruncateEnum.EXPAND
@@ -32,7 +36,7 @@ function TruncatedMessage({ message }) {
           }
         >
           {truncateLabel}
-        </button>
+        </A>
       )}
     </div>
   )

--- a/src/shared/utils/commit.js
+++ b/src/shared/utils/commit.js
@@ -14,8 +14,3 @@ export const UploadTypes = Object.freeze({
   UPLOADED: 'UPLOADED',
   CARRIED_FORWARD: 'CARRIEDFORWARD',
 })
-
-export const TruncateEnum = Object.freeze({
-  EXPAND: 'see more...',
-  COLLAPSE: 'see less...',
-})

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -8,23 +8,6 @@ module.exports = {
     },
     extend: {
       fontFamily: {
-        default: [
-          'Poppins',
-          'ui-sans-serif',
-          'system-ui',
-          'apple-system',
-          'BlinkMacSystemFont',
-          'Segoe UI',
-          'Roboto',
-          'Helvetica Neue',
-          'Arial',
-          'Noto Sans',
-          'sans-serif',
-          'Apple Color Emoji',
-          'Segoe UI Emoji',
-          'Segoe UI Symbol',
-          'Noto Color Emoji',
-        ],
         sans: ['Poppins', ...defaultTheme.fontFamily.sans],
         mono: ['"Source Code Pro"', ...defaultTheme.fontFamily.mono],
       },


### PR DESCRIPTION
# Description
Currently, Long commit messages are rendered as it is, this PR addresses truncating long messages to have a collapse/expand option.  

# Notable Changes
- Created a TruncatedMessage component that checks for the message length and renders expand/collapse button accordingly 
- TruncateMessage.spec.js for the tests
- TruncateEnum to handle truncate buttons labels
- included the component in the header of the commit details page
<del> - added a default font family to use in pre tags, to override the original format </del>

# Screenshots
Short Message:
<img width="912" alt="Screen Shot 2022-04-13 at 2 00 34 PM" src="https://user-images.githubusercontent.com/91732700/163166940-f7802da2-2187-4fbf-b9f5-2de32b073a3b.png">


Long Message:
<img width="1103" alt="Screen Shot 2022-04-13 at 2 00 22 PM" src="https://user-images.githubusercontent.com/91732700/163166975-35198b67-575a-4608-a88c-156ee6a83607.png">
<img width="1163" alt="Screen Shot 2022-04-13 at 2 00 27 PM" src="https://user-images.githubusercontent.com/91732700/163167003-71fa32b4-32d8-4371-80d9-fe169eb66de5.png">


# Link to Sample Entry
/gh/codecov/codecov-api/commit/275246079371127b15779d64e6ead00fb1003cbf