### PR TITLE
Move patch data from file header to segment dividers

### DIFF
--- a/src/pages/PullRequestPage/subroute/Root/FileDiff/FileDiff.js
+++ b/src/pages/PullRequestPage/subroute/Root/FileDiff/FileDiff.js
@@ -39,7 +39,6 @@ const FileDiff = ({
   const headCoverage = headTotals?.percentCovered
   const changeCoverage = headCoverage - baseTotals?.percentCovered
   const patchCoverage = patchTotals?.percentCovered
-  const header = segments[0]?.header
   const fileLabel = setFileLabel({ isNewFile, isRenamedFile, isDeletedFile })
   const coverage = [
     { label: 'HEAD', value: headCoverage },
@@ -50,7 +49,6 @@ const FileDiff = ({
     <div>
       {/* Header */}
       <FileHeader
-        header={header}
         headName={headName}
         coverage={coverage}
         fileLabel={fileLabel}
@@ -60,11 +58,14 @@ const FileDiff = ({
         const content = segment.lines.map((line) => line.content).join('\n')
         return (
           <Fragment key={`${headName}-${segmentIndex}`}>
-            {segment?.hasUnintendedChanges && (
-              <CodeRendererInfoRow
-                type={CODE_RENDERER_INFO.UNEXPECTED_CHANGES}
-              />
-            )}
+            <CodeRendererInfoRow
+              patch={segment?.header}
+              type={
+                segment?.hasUnintendedChanges
+                  ? CODE_RENDERER_INFO.UNEXPECTED_CHANGES
+                  : CODE_RENDERER_INFO.EMPTY
+              }
+            />
             <CodeRenderer
               code={content}
               fileName={headName}

--- a/src/pages/PullRequestPage/subroute/Root/FileDiff/FileDiff.spec.js
+++ b/src/pages/PullRequestPage/subroute/Root/FileDiff/FileDiff.spec.js
@@ -19,7 +19,6 @@ describe('FileDiff', () => {
         headName: 'main.ts',
         segments: [
           {
-            header: '@@ -1 +3 @@',
             lines: [{ content: 'abc' }, { content: 'def' }],
           },
         ],
@@ -32,9 +31,6 @@ describe('FileDiff', () => {
     })
     it('renders the name of a impacted file', () => {
       expect(screen.getByText(/main.ts/i)).toBeInTheDocument()
-    })
-    it('renders the patch of a segment', () => {
-      expect(screen.getByText('@@ -1 +3 @@')).toBeInTheDocument()
     })
     it('renders the lines of a segment', () => {
       expect(screen.getByText(/abc/)).toBeInTheDocument()

--- a/src/shared/utils/fileviewer.js
+++ b/src/shared/utils/fileviewer.js
@@ -36,6 +36,7 @@ export const CODE_RENDERER_TYPE = Object.freeze({
 
 export const CODE_RENDERER_INFO = Object.freeze({
   UNEXPECTED_CHANGES: 'UNEXPECTED_CHANGES',
+  EMPTY: '',
 })
 
 // Enum from https://github.com/codecov/shared/blob/master/shared/utils/merge.py#L275-L279

--- a/src/ui/CodeRenderer/CodeRendererInfoRow/CodeRendererInfoRow.js
+++ b/src/ui/CodeRenderer/CodeRendererInfoRow/CodeRendererInfoRow.js
@@ -14,16 +14,18 @@ const message = {
       </span>
     </div>
   ),
+  [CODE_RENDERER_INFO.EMPTY]: CODE_RENDERER_INFO.EMPTY,
 }
 
-function CodeRendererInfoRow({ type }) {
+function CodeRendererInfoRow({ type, patch }) {
   /**
    * Row to display information related to the code rendered
    * @param {String} type type of information to be shown
    */
 
   return (
-    <div className="bg-ds-gray-primary border-t p-1 border-r border-l border-solid border-ds-gray-tertiary text-xs text-ds-gray-quinary">
+    <div className="flex gap-2 bg-ds-gray-primary border-t px-4 py-1 border-r border-l border-solid border-ds-gray-tertiary text-xs text-ds-gray-quinary">
+      <span data-testid="patch">{patch}</span>
       {message[type]}
     </div>
   )
@@ -31,6 +33,7 @@ function CodeRendererInfoRow({ type }) {
 
 CodeRendererInfoRow.propTypes = {
   type: PropTypes.string,
+  patch: PropTypes.string,
 }
 
 export default CodeRendererInfoRow

--- a/src/ui/CodeRenderer/CodeRendererInfoRow/CodeRendererInfoRow.spec.js
+++ b/src/ui/CodeRenderer/CodeRendererInfoRow/CodeRendererInfoRow.spec.js
@@ -7,24 +7,23 @@ import CodeRendererInfoRow from './CodeRendererInfoRow'
 
 //TODO: Almost there, missing the usenavlinks part
 describe('CodeRendererInfoRow', () => {
-  let container
-
   function setup(props) {
-    ;({ container } = render(
+    render(
       <MemoryRouter initialEntries={['/gh/codecov']}>
         <Route path="/:provider/:owner">
           <CodeRendererInfoRow {...props} />
         </Route>
       </MemoryRouter>
-    ))
+    )
   }
 
   describe('when rendered with unexpected changes', () => {
     beforeEach(() => {
-      setup({ type: CODE_RENDERER_INFO.UNEXPECTED_CHANGES })
+      setup({ type: CODE_RENDERER_INFO.UNEXPECTED_CHANGES, patch: '-1,10' })
     })
 
     it('renders message relevant to unexpected info', () => {
+      expect(screen.getByText(/-1,10/)).toBeInTheDocument()
       expect(screen.getByText(/indirect coverage change/)).toBeInTheDocument()
       const link = screen.getByRole('link', {
         name: /learn more/i,
@@ -34,6 +33,15 @@ describe('CodeRendererInfoRow', () => {
         'href',
         'https://docs.codecov.com/docs/unexpected-coverage-changes'
       )
+    })
+  })
+  describe('when rendered with empty status', () => {
+    beforeEach(() => {
+      setup({ type: CODE_RENDERER_INFO.EMPTY, patch: '-1,10' })
+    })
+
+    it('renders message relevant to no status', () => {
+      expect(screen.getByText(/-1,10/)).toBeInTheDocument()
     })
   })
 })


### PR DESCRIPTION
# Description
Correctly renders segment dividers with patch data.

# Code Example

# Notable Changes
* As decided in the design sync moving the header/patch data from the file header to the segment dividers.
* The first segment now has its own divider with patch data.

# Screenshots
![Screen Shot 2022-05-30 at 5 38 20 PM](https://user-images.githubusercontent.com/87824812/171057277-5424b03c-0afd-43d2-9b38-b29c6fce96f4.png)


# Link to Sample Entry