### PR TITLE
Setup the Header, configured flags and historical trend

### DIFF
--- a/src/pages/RepoPage/FlagsTab/FlagsTab.js
+++ b/src/pages/RepoPage/FlagsTab/FlagsTab.js
@@ -1,13 +1,12 @@
 import { Suspense } from 'react'
 import { Route, useParams } from 'react-router-dom'
 
-import { useLocationParams } from 'services/navigation'
 import { useRepoBackfilled } from 'services/repo/hooks'
 import { useRepoFlagsSelect } from 'services/repo/useRepoFlagsSelect'
-import SearchField from 'ui/SearchField/SearchField'
 import Spinner from 'ui/Spinner'
 
 import FlagsNotConfigured from './FlagsNotConfigured'
+import Header from './Header'
 import FlagsTable from './subroute/FlagsTable/FlagsTable'
 import SyncingBanner from './SyncingBanner'
 import TriggerSyncBanner from './TriggerSyncBanner'
@@ -24,7 +23,6 @@ const getIsRepoBackfilling = ({
 }) => flagsMeasurementsActive && !flagsMeasurementsBackfilled
 
 function FlagsTab() {
-  const { params, updateParams } = useLocationParams({ search: '' })
   const { provider, owner, repo } = useParams()
   const { data: flagsData } = useRepoFlagsSelect()
   const { data } = useRepoBackfilled({ provider, owner, repo })
@@ -40,20 +38,13 @@ function FlagsTab() {
     <div className="flex flex-col gap-4 mx-4 md:mx-0">
       {flagsData && flagsData.length > 0 ? (
         <>
-          <h1>Flags Header Component</h1>
+          <Header />
           {!flagsMeasurementsActive && <TriggerSyncBanner />}
           {isRepoBackfilling && <SyncingBanner />}
           {/*TODO: Show blurred image instead of the table when backfill is running or not active*/}
-          <div className="flex flex-1 flex-col gap-4 border-t border-solid border-ds-gray-secondary">
+          <div className="flex flex-1 flex-col gap-4">
             <Route path="/:provider/:owner/:repo/flags" exact>
               <Suspense fallback={Loader}>
-                <div className="flex justify-end pt-4">
-                  <SearchField
-                    placeholder={'Search for flags'}
-                    searchValue={params?.search}
-                    setSearchValue={(search) => updateParams({ search })}
-                  />
-                </div>
                 <FlagsTable />
               </Suspense>
             </Route>

--- a/src/pages/RepoPage/FlagsTab/FlagsTab.spec.js
+++ b/src/pages/RepoPage/FlagsTab/FlagsTab.spec.js
@@ -1,6 +1,5 @@
-import { render, screen , waitFor } from 'custom-testing-library'
+import { render, screen } from 'custom-testing-library'
 
-import userEvent from '@testing-library/user-event'
 import { QueryClient, QueryClientProvider } from 'react-query'
 import { MemoryRouter, Route, useParams } from 'react-router-dom'
 
@@ -17,6 +16,7 @@ jest.mock(
 )
 jest.mock('./SyncingBanner/SyncingBanner.js', () => () => 'Syncing Banner')
 jest.mock('./subroute/FlagsTable/FlagsTable', () => () => 'Flags table')
+jest.mock('./Header', () => () => 'Flags Header Component')
 
 jest.mock('services/repo/hooks')
 jest.mock('react-router-dom', () => ({
@@ -150,30 +150,6 @@ describe('Flags Tab', () => {
       expect(
         screen.getByText(/The Flags feature is not yet configured/)
       ).toBeInTheDocument()
-    })
-  })
-
-  describe('update search params after typing', () => {
-    beforeEach(() => {
-      setup({
-        data: {
-          data: {
-            flagsMeasurementsActive: true,
-            flagsMeasurementsBackfilled: true,
-          },
-        },
-      })
-      const searchInput = screen.getByRole('textbox', {
-        name: 'Search for flags',
-      })
-      userEvent.type(searchInput, 'flag1')
-    })
-
-    it('calls setSearchValue', async () => {
-      await waitFor(() => expect(updateParams).toHaveBeenCalled())
-      await waitFor(() =>
-        expect(updateParams).toHaveBeenCalledWith({ search: 'flag1' })
-      )
     })
   })
 })

--- a/src/pages/RepoPage/FlagsTab/Header/Header.js
+++ b/src/pages/RepoPage/FlagsTab/Header/Header.js
@@ -1,0 +1,57 @@
+import { useLocationParams } from 'services/navigation'
+import { useRepoFlagsSelect } from 'services/repo/useRepoFlagsSelect'
+import SearchField from 'ui/SearchField'
+import Select from 'ui/Select'
+
+import { TimeOptions } from '../constants'
+
+const Header = () => {
+  const { params, updateParams } = useLocationParams({
+    search: '',
+    historicalTrend: '',
+  })
+  const { data: flagsData } = useRepoFlagsSelect()
+
+  const value = [...TimeOptions]
+    .filter((item) => item.label === params.historicalTrend)
+    .pop()
+
+  return (
+    <div className="flex flex-col justify-end divide-y divide-solid divide-ds-gray-secondary">
+      <div className="flex divide-x divide-solid divide-ds-gray-secondary">
+        <div className="mr-4 mb-4 px-4 flex flex-col justify-between gap-2">
+          <h3 className="text-sm text-ds-gray-octonary font-semibold">
+            Configured flags
+          </h3>
+          <p className="text-xl text-ds-gray-octonary font-light">
+            {flagsData.length}
+          </p>
+        </div>
+        <div className="mb-4 px-4 flex flex-col justify-between gap-2">
+          <h3 className="text-sm text-ds-gray-octonary font-semibold">
+            Historical trend
+          </h3>
+          <Select
+            ariaName="Select Historical Trend"
+            items={TimeOptions}
+            value={value ?? TimeOptions[1]}
+            onChange={(historicalTrend) =>
+              updateParams({ historicalTrend: historicalTrend.label })
+            }
+            renderItem={({ label }) => label}
+            renderSelected={({ label }) => label}
+          />
+        </div>
+      </div>
+      <div className="flex justify-end pt-4">
+        <SearchField
+          placeholder={'Search for flags'}
+          searchValue={params?.search}
+          setSearchValue={(search) => updateParams({ search })}
+        />
+      </div>
+    </div>
+  )
+}
+
+export default Header

--- a/src/pages/RepoPage/FlagsTab/Header/Header.spec.js
+++ b/src/pages/RepoPage/FlagsTab/Header/Header.spec.js
@@ -1,0 +1,93 @@
+import { render, screen, waitFor } from 'custom-testing-library'
+
+import userEvent from '@testing-library/user-event'
+
+import { useLocationParams } from 'services/navigation'
+import { useRepoFlagsSelect } from 'services/repo/useRepoFlagsSelect'
+
+import Header from './Header'
+
+jest.mock('services/navigation')
+jest.mock('services/repo/useRepoFlagsSelect')
+
+describe('Header', () => {
+  const updateLocationMock = jest.fn()
+  function setup() {
+    useLocationParams.mockReturnValue({
+      params: { search: '', historicalTrend: '' },
+      updateParams: updateLocationMock,
+    })
+    useRepoFlagsSelect.mockReturnValue({
+      data: new Array(6),
+    })
+
+    render(<Header />)
+  }
+  describe('Configured Flags', () => {
+    beforeEach(() => {
+      setup()
+    })
+
+    it('Renders the label', () => {
+      expect(screen.getByText(/Configured flags/)).toBeInTheDocument()
+    })
+    it('Renders the correct number of flags on the repo', () => {
+      expect(screen.getByText(/6/)).toBeInTheDocument()
+    })
+  })
+
+  describe('Historical Trend', () => {
+    describe('Title', () => {
+      beforeEach(() => {
+        setup()
+      })
+
+      it('Renders the label', () => {
+        expect(screen.getByText(/Historical trend/)).toBeInTheDocument()
+      })
+    })
+
+    describe('Select', () => {
+      beforeEach(() => {
+        setup()
+        const historicalTrend = screen.getByRole('button', {
+          name: 'Select Historical Trend',
+        })
+        userEvent.click(historicalTrend)
+      })
+
+      it('loads the expected list', async () => {
+        expect(await screen.findByText('All time')).toBeVisible()
+      })
+      it('updates the location params on select', async () => {
+        await screen.findByText('All time')
+
+        const item = screen.getByText('Last 24 hours')
+        userEvent.click(item)
+
+        await waitFor(() =>
+          expect(updateLocationMock).toHaveBeenCalledWith({
+            historicalTrend: 'Last 24 hours',
+          })
+        )
+      })
+    })
+  })
+
+  describe('Search', () => {
+    beforeEach(() => {
+      setup()
+      const searchInput = screen.getByRole('textbox', {
+        name: 'Search for flags',
+      })
+      userEvent.type(searchInput, 'flag1')
+    })
+
+    it('calls setSearchValue', async () => {
+      await waitFor(() => expect(updateLocationMock).toHaveBeenCalled())
+      await waitFor(() =>
+        expect(updateLocationMock).toHaveBeenCalledWith({ search: 'flag1' })
+      )
+    })
+  })
+})

--- a/src/pages/RepoPage/FlagsTab/Header/index.js
+++ b/src/pages/RepoPage/FlagsTab/Header/index.js
@@ -1,0 +1,1 @@
+export { default } from './Header'

--- a/src/pages/RepoPage/FlagsTab/constants.js
+++ b/src/pages/RepoPage/FlagsTab/constants.js
@@ -1,0 +1,14 @@
+export const MEASUREMENT_INTERVAL = Object.freeze({
+  INTERVAL_30_DAY: 'INTERVAL_30_DAY',
+  INTERVAL_7_DAY: 'INTERVAL_7_DAY',
+  INTERVAL_1_DAY: 'INTERVAL_1_DAY',
+})
+
+export const TimeOptions = [
+  { label: 'All time', value: '' },
+  // { label: 'Last 6 months', value: 'SOME_CONST' },
+  // { label: 'Last 3 months', value: 'SOME_CONST' },
+  { label: 'Last 30 days', value: MEASUREMENT_INTERVAL.INTERVAL_30_DAY },
+  { label: 'Last 7 days', value: MEASUREMENT_INTERVAL.INTERVAL_7_DAY },
+  { label: 'Last 24 hours', value: MEASUREMENT_INTERVAL.INTERVAL_1_DAY },
+]

--- a/src/ui/Select/Select.js
+++ b/src/ui/Select/Select.js
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types'
 import Icon from 'ui/Icon'
 
 const SelectClasses = {
-  root: 'w-full relative',
+  root: 'flex-1 relative',
   item: 'block cursor-pointer py-1 px-3 text-sm',
   button:
     'flex justify-between items-center w-full border border-ds-gray-tertiary rounded-md bg-white text-left px-3 outline-none h-8',


### PR DESCRIPTION
# Description
Sets up the header and historical trend dropdown. Now shows how many flags are in the repo.


# Notable Changes
I brought the search up into the "Header" component largely for styling reasons, make some css tweaks to make things match the design a bit more. Note: The design omitted the border but Pavilion has a border top on the table. Leaving it as Pavilions version for now.

# Screenshots
![Screen Shot 2022-07-28 at 11 08 44 AM](https://user-images.githubusercontent.com/87824812/181526067-fc48c3f7-61d6-4a84-aaed-247cd1926938.png)
![Screen Shot 2022-07-28 at 11 08 52 AM](https://user-images.githubusercontent.com/87824812/181526073-89f2d23a-31ca-4c8a-90c9-80f8cba6e5d4.png)
![Screen Shot 2022-07-28 at 11 09 05 AM](https://user-images.githubusercontent.com/87824812/181526074-b5cb8e5b-f723-4666-90f1-cfee603ed9f4.png)

# Link to Sample Entry