### PR TITLE
Code 2642 reduce font size on flags not yet configured message

### DIFF
--- a/src/shared/FlagsNotConfigured/FlagsNotConfigured.jsx
+++ b/src/shared/FlagsNotConfigured/FlagsNotConfigured.jsx
@@ -3,17 +3,17 @@ import A from 'ui/A'
 
 function FlagsNotConfigured() {
   return (
-    <div className="mt-2 flex flex-col items-center justify-center gap-2 text-ds-gray-octonary">
+    <div className="mt-2 flex flex-col items-center justify-center gap-2 text-base text-ds-gray-octonary">
       <div className="flex min-w-[60%] flex-col justify-center gap-2 text-center">
         <img
           alt="Flags feature not configured"
           className="mx-auto mb-8 w-screen"
           src={flagManagement}
         />
-        <span className="text-3xl">
+        <span className="font-semibold">
           The Flags feature is not yet configured{' '}
         </span>
-        <span className="text-base">
+        <span>
           Learn how flags can{' '}
           <A hook="flags" to={{ pageName: 'flags' }}>
             help your team today


### PR DESCRIPTION
# Description
Reduce the font size, it looked kinda weird  ↙️

# Screenshots
before:
<img width="1512" alt="Screenshot 2023-02-21 at 1 24 21 PM" src="https://user-images.githubusercontent.com/91732700/220332288-110bd994-6aea-4961-8627-0d3d352d0a42.png">


after:
<img width="1512" alt="Screenshot 2023-02-21 at 1 17 03 PM" src="https://user-images.githubusercontent.com/91732700/220330796-6c87bd90-3802-480b-9132-b844a9d87cd4.png">


# Link to Sample Entry
/gh/codecov/gazebo/pull/1890/flags