### PR TITLE
Clarify wording on onboarding page regarding GitHub app

### DIFF
--- a/src/pages/RepoPage/NewRepoTab/GithubConfig/GithubConfigBanner.js
+++ b/src/pages/RepoPage/NewRepoTab/GithubConfig/GithubConfigBanner.js
@@ -28,7 +28,7 @@ const GithubConfigBanner = ({ privateRepo }) => {
             >
               Install Codecov&apos;s GitHub App
             </A>
-            . Once installed, you are done! You do not need to set a{' '}
+            . Once installed, you will not need to set a{' '}
             <A data-testid="teamBot-link" to={{ pageName: 'teamBot' }}>
               Team Bot
             </A>

--- a/src/pages/RepoPage/NewRepoTab/GithubConfig/GithubConfigBanner.spec.js
+++ b/src/pages/RepoPage/NewRepoTab/GithubConfig/GithubConfigBanner.spec.js
@@ -27,7 +27,9 @@ describe('GithubConfigBanner', () => {
     })
 
     it('renders banner body', () => {
-      const body = screen.queryByText(/Once installed, you are done!/)
+      const body = screen.queryByText(
+        /Once installed, you will not need to set a/
+      )
       expect(body).toBeInTheDocument()
     })
   })
@@ -43,7 +45,9 @@ describe('GithubConfigBanner', () => {
     })
 
     it('does not render banner body', () => {
-      const body = screen.queryByText(/Once installed, you are done!/)
+      const body = screen.queryByText(
+        /Once installed, you will not need to set a/
+      )
       expect(body).not.toBeInTheDocument()
     })
   })


### PR DESCRIPTION
# Description

The prior wording was leading to confusion. Customers were thinking that the other steps were not needed after installing the App.

Fixes #1496