### PR TITLE
CODE-1979: Highlight Across Line Overlaps Container Borders

### DIFF
--- a/src/shared/utils/fileviewer.js
+++ b/src/shared/utils/fileviewer.js
@@ -13,7 +13,8 @@ export const LINE_STATE = Object.freeze({
 })
 
 export const classNamePerLineState = {
-  [LINE_STATE.COVERED]: 'bg-ds-coverage-covered font-normal',
+  [LINE_STATE.COVERED]:
+    'bg-ds-coverage-covered font-normal border-ds-gray-tertiary border-r',
   [LINE_STATE.UNCOVERED]:
     'bg-ds-coverage-uncovered border-ds-primary-red border-r-2 font-bold',
   [LINE_STATE.BLANK]: 'border-ds-gray-tertiary border-r font-normal',


### PR DESCRIPTION
# Description

This PR adds back in borders to covered lines in the file viewer.