### PR TITLE
One more try at Unfurling

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -23,8 +23,8 @@
     <meta property="twitter:title" content="Codecov">
     <meta property="twitter:description" content="Code coverage done right. Hosted coverage report highly integrated with GitHub, Bitbucket and GitLab. Awesome pull request comments to enhance your QA.">
     <meta property="twitter:image:src" content="https://storage.googleapis.com/codecov-cdn/static/Codecov-icon-600x600.png">
-    <meta property="twitter:image:width" content="600">
-    <meta property="twitter:image:height" content="600">
+    <meta property="twitter:image:width" content="150">
+    <meta property="twitter:image:height" content="150">
 
 
     <meta


### PR DESCRIPTION

# Description

the previous change here lowered the twitter image settings to 600px. I did this to match to default size of the new image (600x600), thinking that Slack honored the `og:...` atrributes for unfurling. Slack does honor these, but it takes preference to twitter attributes if they show up first. So based on this medium post: https://medium.com/slack-developer-blog/everything-you-ever-wanted-to-know-about-unfurling-but-were-afraid-to-ask-or-how-to-make-your-e64b4bb9254

we need to reduce the size for the twitter attributes as well. This will very likely also shrink the thumbnail on twitter, but i'm not sure that's actually a problem.