### PR TITLE
Update Logo and Unfurl Size

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -11,10 +11,10 @@
     <meta property="og:site_name" content="Codecov">
     <meta property="og:title" content="Code coverage done right.">
     <meta property="og:description" content="Hosted coverage report highly integrated with GitHub, Bitbucket and GitLab. Awesome pull request comments to enhance your QA.">
-    <meta property="og:image" content="https://codecov-cdn.storage.googleapis.com/static/codecov-logo.png">
+    <meta property="og:image" content="https://storage.googleapis.com/codecov-cdn/static/Codecov-icon-600x600.png">
     <meta property="og:image:type" content="image/png">
-    <meta property="og:image:width" content="1200">
-    <meta property="og:image:height" content="1200">
+    <meta property="og:image:width" content="150">
+    <meta property="og:image:height" content="150">
     <meta property="twitter:site" content="codecov">
     <meta property="twitter:site:id" content="122181800">
     <meta property="twitter:creator" content="codecov">
@@ -22,9 +22,9 @@
     <meta property="twitter:card" content="summary_large_image">
     <meta property="twitter:title" content="Codecov">
     <meta property="twitter:description" content="Code coverage done right. Hosted coverage report highly integrated with GitHub, Bitbucket and GitLab. Awesome pull request comments to enhance your QA.">
-    <meta property="twitter:image:src" content="https://codecov-cdn.storage.googleapis.com/static/codecov-logo.png">
-    <meta property="twitter:image:width" content="1200">
-    <meta property="twitter:image:height" content="1200">
+    <meta property="twitter:image:src" content="https://storage.googleapis.com/codecov-cdn/static/Codecov-icon-600x600.png">
+    <meta property="twitter:image:width" content="600">
+    <meta property="twitter:image:height" content="600">
 
 
     <meta


### PR DESCRIPTION
# Description

This updates the logo to our new logo and sets a much smaller size for link previews. This should help when codecov links are unfurled in Twitter, Slack, etc. 

Note that I sort of guessed on what would work for `og:image:width` to 150px. It looks about right based on my estimation, but I'm not sure what will actually happen until we see it unfurl in slack. Worst case we can just revert, but I think it will be fine. 

Note that I followed this guide to try and determine some changes to make, we could definitely do more here for specific commits, etc, to include more relevant information if we really wanted to: https://whitep4nth3r.com/blog/level-up-your-link-previews-in-slack/

My guess/hope is this will be small enough to have the image hosted _beside_ the text instead of being so big it wraps underneath it. Regardless, I don't think it can be worse. 

# Code Example
N/A

# Notable Changes
N/A

# Screenshots

Here's the old look
![Screenshot 2023-01-25 at 3 22 08 PM](https://user-images.githubusercontent.com/87772943/214693829-db70ba61-5210-4b2d-ac37-f93c9ad1272d.png)

Direct link to new icon: https://storage.googleapis.com/codecov-cdn/static/Codecov-icon-600x600.png

# Link to Sample Entry
N/A