### PR TITLE
Update Eslint Rules

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -26,14 +26,14 @@
     ],
     "camelcase": ["error", { "properties": "always" }],
     "sort-imports": [
-      "error",
+      "warn",
       {
         "ignoreCase": true,
         "ignoreDeclarationSort": true
       }
     ],
     "import/order": [
-      "error",
+      "warn",
       {
         "groups": [
           "external",


### PR DESCRIPTION
# Description
Make import order lint rules not error/prevent compilation to not inturpt dev workflow (will still block on commit)

# Notable Changes
* Previously if you had an import in the wrong location the app would break in devmod, this makes it a warning so you can work as normally even if the imports arent correct yet for better wip/noodling.
* Will still prevent commits with bad imports.