### PR TITLE
Split circle ci jobs.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,7 +109,7 @@ workflows:
       - test:
           requires:
             - install
-  build:
+  storybook-and-fossa:
     jobs:
       - install
       - storybook:


### PR DESCRIPTION
# Description
With the recent flaky tests splitting the jobs for the checks makes sense. Split is based on "external" and "internal" but not strongly held. I'm not convinced moving install out makes sense till we have more jobs.


# Notable Changes
- Should split the circle ci checks into two checks.
- Less checks to re run on flakey tests.