### PR TITLE
verify commits - handle users not part of org

### DIFF
--- a/src/pages/RepoPage/RepoPage.js
+++ b/src/pages/RepoPage/RepoPage.js
@@ -3,6 +3,7 @@ import { Redirect, Route, Switch, useParams } from 'react-router-dom'
 
 import LogoSpinner from 'old_ui/LogoSpinner'
 import { useCommits } from 'services/commits'
+import { useOwner } from 'services/user'
 import TabNavigation from 'ui/TabNavigation'
 
 import { RepoBreadcrumbProvider } from './context'
@@ -19,6 +20,10 @@ const path = '/:provider/:owner/:repo'
 
 function RepoPage() {
   const { provider, owner, repo } = useParams()
+
+  const { data: currentOwner } = useOwner({ username: owner })
+  const { isCurrentUserPartOfOrg } = currentOwner
+
   const { data } = useCommits({ provider, owner, repo })
   const matchTree = useMatchTreePath()
   const matchBlobs = useMatchBlobsPath()
@@ -43,15 +48,9 @@ function RepoPage() {
                 children: 'Coverage',
                 exact: !matchTree && !matchBlobs,
               },
-              {
-                pageName: 'commits',
-              },
-              {
-                pageName: 'pulls',
-              },
-              {
-                pageName: 'settings',
-              },
+              { pageName: 'commits' },
+              { pageName: 'pulls' },
+              ...(isCurrentUserPartOfOrg ? [{ pageName: 'settings' }] : []),
             ]}
           />
         )}

--- a/src/pages/RepoPage/RepoPage.spec.js
+++ b/src/pages/RepoPage/RepoPage.spec.js
@@ -1,6 +1,7 @@
 import { useBranches } from 'services/branches'
 import { useCommits } from 'services/commits'
 import { useRepo } from 'services/repo/hooks'
+import { useOwner } from 'services/user'
 
 import { fireEvent, repoPageRender, screen, waitFor } from './repo-jest-setup'
 
@@ -9,6 +10,7 @@ import RepoPage from '.'
 jest.mock('services/repo/hooks')
 jest.mock('services/commits')
 jest.mock('services/branches')
+jest.mock('services/user')
 
 // This component is too complex for an integration test imo
 jest.mock('./CoverageTab', () => () => 'CoverageTab')
@@ -50,10 +52,16 @@ const branches = [
 ]
 
 describe('RepoPage', () => {
-  function setup({ repository, commits = [], initialEntries }) {
+  function setup({
+    repository,
+    commits = [],
+    initialEntries,
+    isCurrentUserPartOfOrg = true,
+  }) {
     useRepo.mockReturnValue({ data: { repository } })
     useCommits.mockReturnValue({ data: { commits } })
     useBranches.mockReturnValue({ data: branches })
+    useOwner.mockReturnValue({ data: { isCurrentUserPartOfOrg } })
 
     // repoPageRender is mostly for making individual tabs easier, so this is a bit jank for integration tests.
     if (initialEntries) {
@@ -233,6 +241,23 @@ describe('RepoPage', () => {
     it('renders the name of the branch in the breadcrumb', () => {
       const branch = screen.getAllByText(/test1/)
       expect(branch.length).toEqual(2)
+    })
+  })
+
+  describe('when rendered with user not part of org', () => {
+    beforeEach(() => {
+      setup({
+        repository: {
+          private: false,
+        },
+        commits,
+        isCurrentUserPartOfOrg: false,
+      })
+    })
+
+    it('does not render the settings tab', () => {
+      const tab = screen.queryByText(/Settings/)
+      expect(tab).not.toBeInTheDocument()
     })
   })
 })

--- a/src/pages/RepoPage/SettingsTab/SettingsTab.js
+++ b/src/pages/RepoPage/SettingsTab/SettingsTab.js
@@ -1,8 +1,9 @@
 import { lazy, Suspense } from 'react'
-import { Route, Switch } from 'react-router-dom'
+import { Route, Switch, useParams } from 'react-router-dom'
 
 import SidebarLayout from 'layouts/SidebarLayout'
 import LogoSpinner from 'old_ui/LogoSpinner'
+import { useOwner } from 'services/user'
 
 import SideMenuSettings from './SideMenuSettings'
 import BadgesAndGraphsTab from './tabs/BadgesAndGraphsTab'
@@ -18,6 +19,12 @@ const tabLoading = (
 )
 
 function SettingsTab() {
+  const { owner } = useParams()
+  const { data: currentOwner } = useOwner({ username: owner })
+  const { isCurrentUserPartOfOrg } = currentOwner
+
+  if (!isCurrentUserPartOfOrg) return <NotFound />
+
   return (
     <SidebarLayout sidebar={<SideMenuSettings />}>
       <Suspense fallback={tabLoading}>

--- a/src/pages/RepoPage/SettingsTab/SettingsTab.spec.js
+++ b/src/pages/RepoPage/SettingsTab/SettingsTab.spec.js
@@ -1,10 +1,16 @@
 import { render, screen } from '@testing-library/react'
 import { MemoryRouter, Route } from 'react-router-dom'
 
+import { useOwner } from 'services/user'
+
 import SettingsTab from './SettingsTab'
 
-describe('AccountSettings', () => {
-  function setup({ url }) {
+jest.mock('services/user')
+
+describe('SettingsTab', () => {
+  function setup({ url, isCurrentUserPartOfOrg = true }) {
+    useOwner.mockReturnValue({ data: { isCurrentUserPartOfOrg } })
+
     render(
       <MemoryRouter initialEntries={[url]}>
         <Route path="/:provider/:owner/:repo/settings">
@@ -36,8 +42,17 @@ describe('AccountSettings', () => {
       expect(screen.getByRole('link', { name: /Yaml/ })).toBeInTheDocument()
       expect(screen.getByRole('link', { name: /Badge/ })).toBeInTheDocument()
     })
+  })
 
-    it('renders 404 not found', () => {
+  describe('Render with user not part of org', () => {
+    beforeEach(() => {
+      setup({
+        url: '/gh/codecov/codecov-client/settings',
+        isCurrentUserPartOfOrg: false,
+      })
+    })
+
+    it('renders 404', () => {
       expect(screen.getByText('Error 404')).toBeInTheDocument()
     })
   })


### PR DESCRIPTION
# Description
Meant to strict access of setting page for public repos when user is not part of org

# Notable Changes
I simply used useOwner to tell if user is part of org, if not render 404 
Hid settings tab for users not part of org  

# Screenshots
<img width="1189" alt="Screen Shot 2022-06-20 at 1 21 22 PM" src="https://user-images.githubusercontent.com/91732700/174581523-a1a8f90d-90b3-4bfc-9a4f-66c930ac5c81.png">
<img width="1239" alt="Screen Shot 2022-06-20 at 1 04 17 PM" src="https://user-images.githubusercontent.com/91732700/174581549-bdfbc3e4-9183-4887-90b0-557b03ef4267.png">


# Link to Sample Entry
go to here while not logged in e.g gh/codecov/codecov-python/settings
