### PR TITLE
Remove extra divs 

### DIFF
--- a/src/shared/ListRepo/ReposTable/NoRepoCoverage.jsx
+++ b/src/shared/ListRepo/ReposTable/NoRepoCoverage.jsx
@@ -12,7 +12,7 @@ function NoRepoCoverage({
   return (
     <span className="text-sm text-ds-gray-quinary">
       {activated ? (
-        <div className="whitespace-nowrap">No data available</div>
+        'No data available'
       ) : (
         <InactiveRepo
           owner={owner}

--- a/src/shared/ListRepo/ReposTable/ReposTable.jsx
+++ b/src/shared/ListRepo/ReposTable/ReposTable.jsx
@@ -27,9 +27,7 @@ const tableActive = [
   },
   {
     id: 'lastUpdated',
-    header: (
-      <div className="whitespace-normal sm:whitespace-nowrap">Last updated</div>
-    ),
+    header: 'Last updated',
     accessorKey: 'lastUpdated',
     width: 'w-2/12',
     cell: (info) => info.getValue(),
@@ -37,24 +35,16 @@ const tableActive = [
   },
   {
     id: 'lines',
-    header: (
-      <div className="whitespace-normal sm:whitespace-nowrap">
-        Tracked lines
-      </div>
-    ),
+    header: 'Tracked lines',
     accessorKey: 'lines',
-    width: 'w-2/12 lg:w-1/12',
+    width: 'w-2/12',
     cell: (info) => info.getValue(),
   },
   {
     id: 'coverage',
-    header: (
-      <div className="whitespace-normal sm:whitespace-nowrap">
-        Test coverage
-      </div>
-    ),
+    header: 'Test coverage',
     accessorKey: 'coverage',
-    width: 'w-2/12',
+    width: 'w-3/12',
     cell: (info) => info.getValue(),
   },
 ]

--- a/src/ui/Table/Table.jsx
+++ b/src/ui/Table/Table.jsx
@@ -13,7 +13,7 @@ import Icon from 'ui/Icon'
 
 const TableClasses = {
   headerCell:
-    'flex grow !font-sans font-semibold py-2 text-sm px-0 sm:px-3.5 text-ds-gray-quinary gap-1 items-center whitespace-nowrap',
+    'flex grow !font-sans font-semibold py-2 text-sm px-0 sm:px-3.5 text-ds-gray-quinary gap-1 items-center',
   headerRow: 'flex gap-2 text-left border-t border-b border-ds-black-secondary',
   tableRow: 'flex gap-2 border-t border-ds-black-secondary',
   tableCell:


### PR DESCRIPTION
# Description
removing extra divs of the table

# Screenshots
the word wrapping in small screen is just set to default:
<img width="570" alt="Screenshot 2023-02-23 at 7 47 10 PM" src="https://user-images.githubusercontent.com/91732700/220988169-6c3c3afe-fc69-43aa-b377-dbad1e25a999.png">
<img width="570" alt="Screenshot 2023-02-23 at 7 47 01 PM" src="https://user-images.githubusercontent.com/91732700/220988184-9f14d4ac-1d10-4c51-9c36-43499d5bab8a.png">


# Link to Sample Entry
/gh/codecov