### PR TITLE
Patch coverage value is now a percent

### DIFF
--- a/src/pages/CommitPage/Header/Header.spec.jsx
+++ b/src/pages/CommitPage/Header/Header.spec.jsx
@@ -55,7 +55,7 @@ const dataReturned = {
     },
     compareWithParent: {
       state: 'processed',
-      patchTotals: { coverage: 0.75 },
+      patchTotals: { coverage: 75 },
       impactedFiles: [
         {
           patchCoverage: { coverage: 75 },

--- a/src/pages/CommitPage/Summary/CommitDetailsSummary.spec.jsx
+++ b/src/pages/CommitPage/Summary/CommitDetailsSummary.spec.jsx
@@ -53,7 +53,7 @@ const commit = {
   },
   compareWithParent: {
     state: 'processed',
-    patchTotals: { coverage: 0.75 },
+    patchTotals: { coverage: 75 },
     impactedFiles: [
       {
         patchCoverage: { coverage: 75 },

--- a/src/pages/CommitPage/Summary/hooks.js
+++ b/src/pages/CommitPage/Summary/hooks.js
@@ -12,7 +12,7 @@ export function getCommitDataForSummary({
   commitid,
 }) {
   const rawPatch = compareWithParent?.patchTotals?.coverage
-  const patchCoverage = isNumber(rawPatch) ? rawPatch * 100 : Number.NaN
+  const patchCoverage = isNumber(rawPatch) ? rawPatch : Number.NaN
   const headCoverage = totals?.coverage
   const parentCoverage = parent?.totals?.coverage
 

--- a/src/pages/CommitPage/Summary/hooks.spec.js
+++ b/src/pages/CommitPage/Summary/hooks.spec.js
@@ -73,7 +73,7 @@ const data = {
     },
     compareWithParent: {
       state: 'processed',
-      patchTotals: { coverage: 0.75 },
+      patchTotals: { coverage: 75 },
       impactedFiles: [
         {
           patchCoverage: { coverage: 75 },
@@ -93,7 +93,7 @@ const headCoverage = commit?.totals?.coverage
 
 const successfulExpectedData = {
   headCoverage: commit?.totals?.coverage,
-  patchCoverage: isNumber(rawPatch) ? rawPatch * 100 : Number.NaN,
+  patchCoverage: isNumber(rawPatch) ? rawPatch : Number.NaN,
   changeCoverage: headCoverage - parentCoverage,
   headCommitId: commit?.commitid,
   parentCommitId: commit?.parent?.commitid,

--- a/src/pages/PullRequestPage/Summary/usePullForCompareSummary.js
+++ b/src/pages/PullRequestPage/Summary/usePullForCompareSummary.js
@@ -1,3 +1,4 @@
+import isNumber from 'lodash/isNumber'
 import { useMemo } from 'react'
 import { useParams } from 'react-router-dom'
 
@@ -18,9 +19,11 @@ export function getPullDataForCompareSummary({
     }
   }
 
+  const rawPatch = compareWithBase?.patchTotals?.percentCovered
+
   return {
     headCoverage: head?.totals?.percentCovered,
-    patchCoverage: compareWithBase?.patchTotals?.percentCovered * 100,
+    patchCoverage: isNumber(rawPatch) ? rawPatch : Number.NaN,
     changeCoverage: compareWithBase?.changeWithParent,
     hasDifferentNumberOfHeadAndBaseReports:
       compareWithBase?.hasDifferentNumberOfHeadAndBaseReports,

--- a/src/pages/PullRequestPage/Summary/usePullForCompareSummary.spec.js
+++ b/src/pages/PullRequestPage/Summary/usePullForCompareSummary.spec.js
@@ -39,7 +39,7 @@ const pull = {
   },
   compareWithBase: {
     patchTotals: {
-      percentCovered: 0.9212,
+      percentCovered: 92.12,
     },
     changeWithParent: 38.94,
     hasDifferentNumberOfHeadAndBaseReports: true,
@@ -64,7 +64,7 @@ const commits = [
 
 const succesfulExpectedData = {
   headCoverage: head?.totals?.percentCovered,
-  patchCoverage: compareWithBase?.patchTotals?.percentCovered * 100,
+  patchCoverage: compareWithBase?.patchTotals?.percentCovered,
   changeCoverage: compareWithBase?.changeWithParent,
   head: {
     totals: head?.totals,

--- a/src/pages/RepoPage/CommitsTab/CommitsTable/CommitsTable.jsx
+++ b/src/pages/RepoPage/CommitsTab/CommitsTable/CommitsTable.jsx
@@ -81,7 +81,7 @@ function transformPullToTable(commits) {
       } = commit
       const change = totals?.coverage - parent?.totals?.coverage
       const patchValue = compareWithParent?.patchTotals?.coverage
-        ? compareWithParent?.patchTotals?.coverage * 100
+        ? compareWithParent?.patchTotals?.coverage
         : Number.NaN
 
       return {


### PR DESCRIPTION
https://codecovio.atlassian.net/browse/CODE-1147

Depends on https://github.com/codecov/codecov-api/pull/1300

The GraphQL API will return patch coverage as a percentage now so we don't need to multiply by 100 on the frontend.