### PR TITLE
Fix tab active styles in jit

### DIFF
--- a/src/ui/TabNavigation/TabNavigation.jsx
+++ b/src/ui/TabNavigation/TabNavigation.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 import AppLink from 'shared/AppLink'
 
 const styles = {
-  link: 'mr-5 py-2 border-b-4 border-transparent hover:border-ds-gray-quinary text-ds-gray-quinary',
+  link: 'mr-5 py-2 hover:border-b-4 hover:border-ds-gray-quinary text-ds-gray-quinary',
   activeLink:
     'text-ds-gray-octonary border-b-4 border-ds-gray-octonary font-semibold',
 }


### PR DESCRIPTION
# Description
We switched to JIT which only applies one class at a time, this caused a bug where we were previously rendering two borders at once. To fix the border is only applied when hovering or active preventing the class conflict.

# Code Example

# Notable Changes

# Screenshots

# Link to Sample Entry