### PR TITLE
Enable repo flags pagination 

### DIFF
--- a/src/services/repo/useRepoFlags.js
+++ b/src/services/repo/useRepoFlags.js
@@ -29,7 +29,7 @@ function fetchRepoFlags({
     ) {
       owner(username: $name) {
         repository(name: $repo) {
-          flags(filters: $filters, orderingDirection: $orderingDirection, after: $after) {
+          flags(filters: $filters, orderingDirection: $orderingDirection, after: $after, first: 15) {
             pageInfo {
               hasNextPage
               endCursor


### PR DESCRIPTION
# Description
- loading first 15 repo flags

# Screenshots
<img width="1238" alt="image" src="https://user-images.githubusercontent.com/99655254/185432151-27836b41-2e0e-4125-a6c2-93cf8db92364.png">

# Link to Sample Entry 
https://deploy-preview-1523--gazebo-staging.netlify.app/gh/codecov/codecov-api/flags
