### PR TITLE
Fix useImage Trying to Set State While Unmounted

### DIFF
--- a/src/services/image/useImage.js
+++ b/src/services/image/useImage.js
@@ -45,6 +45,7 @@ export function useImage({ src }) {
         setIsLoading(false)
       })
       .catch((error) => {
+        if (cancel) return
         imageCache.set(src, {
           ...imageCache.get(src),
           cache: 'rejected',


### PR DESCRIPTION
# Description

This PR adds in a check variable that is set to true when the `useEffect` cleanup function is run that will block state being set if the component has been unmounted.