### PR TITLE
Coverage summary queries

### DIFF
--- a/src/pages/RepoPage/CoverageTab/Summary/hooks.js
+++ b/src/pages/RepoPage/CoverageTab/Summary/hooks.js
@@ -1,0 +1,33 @@
+import { useParams } from 'react-router-dom'
+
+import { useRepoCoverage, useRepoOverview } from 'services/repo'
+import { mapEdges } from 'shared/utils/graphql'
+
+export function useSummary() {
+  const { repo, owner, provider } = useParams()
+  const { data: overview, isLoading } = useRepoOverview({
+    provider,
+    repo,
+    owner,
+  })
+  const branch = overview?.defaultBranch // TODO or check local storage
+  const {
+    data,
+    isLoading: isLoadingRepoCoverage,
+    ...rest
+  } = useRepoCoverage({
+    provider,
+    repo,
+    owner,
+    branch,
+  })
+
+  return {
+    isLoading: isLoading && isLoadingRepoCoverage,
+    data,
+    branches: mapEdges(overview?.branches),
+    defaultBranch: branch,
+    coverage: overview?.coverage,
+    ...rest,
+  }
+}

--- a/src/pages/RepoPage/CoverageTab/Summary/hooks.spec.js
+++ b/src/pages/RepoPage/CoverageTab/Summary/hooks.spec.js
@@ -1,0 +1,108 @@
+import { renderHook } from '@testing-library/react-hooks'
+import { QueryClient, QueryClientProvider } from 'react-query'
+import { MemoryRouter, Route } from 'react-router-dom'
+
+import { useRepoCoverage, useRepoOverview } from 'services/repo'
+
+import { useSummary } from './hooks'
+
+jest.mock('services/repo')
+
+const queryClient = new QueryClient()
+const wrapper = ({ children }) => (
+  <MemoryRouter initialEntries={['/gh/caleb/mighty-nein']}>
+    <Route path="/:provider/:owner/:repo">
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    </Route>
+  </MemoryRouter>
+)
+
+describe('useSummary', () => {
+  let hookData
+
+  function setup({ useRepoOverviewMock = {}, useRepoCoverageMock = {} }) {
+    useRepoOverview.mockReturnValue(useRepoOverviewMock)
+    useRepoCoverage.mockReturnValue(useRepoCoverageMock)
+
+    hookData = renderHook(() => useSummary(), { wrapper })
+  }
+
+  describe('both services are pending', () => {
+    beforeEach(() => {
+      setup({
+        useRepoOverviewMock: { data: {}, isLoading: true },
+        useRepoCoverageMock: { data: {}, isLoading: true },
+      })
+    })
+
+    it('isLoading is correct', () => {
+      expect(hookData.result.current.isLoading).toEqual(true)
+    })
+  })
+
+  describe('useRepoCoverageMock is pending', () => {
+    beforeEach(() => {
+      setup({
+        useRepoOverviewMock: {
+          data: {
+            coverage: 70.4,
+            defaultBranch: 'c3',
+            branches: [{ node: { name: 'fcg' } }, { node: { name: 'imogen' } }],
+          },
+          isLoading: false,
+        },
+        useRepoCoverageMock: { data: {}, isLoading: true },
+      })
+    })
+
+    it('isLoading is correct', () => {
+      expect(hookData.result.current.isLoading).toEqual(false)
+    })
+  })
+
+  describe('both services have resolved', () => {
+    beforeEach(() => {
+      setup({
+        useRepoOverviewMock: {
+          data: {
+            coverage: 70.4,
+            defaultBranch: 'c3',
+            branches: {
+              edges: [{ node: { name: 'fcg' } }, { node: { name: 'imogen' } }],
+            },
+          },
+          isLoading: false,
+        },
+        useRepoCoverageMock: {
+          data: { show: 'Critical Role' },
+          isLoading: false,
+        },
+      })
+
+      return hookData.waitFor(() => !hookData.result.current.isLoading)
+    })
+
+    it('isLoading is correct', () => {
+      expect(hookData.result.current.isLoading).toEqual(false)
+    })
+
+    it('passes down useRepoCoverage', () => {
+      expect(hookData.result.current.data).toEqual({ show: 'Critical Role' })
+    })
+
+    it('handles the list of branches', () => {
+      expect(hookData.result.current.branches).toEqual([
+        { name: 'fcg' },
+        { name: 'imogen' },
+      ])
+    })
+
+    it('provides the defaultBranch', () => {
+      expect(hookData.result.current.defaultBranch).toEqual('c3')
+    })
+
+    it('provides the repo coverage', () => {
+      expect(hookData.result.current.coverage).toEqual(70.4)
+    })
+  })
+})

