### PR TITLE
GraphQL error handling demo

### DIFF
--- a/src/pages/PullRequestPage/Summary/CompareSummary.js
+++ b/src/pages/PullRequestPage/Summary/CompareSummary.js
@@ -117,6 +117,7 @@ function lastCommitErrorCard({ recentCommit }) {
 
 function CompareSummary() {
   const {
+    errors,
     headCoverage,
     patchCoverage,
     changeCoverage,
@@ -124,6 +125,18 @@ function CompareSummary() {
     baseCommit,
     recentCommit,
   } = usePullForCompareSummary()
+
+  if (errors) {
+    return errors.map((error, i) => {
+      switch (error.type) {
+        // TODO: maybe we have a GraphQL enum of possible types here
+        case 'MissingComparisonReport':
+          return <div key={i}>Missing comparison report: {error.message}</div>
+        default:
+          return <div key={i}>{error.message}</div>
+      }
+    })
+  }
 
   const fields = [
     ...totalsCards({ headCoverage, headCommit, patchCoverage, changeCoverage }),

--- a/src/pages/PullRequestPage/Summary/hooks.js
+++ b/src/pages/PullRequestPage/Summary/hooks.js
@@ -19,6 +19,7 @@ export function getPullDataForCompareSummary({
   }
 
   return {
+    errors: compareWithBase?._errors || [],
     headCoverage: head?.totals?.percentCovered,
     patchCoverage: compareWithBase?.patchTotals?.percentCovered * 100,
     changeCoverage: compareWithBase?.changeWithParent,


### PR DESCRIPTION
For demonstration purposes only - not intended to be merged.

@adrian-codecov and I have been chatting about various error handling approaches in our GraphQL API.  One option is to have each resolver (that could result in an an expected error) return a union type of either the result or some sort of error representation.  For example, a pull's `compareWithBase` resolver might have the type:

```graphql
union ComparisonResult = Comparison | MissingComparisonReport | ...
```

This has two really nice properties:
- the errors are all explicit in the schema
- the error is localized to the component that handles the result of `compareWithBase`

The downside being that we'd need to rework a lot of the client-side GraphQL queries to something like the following:

```
{
    compareWithBase {
        __typename
        ... on Comparison {
            // all the normal fields here
        }
        ... on MissingComparisonReport {
            // error fields here
        }
    }
}
```
---

This PR demonstrates another potential approach that also localizes the error to the corresponding component but does not explicitly encode all the various error types in the GraphQL schema.  Maybe this approach is a good compromise that would allow us to start adding better error handling more incrementally.

The core idea is just to move errors in the top-level `errors` array (ones which have a `path`) into the resolver data that corresponds to where that error originated.  This PR includes an example of what it might look like to handle a comparison error on the PR compare page.

Curious to hear your thoughts.