### PR TITLE
update z-indexs so selects are ontop of sticky elements

### DIFF
--- a/src/pages/RepoPage/RepoBreadcrumb.jsx
+++ b/src/pages/RepoPage/RepoBreadcrumb.jsx
@@ -6,7 +6,7 @@ export default function RepoBreadcrumb() {
   const crumbs = useCrumbs()
 
   return (
-    <div className="sticky top-0 z-20 bg-white px-6 sm:px-0 py-2 flex flex-row">
+    <div className="sticky top-0 z-10 bg-white px-6 sm:px-0 py-2 flex flex-row">
       <Breadcrumb paths={crumbs} />
     </div>
   )

--- a/src/pages/RepoPage/RepoPage.jsx
+++ b/src/pages/RepoPage/RepoPage.jsx
@@ -95,7 +95,7 @@ function RepoPage() {
       <div>
         <RepoBreadcrumb />
         {repoHasCommits && isRepoActivated && (
-          <div className="sticky top-8 z-30 bg-white mb-2">
+          <div className="sticky top-8 z-10 bg-white mb-2">
             <TabNavigation
               tabs={getRepoTabs({
                 matchTree,

--- a/src/ui/MultiSelect/MultiSelect.jsx
+++ b/src/ui/MultiSelect/MultiSelect.jsx
@@ -17,7 +17,7 @@ const SelectClasses = {
   button:
     'flex justify-between items-center w-full border border-ds-gray-tertiary rounded bg-white text-left px-3 h-8 disabled:text-ds-gray-quaternary disabled:bg-ds-gray-primary disabled:border-ds-gray-tertiary focus:outline-1',
   listContainer:
-    'overflow-hidden rounded-bl rounded-br bg-white border-ds-gray-tertiary absolute w-full z-10 max-h-80 min-w-fit',
+    'overflow-hidden rounded-bl rounded-br bg-white border-ds-gray-tertiary absolute w-full z-20 max-h-80 min-w-fit',
   listItem: 'block cursor-pointer py-1 px-3 text-sm',
   loadMoreTrigger: 'relative top-[-65px] invisible block leading-[0]',
 }

--- a/src/ui/Select/Select.jsx
+++ b/src/ui/Select/Select.jsx
@@ -16,14 +16,14 @@ const SelectClasses = {
   item: 'block cursor-pointer py-1 px-3 text-sm font-normal',
   button:
     'flex justify-between items-center w-full rounded bg-white text-left whitespace-nowrap disabled:text-ds-gray-quaternary disabled:bg-ds-gray-primary disabled:border-ds-gray-tertiary focus:outline-1',
-  ul: 'overflow-hidden rounded-bl rounded-br bg-white border-ds-gray-tertiary absolute w-full z-10 max-h-80 min-w-fit',
+  ul: 'overflow-hidden rounded-bl rounded-br bg-white border-ds-gray-tertiary absolute w-full z-20 max-h-80 min-w-fit',
   loadMoreTrigger: 'relative top-[-65px] invisible block leading-[0]',
 }
 
 const UlVariantClass = {
   default: 'w-full border-gray-ds-tertiary',
   gray: 'w-full border-gray-ds-tertiary',
-  text: 'left-0 z-10 whitespace-nowrap',
+  text: 'left-0 whitespace-nowrap',
 }
 
 const ButtonVariantClass = {


### PR DESCRIPTION
# Description
Previously I had the open select boxes hide under the sticky header elements but in the case of a file viewer on the coverage tab to header was below the select visually making it look odd. This change makes them render on top. A bit jank but I don't think I'm concerned enough with it to move to a JS solution till we're really polishing, we have bigger styles to fry (like fixing mobile).

# Code Example

# Notable Changes

# Screen
<img width="759" alt="Screenshot 2023-01-26 at 9 38 57 AM" src="https://user-images.githubusercontent.com/87824812/214852047-c5afdeff-2546-4e51-bacd-e9028bd2f953.png">


# Link to Sample Entry