--- a/src/services/repo/index.js
+++ b/src/services/repo/index.js
@@ -1,1 +1,3 @@
 export * from './hooks'
+export * from './useRepoOverview'
+export * from './useRepoCoverage'

--- a/src/services/repo/useRepoCoverage.js
+++ b/src/services/repo/useRepoCoverage.js
@@ -1,0 +1,37 @@
+import { useQuery } from 'react-query'
+
+import Api from 'shared/api'
+
+function fetchRepoBranchCoverage({ provider, owner, repo, branch }) {
+  const query = `
+    query GetRepoCoverage($name: String!, $repo: String!, $branch: String!) {
+      owner(username:$name){
+        repository(name:$repo){
+          branch(name:$branch) {
+            head {
+              totals {
+                percentCovered
+              }
+            }
+          }
+        }
+      }
+    }
+  `
+  return Api.graphql({
+    provider,
+    repo,
+    query,
+    variables: {
+      name: owner,
+      repo,
+      branch,
+    },
+  }).then((res) => res?.data?.owner?.repository?.branch || {})
+}
+
+export function useRepoCoverage({ provider, owner, repo, branch }) {
+  return useQuery(['coverage', provider, owner, repo, branch], () => {
+    return fetchRepoBranchCoverage({ provider, owner, repo, branch })
+  })
+}

--- a/src/services/repo/useRepoCoverage.spec.js
+++ b/src/services/repo/useRepoCoverage.spec.js
@@ -1,0 +1,91 @@
+import { renderHook } from '@testing-library/react-hooks'
+import { graphql } from 'msw'
+import { setupServer } from 'msw/node'
+import { QueryClient, QueryClientProvider } from 'react-query'
+
+import { useRepoCoverage } from './useRepoCoverage'
+
+const queryClient = new QueryClient()
+
+const wrapper = ({ children }) => (
+  <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+)
+
+const server = setupServer()
+
+beforeAll(() => server.listen())
+afterEach(() => server.resetHandlers())
+afterAll(() => server.close())
+
+describe('useRepoCoverage', () => {
+  let hookData
+
+  function setup(data) {
+    server.use(
+      graphql.query('GetRepoCoverage', (req, res, ctx) => {
+        return res(ctx.status(200), ctx.data(data))
+      })
+    )
+
+    hookData = renderHook(
+      () => useRepoCoverage({ provider: 'bb', owner: 'doggo', repo: 'woof' }),
+      {
+        wrapper,
+      }
+    )
+  }
+
+  describe('when called with successful res', () => {
+    beforeEach(() => {
+      setup({
+        owner: {
+          repository: {
+            branch: {
+              head: {
+                totals: {
+                  percentCovered: 70.44,
+                },
+              },
+            },
+          },
+        },
+      })
+    })
+    afterEach(() => server.resetHandlers())
+
+    it('renders isLoading true', () => {
+      expect(hookData.result.current.isLoading).toBeTruthy()
+    })
+
+    describe('when data is loaded', () => {
+      beforeEach(() => {
+        return hookData.waitFor(() => hookData.result.current.isSuccess)
+      })
+
+      it('returns the data', async () => {
+        await hookData.waitFor(() =>
+          expect(hookData.result.current.data).toEqual({
+            head: {
+              totals: {
+                percentCovered: 70.44,
+              },
+            },
+          })
+        )
+      })
+    })
+  })
+
+  describe('when called with unsuccessful res', () => {
+    beforeEach(() => {
+      setup({})
+    })
+    afterEach(() => server.resetHandlers())
+
+    it('returns the data', async () => {
+      await hookData.waitFor(() =>
+        expect(hookData.result.current.data).toEqual({})
+      )
+    })
+  })
+})

