### PR TITLE
Mostly fix border on uploads and yaml loading spinner

### DIFF
--- a/src/pages/CommitPage/UploadsCard/Upload.jsx
+++ b/src/pages/CommitPage/UploadsCard/Upload.jsx
@@ -26,7 +26,7 @@ const Upload = ({
   const isCarriedForward = uploadType === UploadTypeEnum.CARRIED_FORWARD
 
   return (
-    <div className="py-2 px-4 flex flex-col gap-1">
+    <div className="py-2 px-4 flex flex-col gap-1 border-r border-ds-gray-secondary">
       <div className="flex justify-between ">
         <div className="flex-1 flex gap-1 flex-wrap">
           <UploadReference ciUrl={ciUrl} name={name} buildCode={buildCode} />

--- a/src/pages/CommitPage/UploadsCard/UploadsCard.jsx
+++ b/src/pages/CommitPage/UploadsCard/UploadsCard.jsx
@@ -26,11 +26,11 @@ function UploadsCard() {
           </div>
           <span className="text-ds-gray-quinary">{uploadsOverview}</span>
         </div>
-        <div className="bg-ds-gray-primary h-64 max-h-64 min-w-[24rem] overflow-auto flex flex-col flex-1 divide-y divide-solid divide-ds-gray-secondary">
+        <div className="bg-ds-gray-primary max-h-64 min-w-[24rem] overflow-auto flex flex-col flex-1 divide-y divide-solid divide-ds-gray-secondary">
           {uploadsProviderList.map((title) => (
             <Fragment key={title}>
               {title !== NULL && (
-                <span className="sticky top-0 bg-ds-gray-primary text-sm font-semibold flex-1 py-1 px-4">
+                <span className="sticky top-0 bg-ds-gray-primary text-sm font-semibold flex-1 py-1 px-4 border-r border-ds-gray-secondary">
                   {title}
                 </span>
               )}

--- a/src/pages/CommitPage/YamlModal/YamlModal.jsx
+++ b/src/pages/CommitPage/YamlModal/YamlModal.jsx
@@ -22,7 +22,13 @@ function YamlModal({ showYAMLModal, setShowYAMLModal }) {
       onClose={() => setShowYAMLModal(false)}
       title="Yaml"
       body={
-        <Suspense fallback={<Spinner size={40} />}>
+        <Suspense
+          fallback={
+            <div className="mx-auto w-fit">
+              <Spinner size={40} />
+            </div>
+          }
+        >
           <div className="flex flex-col gap-3">
             {invalidYaml && <YamlModalErrorBanner />}
             <YAMLViewer />


### PR DESCRIPTION
# Description
Quick css fix.

# Notable Changes
- The border is being rendered off by 1px but I think this is better. We'd need more time to investigate why the contents is being pushed out 1px.

# Screenshots
![Screenshot 2023-01-16 at 4 37 26 PM](https://user-images.githubusercontent.com/87824812/212761998-bea65157-f91a-430a-8014-81f7db048de0.png)

![Screenshot 2023-01-16 at 4 38 47 PM](https://user-images.githubusercontent.com/87824812/212762166-be07d4d0-fec3-47e3-89d5-ca952808b5c2.png)

# Link to Sample Entry