### PR TITLE
Fix Critical File Label Not Being Centered

### DIFF
--- a/src/shared/ContentsTable/TableEntries/BaseEntries/FileEntry.jsx
+++ b/src/shared/ContentsTable/TableEntries/BaseEntries/FileEntry.jsx
@@ -33,7 +33,10 @@ function FileEntry({
 }) {
   const displayAsList = displayType === displayTypeParameter.list
   return (
-    <div onMouseEnter={async () => await runPrefetch()}>
+    <div
+      className="flex items-center"
+      onMouseEnter={async () => await runPrefetch()}
+    >
       <A
         to={{
           pageName,


### PR DESCRIPTION
# Description

Super small PR to fix the alignment of the `Critical File` label in the file explorer tables