### PR TITLE
Update erase copy to inform user it will happen in the background

### DIFF
--- a/src/pages/RepoPage/SettingsTab/tabs/GeneralTab/DangerZone/EraseRepoContent/EraseRepoContent.jsx
+++ b/src/pages/RepoPage/SettingsTab/tabs/GeneralTab/DangerZone/EraseRepoContent/EraseRepoContent.jsx
@@ -16,8 +16,7 @@ function EraseRepoContent() {
         <p>This will remove all coverage reporting from the repo.</p>
         <p className="text-xs">
           <span className="font-semibold">Note: </span>
-          This process happens in the background and may take a few minutes
-          depending on the size of your repository.
+          Erasing may take a few minutes depending on repository size.
         </p>
       </div>
       <div>

--- a/src/pages/RepoPage/SettingsTab/tabs/GeneralTab/DangerZone/EraseRepoContent/EraseRepoContent.spec.jsx
+++ b/src/pages/RepoPage/SettingsTab/tabs/GeneralTab/DangerZone/EraseRepoContent/EraseRepoContent.spec.jsx
@@ -41,10 +41,15 @@ describe('EraseRepoContent', () => {
     it('renders body', () => {
       render(<EraseRepoContent />, { wrapper })
 
-      const p = screen.getByText(
+      const firstBlock = screen.getByText(
         'This will remove all coverage reporting from the repo.'
       )
-      expect(p).toBeInTheDocument()
+      expect(firstBlock).toBeInTheDocument()
+
+      const secondBlock = screen.getByText(
+        'Erasing may take a few minutes depending on repository size.'
+      )
+      expect(secondBlock).toBeInTheDocument()
     })
 
     it('renders regenerate button', () => {


### PR DESCRIPTION
# Description

I'd like to merge https://github.com/codecov/codecov-api/pull/1505 which moves the repo erase functionality into a background job.

Before doing that I think we should make sure the user is aware this is what's going on.

# Code Example

# Notable Changes

# Screenshots

<img width="893" alt="Screenshot 2023-05-11 at 9 26 27 AM" src="https://github.com/codecov/gazebo/assets/103445133/fceadb9f-1a46-46b6-bae4-856da985305f">



# Link to Sample Entry