### PR TITLE
Update UI/Progress bar to always render 0.00% if an invalid amount is set.

### DIFF
--- a/src/ui/Progress/Progress.js
+++ b/src/ui/Progress/Progress.js
@@ -20,22 +20,20 @@ function Progress({ amount, label, color = 'default', variant = 'default' }) {
 
   return (
     <div className="w-full items-center flex gap-4">
-      {amountInNumber && (
+      <div
+        className={cs('flex-1 bg-ds-gray-secondary', variantClasses[variant])}
+      >
         <div
-          className={cs('flex-1 bg-ds-gray-secondary', variantClasses[variant])}
-        >
-          <div
-            data-testid="org-progress-bar"
-            className={cs('h-full', progressClasses[color])}
-            style={{ width: `${amountInNumber}%` }}
-          />
-        </div>
-      )}
+          data-testid="org-progress-bar"
+          className={cs('h-full', progressClasses[color])}
+          style={{ width: `${amountInNumber}%` }}
+        />
+      </div>
 
       {label && (
         <div
           className={cs({
-            'flex-1 flex justify-end': !amountInNumber,
+            'flex-none flex justify-end': !amountInNumber,
           })}
         >
           <TotalsNumber
@@ -51,7 +49,7 @@ function Progress({ amount, label, color = 'default', variant = 'default' }) {
 }
 
 Progress.propTypes = {
-  amount: PropTypes.number.isRequired,
+  amount: PropTypes.number,
   label: PropTypes.bool,
   variant: PropTypes.oneOf(['default', 'tall']),
   color: PropTypes.oneOf(['default', 'neutral', 'danger']),

--- a/src/ui/Progress/Progress.stories.js
+++ b/src/ui/Progress/Progress.stories.js
@@ -8,6 +8,30 @@ Progress.args = {
   amount: 50,
 }
 
+export const ProgressZero = Template.bind({})
+
+ProgressZero.args = {
+  amount: 0,
+}
+
+export const ProgressNaN = Template.bind({})
+
+ProgressNaN.args = {
+  amount: NaN,
+}
+
+export const ProgressNull = Template.bind({})
+
+ProgressNull.args = {
+  amount: null,
+}
+
+export const ProgressUndefined = Template.bind({})
+
+ProgressUndefined.args = {
+  amount: undefined,
+}
+
 export const ProgressTall = Template.bind({})
 
 ProgressTall.args = {
@@ -19,6 +43,13 @@ export const ProgressWithLabel = Template.bind({})
 
 ProgressWithLabel.args = {
   amount: 50,
+  label: true,
+}
+
+export const ProgressInvalidWithLabel = Template.bind({})
+
+ProgressInvalidWithLabel.args = {
+  amount: 0,
   label: true,
 }
 


### PR DESCRIPTION
# Description
There has been a UI bug floating around with the progress bar when things go wrong. Because it's used all over the place I figured I'd make is fail gracefully.

Codecov check failure is expected cause we reduced complexity

Old behaviour:
if an invalid number was sent to the Progress bar it would render literally a `0`

New Behaviour:
Render a 0% progress bar if undefined, NaN, or some other invalid data is sent to fail more gracefully.


# Notable Changes
* I also updated the flex code for cases with labels so the bar is always flush with the text.
* amount is no longer required now that if it's not valid it will render a grey bar regardless.


# Screenshots
Before:
![Screen Shot 2022-06-15 at 10 08 37 AM](https://user-images.githubusercontent.com/87824812/173834609-a043b081-1de7-41b2-8909-1be6346efb12.png)

After:
![Screen Shot 2022-06-15 at 10 08 18 AM](https://user-images.githubusercontent.com/87824812/173834635-6d5412da-95d2-46b8-ac63-17dc3366669d.png)

# Link to Sample Entry
See chromium storybook link