### PR TITLE
Make failures with sentry sdk actually fail PRs

### DIFF
--- a/scripts/sentry.js
+++ b/scripts/sentry.js
@@ -5,6 +5,7 @@ async function createReleaseAndUpload() {
   const release = process.env.REACT_APP_SENTRY_RELEASE
   if (!release) {
     console.warn('REACT_APP_SENTRY_RELEASE is not set')
+    process.exitCode = 1
     return
   }
   const cli = new SentryCli()
@@ -21,6 +22,7 @@ async function createReleaseAndUpload() {
     await cli.releases.finalize(release)
   } catch (e) {
     console.error('Source maps uploading failed:', e)
+    process.exitCode = 1
   }
 }
 


### PR DESCRIPTION
# Description
Have `sentry.js` exit so we know when it is failing rather then being a passing check 100% of the time. (This still doesn't resolve our issues sadly, just making sure we dont go months without alerts)

# Code Example

# Notable Changes

# Screenshots

# Link to Sample Entry