### PR TITLE
Add optional chaining to prevent undefined coverageFile

### DIFF
--- a/src/services/file/utils.js
+++ b/src/services/file/utils.js
@@ -7,12 +7,12 @@ export function extractCoverageFromResponse(res) {
   const coverageSource = commit || branch
   const coverageFile = coverageSource?.coverageFile
   if (!coverageFile) return null
-  const lineWithCoverage = keyBy(coverageFile.coverage, 'line')
+  const lineWithCoverage = keyBy(coverageFile?.coverage, 'line')
   const fileCoverage = mapValues(lineWithCoverage, 'coverage')
-  const coverageTotal = coverageFile.totals?.coverage
+  const coverageTotal = coverageFile?.totals?.coverage
 
   return {
-    content: coverageFile.content,
+    content: coverageFile?.content,
     coverage: fileCoverage,
     totals: isNaN(coverageTotal) ? 0 : coverageTotal,
     flagNames: coverageSource?.flagNames ?? [],


### PR DESCRIPTION
# Description
Super baby PR; basically adding optional chaining as a failsafe for the fileviewer. There was an error triggered in sentry a couple of months ago, https://codecovio.atlassian.net/browse/CODE-766, that I'm sure its resolved by now but thought I'd make these changes real quick as an opportunity to improve this.

# Notable Changes
- Just optional chaining rlly

# Screenshots
N/A

# Link to Sample Entry