### PR TITLE
Fix use of download url

### DIFF
--- a/src/pages/CommitPage/UploadsCard/Upload.js
+++ b/src/pages/CommitPage/UploadsCard/Upload.js
@@ -1,7 +1,5 @@
 import PropTypes from 'prop-types'
 
-import config from 'config'
-
 import {
   ErrorCodeEnum,
   UploadStateEnum,
@@ -57,12 +55,7 @@ const Upload = ({
           )}
         </div>
         {downloadUrl && (
-          <A
-            href={`${config.API_URL}${downloadUrl}`}
-            hook="download report"
-            download
-            isExternal
-          >
+          <A href={downloadUrl} hook="download report" download isExternal>
             Download
           </A>
         )}


### PR DESCRIPTION
# Description
instead of routing to **https://api.codecov.iohttps//storage.googleapis.com**/codecov/v4/raw/2022-07.. route to **https//storage.googleapis.com**/codecov/v4/raw/2022-07-

# Code Example

# Notable Changes

# Screenshots

# Link to Sample Entry