### PR TITLE
Add header for x-frame-options to prevent clickjacking

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -8,3 +8,4 @@
   for = "/*"
   [headers.values]
     Access-Control-Allow-Origin = "events.launchdarkly.com"
+    X-Frame-Options = "DENY"


### PR DESCRIPTION
# Description
We have a clickjacking vulnerability client side, https://codecovio.atlassian.net/browse/CODE-2438. This is pretty much when any client embeds our website in theirs via an iframe. To fix that, we can set the x-frame-options to DENY. 

# Notable Changes
- Add headers `X-Frame-Options` to `DENY`

# Link to Sample Entry
To test this, I tested it w/ the preview deploy environment
``` html
<!DOCTYPE html>
<html lang="en-US">
  <head>
    <meta charset="UTF-8" />
    <title>i Frame</title>
  </head>
  <body>
    <h3>This is not clickjacking vulnerable</h3>
    <iframe
      src="https://deploy-preview-2012--gazebo-staging.netlify.app/login/gh"
      height="500px"
      width="500px"
    ></iframe>
  </body>
</html>

```

![Screenshot 2023-04-19 at 1 35 49 PM](https://user-images.githubusercontent.com/82913673/233193963-466da106-7d1a-4d86-b6ce-9fd7bc094ce3.png)

