### PR TITLE
Fix file sorting flakey tests

### DIFF
--- a/src/pages/CommitDetailPage/subRoute/CommitDetailFileExplorer/CommitDetailFileExplorer.spec.jsx
+++ b/src/pages/CommitDetailPage/subRoute/CommitDetailFileExplorer/CommitDetailFileExplorer.spec.jsx
@@ -1,5 +1,10 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { render, screen, waitFor, within } from '@testing-library/react'
+import {
+  render,
+  screen,
+  waitFor,
+  waitForElementToBeRemoved,
+} from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { graphql } from 'msw'
 import { setupServer } from 'msw/node'
@@ -140,45 +145,45 @@ describe('CommitDetailFileExplorer', () => {
     describe('displaying the table head', () => {
       beforeEach(() => setup())
 
-      it('has a files column', async () => {
+      it('has a files column', () => {
         render(<CommitDetailFileExplorer />, { wrapper: wrapper() })
 
-        const files = await screen.findByText('Files')
+        const files = screen.getByText('Files')
         expect(files).toBeInTheDocument()
       })
 
-      it('has a tracked lines column', async () => {
+      it('has a tracked lines column', () => {
         render(<CommitDetailFileExplorer />, { wrapper: wrapper() })
 
-        const trackedLines = await screen.findByText('Tracked lines')
+        const trackedLines = screen.getByText('Tracked lines')
         expect(trackedLines).toBeInTheDocument()
       })
 
-      it('has a covered column', async () => {
+      it('has a covered column', () => {
         render(<CommitDetailFileExplorer />, { wrapper: wrapper() })
 
-        const covered = await screen.findByText('Covered')
+        const covered = screen.getByText('Covered')
         expect(covered).toBeInTheDocument()
       })
 
-      it('has a partial column', async () => {
+      it('has a partial column', () => {
         render(<CommitDetailFileExplorer />, { wrapper: wrapper() })
 
-        const partial = await screen.findByText('Partial')
+        const partial = screen.getByText('Partial')
         expect(partial).toBeInTheDocument()
       })
 
-      it('has a missed column', async () => {
+      it('has a missed column', () => {
         render(<CommitDetailFileExplorer />, { wrapper: wrapper() })
 
-        const missed = await screen.findByText('Missed')
+        const missed = screen.getByText('Missed')
         expect(missed).toBeInTheDocument()
       })
 
-      it('has a coverage column', async () => {
+      it('has a coverage column', () => {
         render(<CommitDetailFileExplorer />, { wrapper: wrapper() })
 
-        const coverage = await screen.findByText('Coverage %')
+        const coverage = screen.getByText('Coverage %')
         expect(coverage).toBeInTheDocument()
       })
     })
@@ -189,6 +194,8 @@ describe('CommitDetailFileExplorer', () => {
           const { requestFilters } = setup()
           render(<CommitDetailFileExplorer />, { wrapper: wrapper() })
 
+          await waitForElementToBeRemoved(() => screen.queryByTestId('spinner'))
+
           await waitFor(() =>
             expect(requestFilters).toBeCalledWith({
               ordering: { direction: 'ASC', parameter: 'NAME' },
@@ -198,17 +205,17 @@ describe('CommitDetailFileExplorer', () => {
       })
 
       describe('displaying a directory', () => {
+        beforeEach(() => setup())
+
         it('has the correct url', async () => {
-          setup()
           render(<CommitDetailFileExplorer />, { wrapper: wrapper() })
 
-          const dir = await screen.findByText('src')
-          expect(dir).toBeInTheDocument()
+          await waitForElementToBeRemoved(() => screen.queryByTestId('spinner'))
 
-          const links = await within(
-            await screen.findByRole('table')
-          ).findAllByRole('link')
-          expect(links[1]).toHaveAttribute(
+          const link = screen.getByRole('link', {
+            name: 'folder.svg src',
+          })
+          expect(link).toHaveAttribute(
             'href',
             '/gh/codecov/cool-repo/commit/sha256/tree/a/b/c/src'
           )
@@ -216,17 +223,17 @@ describe('CommitDetailFileExplorer', () => {
       })
 
       describe('displaying a file', () => {
+        beforeEach(() => setup())
+
         it('has the correct url', async () => {
-          setup()
           render(<CommitDetailFileExplorer />, { wrapper: wrapper() })
 
-          const file = await screen.findByText('file.js')
-          expect(file).toBeInTheDocument()
+          await waitForElementToBeRemoved(() => screen.queryByTestId('spinner'))
 
-          const links = await within(
-            await screen.findByRole('table')
-          ).findAllByRole('link')
-          expect(links[2]).toHaveAttribute(
+          const link = screen.getByRole('link', {
+            name: 'document.svg file.js',
+          })
+          expect(link).toHaveAttribute(
             'href',
             '/gh/codecov/cool-repo/commit/sha256/blob/a/b/c/file.js'
           )
@@ -240,35 +247,35 @@ describe('CommitDetailFileExplorer', () => {
           const { requestFilters } = setup()
           render(<CommitDetailFileExplorer />, {
             wrapper: wrapper([
-              '/gh/codecov/cool-repo/commit/sha256/tree/a/b/c?displayType=list',
+              '/gh/codecov/cool-repo/commit/123/tree/a/b/c?displayType=list',
             ]),
           })
 
-          await waitFor(() =>
-            expect(requestFilters).toBeCalledWith({
-              displayType: 'LIST',
-              ordering: { direction: 'DESC', parameter: 'MISSES' },
-            })
-          )
+          await waitForElementToBeRemoved(() => screen.queryByTestId('spinner'))
+
+          expect(requestFilters).toBeCalledWith({
+            displayType: 'LIST',
+            ordering: { direction: 'DESC', parameter: 'MISSES' },
+          })
         })
       })
 
       describe('displaying a file', () => {
+        beforeEach(() => setup())
+
         it('has the correct url', async () => {
-          setup()
           render(<CommitDetailFileExplorer />, {
             wrapper: wrapper([
               '/gh/codecov/cool-repo/commit/sha256/tree/a/b/c?displayType=list',
             ]),
           })
 
-          const file = await screen.findByText('a/b/c/file.js')
-          expect(file).toBeInTheDocument()
+          await waitForElementToBeRemoved(() => screen.queryByTestId('spinner'))
 
-          const links = await within(
-            await screen.findByRole('table')
-          ).findAllByRole('link')
-          expect(links[0]).toHaveAttribute(
+          const link = screen.getByRole('link', {
+            name: /a\/b\/c\/file.js/i,
+          })
+          expect(link).toHaveAttribute(
             'href',
             '/gh/codecov/cool-repo/commit/sha256/blob/a/b/c/file.js'
           )
@@ -277,12 +284,16 @@ describe('CommitDetailFileExplorer', () => {
     })
 
     describe('there is no results found', () => {
-      beforeEach(() => setup(true))
+      beforeEach(() => {
+        setup(true)
+      })
 
       it('displays error fetching data message', async () => {
         render(<CommitDetailFileExplorer />, { wrapper: wrapper() })
 
-        const message = await screen.findByText(
+        await waitForElementToBeRemoved(() => screen.queryByTestId('spinner'))
+
+        const message = screen.getByText(
           'There was a problem getting repo contents from your provider'
         )
         expect(message).toBeInTheDocument()
@@ -290,186 +301,85 @@ describe('CommitDetailFileExplorer', () => {
     })
   })
 
-  describe('sorting on head columns', () => {
-    describe('sorting on name column', () => {
-      describe('sorting in asc order', () => {
-        it('sets the correct api variables', async () => {
-          const { user, requestFilters } = setup()
-          render(<CommitDetailFileExplorer />, { wrapper: wrapper() })
+  describe.each([
+    ['Files', 'NAME'], // I don't know why NAME is reversed...
+  ])('sorting on %s column', (column, code) => {
+    describe('desc order', () => {
+      beforeEach(() => jest.clearAllMocks())
+      it('sets the api variables', async () => {
+        const { requestFilters, user } = setup()
+        render(<CommitDetailFileExplorer />, { wrapper: wrapper() })
 
-          const files = await screen.findByText('Files')
-          await user.click(files)
+        await waitForElementToBeRemoved(() => screen.queryByTestId('spinner'))
 
-          await waitFor(() => {
-            expect(requestFilters).toHaveBeenCalledWith({
-              ordering: { direction: 'ASC', parameter: 'NAME' },
-            })
-          })
-        })
-      })
+        let header = screen.getByText(column)
+        await user.click(header)
 
-      describe('sorting in desc order', () => {
-        it('sets the correct api variables', async () => {
-          const { user, requestFilters } = setup()
-          render(<CommitDetailFileExplorer />, { wrapper: wrapper() })
-
-          let files = await screen.findByText('Files')
-          await user.click(files)
-          files = await screen.findByText('Files')
-          await user.click(files)
-
-          await waitFor(() => {
-            expect(requestFilters).toHaveBeenCalledWith({
-              ordering: { direction: 'DESC', parameter: 'NAME' },
-            })
-          })
+        expect(requestFilters).toHaveBeenLastCalledWith({
+          ordering: { direction: 'DESC', parameter: code },
         })
       })
     })
 
-    describe('sorting on tracked lines column', () => {
-      describe('sorting in asc order', () => {
-        it('sets the correct api variables', async () => {
-          const { user, requestFilters } = setup()
-          render(<CommitDetailFileExplorer />, { wrapper: wrapper() })
+    describe('asc order', () => {
+      beforeEach(() => jest.clearAllMocks())
+      it('sets the api variables', async () => {
+        const { requestFilters, user } = setup()
+        render(<CommitDetailFileExplorer />, { wrapper: wrapper() })
 
-          const trackedLines = await screen.findByText('Tracked lines')
-          await user.click(trackedLines)
+        await waitForElementToBeRemoved(() => screen.queryByTestId('spinner'))
 
-          await waitFor(() => {
-            expect(requestFilters).toHaveBeenCalledWith({
-              ordering: { direction: 'ASC', parameter: 'LINES' },
-            })
-          })
+        let header = screen.getByText(column)
+        await user.click(header)
+        header = screen.getByText(column)
+        await user.click(header)
+
+        expect(requestFilters).toHaveBeenLastCalledWith({
+          ordering: { direction: 'ASC', parameter: code },
         })
       })
+    })
+  })
 
-      describe('sorting in desc order', () => {
-        it('sets the correct api variables', async () => {
-          const { user, requestFilters } = setup()
-          render(<CommitDetailFileExplorer />, { wrapper: wrapper() })
+  describe.each([
+    ['Tracked lines', 'LINES'],
+    ['Covered', 'HITS'],
+    ['Partial', 'PARTIALS'],
+    ['Missed', 'MISSES'],
+    ['Coverage %', 'COVERAGE'],
+  ])('sorting on %s column', (column, code) => {
+    describe('desc order', () => {
+      beforeEach(() => jest.clearAllMocks())
+      it('sets the api variables', async () => {
+        const { requestFilters, user } = setup()
+        render(<CommitDetailFileExplorer />, { wrapper: wrapper() })
 
-          let trackedLines = await screen.findByText('Tracked lines')
-          await user.click(trackedLines)
-          trackedLines = await screen.findByText('Tracked lines')
-          await user.click(trackedLines)
+        await waitForElementToBeRemoved(() => screen.queryByTestId('spinner'))
 
-          await waitFor(() => {
-            expect(requestFilters).toHaveBeenCalledWith({
-              ordering: { direction: 'DESC', parameter: 'LINES' },
-            })
-          })
+        let header = screen.getByText(column)
+        await user.click(header)
+        header = screen.getByText(column)
+        await user.click(header)
+
+        expect(requestFilters).toHaveBeenLastCalledWith({
+          ordering: { direction: 'DESC', parameter: code },
         })
       })
     })
 
-    describe('sorting on the covered column', () => {
-      describe('sorting in asc order', () => {
-        it('sets the correct api variables', async () => {
-          const { user, requestFilters } = setup()
-          render(<CommitDetailFileExplorer />, { wrapper: wrapper() })
+    describe('asc order', () => {
+      beforeEach(() => jest.clearAllMocks())
+      it('sets the api variables', async () => {
+        const { requestFilters, user } = setup()
+        render(<CommitDetailFileExplorer />, { wrapper: wrapper() })
 
-          const covered = await screen.findByText('Covered')
+        await waitForElementToBeRemoved(() => screen.queryByTestId('spinner'))
 
-          await user.click(covered)
+        let header = screen.getByText(column)
+        await user.click(header)
 
-          await waitFor(() => {
-            expect(requestFilters).toHaveBeenCalledWith({
-              ordering: { direction: 'ASC', parameter: 'HITS' },
-            })
-          })
-        })
-      })
-
-      describe('sorting in desc order', () => {
-        it('sets the correct api variables', async () => {
-          const { user, requestFilters } = setup()
-          render(<CommitDetailFileExplorer />, { wrapper: wrapper() })
-
-          let covered = await screen.findByText('Covered')
-          await user.click(covered)
-          covered = await screen.findByText('Covered')
-          await user.click(covered)
-
-          await waitFor(() => {
-            expect(requestFilters).toHaveBeenCalledWith({
-              ordering: { direction: 'DESC', parameter: 'HITS' },
-            })
-          })
-        })
-      })
-    })
-
-    describe('sorting on the partial column', () => {
-      describe('sorting in asc order', () => {
-        it('sets the correct api variables', async () => {
-          const { user, requestFilters } = setup()
-          render(<CommitDetailFileExplorer />, { wrapper: wrapper() })
-
-          const partial = await screen.findByText('Partial')
-
-          await user.click(partial)
-
-          await waitFor(() => {
-            expect(requestFilters).toHaveBeenCalledWith({
-              ordering: { direction: 'ASC', parameter: 'PARTIALS' },
-            })
-          })
-        })
-      })
-
-      describe('sorting in desc order', () => {
-        it('sets the correct api variables', async () => {
-          const { user, requestFilters } = setup()
-          render(<CommitDetailFileExplorer />, { wrapper: wrapper() })
-
-          let partial = await screen.findByText('Partial')
-          await user.click(partial)
-          partial = await screen.findByText('Partial')
-          await user.click(partial)
-
-          await waitFor(() => {
-            expect(requestFilters).toHaveBeenCalledWith({
-              ordering: { direction: 'DESC', parameter: 'PARTIALS' },
-            })
-          })
-        })
-      })
-    })
-
-    describe('sorting on the coverage line', () => {
-      describe('sorting in asc order', () => {
-        it('sets the correct api variables', async () => {
-          const { user, requestFilters } = setup()
-          render(<CommitDetailFileExplorer />, { wrapper: wrapper() })
-
-          const missed = await screen.findByText('Missed')
-
-          await user.click(missed)
-
-          await waitFor(() => {
-            expect(requestFilters).toHaveBeenCalledWith({
-              ordering: { direction: 'ASC', parameter: 'MISSES' },
-            })
-          })
-        })
-      })
-
-      describe('sorting in desc order', () => {
-        it('sets the correct api variables', async () => {
-          const { user, requestFilters } = setup()
-          render(<CommitDetailFileExplorer />, { wrapper: wrapper() })
-
-          let missed = await screen.findByText('Missed')
-          await user.click(missed)
-          missed = await screen.findByText('Missed')
-          await user.click(missed)
-
-          await waitFor(() => {
-            expect(requestFilters).toHaveBeenCalledWith({
-              ordering: { direction: 'DESC', parameter: 'MISSES' },
-            })
-          })
+        expect(requestFilters).toHaveBeenLastCalledWith({
+          ordering: { direction: 'ASC', parameter: code },
         })
       })
     })
@@ -478,8 +388,10 @@ describe('CommitDetailFileExplorer', () => {
   describe('searching on the table', () => {
     describe('api variables are being set', () => {
       it('sets the correct api variables', async () => {
-        const { user, requestFilters } = setup()
+        const { requestFilters, user } = setup()
         render(<CommitDetailFileExplorer />, { wrapper: wrapper() })
+
+        await waitForElementToBeRemoved(() => screen.queryByTestId('spinner'))
 
         const search = await screen.findByRole('textbox', {
           name: 'Search for files',
@@ -496,10 +408,11 @@ describe('CommitDetailFileExplorer', () => {
     })
 
     describe('there are no files to be found', () => {
-      beforeEach(() => setup())
       it('displays no items found message', async () => {
         const { user } = setup()
         render(<CommitDetailFileExplorer />, { wrapper: wrapper() })
+
+        await waitForElementToBeRemoved(() => screen.queryByTestId('spinner'))
 
         const dir = await screen.findByText('src')
         expect(dir).toBeInTheDocument()

--- a/src/pages/PullRequestPage/subroute/FileExplorer/FileExplorer.spec.jsx
+++ b/src/pages/PullRequestPage/subroute/FileExplorer/FileExplorer.spec.jsx
@@ -1,5 +1,10 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { render, screen, waitFor, within } from '@testing-library/react'
+import {
+  render,
+  screen,
+  waitFor,
+  waitForElementToBeRemoved,
+} from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { graphql } from 'msw'
 import { setupServer } from 'msw/node'
@@ -151,45 +156,45 @@ describe('FileExplorer', () => {
     describe('displaying the table head', () => {
       beforeEach(() => setup())
 
-      it('has a files column', async () => {
+      it('has a files column', () => {
         render(<FileExplorer />, { wrapper: wrapper() })
 
-        const files = await screen.findByText('Files')
+        const files = screen.getByText('Files')
         expect(files).toBeInTheDocument()
       })
 
-      it('has a tracked lines column', async () => {
+      it('has a tracked lines column', () => {
         render(<FileExplorer />, { wrapper: wrapper() })
 
-        const trackedLines = await screen.findByText('Tracked lines')
+        const trackedLines = screen.getByText('Tracked lines')
         expect(trackedLines).toBeInTheDocument()
       })
 
-      it('has a covered column', async () => {
+      it('has a covered column', () => {
         render(<FileExplorer />, { wrapper: wrapper() })
 
-        const covered = await screen.findByText('Covered')
+        const covered = screen.getByText('Covered')
         expect(covered).toBeInTheDocument()
       })
 
-      it('has a partial column', async () => {
+      it('has a partial column', () => {
         render(<FileExplorer />, { wrapper: wrapper() })
 
-        const partial = await screen.findByText('Partial')
+        const partial = screen.getByText('Partial')
         expect(partial).toBeInTheDocument()
       })
 
-      it('has a missed column', async () => {
+      it('has a missed column', () => {
         render(<FileExplorer />, { wrapper: wrapper() })
 
-        const missed = await screen.findByText('Missed')
+        const missed = screen.getByText('Missed')
         expect(missed).toBeInTheDocument()
       })
 
-      it('has a coverage column', async () => {
+      it('has a coverage column', () => {
         render(<FileExplorer />, { wrapper: wrapper() })
 
-        const coverage = await screen.findByText('Coverage %')
+        const coverage = screen.getByText('Coverage %')
         expect(coverage).toBeInTheDocument()
       })
     })
@@ -200,6 +205,8 @@ describe('FileExplorer', () => {
           const { requestFilters } = setup()
           render(<FileExplorer />, { wrapper: wrapper() })
 
+          await waitForElementToBeRemoved(() => screen.queryByTestId('spinner'))
+
           await waitFor(() =>
             expect(requestFilters).toBeCalledWith({
               ordering: { direction: 'ASC', parameter: 'NAME' },
@@ -209,17 +216,17 @@ describe('FileExplorer', () => {
       })
 
       describe('displaying a directory', () => {
+        beforeEach(() => setup())
+
         it('has the correct url', async () => {
-          setup()
           render(<FileExplorer />, { wrapper: wrapper() })
 
-          const dir = await screen.findByText('src')
-          expect(dir).toBeInTheDocument()
+          await waitForElementToBeRemoved(() => screen.queryByTestId('spinner'))
 
-          const links = await within(
-            await screen.findByRole('table')
-          ).findAllByRole('link')
-          expect(links[1]).toHaveAttribute(
+          const link = screen.getByRole('link', {
+            name: 'folder.svg src',
+          })
+          expect(link).toHaveAttribute(
             'href',
             '/gh/codecov/cool-repo/pull/123/tree/a/b/c/src'
           )
@@ -227,17 +234,17 @@ describe('FileExplorer', () => {
       })
 
       describe('displaying a file', () => {
+        beforeEach(() => setup())
+
         it('has the correct url', async () => {
-          setup()
           render(<FileExplorer />, { wrapper: wrapper() })
 
-          const file = await screen.findByText('file.js')
-          expect(file).toBeInTheDocument()
+          await waitForElementToBeRemoved(() => screen.queryByTestId('spinner'))
 
-          const links = await within(
-            await screen.findByRole('table')
-          ).findAllByRole('link')
-          expect(links[2]).toHaveAttribute(
+          const link = screen.getByRole('link', {
+            name: 'document.svg file.js',
+          })
+          expect(link).toHaveAttribute(
             'href',
             '/gh/codecov/cool-repo/pull/123/blob/a/b/c/file.js'
           )
@@ -255,31 +262,31 @@ describe('FileExplorer', () => {
             ]),
           })
 
-          await waitFor(() =>
-            expect(requestFilters).toBeCalledWith({
-              displayType: 'LIST',
-              ordering: { direction: 'DESC', parameter: 'MISSES' },
-            })
-          )
+          await waitForElementToBeRemoved(() => screen.queryByTestId('spinner'))
+
+          expect(requestFilters).toBeCalledWith({
+            displayType: 'LIST',
+            ordering: { direction: 'DESC', parameter: 'MISSES' },
+          })
         })
       })
 
       describe('displaying a file', () => {
+        beforeEach(() => setup())
+
         it('has the correct url', async () => {
-          setup()
           render(<FileExplorer />, {
             wrapper: wrapper([
               '/gh/codecov/cool-repo/pull/123/tree/a/b/c?displayType=list',
             ]),
           })
 
-          const file = await screen.findByText('a/b/c/file.js')
-          expect(file).toBeInTheDocument()
+          await waitForElementToBeRemoved(() => screen.queryByTestId('spinner'))
 
-          const links = await within(
-            await screen.findByRole('table')
-          ).findAllByRole('link')
-          expect(links[0]).toHaveAttribute(
+          const link = screen.getByRole('link', {
+            name: /a\/b\/c\/file.js/i,
+          })
+          expect(link).toHaveAttribute(
             'href',
             '/gh/codecov/cool-repo/pull/123/blob/a/b/c/file.js'
           )
@@ -295,7 +302,9 @@ describe('FileExplorer', () => {
       it('displays error fetching data message', async () => {
         render(<FileExplorer />, { wrapper: wrapper() })
 
-        const message = await screen.findByText(
+        await waitForElementToBeRemoved(() => screen.queryByTestId('spinner'))
+
+        const message = screen.getByText(
           'There was a problem getting repo contents from your provider'
         )
         expect(message).toBeInTheDocument()
@@ -303,206 +312,85 @@ describe('FileExplorer', () => {
     })
   })
 
-  describe('sorting on head columns', () => {
-    describe('sorting on head column', () => {
-      describe('sorting in asc order', () => {
-        it('sets the correct api variables', async () => {
-          const { requestFilters, user } = setup()
+  describe.each([
+    ['Files', 'NAME'], // I don't know why NAME is reversed...
+  ])('sorting on %s column', (column, code) => {
+    describe('desc order', () => {
+      beforeEach(() => jest.clearAllMocks())
+      it('sets the api variables', async () => {
+        const { requestFilters, user } = setup()
+        render(<FileExplorer />, { wrapper: wrapper() })
 
-          render(<FileExplorer />, { wrapper: wrapper() })
+        await waitForElementToBeRemoved(() => screen.queryByTestId('spinner'))
 
-          let files = await screen.findByText('Files')
+        let header = screen.getByText(column)
+        await user.click(header)
 
-          await user.click(files)
-          files = await screen.findByText('Files')
-          await user.click(files)
-          files = await screen.findByText('Files')
-          await user.click(files)
-
-          await waitFor(() =>
-            expect(requestFilters).toHaveBeenCalledWith({
-              ordering: { direction: 'ASC', parameter: 'NAME' },
-            })
-          )
-        })
-      })
-
-      describe('sorting in desc order', () => {
-        it('sets the correct api variables', async () => {
-          const { requestFilters, user } = setup()
-
-          render(<FileExplorer />, { wrapper: wrapper() })
-
-          let files = await screen.findByText('Files')
-          await user.click(files)
-          files = await screen.findByText('Files')
-          await user.click(files)
-
-          await waitFor(() =>
-            expect(requestFilters).toHaveBeenCalledWith({
-              ordering: { direction: 'DESC', parameter: 'NAME' },
-            })
-          )
+        expect(requestFilters).toHaveBeenLastCalledWith({
+          ordering: { direction: 'DESC', parameter: code },
         })
       })
     })
 
-    describe('sorting on tracked lines column', () => {
-      describe('sorting in asc order', () => {
-        it('sets the correct api variables', async () => {
-          const { requestFilters, user } = setup()
+    describe('asc order', () => {
+      beforeEach(() => jest.clearAllMocks())
+      it('sets the api variables', async () => {
+        const { requestFilters, user } = setup()
+        render(<FileExplorer />, { wrapper: wrapper() })
 
-          render(<FileExplorer />, { wrapper: wrapper() })
+        await waitForElementToBeRemoved(() => screen.queryByTestId('spinner'))
 
-          const trackedLines = await screen.findByText('Tracked lines')
+        let header = screen.getByText(column)
+        await user.click(header)
+        header = screen.getByText(column)
+        await user.click(header)
 
-          await user.click(trackedLines)
-          await user.click(trackedLines)
-
-          await waitFor(() =>
-            expect(requestFilters).toHaveBeenCalledWith({
-              ordering: { direction: 'ASC', parameter: 'LINES' },
-            })
-          )
+        expect(requestFilters).toHaveBeenLastCalledWith({
+          ordering: { direction: 'ASC', parameter: code },
         })
       })
+    })
+  })
 
-      describe('sorting in desc order', () => {
-        it('sets the correct api variables', async () => {
-          const { requestFilters, user } = setup()
+  describe.each([
+    ['Tracked lines', 'LINES'],
+    ['Covered', 'HITS'],
+    ['Partial', 'PARTIALS'],
+    ['Missed', 'MISSES'],
+    ['Coverage %', 'COVERAGE'],
+  ])('sorting on %s column', (column, code) => {
+    describe('desc order', () => {
+      beforeEach(() => jest.clearAllMocks())
+      it('sets the api variables', async () => {
+        const { requestFilters, user } = setup()
+        render(<FileExplorer />, { wrapper: wrapper() })
 
-          render(<FileExplorer />, { wrapper: wrapper() })
+        await waitForElementToBeRemoved(() => screen.queryByTestId('spinner'))
 
-          let trackedLines = await screen.findByText('Tracked lines')
-          await user.click(trackedLines)
-          trackedLines = await screen.findByText('Tracked lines')
-          await user.click(trackedLines)
+        let header = screen.getByText(column)
+        await user.click(header)
+        header = screen.getByText(column)
+        await user.click(header)
 
-          await waitFor(() =>
-            expect(requestFilters).toHaveBeenCalledWith({
-              ordering: { direction: 'DESC', parameter: 'LINES' },
-            })
-          )
+        expect(requestFilters).toHaveBeenLastCalledWith({
+          ordering: { direction: 'DESC', parameter: code },
         })
       })
     })
 
-    describe('sorting on the covered column', () => {
-      describe('sorting in asc order', () => {
-        it('sets the correct api variables', async () => {
-          const { requestFilters, user } = setup()
+    describe('asc order', () => {
+      beforeEach(() => jest.clearAllMocks())
+      it('sets the api variables', async () => {
+        const { requestFilters, user } = setup()
+        render(<FileExplorer />, { wrapper: wrapper() })
 
-          render(<FileExplorer />, { wrapper: wrapper() })
+        await waitForElementToBeRemoved(() => screen.queryByTestId('spinner'))
 
-          const covered = await screen.findByText('Covered')
+        let header = screen.getByText(column)
+        await user.click(header)
 
-          await user.click(covered)
-          await user.click(covered)
-
-          await waitFor(() =>
-            expect(requestFilters).toHaveBeenCalledWith({
-              ordering: { direction: 'ASC', parameter: 'HITS' },
-            })
-          )
-        })
-      })
-
-      describe('sorting in desc order', () => {
-        it('sets the correct api variables', async () => {
-          const { requestFilters, user } = setup()
-
-          render(<FileExplorer />, { wrapper: wrapper() })
-
-          let covered = await screen.findByText('Covered')
-          await user.click(covered)
-          covered = await screen.findByText('Covered')
-          await user.click(covered)
-
-          await waitFor(() =>
-            expect(requestFilters).toHaveBeenCalledWith({
-              ordering: { direction: 'DESC', parameter: 'HITS' },
-            })
-          )
-        })
-      })
-    })
-
-    describe('sorting on the partial column', () => {
-      describe('sorting in asc order', () => {
-        it('sets the correct api variables', async () => {
-          const { requestFilters, user } = setup()
-
-          render(<FileExplorer />, { wrapper: wrapper() })
-
-          const partial = await screen.findByText('Partial')
-
-          await user.click(partial)
-          await user.click(partial)
-
-          await waitFor(() =>
-            expect(requestFilters).toHaveBeenCalledWith({
-              ordering: { direction: 'ASC', parameter: 'PARTIALS' },
-            })
-          )
-        })
-      })
-
-      describe('sorting in desc order', () => {
-        it('sets the correct api variables', async () => {
-          const { requestFilters, user } = setup()
-
-          render(<FileExplorer />, { wrapper: wrapper() })
-
-          let partial = await screen.findByText('Partial')
-          await user.click(partial)
-          partial = await screen.findByText('Partial')
-          await user.click(partial)
-
-          await waitFor(() =>
-            expect(requestFilters).toHaveBeenCalledWith({
-              ordering: { direction: 'DESC', parameter: 'PARTIALS' },
-            })
-          )
-        })
-      })
-    })
-
-    describe('sorting on the coverage line', () => {
-      describe('sorting in asc order', () => {
-        it('sets the correct api variables', async () => {
-          const { requestFilters, user } = setup()
-
-          render(<FileExplorer />, { wrapper: wrapper() })
-
-          const missed = await screen.findByText('Missed')
-
-          await user.click(missed)
-          await user.click(missed)
-
-          await waitFor(() =>
-            expect(requestFilters).toHaveBeenCalledWith({
-              ordering: { direction: 'ASC', parameter: 'MISSES' },
-            })
-          )
-        })
-      })
-
-      describe('sorting in desc order', () => {
-        it('sets the correct api variables', async () => {
-          const { requestFilters, user } = setup()
-
-          render(<FileExplorer />, { wrapper: wrapper() })
-
-          let missed = await screen.findByText('Missed')
-          await user.click(missed)
-          missed = await screen.findByText('Missed')
-          await user.click(missed)
-
-          await waitFor(() =>
-            expect(requestFilters).toHaveBeenCalledWith({
-              ordering: { direction: 'DESC', parameter: 'MISSES' },
-            })
-          )
+        expect(requestFilters).toHaveBeenLastCalledWith({
+          ordering: { direction: 'ASC', parameter: code },
         })
       })
     })
@@ -512,28 +400,30 @@ describe('FileExplorer', () => {
     describe('api variables are being set', () => {
       it('sets the correct api variables', async () => {
         const { requestFilters, user } = setup()
-
         render(<FileExplorer />, { wrapper: wrapper() })
+
+        await waitForElementToBeRemoved(() => screen.queryByTestId('spinner'))
 
         const search = await screen.findByRole('textbox', {
           name: 'Search for files',
         })
         await user.type(search, 'cool-file.rs')
 
-        await waitFor(() =>
+        await waitFor(() => {
           expect(requestFilters).toHaveBeenCalledWith({
             searchValue: 'cool-file.rs',
             ordering: { direction: 'ASC', parameter: 'NAME' },
           })
-        )
+        })
       })
     })
 
     describe('there are no files to be found', () => {
-      beforeEach(() => setup())
-
       it('displays no items found message', async () => {
+        const { user } = setup()
         render(<FileExplorer />, { wrapper: wrapper() })
+
+        await waitForElementToBeRemoved(() => screen.queryByTestId('spinner'))
 
         const dir = await screen.findByText('src')
         expect(dir).toBeInTheDocument()
@@ -541,7 +431,7 @@ describe('FileExplorer', () => {
         const search = await screen.findByRole('textbox', {
           name: 'Search for files',
         })
-        userEvent.type(search, 'cool-file.rs')
+        await user.type(search, 'cool-file.rs')
 
         const noResults = await screen.findByText(/no results found/i)
         expect(noResults).toBeInTheDocument()

--- a/src/pages/RepoPage/CoverageTab/subroute/FileExplorer/FileExplorer.jsx
+++ b/src/pages/RepoPage/CoverageTab/subroute/FileExplorer/FileExplorer.jsx
@@ -10,19 +10,11 @@ import Table from 'ui/Table'
 
 import { useRepoBranchContentsTable } from './hooks'
 
-const Loader = ({ isLoading }) => {
-  return (
-    isLoading && (
-      <div className="flex flex-1 justify-center">
-        <Spinner size={60} />
-      </div>
-    )
-  )
-}
-
-Loader.propTypes = {
-  isLoading: PropType.bool,
-}
+const Loader = () => (
+  <div className="flex flex-1 justify-center">
+    <Spinner size={60} />
+  </div>
+)
 
 function RepoContentsResult({ isSearching, isMissingHeadReport }) {
   if (isMissingHeadReport) {
@@ -71,7 +63,7 @@ function FileExplorer() {
           setSearchValue={(search) => updateParams({ search })}
         />
       </div>
-      <div className=" grid flex-1 grid-cols-12 gap-8">
+      <div className="grid flex-1 grid-cols-12 gap-8">
         <div className="col-span-12 flex flex-col md:col-span-12">
           <Table
             data={data}
@@ -80,8 +72,8 @@ function FileExplorer() {
             enableHover
           />
           <div className="mt-4">
-            <Loader isLoading={isLoading} />
-            {data?.length === 0 && !isLoading && (
+            {isLoading && <Loader />}
+            {!isLoading && (
               <RepoContentsResult
                 isSearching={isSearching}
                 isMissingHeadReport={isMissingHeadReport}


### PR DESCRIPTION
Edit: Downgrading to react 17 the source code in now behaving differently, I think the core code needs to be refactored along with TableUI, not sure I should actually be spending time on resolving.

# Description
This is PR the timing of the tests for clicking on the table header was flakey due to it not correctly waiting for the table to finish rendering before asserting its tests. This work also removes unnecessary async tests where possible and condensed the repetitive logic into `describe.each`s and reusing the fixed/correct test assertions for each column.

For what ever reason some NAME columns are configured for the reverse behaviors so they got their own variation of the block, left as an each in case the expected behavior changes over time, this will let dev switch the order without rewriting large parts of the test suite.


# Code Example
The key fix for async code tests is waiting for the spinner to leave the screen before making assertions in various places.
```
await waitForElementToBeRemoved(() => screen.queryByTestId('spinner'))
```
# Notable Changes
- Rewrote the tests to use `each` for repetition assertions on the table header interactions. 
