### PR TITLE
Update sentry round 2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
       "dependencies": {
         "@hookform/resolvers": "^2.8.5",
         "@reach/menu-button": "^0.18.0",
-        "@sentry/cli": "^2.13.0",
         "@sentry/react": "^7.39.0",
         "@sentry/replay": "^7.39.0",
         "@sentry/tracing": "^7.39.0",
@@ -54,6 +53,7 @@
       },
       "devDependencies": {
         "@babel/core": "^7.17.8",
+        "@sentry/cli": "^2.13.0",
         "@storybook/addon-a11y": "^6.5.16",
         "@storybook/addon-actions": "^6.5.16",
         "@storybook/addon-essentials": "^6.5.16",
@@ -4773,6 +4773,7 @@
       "version": "2.13.0",
       "resolved": "https://registry.npmjs.org/@sentry/cli/-/cli-2.13.0.tgz",
       "integrity": "sha512-F0WmiMmVjn6zZyD89MF8B1zGgcrJTi5yxPmd+sqpRKOfGCtucdRdM/BL1aU27BApaseCCfI1bgwtJSB2fUQqlw==",
+      "dev": true,
       "hasInstallScript": true,
       "dependencies": {
         "https-proxy-agent": "^5.0.0",
@@ -12721,6 +12722,7 @@
     },
     "node_modules/agent-base": {
       "version": "6.0.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "4"
@@ -16571,6 +16573,7 @@
     },
     "node_modules/debug": {
       "version": "4.3.4",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "2.1.2"
@@ -20285,6 +20288,7 @@
     },
     "node_modules/https-proxy-agent": {
       "version": "5.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "agent-base": "6",
@@ -21323,6 +21327,7 @@
     },
     "node_modules/isexe": {
       "version": "2.0.0",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/isobject": {
@@ -26586,6 +26591,7 @@
     },
     "node_modules/ms": {
       "version": "2.1.2",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/msw": {
@@ -26867,6 +26873,7 @@
     },
     "node_modules/node-fetch": {
       "version": "2.6.7",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "whatwg-url": "^5.0.0"
@@ -29318,6 +29325,7 @@
     },
     "node_modules/progress": {
       "version": "2.0.3",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
@@ -29426,6 +29434,7 @@
     },
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/prr": {
@@ -34054,6 +34063,7 @@
     },
     "node_modules/tr46": {
       "version": "0.0.3",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/tree-kill": {
@@ -36097,6 +36107,7 @@
     },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tr46": "~0.0.3",
@@ -36105,10 +36116,12 @@
     },
     "node_modules/whatwg-url/node_modules/webidl-conversions": {
       "version": "3.0.1",
+      "dev": true,
       "license": "BSD-2-Clause"
     },
     "node_modules/which": {
       "version": "2.0.2",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -39557,6 +39570,7 @@
       "version": "2.13.0",
       "resolved": "https://registry.npmjs.org/@sentry/cli/-/cli-2.13.0.tgz",
       "integrity": "sha512-F0WmiMmVjn6zZyD89MF8B1zGgcrJTi5yxPmd+sqpRKOfGCtucdRdM/BL1aU27BApaseCCfI1bgwtJSB2fUQqlw==",
+      "dev": true,
       "requires": {
         "https-proxy-agent": "^5.0.0",
         "node-fetch": "^2.6.7",
@@ -44996,6 +45010,7 @@
     },
     "agent-base": {
       "version": "6.0.2",
+      "dev": true,
       "requires": {
         "debug": "4"
       }
@@ -47508,6 +47523,7 @@
     },
     "debug": {
       "version": "4.3.4",
+      "dev": true,
       "requires": {
         "ms": "2.1.2"
       }
@@ -49957,6 +49973,7 @@
     },
     "https-proxy-agent": {
       "version": "5.0.1",
+      "dev": true,
       "requires": {
         "agent-base": "6",
         "debug": "4"
@@ -50544,7 +50561,8 @@
       "dev": true
     },
     "isexe": {
-      "version": "2.0.0"
+      "version": "2.0.0",
+      "dev": true
     },
     "isobject": {
       "version": "3.0.1"
@@ -54024,7 +54042,8 @@
       }
     },
     "ms": {
-      "version": "2.1.2"
+      "version": "2.1.2",
+      "dev": true
     },
     "msw": {
       "version": "0.47.3",
@@ -54209,6 +54228,7 @@
     },
     "node-fetch": {
       "version": "2.6.7",
+      "dev": true,
       "requires": {
         "whatwg-url": "^5.0.0"
       }
@@ -55620,7 +55640,8 @@
       "dev": true
     },
     "progress": {
-      "version": "2.0.3"
+      "version": "2.0.3",
+      "dev": true
     },
     "promise": {
       "version": "8.2.0",
@@ -55694,7 +55715,8 @@
       }
     },
     "proxy-from-env": {
-      "version": "1.1.0"
+      "version": "1.1.0",
+      "dev": true
     },
     "prr": {
       "version": "1.0.1",
@@ -58782,7 +58804,8 @@
       }
     },
     "tr46": {
-      "version": "0.0.3"
+      "version": "0.0.3",
+      "dev": true
     },
     "tree-kill": {
       "version": "1.2.2",
@@ -60163,18 +60186,21 @@
     },
     "whatwg-url": {
       "version": "5.0.0",
+      "dev": true,
       "requires": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
       },
       "dependencies": {
         "webidl-conversions": {
-          "version": "3.0.1"
+          "version": "3.0.1",
+          "dev": true
         }
       }
     },
     "which": {
       "version": "2.0.2",
+      "dev": true,
       "requires": {
         "isexe": "^2.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "dependencies": {
     "@hookform/resolvers": "^2.8.5",
     "@reach/menu-button": "^0.18.0",
-    "@sentry/cli": "^2.13.0",
     "@sentry/react": "^7.39.0",
     "@sentry/replay": "^7.39.0",
     "@sentry/tracing": "^7.39.0",
@@ -84,6 +83,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.17.8",
+    "@sentry/cli": "^2.13.0",
     "@storybook/addon-a11y": "^6.5.16",
     "@storybook/addon-actions": "^6.5.16",
     "@storybook/addon-essentials": "^6.5.16",


### PR DESCRIPTION
# Description
The last PR the lock file was still resolving to 3.28, so we're going heavy handed about it.

# Notable Changes
* Trying to fix sentry to actually be useful.
* Also updated browser list which should not impact anything, just sets targets for postcss / some other dev server stuff.
