### PR TITLE
fix path for impacted files

### DIFF
--- a/src/pages/PullRequestPage/subroute/Root/ImpactedFiles/ImpactedFiles.js
+++ b/src/pages/PullRequestPage/subroute/Root/ImpactedFiles/ImpactedFiles.js
@@ -131,7 +131,8 @@ const Loader = (
 
 const renderSubComponent = ({ row }) => {
   const nameColumn = row.getValue('name')
-  const [, pathItem] = nameColumn?.props?.children
+  const [fileNames] = nameColumn?.props?.children
+  const [, pathItem] = fileNames?.props?.children
   const path = pathItem?.props?.children
   // TODO: this component has a nested table and needs to be reworked as it is used inside the Table component, which leads to an accessibilty issue
   return (


### PR DESCRIPTION
# Description
Gotta love it right?

This PR is to adjust the path used for the fileDiff. In short, we send markup to the `Table` component as it's row contents. Because of this, we're limited in how we access the information we need for this component (in this case, the path). In the last PR, I added markup which changed the sibling relationship between the previous row items, thus changing the location of the path.

# Notable Changes
- Adjusted how we get the path