### PR TITLE
Update: use jest.useFakeTimers().setSystemTime() for a static time 

### DIFF
--- a/src/shared/utils/dates.spec.js
+++ b/src/shared/utils/dates.spec.js
@@ -23,6 +23,7 @@ describe('useDateFormatted and formatTimeToNow functions', () => {
 
   describe('when called with a iso date', () => {
     beforeEach(() => {
+      jest.useFakeTimers().setSystemTime(new Date('2022-09-01'))
       setup('2020-09-08T10:45:06Z')
     })
 
@@ -34,6 +35,7 @@ describe('useDateFormatted and formatTimeToNow functions', () => {
 
   describe('when called with an alternative date format', () => {
     beforeEach(() => {
+      jest.useFakeTimers().setSystemTime(new Date('2022-09-01'))
       setup('2020-09-08T10:45:06Z', 'MMMM yyyy')
     })
 
@@ -45,12 +47,13 @@ describe('useDateFormatted and formatTimeToNow functions', () => {
 
   describe('when called with a unix timestamp', () => {
     beforeEach(() => {
+      jest.useFakeTimers().setSystemTime(new Date('2022-09-01'))
       setup(1595270468)
     })
 
     it('returns the date with the default format', () => {
       expect(hookData.result.current).toBe('July 20th 2020')
-      expect(formattedDate).toBe('almost 2 years ago')
+      expect(formattedDate).toBe('about 2 years ago')
     })
   })
 })


### PR DESCRIPTION
# Description
Quick tests fix of dates, replace “almost 2 years ago” with “over 1 year ago” 
