### PR TITLE
Prevent pullid from being casted to NaN

### DIFF
--- a/src/pages/RepoPage/CommitsTab/CommitsTable/CommitsTable.jsx
+++ b/src/pages/RepoPage/CommitsTab/CommitsTable/CommitsTable.jsx
@@ -123,7 +123,7 @@ const Loader = () => (
 
 // eslint-disable-next-line complexity
 function CommitsTable({ branch, states, search }) {
-  const { provider, owner, repo, pullId } = useParams()
+  const { provider, owner, repo } = useParams()
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading } =
     useCommits({
       provider,
@@ -132,7 +132,6 @@ function CommitsTable({ branch, states, search }) {
       filters: {
         states,
         branchName: branch,
-        pullId: pullId ? +pullId : null,
         search,
       },
       opts: { suspense: false },


### PR DESCRIPTION
A `null` or `undefined` `pullId` was being casted to `NaN` here.  This resulted in `includeTotalCount` being `true` inside `useCommits`: https://github.com/codecov/gazebo/blob/3190365a40adc09a2a2725e291dac1d56621b3af/src/services/commits/useCommits.js#L83

We want to avoid fetching the `totalCount` outside the context of a pull since the backing database query could be quite slow to count ALL commits for a large repo.