### PR TITLE
create custom hook for settings page

### DIFF
--- a/src/pages/RepoPage/SettingsTab/tabs/GeneralTab/GeneralTab.js
+++ b/src/pages/RepoPage/SettingsTab/tabs/GeneralTab/GeneralTab.js
@@ -1,6 +1,4 @@
-import { useParams } from 'react-router-dom'
-
-import { useRepo } from 'services/repo'
+import { useRepoSettings } from 'services/repo'
 
 import DefaultBranch from './DefaultBranch'
 import GraphToken from './GraphToken'
@@ -8,8 +6,7 @@ import ImpactAnalysisToken from './ImpactAnalysisToken'
 import RepoUploadToken from './RepoUploadToken'
 
 function GeneralTab() {
-  const { provider, owner, repo } = useParams()
-  const { data } = useRepo({ provider, owner, repo })
+  const { data } = useRepoSettings()
   const repository = data?.repository
 
   return (

--- a/src/pages/RepoPage/SettingsTab/tabs/GeneralTab/GeneralTab.spec.js
+++ b/src/pages/RepoPage/SettingsTab/tabs/GeneralTab/GeneralTab.spec.js
@@ -2,7 +2,7 @@ import { render, screen } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from 'react-query'
 import { MemoryRouter, Route } from 'react-router-dom'
 
-import { useRepo, useUpdateRepo } from 'services/repo'
+import { useRepoSettings, useUpdateRepo } from 'services/repo'
 
 import GeneralTab from './GeneralTab'
 
@@ -12,7 +12,7 @@ const queryClient = new QueryClient()
 describe('GeneralTab', () => {
   function setup({ uploadToken, defaultBranch, profilingToken, graphToken }) {
     const mutate = jest.fn()
-    useRepo.mockReturnValue({
+    useRepoSettings.mockReturnValue({
       data: {
         repository: { uploadToken, defaultBranch, profilingToken, graphToken },
       },

--- a/src/services/repo/hooks.js
+++ b/src/services/repo/hooks.js
@@ -13,8 +13,6 @@ function fetchRepoDetails({ provider, owner, repo }) {
           private
           uploadToken
           defaultBranch
-          profilingToken
-          graphToken
         }
       }
     }

--- a/src/services/repo/hooks.spec.js
+++ b/src/services/repo/hooks.spec.js
@@ -50,8 +50,6 @@ describe('useRepo', () => {
         defaultBranch: 'master',
         private: true,
         uploadToken: 'token',
-        profilingToken: 'token',
-        graphToken: 'token'
       },
     }
     const dataReturned = {
@@ -61,8 +59,6 @@ describe('useRepo', () => {
           defaultBranch: 'master',
           private: true,
           uploadToken: 'token',
-          profilingToken: 'token',
-          graphToken: 'token'
         },
       },
     }

--- a/src/services/repo/index.js
+++ b/src/services/repo/index.js
@@ -1,3 +1,4 @@
 export * from './hooks'
 export * from './useRepoOverview'
 export * from './useRepoCoverage'
+export * from './useRepoSettings'

--- a/src/services/repo/useRepoSettings.js
+++ b/src/services/repo/useRepoSettings.js
@@ -1,0 +1,41 @@
+import { useQuery } from 'react-query'
+import { useParams } from 'react-router-dom/cjs/react-router-dom.min'
+
+import Api from 'shared/api'
+
+function fetchRepoSettingsDetails({ provider, owner, repo }) {
+  const query = `
+    query GetRepoSettings($name: String!, $repo: String!){
+      owner(username:$name){
+        repository(name:$repo){
+          private
+          uploadToken
+          defaultBranch
+          profilingToken
+          graphToken
+        }
+      }
+    }
+`
+  return Api.graphql({
+    provider,
+    repo,
+    query,
+    variables: {
+      name: owner,
+      repo,
+    },
+  }).then((res) => {
+    return {
+      repository: res?.data?.owner?.repository,
+    }
+  })
+}
+
+export function useRepoSettings() {
+  const { provider, owner, repo } = useParams()
+
+  return useQuery([provider, owner, repo, 'settings'], () => {
+    return fetchRepoSettingsDetails({ provider, owner, repo })
+  })
+}

--- a/src/services/repo/useRepoSettings.spec.js
+++ b/src/services/repo/useRepoSettings.spec.js
@@ -1,0 +1,93 @@
+import { renderHook } from '@testing-library/react-hooks'
+import { graphql } from 'msw'
+import { setupServer } from 'msw/node'
+import { QueryClient, QueryClientProvider } from 'react-query'
+import { MemoryRouter, Route } from 'react-router-dom'
+
+import { useRepoSettings } from './useRepoSettings'
+
+const queryClient = new QueryClient()
+
+const wrapper = ({ children }) => (
+  <MemoryRouter initialEntries={['/gh/codecov/gazebo']}>
+    <Route path="/:provider/:owner/:repo">
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    </Route>
+  </MemoryRouter>
+)
+
+const server = setupServer()
+
+beforeAll(() => server.listen())
+afterEach(() => server.resetHandlers())
+afterAll(() => server.close())
+
+describe('useRepoSettings', () => {
+  let hookData
+
+  function setup(data) {
+    server.use(
+      graphql.query('GetRepoSettings', (req, res, ctx) => {
+        return res(ctx.status(200), ctx.data(data))
+      })
+    )
+
+    hookData = renderHook(() => useRepoSettings(), {
+      wrapper,
+    })
+  }
+
+  describe('when called with successful res', () => {
+    beforeEach(() => {
+      setup({
+        owner: {
+          repository: {
+            defaultBranch: 'master',
+            private: true,
+            uploadToken: 'token',
+            profilingToken: 'token',
+            graphToken: 'token',
+          },
+        },
+      })
+    })
+    afterEach(() => server.resetHandlers())
+
+    it('renders isLoading true', () => {
+      expect(hookData.result.current.isLoading).toBeTruthy()
+    })
+
+    describe('when data is loaded', () => {
+      beforeEach(() => {
+        return hookData.waitFor(() => hookData.result.current.isSuccess)
+      })
+
+      it('returns the data', async () => {
+        await hookData.waitFor(() =>
+          expect(hookData.result.current.data).toEqual({
+            repository: {
+              defaultBranch: 'master',
+              private: true,
+              uploadToken: 'token',
+              profilingToken: 'token',
+              graphToken: 'token',
+            },
+          })
+        )
+      })
+    })
+  })
+
+  describe('when called with unsuccessful res', () => {
+    beforeEach(() => {
+      setup({})
+    })
+    afterEach(() => server.resetHandlers())
+
+    it('returns the data', async () => {
+      await hookData.waitFor(() =>
+        expect(hookData.result.current.data).toEqual({})
+      )
+    })
+  })
+})


### PR DESCRIPTION
# Description
Create new custom hook for the repo settings page, moving the logic to a separate file, use it general tab

# Code Example
instead of `useRepo({ provider, owner, repo })` using `useRepoSettings()` in settings page 

# Notable Changes
new file for the hook mainly, no major changes

# Screenshots
nothing visual changed

# Link to Sample Entry