### PR TITLE
Use `react-router-dom`

### DIFF
--- a/src/layouts/Header/DesktopMenu.js
+++ b/src/layouts/Header/DesktopMenu.js
@@ -1,5 +1,4 @@
-import { useLocation } from 'react-router'
-import { useParams } from 'react-router-dom'
+import { useLocation , useParams } from 'react-router-dom'
 
 import { ReactComponent as CodecovIcon } from 'assets/svg/codecov.svg'
 import { useUser } from 'services/user'

--- a/src/layouts/Header/Dropdown.js
+++ b/src/layouts/Header/Dropdown.js
@@ -1,7 +1,7 @@
 import { Menu, MenuButton, MenuLink, MenuList } from '@reach/menu-button'
 import PropTypes from 'prop-types'
 import '@reach/menu-button/styles.css'
-import { useParams } from 'react-router'
+import { useParams } from 'react-router-dom'
 
 import AppLink from 'shared/AppLink'
 import { providerToName } from 'shared/utils/provider'

--- a/src/pages/AccountSettings/tabs/BillingAndUsers/CurrentPlanCard/Usage/Usage.js
+++ b/src/pages/AccountSettings/tabs/BillingAndUsers/CurrentPlanCard/Usage/Usage.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types'
-import { useParams } from 'react-router'
+import { useParams } from 'react-router-dom'
 
 import { accountDetailsPropType } from 'services/account'
 import { useUploadsNumber } from 'services/uploadsNumber/hooks'

--- a/src/pages/HomePage/HomePage.js
+++ b/src/pages/HomePage/HomePage.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types'
-import { useHistory, useParams } from 'react-router'
+import { useHistory, useParams } from 'react-router-dom'
 
 import LogoSpinner from 'old_ui/LogoSpinner'
 import { useUser } from 'services/user'

--- a/src/pages/LoginPage/LoginPage.js
+++ b/src/pages/LoginPage/LoginPage.js
@@ -1,4 +1,4 @@
-import { useParams } from 'react-router'
+import { useParams } from 'react-router-dom'
 
 import A from 'ui/A'
 

--- a/src/pages/RepoPage/CommitsTab/CommitsTab.js
+++ b/src/pages/RepoPage/CommitsTab/CommitsTab.js
@@ -1,5 +1,5 @@
 import { useLayoutEffect } from 'react'
-import { useParams } from 'react-router'
+import { useParams } from 'react-router-dom'
 
 import { useBranches } from 'services/branches'
 import { useCommits } from 'services/commits'

--- a/src/pages/RepoPage/NewRepoTab/GithubConfig/GithubConfigBanner.js
+++ b/src/pages/RepoPage/NewRepoTab/GithubConfig/GithubConfigBanner.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types'
-import { useParams } from 'react-router'
+import { useParams } from 'react-router-dom'
 
 import { providerToName } from 'shared/utils/provider'
 import Banner from 'ui/Banner'

--- a/src/pages/RepoPage/NewRepoTab/NewRepoTab.js
+++ b/src/pages/RepoPage/NewRepoTab/NewRepoTab.js
@@ -1,4 +1,4 @@
-import { useParams } from 'react-router'
+import { useParams } from 'react-router-dom'
 
 import { useRepo } from 'services/repo'
 import { NotFoundException } from 'shared/utils'

--- a/src/pages/RepoPage/NewRepoTab/hooks.js
+++ b/src/pages/RepoPage/NewRepoTab/hooks.js
@@ -1,5 +1,5 @@
 import { useEffect } from 'react'
-import { useParams } from 'react-router'
+import { useParams } from 'react-router-dom'
 
 import { useCommits } from 'services/commits'
 import { useRedirect } from 'shared/useRedirect'

--- a/src/pages/RepoPage/PullsTab/PullsTab.js
+++ b/src/pages/RepoPage/PullsTab/PullsTab.js
@@ -1,5 +1,5 @@
 import { useLayoutEffect, useState } from 'react'
-import { useParams } from 'react-router'
+import { useParams } from 'react-router-dom'
 
 import { useLocationParams } from 'services/navigation'
 import { usePulls } from 'services/pulls'

--- a/src/ui/ContextSwitcher/ContextSwitcher.js
+++ b/src/ui/ContextSwitcher/ContextSwitcher.js
@@ -1,7 +1,7 @@
 import { Menu, MenuButton, MenuLink, MenuList } from '@reach/menu-button'
 import cs from 'classnames'
 import PropTypes from 'prop-types'
-import { useParams } from 'react-router'
+import { useParams } from 'react-router-dom'
 
 import AppLink from 'shared/AppLink'
 import { providerToName } from 'shared/utils/provider'


### PR DESCRIPTION
# Description

The react-router package is intended to be consumed via either `react-router-dom` or `react-router-native`:[^1]

> If you're using React Router, you should never `import` anything directly from the `react-router` package, but you should have everything you need in either `react-router-dom` or `react-router-native`. Both of those packages re-export everything from `react-router`.

[^1]: [react-router/README.md at main · remix-run/react-router]

[react-router/README.md at main · remix-run/react-router]: https://github.com/remix-run/react-router/blob/1e1b9fe4dcc3abae71920266c68dc60453635a9e/packages/react-router/README.md

# Code Example

# Notable Changes

In a general sense, the PR makes changes of the following nature:

```diff
-import "react-router";
+import "react-router-dom";
```

# Screenshots

# Link to Sample Entry