### PR TITLE
 CODE-1967-pulls-commit-type-styles-update-to-design-library-and-ui-consistency

### DIFF
--- a/src/pages/RepoPage/CommitsTab/CommitsTable/Title/Title.jsx
+++ b/src/pages/RepoPage/CommitsTab/CommitsTable/Title/Title.jsx
@@ -26,7 +26,7 @@ const Title = ({ message, author, commitid, createdAt }) => {
       </span>
       <div className="flex flex-col w-5/6 lg:w-auto">
         <A to={{ pageName: 'commit', options: { commit: commitid } }}>
-          <h2 className="font-medium text-sm md:text-base text-black">
+          <h2 className="font-semibold text-sm text-black">
             {commitMessage()}
           </h2>
         </A>

--- a/src/pages/RepoPage/PullsTab/PullsTable/Title/Title.jsx
+++ b/src/pages/RepoPage/PullsTab/PullsTable/Title/Title.jsx
@@ -17,9 +17,7 @@ const Title = ({ author, pullId, title, updatestamp }) => {
       </span>
       <div className="flex flex-col w-5/6 lg:w-auto">
         <A to={{ pageName: 'pullDetail', options: { pullId } }}>
-          <h2 className="font-medium text-sm md:text-base text-black">
-            {title}
-          </h2>
+          <h2 className="font-semibold text-sm text-black">{title}</h2>
         </A>
         <p className="text-xs">
           <A to={{ pageName: 'owner' }}>


### PR DESCRIPTION
# Description

Pull/commit landing page update the commit/pull name w/:
- font-weight: 600;
- font-size: .85rem

# Screenshots
<img width="1512" alt="Screen Shot 2022-11-10 at 11 26 50 AM" src="https://user-images.githubusercontent.com/91732700/201052932-752a3d3b-ff44-4e82-9f80-e97e5387b16d.png">
<img width="1512" alt="Screen Shot 2022-11-10 at 11 26 13 AM" src="https://user-images.githubusercontent.com/91732700/201052947-004db68b-a4f3-45dd-8b77-15cb60173aab.png">


# Link to Sample Entry
/gh/codecov/gazebo/commits
/gh/codecov/gazebo/pulls