--- a/src/services/repo/useRepoOverview.js
+++ b/src/services/repo/useRepoOverview.js
@@ -1,0 +1,42 @@
+import { useQuery } from 'react-query'
+
+import Api from 'shared/api'
+
+function fetchRepoOverviewInitial({ provider, owner, repo }) {
+  const query = `
+    query GetRepoOverview($name: String!, $repo: String!) {
+      owner(username:$name){
+        repository(name:$repo){
+          defaultBranch
+          coverage
+          branches {
+            edges {
+              node {
+                name
+                head {
+                  commitid
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  `
+
+  return Api.graphql({
+    provider,
+    repo,
+    query,
+    variables: {
+      name: owner,
+      repo,
+    },
+  }).then((res) => res?.data?.owner?.repository || {})
+}
+
+export function useRepoOverview({ provider, owner, repo }) {
+  return useQuery(['overview init', provider, owner, repo], () => {
+    return fetchRepoOverviewInitial({ provider, owner, repo })
+  })
+}

--- a/src/services/repo/useRepoOverview.spec.js
+++ b/src/services/repo/useRepoOverview.spec.js
@@ -1,0 +1,93 @@
+import { renderHook } from '@testing-library/react-hooks'
+import { graphql } from 'msw'
+import { setupServer } from 'msw/node'
+import { QueryClient, QueryClientProvider } from 'react-query'
+
+import { useRepoOverview } from './useRepoOverview'
+
+const queryClient = new QueryClient()
+
+const wrapper = ({ children }) => (
+  <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+)
+
+const server = setupServer()
+
+beforeAll(() => server.listen())
+afterEach(() => server.resetHandlers())
+afterAll(() => server.close())
+
+describe('useRepoOverview', () => {
+  let hookData
+
+  function setup(data) {
+    server.use(
+      graphql.query('GetRepoOverview', (req, res, ctx) => {
+        return res(ctx.status(200), ctx.data(data))
+      })
+    )
+
+    hookData = renderHook(
+      () => useRepoOverview({ provider: 'bb', owner: 'doggo', repo: 'woof' }),
+      {
+        wrapper,
+      }
+    )
+  }
+
+  describe('when called with successful res', () => {
+    beforeEach(() => {
+      setup({
+        owner: {
+          repository: {
+            defaultBranch: 'main',
+            coverage: 70.44,
+            branches: {
+              edges: [
+                { node: { name: 'test', head: { commitid: '1234567' } } },
+              ],
+            },
+          },
+        },
+      })
+    })
+    afterEach(() => server.resetHandlers())
+
+    it('renders isLoading true', () => {
+      expect(hookData.result.current.isLoading).toBeTruthy()
+    })
+
+    describe('when data is loaded', () => {
+      beforeEach(() => {
+        return hookData.waitFor(() => hookData.result.current.isSuccess)
+      })
+
+      it('returns the data', async () => {
+        await hookData.waitFor(() =>
+          expect(hookData.result.current.data).toEqual({
+            defaultBranch: 'main',
+            coverage: 70.44,
+            branches: {
+              edges: [
+                { node: { name: 'test', head: { commitid: '1234567' } } },
+              ],
+            },
+          })
+        )
+      })
+    })
+  })
+
+  describe('when called with unsuccessful res', () => {
+    beforeEach(() => {
+      setup({})
+    })
+    afterEach(() => server.resetHandlers())
+
+    it('returns the data', async () => {
+      await hookData.waitFor(() =>
+        expect(hookData.result.current.data).toEqual({})
+      )
+    })
+  })
+})


### PR DESCRIPTION
# Description
Purely service work. Two repo services and a custom hook consuming the services for Summary component on the coverage tab.

Setups two coverage tab querys, one that gets the default branch and branches and another for the actual coverage data. Also made a hooks file for summary to combine the needed data.

# Code Example
```js
  const { data, defaultBranch, coverage, isLoading } = useSummary()
```

```js
  const { data, isLoading } = useRepoOverview({
    provider,
    repo,
    owner,
  })

  const {
    data,
    isLoading
  } = useRepoCoverage({
    provider,
    repo,
    owner,
    branch,
  })
```

# Notable Changes
* Seperate service files so we dont have merge comflicts with each other / Rula's work.
* Two queries are needed
the initial call for the configured default branch + branch list to know what branch to load the rest of the tabs data (branch selector)

* Branch specific query including the returned files, coverage, etc