### PR TITLE
CODE-3044: Update Plan Page to Show Accurate Sentry Pricing

### DIFF
--- a/src/pages/PlanPage/subRoutes/CurrentOrgPlan/CurrentPlanCard/PlanPricing/PlanPricing.jsx
+++ b/src/pages/PlanPage/subRoutes/CurrentOrgPlan/CurrentPlanCard/PlanPricing/PlanPricing.jsx
@@ -1,6 +1,10 @@
 import PropTypes from 'prop-types'
 
-import { isEnterprisePlan, isFreePlan } from 'shared/utils/billing'
+import {
+  isEnterprisePlan,
+  isFreePlan,
+  isSentryPlan,
+} from 'shared/utils/billing'
 
 function PlanPricing({ value, baseUnitPrice }) {
   if (isFreePlan(value)) {
@@ -9,6 +13,10 @@ function PlanPricing({ value, baseUnitPrice }) {
 
   if (isEnterprisePlan(value)) {
     return <h2 className="text-4xl">Custom pricing</h2>
+  }
+
+  if (isSentryPlan(value)) {
+    return <h2 className="text-4xl">$29.99</h2>
   }
 
   return <h2 className="text-4xl uppercase">${baseUnitPrice}</h2>

--- a/src/pages/PlanPage/subRoutes/CurrentOrgPlan/CurrentPlanCard/PlanPricing/PlanPricing.spec.jsx
+++ b/src/pages/PlanPage/subRoutes/CurrentOrgPlan/CurrentPlanCard/PlanPricing/PlanPricing.spec.jsx
@@ -1,48 +1,114 @@
 import { render, screen } from '@testing-library/react'
 
+import { Plans } from 'shared/utils/billing'
+
 import PlanPricing from './PlanPricing'
 
 describe('PlanPricing', () => {
-  function setup(value) {
-    render(<PlanPricing value={value} baseUnitPrice={12} />)
-  }
-
   describe('user is on a free plan', () => {
-    beforeEach(() => {
-      setup('users-free')
-    })
-
     it('renders price is free', () => {
-      expect(screen.getByText('Free')).toBeInTheDocument()
+      render(<PlanPricing value={Plans.USERS_FREE} baseUnitPrice={12} />)
+
+      const price = screen.getByText('Free')
+      expect(price).toBeInTheDocument()
+    })
+  })
+
+  describe('user is on a basic plan', () => {
+    it('renders price is free', () => {
+      render(<PlanPricing value={Plans.USERS_BASIC} baseUnitPrice={12} />)
+
+      const price = screen.getByText('Free')
+      expect(price).toBeInTheDocument()
     })
   })
 
   describe('user is on a pro plan', () => {
-    beforeEach(() => {
-      setup('users-pr-inappm')
+    describe('monthly pro plan', () => {
+      describe('old pro plan', () => {
+        it('renders the base unit price', () => {
+          render(<PlanPricing value={Plans.USERS_INAPP} baseUnitPrice={12} />)
+
+          const price = screen.getByText('$12')
+          expect(price).toBeInTheDocument()
+        })
+      })
+
+      describe('new pro plan', () => {
+        it('renders the base unit price', () => {
+          render(
+            <PlanPricing value={Plans.USERS_PR_INAPPM} baseUnitPrice={12} />
+          )
+
+          const price = screen.getByText('$12')
+          expect(price).toBeInTheDocument()
+        })
+      })
     })
 
-    it('renders the base unit price', () => {
-      expect(screen.getByText('$12')).toBeInTheDocument()
+    describe('annual pro plan', () => {
+      describe('old pro plan', () => {
+        it('renders the base unit price', () => {
+          render(<PlanPricing value={Plans.USERS_INAPPY} baseUnitPrice={10} />)
+
+          const price = screen.getByText('$10')
+          expect(price).toBeInTheDocument()
+        })
+      })
+
+      describe('new pro plan', () => {
+        it('renders the base unit price', () => {
+          render(
+            <PlanPricing value={Plans.USERS_PR_INAPPY} baseUnitPrice={10} />
+          )
+
+          const price = screen.getByText('$10')
+          expect(price).toBeInTheDocument()
+        })
+      })
     })
   })
 
   describe('users is on an enterprise plan', () => {
     describe('enterprise plan is monthly', () => {
-      beforeEach(() => {
-        setup('users-enterprisem')
-      })
       it('renders custom pricing', () => {
-        expect(screen.getByText('Custom pricing')).toBeInTheDocument()
+        render(
+          <PlanPricing value={Plans.USERS_ENTERPRISEM} baseUnitPrice={10} />
+        )
+
+        const price = screen.getByText('Custom pricing')
+        expect(price).toBeInTheDocument()
       })
     })
 
     describe('enterprise plan is yearly', () => {
-      beforeEach(() => {
-        setup('users-enterprisey')
-      })
       it('renders custom pricing', () => {
-        expect(screen.getByText('Custom pricing')).toBeInTheDocument()
+        render(
+          <PlanPricing value={Plans.USERS_ENTERPRISEY} baseUnitPrice={10} />
+        )
+
+        const price = screen.getByText('Custom pricing')
+        expect(price).toBeInTheDocument()
+      })
+    })
+  })
+
+  describe('user is on a sentry plan', () => {
+    describe('annual sentry plan', () => {
+      it('renders the base unit price', () => {
+        render(<PlanPricing value={Plans.USERS_SENTRYY} baseUnitPrice={10} />)
+
+        const basePrice = screen.getByText(/\$29.99/)
+        expect(basePrice).toBeInTheDocument()
+      })
+    })
+
+    describe('monthly sentry plan', () => {
+      it('renders the base unit price', () => {
+        render(<PlanPricing value={Plans.USERS_SENTRYY} baseUnitPrice={12} />)
+
+        const price = screen.getByText(/\$29.99/)
+        expect(price).toBeInTheDocument()
       })
     })
   })


### PR DESCRIPTION
# Description

Currently only showing the additional user price, this switches it up to show the base Sentry plan price.

# Notable Changes

- Add check and show Sentry pricing value if the user is on a Sentry plan

# Screenshots

> **Note**: Another benefit has been added on the API side that is not present in this screenshot

![Screenshot 2023-03-23 at 11 38 57 AM](https://user-images.githubusercontent.com/105234307/227238073-c390a5d6-9d36-4ecf-bfb8-bf25519d3a7c.png)