### PR TITLE
Disappearing Impacted Files Table Header

### DIFF
--- a/src/pages/PullRequestPage/subroute/Root/ImpactedFiles/ImpactedFiles.jsx
+++ b/src/pages/PullRequestPage/subroute/Root/ImpactedFiles/ImpactedFiles.jsx
@@ -114,21 +114,20 @@ const renderSubComponent = ({ row }) => {
 function ImpactedFiles() {
   const { data, handleSort, isLoading } = useImpactedFilesTable()
 
-  if (isLoading) {
-    return <Loader />
-  }
-
   const tableContent = createTable({
     tableData: data?.impactedFiles,
   })
 
   return (
-    <Table
-      data={tableContent}
-      columns={columns}
-      onSort={handleSort}
-      renderSubComponent={renderSubComponent}
-    />
+    <>
+      <Table
+        data={tableContent}
+        columns={columns}
+        onSort={handleSort}
+        renderSubComponent={renderSubComponent}
+      />
+      {isLoading && <Loader />}
+    </>
   )
 }
 


### PR DESCRIPTION
# Description

Currently the header for the impacted files table is disappearing when users sort, this is because the loader is being returned instead of the table itself. This PR fixes that by constantly showing the table and a spinner for the data

# Notable Changes

- Remove early return if loading
- Return both loader and table in a fragment