### PR TITLE
Add whitespace-nowrap to button option

### DIFF
--- a/src/ui/OptionButton/OptionButton.jsx
+++ b/src/ui/OptionButton/OptionButton.jsx
@@ -7,11 +7,14 @@ function OptionButton({ active, options, onChange }) {
       {options.map((o, index) => {
         return (
           <button
-            className={cs('flex-1 py-1 px-2 text-sm cursor-pointer', {
-              'bg-ds-blue-darker text-white font-semibold': active === o.text,
-              'rounded-l': index === 0,
-              'rounded-r': index === options.length - 1,
-            })}
+            className={cs(
+              'flex-1 py-1 px-2 text-sm cursor-pointer whitespace-nowrap',
+              {
+                'bg-ds-blue-darker text-white font-semibold': active === o.text,
+                'rounded-l': index === 0,
+                'rounded-r': index === options.length - 1,
+              }
+            )}
             onClick={() => {
               onChange(o)
             }}


### PR DESCRIPTION
# Description
https://developer.mozilla.org/en-US/docs/Web/CSS/white-space
Prevents text from breaking a new line on an element, good for UI elements with shorter text so things don't break weirdly as the screen scales down.

# Screenshots
Before
![Screenshot 2023-01-12 at 2 55 01 PM](https://user-images.githubusercontent.com/87824812/212158171-082c80ce-f6a3-41a4-aafe-bbdcc6553f47.png)

After
![Screenshot 2023-01-12 at 10 58 13 AM](https://user-images.githubusercontent.com/87824812/212157913-5719383c-b24d-44c2-9c25-706bb5d2e7ed.png)
