### PR TITLE
Disabled the onboarding popup when impersonating

### DIFF
--- a/src/layouts/UserOnboarding/UserOnboarding.js
+++ b/src/layouts/UserOnboarding/UserOnboarding.js
@@ -1,3 +1,5 @@
+import Cookie from 'js-cookie'
+
 import { useUser } from 'services/user'
 import { useFlags } from 'shared/featureFlags'
 
@@ -11,11 +13,14 @@ function UserOnboarding() {
     userSignupOnboardingQuestions: false,
   })
 
+  const staffCookie = Cookie.get('staff_user')
+
   // render the onboarding flow if
   const shouldRender = [
     userSignupOnboardingQuestions, // feature flag is true
     Boolean(currentUser), // user is authenticated
     !Boolean(currentUser?.onboardingCompleted), // user hasnt done onboarding
+    !staffCookie, // user is not a staff member
   ].every(Boolean)
 
   if (!shouldRender) return null

--- a/src/layouts/UserOnboarding/UserOnboarding.spec.js
+++ b/src/layouts/UserOnboarding/UserOnboarding.spec.js
@@ -1,4 +1,5 @@
 import { render, screen } from '@testing-library/react'
+import Cookie from 'js-cookie'
 
 import { useUser } from 'services/user'
 import { useFlags } from 'shared/featureFlags'
@@ -62,6 +63,18 @@ describe('UserOnboarding', () => {
     beforeEach(() => {
       setup(userNotOnboarded, false)
     })
+
+    it('doesnt render the onboarding modal', () => {
+      expect(screen.queryByText(/UserOnboardingModal/)).not.toBeInTheDocument()
+    })
+  })
+
+  describe(`when the user is impersonating don't show the onboarding even if the user isnt onbored and the flag is true.`, () => {
+    beforeEach(() => {
+      Cookie.set('staff_user', 'chetney')
+      setup(userNotOnboarded, true)
+    })
+    afterEach(() => Cookie.remove('staff_user'))
 
     it('doesnt render the onboarding modal', () => {
       expect(screen.queryByText(/UserOnboardingModal/)).not.toBeInTheDocument()


### PR DESCRIPTION
# Description
Stop the on boarding modal if a staff member is impersonating.


# Notable Changes
* Adds a cookie check there. Long term I'd like to move away from the cookie though.