### PR TITLE
Css/style update to better serve users with color blindnes 

### DIFF
--- a/src/shared/utils/fileviewer.js
+++ b/src/shared/utils/fileviewer.js
@@ -16,10 +16,10 @@ export const classNamePerLineState = {
   [LINE_STATE.COVERED]:
     'bg-ds-coverage-covered border-ds-primary-green border-r-2',
   [LINE_STATE.UNCOVERED]:
-    'bg-ds-coverage-uncovered border-ds-primary-red border-r-2',
+    'text-[#E1B3BA] bg-ds-coverage-uncovered border-ds-primary-red border-r-2 pattern-dots',
   [LINE_STATE.BLANK]: 'border-ds-gray-tertiary border-r',
   [LINE_STATE.PARTIAL]:
-    'bg-ds-coverage-partial border-ds-primary-yellow border-r-2',
+    'text-[#E8DFB2] bg-ds-coverage-partial border-ds-primary-yellow border-r-2 pattern-grid',
 }
 
 export const lineStateToLabel = {

--- a/src/ui/CodeRenderer/CodeRenderer.css
+++ b/src/ui/CodeRenderer/CodeRenderer.css
@@ -20,3 +20,14 @@ tbody tr:last-child td {
 .style .token.string {
   @apply bg-transparent;
 }
+
+.pattern-grid {
+  background-image: linear-gradient(currentColor 1px, transparent 1px),
+    linear-gradient(to right, currentColor 1px, transparent 1px);
+  background-size: 11px 11px;
+}
+
+.pattern-dots {
+  background-image: radial-gradient(currentColor 1px, transparent 1px);
+  background-size: calc(10 * 1px) calc(10 * 1px);
+}

--- a/src/ui/CodeRenderer/CodeRendererInfoRow/CodeRendererInfoRow.js
+++ b/src/ui/CodeRenderer/CodeRendererInfoRow/CodeRendererInfoRow.js
@@ -6,7 +6,7 @@ import Icon from 'ui/Icon'
 
 const message = {
   [CODE_RENDERER_INFO.UNEXPECTED_CHANGES]: (
-    <div className="flex gap-1">
+    <div className="flex gap-1 pattern-grid">
       <Icon variant="outline" name="information-circle" size="sm" />
       <span>
         indirect coverage change{' '}

--- a/src/ui/CodeRenderer/DiffLine/DiffLine.js
+++ b/src/ui/CodeRenderer/DiffLine/DiffLine.js
@@ -46,7 +46,7 @@ function DiffLine({
           classNamePerLineState[baseLineState]
         )}
       >
-        {baseNumber}
+        <span className="text-black">{baseNumber}</span>
       </td>
       <td
         aria-label={lineStateToLabel[headLineState]}
@@ -55,7 +55,7 @@ function DiffLine({
           classNamePerLineState[headLineState]
         )}
       >
-        {headNumber}
+        <span className="text-black">{headNumber}</span>
       </td>
       <td
         data-testid="affected-lines"

--- a/src/ui/CodeRenderer/SingleLine/SingleLine.js
+++ b/src/ui/CodeRenderer/SingleLine/SingleLine.js
@@ -27,7 +27,7 @@ function SingleLine({
           classNamePerLineState[lineState]
         )}
       >
-        {number}
+        <span className="text-black">{number}</span>
       </td>
       <td className="pl-2 break-all">
         {line.map((token, key) => (

--- a/src/ui/FileViewer/ToggleHeader/Title/CoverageSelect.js
+++ b/src/ui/FileViewer/ToggleHeader/Title/CoverageSelect.js
@@ -5,8 +5,10 @@ import { LINE_STATE } from 'shared/utils/fileviewer'
 
 const classNamePerLineState = {
   [LINE_STATE.COVERED]: 'bg-ds-coverage-covered border-ds-primary-green',
-  [LINE_STATE.UNCOVERED]: 'bg-ds-coverage-uncovered border-ds-primary-red',
-  [LINE_STATE.PARTIAL]: 'bg-ds-coverage-partial border-ds-primary-yellow',
+  [LINE_STATE.UNCOVERED]:
+    'text-[#E1B3BA] bg-ds-coverage-uncovered border-ds-primary-red pattern-dots',
+  [LINE_STATE.PARTIAL]:
+    'text-[#E8DFB2] bg-ds-coverage-partial border-ds-primary-yellow pattern-grid',
 }
 
 function CoverageSelect({ coverage, checked, onChange }) {
@@ -29,7 +31,7 @@ function CoverageSelect({ coverage, checked, onChange }) {
           classNamePerLineState[coverage]
         )}
       >
-        {coverage.toLowerCase()}
+        <span className="text-black">{coverage.toLowerCase()}</span>
       </label>
     </div>
   )


### PR DESCRIPTION
# Description
We got a customer complaint via twitter and never made any action, I took a pass to make the app more usable for the user / others with color blindness by adding a background pattern to partial and missed coverage.

TODO: We need designs input for colors / options, this might ship pending @CodecovKirsten 's decision on the matter :)


# Notable Changes
The pattern uses current color so I wrapped some text in a span to differentiate text color.


The pattern is applied to the label/key and in the line number.

# Screenshots
Prod today regular + with blindness:
![Screen Shot 2022-07-21 at 3 35 23 PM](https://user-images.githubusercontent.com/87824812/180298183-6faff08b-7482-4fae-81b0-d8e0f9404621.png)
![Screen Shot 2022-07-21 at 3 35 29 PM](https://user-images.githubusercontent.com/87824812/180298187-810586f9-96c8-4825-a844-8d8ffd25d0b8.png)

New version for normal users (Tried to keep it very subtle)
![Screen Shot 2022-07-21 at 3 58 06 PM](https://user-images.githubusercontent.com/87824812/180298256-2c5dc44e-b946-496c-847a-69abc090ed45.png)

What it looks like for people with color blindness

![Screen Shot 2022-07-21 at 3 58 24 PM](https://user-images.githubusercontent.com/87824812/180298315-53451c08-99c5-4126-af4b-0fc888e21913.png)
![Screen Shot 2022-07-21 at 3 58 33 PM](https://user-images.githubusercontent.com/87824812/180298317-0cfca5c3-6be3-4313-a403-e353bb3644f4.png)
![Screen Shot 2022-07-21 at 3 58 44 PM](https://user-images.githubusercontent.com/87824812/180298321-6b58b8ec-a401-4bed-add0-fdc818216aaa.png)



# Link to Sample Entry