### PR TITLE
Repo Settings Page Not Showing On Deactivated Repos

### DIFF
--- a/src/pages/RepoPage/RepoPage.jsx
+++ b/src/pages/RepoPage/RepoPage.jsx
@@ -138,11 +138,11 @@ function RepoPage() {
             <>
               {repoHasCommits ? (
                 <Switch>
-                  <Route path={path}>
-                    <DeactivatedRepo />
-                  </Route>
                   <Route path={`${path}/settings`}>
                     <SettingsTab />
+                  </Route>
+                  <Route path={path}>
+                    <DeactivatedRepo />
                   </Route>
                 </Switch>
               ) : (


### PR DESCRIPTION
# Description

Playing around locally I noticed that the settings page was not showing when a repo was deactivated, because the route was being eaten up by the deactivated repo path, this pr re-orders the routes so that if the settings one is navigated to it will show that page

# Notable Changes

- re-order so regular path does not eat up requests to settings page