### PR TITLE
Add a 30 second cache time to legacy chart apis

### DIFF
--- a/src/pages/AnalyticsPage/Chart/useCoverage.js
+++ b/src/pages/AnalyticsPage/Chart/useCoverage.js
@@ -44,6 +44,8 @@ export const useCoverage = ({ params }, options = {}) => {
           return newData
         }
       },
+      staleTime: 30000,
+      keepPreviousData: false,
       ...newOptions,
     },
   })

--- a/src/pages/RepoPage/CoverageTab/hooks/useRepoCoverageTimeseries.js
+++ b/src/pages/RepoPage/CoverageTab/hooks/useRepoCoverageTimeseries.js
@@ -68,6 +68,8 @@ export function useRepoCoverageTimeseries({ branch }, options = {}) {
           return newData
         }
       },
+      staleTime: 30000,
+      keepPreviousData: false,
       ...newOptions,
     },
   })


### PR DESCRIPTION
# Description
Add a safety throttle to the front end to prevent too many internal chart api requests via normal use.

# Code Example

# Notable Changes

# Screenshots

# Link to Sample Entry