### PR TITLE
Fix gitlab subgroup link check

### DIFF
--- a/src/ui/A/A.jsx
+++ b/src/ui/A/A.jsx
@@ -29,7 +29,7 @@ function _adjustPathForGLSubgroups(path) {
   // this => "user:subgroup", but Gitlab URLs look like this => "user/subgroup". Hence, this function
   // is to detect if we have a gitlab user with a subgroup and adjust it accordingly. The regex identifies the
   // domain + owner (by selecting everything till the next forward slash) and selecting everything else
-  if (!path.includes('gitlab')) {
+  if (!path.includes('gitlab.com')) {
     return path
   }
 


### PR DESCRIPTION
# Description
Fix gitlab subgroup link check to only fire if the link is to gitlab.com not if any of the url contains the word gitlab

# Notable Changes
The regex for a link to github was a bit too loose, so a link containing gitlab broke in the url but was not linking to the site caused the whole app to fail for a user.

https://app.codecov.io/gh/larscom/gitlab-ci-dashboard/blob/master/api/src/main/kotlin/com/github/larscom/gitlabcidashboard/feign/GitlabFeignClient.kt