### PR TITLE
Increase resources for test check

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,7 @@ jobs:
   test:
     docker:
       - image: cimg/node:16.14.2
-    parallelism: 3
+    parallelism: 6
     steps:
       - checkout
       - restore_cache:
@@ -37,7 +37,7 @@ jobs:
           name: Run tests
           command: |
             TESTFILES=$(circleci tests glob "src/**/*.spec.js" "src/**/*.test.js" | circleci tests split --split-by=timings)
-            CI=true npm run test:ci -- --maxWorkers=3 $TESTFILES
+            CI=true npm run test:ci -- --maxWorkers=6 $TESTFILES
           environment:
             JEST_JUNIT_OUTPUT_DIR: ./reports/junit/
       - store_test_results:


### PR DESCRIPTION
# Description
We have more tests making the tasks slower. We've been having issues this week. This might help alleviate. Going from 3 threads to 6. Some of this speed problem is also poorly written tests/needs an audit for speed increases.