### PR TITLE
remove note from setup page

### DIFF
--- a/src/pages/RepoPage/NewRepoTab/Token/Token.jsx
+++ b/src/pages/RepoPage/NewRepoTab/Token/Token.jsx
@@ -1,7 +1,5 @@
 import PropTypes from 'prop-types'
 
-import config from 'config'
-
 import { useOnboardingTracking } from 'layouts/UserOnboarding/useOnboardingTracking'
 import CopyClipboard from 'ui/CopyClipboard'
 
@@ -24,12 +22,6 @@ export default function Token({
           </span>
           <CopyClipboard string={token} onClick={() => copiedCIToken(token)} />
         </p>
-      )}
-      {!config.IS_SELF_HOSTED && (
-        <i className="font-light">
-          *Not required if your repo is using GitHub Actions, Travic CI,
-          CircleCI, AppVeyor, or Azure Pipelines.
-        </i>
       )}
     </div>
   )

--- a/src/pages/RepoPage/NewRepoTab/Token/Token.spec.jsx
+++ b/src/pages/RepoPage/NewRepoTab/Token/Token.spec.jsx
@@ -28,9 +28,6 @@ describe('Token', () => {
       setup({ uploadToken: 'mytoken', privateRepo: true })
     })
     it('with a token', () => {
-      expect(
-        screen.getByText(/Not required if your repo is using GitHub Actions/)
-      ).toBeInTheDocument()
       expect(screen.getByText(/mytoken/, { exact: false })).toBeInTheDocument()
     })
   })
@@ -43,11 +40,6 @@ describe('Token', () => {
         isCurrentUserPartOfOrg: true,
       })
 
-      expect(
-        screen.getByText(/Not required if your repo is using GitHub Actions/, {
-          exact: false,
-        })
-      ).toBeInTheDocument()
       expect(screen.getByText(/mytoken/)).toBeInTheDocument()
     })
 
@@ -58,11 +50,6 @@ describe('Token', () => {
         isCurrentUserPartOfOrg: false,
       })
 
-      expect(
-        screen.getByText(/Not required if your repo is using GitHub Actions/, {
-          exact: false,
-        })
-      ).toBeInTheDocument()
       expect(screen.queryByText(/mytoken/)).not.toBeInTheDocument()
     })
   })


### PR DESCRIPTION
# Description
We are trying to bring our Github rate limit under control and want to stop proposing tokenless uploads for open source usage.  
Remove the note from repo setup page.