### PR TITLE
Add a Licensing link for self hosted

### DIFF
--- a/src/layouts/Footer/Footer.jsx
+++ b/src/layouts/Footer/Footer.jsx
@@ -12,23 +12,25 @@ function Footer() {
   })
 
   const year = new Date().getUTCFullYear()
-  const version = config.IS_SELF_HOSTED
+  const buildModeLeftMenu = config.IS_SELF_HOSTED
     ? [{ text: config?.CODECOV_VERSION }]
     : []
+
   const leftMenu = [
     { text: `© ${year} Codecov` },
-    ...version,
+    ...buildModeLeftMenu,
     { to: { pageName: 'terms' } },
     { to: { pageName: 'privacy' } },
     { to: { pageName: 'security' } },
     { to: { pageName: 'gdpr' } },
   ]
 
-  const pricing = !config.IS_SELF_HOSTED
-    ? [{ to: { pageName: 'pricing' } }]
-    : []
+  const buildModeRightMenu = config.IS_SELF_HOSTED
+    ? [{ to: { pageName: 'selfHostedLicensing' } }]
+    : [{ to: { pageName: 'pricing' } }]
+
   const rightMenu = [
-    ...pricing,
+    ...buildModeRightMenu,
     { to: { pageName: 'support' } },
     { to: { pageName: 'docs' } },
     { to: { pageName: 'enterprise' } },

--- a/src/layouts/Footer/Footer.spec.jsx
+++ b/src/layouts/Footer/Footer.spec.jsx
@@ -76,7 +76,7 @@ describe('Footer', () => {
     })
   })
 
-  describe('pricing link', () => {
+  describe('build mode specific links', () => {
     describe('on cloud', () => {
       beforeEach(() => {
         setup()
@@ -86,6 +86,9 @@ describe('Footer', () => {
         const pricing = screen.getByText('Pricing')
         expect(pricing).toBeInTheDocument()
       })
+      it('renders licensing link', () => {
+        expect(screen.queryByText('Licensing')).not.toBeInTheDocument()
+      })
     })
     describe('self hosted build', () => {
       beforeEach(() => {
@@ -94,6 +97,9 @@ describe('Footer', () => {
       afterEach(() => jest.resetAllMocks())
       it('does not render pricing link', () => {
         expect(screen.queryByText('Pricing')).not.toBeInTheDocument()
+      })
+      it('renders licensing link', () => {
+        expect(screen.getByText('Licensing')).toBeInTheDocument()
       })
     })
   })

--- a/src/services/navigation/useNavLinks/useStaticNavLinks.js
+++ b/src/services/navigation/useNavLinks/useStaticNavLinks.js
@@ -238,5 +238,12 @@ export function useStaticNavLinks() {
       isExternalLink: true,
       openNewTab: true,
     },
+    selfHostedLicensing: {
+      text: 'Licensing',
+      path: () =>
+        'https://docs.codecov.com/docs/self-hosted-dependency-licensing',
+      isExternalLink: true,
+      openNewTab: true,
+    },
   }
 }

--- a/src/services/navigation/useNavLinks/useStatickNavLinks.spec.js
+++ b/src/services/navigation/useNavLinks/useStatickNavLinks.spec.js
@@ -56,6 +56,7 @@ describe('useStaticNavLinks', () => {
       ${links.missingComparisonReport} | ${'https://docs.codecov.com/docs/error-reference#missing-base-report'}
       ${links.flagsFeedback}           | ${'https://github.com/codecov/Codecov-user-feedback/issues/27'}
       ${links.orgUploadTokenDoc}       | ${'https://docs.codecov.com/codecov-uploader#organization-upload-token'}
+      ${links.selfHostedLicensing}     | ${'https://docs.codecov.com/docs/self-hosted-dependency-licensing'}
     `('static links return path', ({ link, outcome }) => {
       it(`${link.text}: Returns the correct link`, () => {
         expect(link.path()).toBe(outcome)


### PR DESCRIPTION
# Description
When Gazebo is running in self hosted mode add a link for licensing dependency agreements.

# Screenshots
![Screenshot 2023-01-11 at 11 13 08 AM](https://user-images.githubusercontent.com/87824812/211842837-1085b635-6a37-4315-95d2-161de32d94ff.png)
