### PR TITLE
CODE-1297 - Implement "select default organization" modal

### DIFF
--- a/src/ui/Button/Button.js
+++ b/src/ui/Button/Button.js
@@ -6,12 +6,9 @@ import Spinner from 'ui/Spinner'
 
 const baseClass = `
   flex justify-center items-center gap-1
-  border-solid border
-  font-semibold rounded py-1 px-4 shadow
+  font-semibold rounded 
   transition-colors duration-150 motion-reduce:transition-none
-
   focus:outline-none focus:ring
-
   disabled:cursor-not-allowed 
 `
 const baseDisabledClasses = `disabled:text-ds-gray-quaternary disabled:border-ds-gray-tertiary disabled:bg-ds-gray-primary`
@@ -35,6 +32,10 @@ const variantClasses = {
     text-white bg-ds-pink border-ds-pink-tertiary
     hover:bg-ds-pink-tertiary
   `,
+  link: `
+    text-ds-blue-darker
+    hover:text-ds-blue-quinary
+  `,
 }
 
 const loadingVariantClasses = {
@@ -42,6 +43,7 @@ const loadingVariantClasses = {
   primary: `disabled:bg-ds-blue-darker disabled:bg-ds-blue-medium text-white disabled:border-ds-blue-quinary`,
   danger: `disabled:text-white disabled:border-ds-primary-red disabled:bg-ds-primary-red`,
   secondary: `disabled:text-white disabled:border-ds-pink-tertiary disabled:bg-ds-pink`,
+  link: `disabled:text-white`,
 }
 
 function pickVariant(variant, loading) {
@@ -62,7 +64,8 @@ function Button({
   const className = cs(
     baseClass,
     { [baseDisabledClasses]: !isLoading },
-    pickVariant(variant, isLoading)
+    pickVariant(variant, isLoading),
+    { 'border-solid border shadow py-1 px-4': variant !== 'link' }
   )
 
   const content = (
@@ -101,7 +104,13 @@ function Button({
 
 Button.propTypes = {
   to: PropTypes.shape(AppLink.propTypes),
-  variant: PropTypes.oneOf(['default', 'primary', 'danger', 'secondary']),
+  variant: PropTypes.oneOf([
+    'default',
+    'primary',
+    'danger',
+    'secondary',
+    'link',
+  ]),
   isLoading: PropTypes.bool,
   disabled: PropTypes.bool,
   hook: function (props, propName) {

--- a/src/ui/ContextSwitcher/ContextSwitcher.js
+++ b/src/ui/ContextSwitcher/ContextSwitcher.js
@@ -1,6 +1,7 @@
 import { Menu, MenuButton, MenuLink, MenuList } from '@reach/menu-button'
 import cs from 'classnames'
 import PropTypes from 'prop-types'
+import { useState } from 'react'
 import { useParams } from 'react-router-dom'
 
 import AppLink from 'shared/AppLink'
@@ -10,11 +11,13 @@ import Avatar from 'ui/Avatar'
 import Icon from 'ui/Icon'
 
 import './ContextSwitcher.css'
+import DefaultOrganizationSelector from './DefaultOrganizationSelector'
 
 const styles = {
   button: 'flex items-center text-xl font-semibold',
   image: 'w-6 h-6 rounded-full',
-  switchContext: 'px-4 py-2 border-b border-ds-gray-secondary font-semibold',
+  switchContext:
+    'px-4 py-2 border-b border-ds-gray-secondary font-semibold flex justify-between',
 }
 
 function getCurrentContext({ activeContext, contexts }) {
@@ -27,6 +30,7 @@ function ContextSwitcher({ activeContext, contexts }) {
   const currentContext = getCurrentContext({ activeContext, contexts })
   const { provider } = useParams()
   const isGh = providerToName(provider) === 'Github'
+  const [showDefaultOrgSelector, setShowDefaultOrgSelector] = useState(false)
 
   function renderContext(context) {
     const { owner, pageName } = context
@@ -47,46 +51,63 @@ function ContextSwitcher({ activeContext, contexts }) {
   }
 
   return (
-    <Menu id="context-switcher">
-      <MenuButton className={styles.button}>
-        {currentContext ? (
-          <>
-            <Avatar user={currentContext.owner} bordered />
-            <div className="ml-2 mr-1">{currentContext.owner.username}</div>
-          </>
-        ) : (
-          <>
-            <Icon name="home" />
-            <div className="ml-2 mr-1">All my orgs and repos</div>
-          </>
-        )}
-        <span aria-hidden="true">
-          <Icon variant="solid" name="chevron-down" />
-        </span>
-      </MenuButton>
-      <MenuList>
-        <div className={styles.switchContext}>Switch context</div>
-        <div className="max-h-64 overflow-y-auto">
-          <MenuLink as={AppLink} pageName="provider">
-            <Icon name="home" />
-            <div className={cs('mx-2', { 'font-semibold': !activeContext })}>
-              All orgs and repos
-            </div>
-          </MenuLink>
-          {contexts.map(renderContext)}
-        </div>
-        {isGh && (
-          <div className="max-h-64 overflow-y-auto text-ds-gray-quinary text-xsm px-4 py-2 border-t border-ds-gray-secondary">
-            <span className="font-semibold">Don&apos;t see your org?</span>
-            <br />
-            <A to={{ pageName: 'userAppManagePage' }}>
-              {' '}
-              Manage access restrictions
-            </A>
+    <>
+      <Menu id="context-switcher" data-testid="context-menu-popover">
+        <MenuButton className={styles.button}>
+          {currentContext ? (
+            <>
+              <Avatar user={currentContext.owner} bordered />
+              <div className="ml-2 mr-1">{currentContext.owner.username}</div>
+            </>
+          ) : (
+            <>
+              <Icon name="home" />
+              <div className="ml-2 mr-1">All my orgs and repos</div>
+            </>
+          )}
+          <span aria-hidden="true">
+            <Icon variant="solid" name="chevron-down" />
+          </span>
+        </MenuButton>
+        <MenuList>
+          <div className={styles.switchContext}>
+            Switch context{' '}
+            <button
+              className="text-ds-blue-darker"
+              onClick={() => setShowDefaultOrgSelector(true)}
+            >
+              edit default
+            </button>
           </div>
-        )}
-      </MenuList>
-    </Menu>
+          <div className="max-h-64 overflow-y-auto">
+            <MenuLink as={AppLink} pageName="provider">
+              <Icon name="home" />
+              <div className={cs('mx-2', { 'font-semibold': !activeContext })}>
+                All orgs and repos
+              </div>
+            </MenuLink>
+            {contexts.map(renderContext)}
+          </div>
+          {isGh && (
+            <div className="max-h-64 overflow-y-auto text-ds-gray-quinary text-xsm px-4 py-2 border-t border-ds-gray-secondary">
+              <span className="font-semibold">Don&apos;t see your org?</span>
+              <br />
+              <A to={{ pageName: 'userAppManagePage' }}>
+                {' '}
+                Manage access restrictions
+              </A>
+            </div>
+          )}
+        </MenuList>
+      </Menu>
+      {showDefaultOrgSelector && (
+        <DefaultOrganizationSelector
+          onClose={() => {
+            setShowDefaultOrgSelector(false)
+          }}
+        />
+      )}
+    </>
   )
 }
 

--- a/src/ui/ContextSwitcher/DefaultOrganizationSelector.js
+++ b/src/ui/ContextSwitcher/DefaultOrganizationSelector.js
@@ -1,0 +1,55 @@
+import noop from 'lodash/noop'
+import PropTypes from 'prop-types'
+import { useState } from 'react'
+import ReactModal from 'react-modal'
+
+import OrganizationsList from './OrganizationsList'
+
+import Button from '../Button'
+import BaseModal from '../Modal/BaseModal'
+
+function DefaultOrganizationSelector({ onClose }) {
+  const [selectedOrg, setSelectedOrg] = useState()
+
+  const handleDefaultOrgUpdate = () => {
+    localStorage.setItem('gz-defaultOrganization', JSON.stringify(selectedOrg))
+    onClose()
+  }
+
+  const modalProps = {
+    title: 'Select default organization',
+    subtitle: 'Org will appear as default for landing page context',
+    body: <OrganizationsList onSelect={(org) => setSelectedOrg(org)} />,
+    footer: (
+      <div className="flex justify-between gap-4">
+        <Button variant="link" onClick={onClose}>
+          Cancel
+        </Button>
+        <Button
+          variant="primary"
+          type="submit"
+          disabled={!Boolean(selectedOrg)}
+          onClick={handleDefaultOrgUpdate}
+        >
+          Update
+        </Button>
+      </div>
+    ),
+  }
+  return (
+    <ReactModal
+      isOpen
+      onRequestClose={noop}
+      className="h-screen w-screen flex items-center justify-center"
+      overlayClassName="fixed inset-0 bg-ds-gray-octonary/70 z-10"
+    >
+      <BaseModal hasCloseButton={false} onClose={noop} {...modalProps} />
+    </ReactModal>
+  )
+}
+
+DefaultOrganizationSelector.propTypes = {
+  onClose: PropTypes.func.isRequired,
+}
+
+export default DefaultOrganizationSelector

--- a/src/ui/ContextSwitcher/DefaultOrganizationSelector.spec.js
+++ b/src/ui/ContextSwitcher/DefaultOrganizationSelector.spec.js
@@ -1,0 +1,128 @@
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter, Route } from 'react-router-dom'
+
+import { useMyContexts } from 'services/user'
+
+import DefaultOrganizationSelector from './DefaultOrganizationSelector'
+
+jest.spyOn(window.localStorage.__proto__, 'setItem')
+window.localStorage.__proto__.setItem = jest.fn()
+
+jest.mock('services/user')
+
+const contextData = {
+  currentUser: {
+    username: 'Rabee-AbuBaker',
+    avatarUrl: 'https://avatars0.githubusercontent.com/u/99655254?v=3&s=55',
+  },
+  myOrganizations: [
+    {
+      username: 'codecov',
+      avatarUrl: 'https://avatars0.githubusercontent.com/u/8226205?v=3&s=55',
+    },
+  ],
+}
+
+describe('OrganizationSelector', () => {
+  let container
+  const onClose = jest.fn()
+  function setup() {
+    useMyContexts.mockReturnValue({
+      data: contextData,
+    })(
+      ({ container } = render(
+        <MemoryRouter initialEntries={['/gh']}>
+          <Route path="/:provider">
+            <DefaultOrganizationSelector onClose={onClose} />
+          </Route>
+        </MemoryRouter>
+      ))
+    )
+  }
+
+  describe('when rendered', () => {
+    beforeEach(() => {
+      setup()
+    })
+
+    it('renders title', () => {
+      expect(container).toBeInTheDocument()
+      expect(
+        screen.getByText(/Select default organization/)
+      ).toBeInTheDocument()
+    })
+
+    it('renders subtitle', () => {
+      expect(
+        screen.getByText(/Org will appear as default for landing page context/)
+      ).toBeInTheDocument()
+    })
+
+    it('renders organizations list', () => {
+      expect(screen.getByText('Rabee-AbuBaker')).toBeInTheDocument()
+      expect(screen.getByText('codecov')).toBeInTheDocument()
+    })
+
+    it('renders footer', () => {
+      expect(
+        screen.getByRole('button', {
+          name: /cancel/i,
+        })
+      ).toBeInTheDocument()
+
+      const updateButton = screen.getByRole('button', {
+        name: /Update/i,
+      })
+
+      expect(updateButton).toBeInTheDocument()
+      expect(updateButton).toBeDisabled()
+    })
+  })
+
+  describe('when user selects an organization', () => {
+    beforeEach(() => {
+      setup()
+      screen.getByText(/codecov/i).click()
+    })
+
+    it('enabled update button', () => {
+      expect(
+        screen.getByRole('button', {
+          name: /Update/i,
+        })
+      ).toBeEnabled()
+    })
+
+    describe('when user clicks update', () => {
+      beforeEach(() => {
+        screen
+          .getByRole('button', {
+            name: /Update/i,
+          })
+          .click()
+      })
+
+      it('stores selected org to the localstorage', () => {
+        expect(localStorage.setItem).toBeCalledWith(
+          'gz-defaultOrganization',
+          '"codecov"'
+        )
+      })
+
+      it('calls onClose', () => {
+        expect(onClose).toBeCalled()
+      })
+    })
+  })
+
+  describe('when user clicks cancel', () => {
+    beforeEach(() => {
+      setup()
+      screen.getByText(/cancel/i).click()
+    })
+
+    it('calls onClose', () => {
+      expect(onClose).toBeCalled()
+    })
+  })
+})

--- a/src/ui/ContextSwitcher/OrganizationsList.js
+++ b/src/ui/ContextSwitcher/OrganizationsList.js
@@ -1,0 +1,83 @@
+import PropTypes from 'prop-types'
+import { useState } from 'react'
+
+import { useMyContexts } from 'services/user'
+import Avatar from 'ui/Avatar'
+import Icon from 'ui/Icon'
+import List from 'ui/List'
+
+const getListItems = ({ organizations }) =>
+  organizations.map((org) => ({
+    name: org.username,
+    value: (
+      <div className="flex items-center py-2">
+        {org.isAllOrgs ? <Icon name="home" /> : <Avatar user={org} bordered />}
+        <div className="mx-2 text-base flex flex-1 justify-between">
+          {org.username}{' '}
+          {org.isDefault && (
+            <span className="text-sm text-ds-gray-quinary">
+              Current org view
+            </span>
+          )}
+        </div>
+      </div>
+    ),
+    selected: org.isSelected,
+  }))
+
+const unshiftOrg = ({ orgs, defaultOrg }) => [
+  {
+    ...orgs.find(({ username }) => username === defaultOrg),
+    isDefault: true,
+  },
+  ...orgs.filter(({ username }) => username !== defaultOrg),
+]
+
+function OrganizationsList({ onSelect }) {
+  const { data: myContexts } = useMyContexts()
+
+  const [defaultOrg] = useState(
+    JSON.parse(localStorage.getItem('gz-defaultOrganization'))
+  )
+
+  const { currentUser, myOrganizations } = myContexts
+
+  const initOrgs = [
+    { username: 'Show all orgs and repos', isAllOrgs: true },
+    {
+      ...currentUser,
+    },
+    ...myOrganizations.map((context) => ({
+      ...context,
+    })),
+  ]
+
+  const [organizations, setOrganizations] = useState(
+    Boolean(defaultOrg) ? unshiftOrg({ orgs: initOrgs, defaultOrg }) : initOrgs
+  )
+
+  const handleOrganizationSelect = (orgName) => {
+    setOrganizations((prevState) =>
+      prevState.map((org) => ({
+        ...org,
+        isSelected: org.username === orgName,
+      }))
+    )
+    onSelect(orgName)
+  }
+
+  return (
+    <div className="h-80">
+      <List
+        items={getListItems({ organizations })}
+        onItemSelect={handleOrganizationSelect}
+      />
+    </div>
+  )
+}
+
+OrganizationsList.propTypes = {
+  onSelect: PropTypes.func.isRequired,
+}
+
+export default OrganizationsList

--- a/src/ui/ContextSwitcher/OrganizationsList.spec.js
+++ b/src/ui/ContextSwitcher/OrganizationsList.spec.js
@@ -1,0 +1,88 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { MemoryRouter, Route } from 'react-router-dom'
+
+import { useMyContexts } from 'services/user'
+
+import OrganizationsList from './OrganizationsList'
+
+jest.mock('services/user')
+
+const contextData = {
+  currentUser: {
+    username: 'Rabee-AbuBaker',
+    avatarUrl: 'https://avatars0.githubusercontent.com/u/99655254?v=3&s=55',
+  },
+  myOrganizations: [
+    {
+      username: 'codecov',
+      avatarUrl: 'https://avatars0.githubusercontent.com/u/8226205?v=3&s=55',
+    },
+  ],
+}
+
+const selectedOrg = 'codecov'
+
+describe('OrganizationsList', () => {
+  const onSelect = jest.fn()
+  function setup(withLocalStorage) {
+    if (withLocalStorage) {
+      window.localStorage.setItem(
+        'gz-defaultOrganization',
+        JSON.stringify('codecov')
+      )
+    }
+
+    useMyContexts.mockReturnValue({
+      data: contextData,
+    })(
+      render(
+        <MemoryRouter initialEntries={['/gh']}>
+          <Route path="/:provider">
+            <OrganizationsList onSelect={onSelect} />
+          </Route>
+        </MemoryRouter>
+      )
+    )
+  }
+
+  describe('when rendered', () => {
+    beforeEach(() => {
+      setup()
+    })
+
+    it('renders all organizations', () => {
+      expect(screen.getByText(/codecov/i)).toBeInTheDocument()
+      expect(screen.getByText(/Rabee-AbuBaker/i)).toBeInTheDocument()
+      expect(screen.getByText(/Show all orgs and repos/i)).toBeInTheDocument()
+    })
+  })
+
+  describe('when there is a previously selected default org', () => {
+    beforeEach(() => {
+      setup(true)
+    })
+
+    it('renders current org view next to it', () => {
+      expect(screen.getByText(/Current org view/i)).toBeInTheDocument()
+    })
+
+    it('renders the default org at the top of the list', () => {
+      expect(screen.queryAllByRole('listitem')[0]).toHaveTextContent(
+        selectedOrg
+      )
+    })
+  })
+
+  describe('when user selects an organization', () => {
+    beforeEach(() => {
+      setup()
+      const organization = screen.getByText(/codecov/i)
+      expect(organization).toBeInTheDocument()
+      fireEvent.click(organization)
+    })
+
+    it('calls onSelect with organization value', () => {
+      expect(onSelect).toHaveBeenCalledWith(selectedOrg)
+    })
+  })
+})

--- a/src/ui/List/List.js
+++ b/src/ui/List/List.js
@@ -1,12 +1,18 @@
 import cs from 'classnames'
 import PropTypes from 'prop-types'
 
-const getListClasses = () =>
+const getListClasses = ({ index, selected }) =>
   cs(
     'flex text-left px-6 py-2',
     'hover:bg-ds-gray-primary',
     'transition duration-500',
-    'cursor-pointer'
+    'cursor-pointer',
+    {
+      'border-t border-gray-200': index !== 0,
+    },
+    {
+      'border border-ds-blue-darker': selected,
+    }
   )
 
 function List({ items, onItemSelect, noBorder }) {
@@ -14,15 +20,12 @@ function List({ items, onItemSelect, noBorder }) {
     items &&
     items.length > 0 && (
       <ul
-        className={cs(
-          'w-full text-ds-gray-octonary divide-y divide-solid divide-gray-200',
-          {
-            'border border-ds-gray-secondary': !noBorder,
-          }
-        )}
+        className={cs('w-full text-ds-gray-octonary', {
+          'border border-ds-gray-secondary': !noBorder,
+        })}
       >
-        {items.map(({ name, value }) => (
-          <li key={name} className={getListClasses()}>
+        {items.map(({ name, value, selected }, index) => (
+          <li key={name} className={getListClasses({ index, selected })}>
             <button
               className="w-full"
               onClick={() => onItemSelect && onItemSelect(name)}
@@ -42,6 +45,7 @@ List.propTypes = {
       name: PropTypes.string.isRequired,
       value: PropTypes.oneOfType([PropTypes.element, PropTypes.string])
         .isRequired,
+      selected: PropTypes.bool,
     })
   ),
   onItemSelect: PropTypes.func,

--- a/src/ui/List/List.spec.js
+++ b/src/ui/List/List.spec.js
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 
 import List from '.'
 
@@ -42,20 +42,28 @@ describe('List', () => {
     expect(screen.getByText('Markup value')).toBeInTheDocument()
   })
 
-  it('calls onItemSelect prop when clicked', () => {
-    const items = [
-      {
-        name: 'firstItem',
-        value: 'Click me',
-      },
-    ]
-    setup({ items })
+  describe('when user selects an item', () => {
+    beforeEach(() => {
+      const items = [
+        {
+          name: 'firstItem',
+          value: 'Click me',
+          selected: true,
+        },
+      ]
+      setup({ items })
+      screen.getByText(/click me/i).click()
+    })
 
-    expect(container).not.toBeEmptyDOMElement()
-    const listItem = screen.getByText(/click me/i)
-    expect(listItem).toBeInTheDocument()
-    fireEvent.click(listItem)
-    expect(onItemSelect).toHaveBeenCalledTimes(1)
+    it('calls onItemSelect', () => {
+      expect(onItemSelect).toHaveBeenCalledTimes(1)
+    })
+
+    it('shows a border', () => {
+      expect(screen.queryByRole('listitem', /click me/i)).toHaveClass(
+        'border border-ds-blue-darker'
+      )
+    })
   })
 
   it('Renders without a border when noBorder is true', () => {

--- a/src/ui/List/List.stories.js
+++ b/src/ui/List/List.stories.js
@@ -50,6 +50,36 @@ ListWithElements.args = {
   items: getListItems(),
 }
 
+export const ListWithSelectedItem = Template.bind({})
+
+const getItems = () => {
+  const listData = [
+    {
+      username: 'Rabee-AbuBaker',
+      avatarUrl: 'https://avatars0.githubusercontent.com/u/99655254?v=3&s=55',
+      selected: true,
+    },
+    {
+      username: 'codecov',
+      avatarUrl: 'https://avatars0.githubusercontent.com/u/8226205?v=3&s=55',
+    },
+  ]
+  return listData.map((org) => ({
+    name: org.username,
+    value: (
+      <div className="flex items-center py-2">
+        <Avatar user={org} bordered />
+        <div className="mx-2 text-base">{org.username}</div>
+      </div>
+    ),
+    selected: org.selected,
+  }))
+}
+
+ListWithSelectedItem.args = {
+  items: getItems(),
+}
+
 export default {
   title: 'Components/List',
   component: List,


### PR DESCRIPTION
# Description
- Initial implementation for Default Organization Selector from the context menu 
- Added new "Link" button
- Wrote tests and modified existing ones
- Updated list component to support adding border to selected item

# Notes about the PR
- Routing users after org selection is still not implemented because of issues with local env at the moment
- What is a better approach, to move the "selected" logic inside the list component? or keep it as it is right now?

# Screenshots

![image](https://user-images.githubusercontent.com/99655254/171499200-1cedad9c-7cf3-4b4e-ab44-0a5eea2b2485.png)

![image](https://user-images.githubusercontent.com/99655254/171499164-5f5ec156-bc12-4bb8-a8ce-f9c2758a9f28.png)
