### PR TITLE
Attempt Summary card designation

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -19,7 +19,7 @@
     <meta property="twitter:site:id" content="122181800">
     <meta property="twitter:creator" content="codecov">
     <meta property="twitter:creator:id" content="122181800">
-    <meta property="twitter:card" content="summary_large_image">
+    <meta property="twitter:card" content="summary">
     <meta property="twitter:title" content="Codecov">
     <meta property="twitter:description" content="Code coverage done right. Hosted coverage report highly integrated with GitHub, Bitbucket and GitLab. Awesome pull request comments to enhance your QA.">
     <meta property="twitter:image:src" content="https://storage.googleapis.com/codecov-cdn/static/Codecov-icon-600x600.png">


### PR DESCRIPTION
# Description

This changes the twitter card type to `summary` from `summary_large_image`. This is my last attempt to shrink the image preview in slack and other locations when app.codecov.io urls are shared. 

docs for this madness are here: https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/summary

General guidelines state that the large summary card _shouldn't_ be used for application logos, but provides no alternative for what to use if you're representing a logo.

# Grumbling

The fact that twitter won the Unfurling War to such a point that other websites rely on their meta tags and prioritize them over open standards is really something else. 