### PR TITLE
Routes only changes for coverage tab

### DIFF
--- a/src/pages/RepoPage/CoverageTab/CoverageTab.js
+++ b/src/pages/RepoPage/CoverageTab/CoverageTab.js
@@ -19,10 +19,19 @@ function CoverageTab() {
       <Summary />
       <div className="flex flex-1 flex-col gap-4">
         <Switch>
-          <Route path="/:provider/:owner/:repo/tree/:path+" exact>
+          <Route path="/:provider/:owner/:repo/tree/:branch/:path+" exact>
+            <Suspense fallback={Loader}>
+              {/* Tree Component after being clicked for the 1st time */}
+              <h1>Tree Component after Clicked including a folder location</h1>
+            </Suspense>
+          </Route>
+          <Route path="/:provider/:owner/:repo/tree/:branch" exact>
             <Suspense fallback={Loader}>
               {/* Same Root Tree Component after being clicked for the 1st time */}
-              <h1>Root Tree Component after Clicked</h1>
+              <h1>
+                Root Tree Component Branch switch, this is the root of the
+                projects source
+              </h1>
             </Suspense>
           </Route>
           <Route path="/:provider/:owner/:repo/blobs/:ref/:path+" exact>
@@ -33,7 +42,7 @@ function CoverageTab() {
           <Route path="/:provider/:owner/:repo/" exact>
             <Suspense fallback={Loader}>
               {/* Root Tree Component */}
-              <h1>Root OG Tree Component</h1>
+              <h1>Root OG Tree Component on the default branch</h1>
             </Suspense>
           </Route>
         </Switch>

--- a/src/pages/RepoPage/CoverageTab/CoverageTab.spec.js
+++ b/src/pages/RepoPage/CoverageTab/CoverageTab.spec.js
@@ -11,10 +11,13 @@ describe('Coverage Tab', () => {
   function setup({ initialEntries }) {
     render(
       <MemoryRouter initialEntries={initialEntries}>
-        <Route path="/:provider/:owner/:repo/tree/:path+">
+        <Route path="/:provider/:owner/:repo/tree/:branch/:path+" exact>
           <CoverageTab />
         </Route>
-        <Route path="/:provider/:owner/:repo/blobs/:path+">
+        <Route path="/:provider/:owner/:repo/tree/:branch" exact>
+          <CoverageTab />
+        </Route>
+        <Route path="/:provider/:owner/:repo/blobs/:ref/:path+">
           <CoverageTab />
         </Route>
         <Route path="/:provider/:owner/:repo/" exact={true}>
@@ -31,26 +34,70 @@ describe('Coverage Tab', () => {
 
     it('renders summary and root tree component', () => {
       expect(screen.getByText(/Summary Component/)).toBeInTheDocument()
-      expect(screen.getByText(/Root OG Tree Component/)).toBeInTheDocument()
       expect(
-        screen.queryByText(/Root Tree Component after Clicked/)
+        screen.getByText(/Root OG Tree Component on the default branch/)
+      ).toBeInTheDocument()
+      expect(
+        screen.queryByText(
+          /Root Tree Component Branch switch, this is the root of the projects source/
+        )
       ).not.toBeInTheDocument()
       expect(screen.queryByText(/Fileviewer Component/)).not.toBeInTheDocument()
     })
   })
 
-  describe('when rendered with tree route', () => {
+  describe('when rendered with tree+branch on default route returns the root of the project', () => {
     beforeEach(() => {
-      setup({ initialEntries: ['/gh/test-org/test-repo/tree/123'] })
+      setup({ initialEntries: ['/gh/test-org/test-repo/tree/some-branch'] })
     })
 
     it('renders summary and root tree component', () => {
       expect(screen.getByText(/Summary Component/)).toBeInTheDocument()
       expect(
-        screen.getByText(/Root Tree Component after Clicked/)
+        screen.getByText(
+          /Root Tree Component Branch switch, this is the root of the projects source/
+        )
       ).toBeInTheDocument()
       expect(
-        screen.queryByText(/Root OG Tree Component/)
+        screen.queryByText(/Root OG Tree Component on the default branch/)
+      ).not.toBeInTheDocument()
+      expect(screen.queryByText(/Fileviewer Component/)).not.toBeInTheDocument()
+    })
+  })
+
+  describe('when rendered with tree+branch route returns the root of that branch', () => {
+    beforeEach(() => {
+      setup({ initialEntries: ['/gh/test-org/test-repo/tree/main'] })
+    })
+
+    it('renders summary and root tree component', () => {
+      expect(screen.getByText(/Summary Component/)).toBeInTheDocument()
+      expect(
+        screen.getByText(
+          /Root Tree Component Branch switch, this is the root of the projects source/
+        )
+      ).toBeInTheDocument()
+      expect(
+        screen.queryByText(/Root OG Tree Component on the default branch/)
+      ).not.toBeInTheDocument()
+      expect(screen.queryByText(/Fileviewer Component/)).not.toBeInTheDocument()
+    })
+  })
+
+  describe('when rendered with tree+branch route on a sub folder', () => {
+    beforeEach(() => {
+      setup({ initialEntries: ['/gh/test-org/test-repo/tree/master/src'] })
+    })
+
+    it('renders summary and root tree component', () => {
+      expect(screen.getByText(/Summary Component/)).toBeInTheDocument()
+      expect(
+        screen.getByText(
+          /Tree Component after Clicked including a folder location/
+        )
+      ).toBeInTheDocument()
+      expect(
+        screen.queryByText(/Root OG Tree Component on the default branch/)
       ).not.toBeInTheDocument()
       expect(screen.queryByText(/Fileviewer Component/)).not.toBeInTheDocument()
     })
@@ -70,7 +117,9 @@ describe('Coverage Tab', () => {
       expect(screen.getByText(/Summary Component/)).toBeInTheDocument()
       expect(screen.getByText(/Fileviewer Component/)).toBeInTheDocument()
       expect(
-        screen.queryByText(/Root Tree Component after Clicked/)
+        screen.queryByText(
+          /Root Tree Component Branch switch, this is the root of the projects source/
+        )
       ).not.toBeInTheDocument()
       expect(
         screen.queryByText(/Root OG Tree Component/)

--- a/src/pages/RepoPage/RepoPage.js
+++ b/src/pages/RepoPage/RepoPage.js
@@ -70,7 +70,10 @@ function RepoPage() {
             <Route path={`${path}/settings`}>
               <SettingsTab />
             </Route>
-            <Route path={`${path}/tree/:path+`} exact>
+            <Route path={`${path}/tree/:branch/:path+`} exact>
+              <CoverageTab />
+            </Route>
+            <Route path={`${path}/tree/:branch`} exact>
               <CoverageTab />
             </Route>
             <Route path={`${path}/blobs/:ref/:path+`} exact>


### PR DESCRIPTION
# Description
Based apon this draft  https://github.com/codecov/gazebo/pull/1363

# Code Example

# Notable Changes
* adds branch support to tree + blobs
* Should we just make the raw fileviewer have the summary and just use blob instead of blobs?

# Screenshots

# Link to Sample Entry