### PR TITLE
Switch to using repositoryDeprecated resolver

### DIFF
--- a/src/pages/CommitDetailPage/Header/hooks/useCommitHeaderData.js
+++ b/src/pages/CommitDetailPage/Header/hooks/useCommitHeaderData.js
@@ -5,7 +5,7 @@ import Api from 'shared/api'
 const query = `
   query CommitPageHeaderData($owner: String!, $repo: String!, $commitId: String!) {
     owner(username: $owner) {
-      repository(name: $repo) {
+      repository: repositoryDeprecated(name: $repo) {
         commit(id: $commitId) {
           author {
             username

--- a/src/pages/CommitDetailPage/hooks/useCommitPageData.js
+++ b/src/pages/CommitDetailPage/hooks/useCommitPageData.js
@@ -6,7 +6,7 @@ const query = `
   query CommitPageData($owner: String!, $repo: String!, $commitId: String!) {
     owner(username: $owner) {
       isCurrentUserPartOfOrg
-      repository(name: $repo) {
+      repository: repositoryDeprecated(name: $repo) {
         commit(id: $commitId) {
           commitid
         }

--- a/src/pages/PullRequestPage/Header/hooks/usePullHeadData.js
+++ b/src/pages/PullRequestPage/Header/hooks/usePullHeadData.js
@@ -5,7 +5,7 @@ import Api from 'shared/api'
 const query = `
   query PullHeadData ($owner: String!, $repo: String!, $pullId: Int!) {
     owner(username: $owner) {
-      repository(name: $repo) {
+      repository: repositoryDeprecated(name: $repo) {
         pull(id: $pullId) {
           pullId
           title

--- a/src/pages/PullRequestPage/hooks/usePullPageData.js
+++ b/src/pages/PullRequestPage/hooks/usePullPageData.js
@@ -7,7 +7,7 @@ const query = `
   query PullPageData ($owner: String!, $repo: String!, $pullId: Int!) {
     owner(username: $owner) {
       isCurrentUserPartOfOrg
-      repository(name: $repo) {
+      repository: repositoryDeprecated(name: $repo) {
         private
         pull(id: $pullId) {
           pullId

--- a/src/pages/PullRequestPage/subroute/ComponentsTab/hooks/query.js
+++ b/src/pages/PullRequestPage/subroute/ComponentsTab/hooks/query.js
@@ -5,7 +5,7 @@ export const query = `
     $pullId: Int!
   ) {
     owner(username: $owner) {
-      repository(name: $repo) {
+      repository: repositoryDeprecated(name: $repo) {
         pull(id: $pullId) {
           compareWithBase {
             __typename

--- a/src/services/branches/useBranch.ts
+++ b/src/services/branches/useBranch.ts
@@ -31,7 +31,7 @@ export interface UseBranchArgs {
 export const query = `
   query GetBranch($owner: String!, $repo: String!, $branch: String!) {
     owner(username: $owner) {
-      repository(name: $repo) {
+      repository: repositoryDeprecated(name: $repo) {
         branch(name: $branch) {
           name
           head {

--- a/src/services/branches/useBranches.js
+++ b/src/services/branches/useBranches.js
@@ -11,7 +11,7 @@ const query = `
     $filters: BranchesSetFilters
   ) {
     owner(username: $owner) {
-      repository(name: $repo) {
+      repository: repositoryDeprecated(name: $repo) {
         branches(
           first: 20
           after: $after

--- a/src/services/charts/useBranchCoverageMeasurements.js
+++ b/src/services/charts/useBranchCoverageMeasurements.js
@@ -12,7 +12,7 @@ const query = `
     $interval: MeasurementInterval!
   ) {
     owner(username: $owner) {
-      repository(name: $repo) {
+      repository: repositoryDeprecated(name: $repo) {
         measurements(
           interval: $interval
           after: $after

--- a/src/services/commit/useCommit.js
+++ b/src/services/commit/useCommit.js
@@ -51,7 +51,7 @@ export function useCommit({
   const query = `
       query Commit($owner: String!, $repo: String!, $commitid: String!, $filters: ImpactedFilesFilters) {
           owner(username: $owner) {
-            repository(name: $repo) {
+            repository: repositoryDeprecated(name: $repo) {
               commit(id: $commitid) {
                 totals {
                   coverage # Absolute coverage of the commit

--- a/src/services/commit/useCommitYaml.js
+++ b/src/services/commit/useCommitYaml.js
@@ -6,7 +6,7 @@ export function useCommitYaml({ provider, owner, repo, commitid }) {
   const query = `
     query CommitYaml($owner: String!, $repo: String!, $commitid: String!) {
       owner(username: $owner) {
-        repository(name: $repo) {
+        repository: repositoryDeprecated(name: $repo) {
           commit(id: $commitid) {
             commitid
             yaml

--- a/src/services/commit/useCompareTotals.js
+++ b/src/services/commit/useCompareTotals.js
@@ -38,7 +38,7 @@ export function useCompareTotals({
   const query = `
       query CompareTotals($owner: String!, $repo: String!, $commitid: String!) {
         owner(username: $owner) {
-          repository(name: $repo) {
+          repository: repositoryDeprecated(name: $repo) {
             commit(id: $commitid) {
               ...ComparisonFragment
             }

--- a/src/services/commitErrors/useCommitErrors.js
+++ b/src/services/commitErrors/useCommitErrors.js
@@ -9,7 +9,7 @@ export function useCommitErrors() {
   const query = `
       query CommitErrors($owner: String!, $repo: String!, $commitid: String!) {
         owner(username: $owner) {
-          repository(name: $repo) {
+          repository: repositoryDeprecated(name: $repo) {
             commit(id: $commitid) {
               yamlErrors: errors(errorType: YAML_ERROR){
                 edges{

--- a/src/services/commits/useCommits.js
+++ b/src/services/commits/useCommits.js
@@ -36,7 +36,7 @@ function fetchRepoCommits({ provider, owner, repo, variables, after, signal }) {
   const query = `
     query GetCommits($owner: String!, $repo: String!, $filters:CommitsSetFilters, $after: String, $includeTotalCount: Boolean!){
         owner(username:$owner){
-            repository(name: $repo){
+            repository: repositoryDeprecated(name: $repo){
                 commits(filters: $filters, first: 20, after: $after){
                   totalCount @include(if: $includeTotalCount)
                   edges{

--- a/src/services/comparison/useComparisonForCommitAndParent/query.js
+++ b/src/services/comparison/useComparisonForCommitAndParent/query.js
@@ -9,7 +9,7 @@ export const query = `
     $filters: SegmentsFilters
   ) {
     owner(username: $owner) {
-      repository(name: $repo) {
+      repository: repositoryDeprecated(name: $repo) {
         commit(id: $commitid) {
           compareWithParent {
             ...ComparisonFragment

--- a/src/services/file/useCoverageWithFlags.js
+++ b/src/services/file/useCoverageWithFlags.js
@@ -16,7 +16,7 @@ export function useCoverageWithFlags({
   const query = `
   query CoverageForFileWithFlags($owner: String!, $repo: String!, $ref: String!, $path: String!, $flags: [String]) {
     owner(username: $owner) {
-      repository(name: $repo){
+      repository: repositoryDeprecated(name: $repo){
         commit(id: $ref) {
           coverageFile(path: $path, flags: $flags) {
             isCriticalFile

--- a/src/services/pathContents/branch/dir/constants.js
+++ b/src/services/pathContents/branch/dir/constants.js
@@ -8,7 +8,7 @@ export const query = `
     ) {
       owner(username: $name) {
         username
-        repository(name: $repo) {
+        repository: repositoryDeprecated(name: $repo) {
           repositoryConfig {
             indicationRange {
               upperRange

--- a/src/services/pathContents/commit/dir/constants.js
+++ b/src/services/pathContents/commit/dir/constants.js
@@ -8,7 +8,7 @@ export const query = `
   ) {
     owner(username: $name) {
       username
-      repository(name: $repo) {
+      repository: repositoryDeprecated(name: $repo) {
         repositoryConfig {
           indicationRange {
             upperRange

--- a/src/services/pathContents/constants.js
+++ b/src/services/pathContents/constants.js
@@ -6,7 +6,7 @@ query CoverageForFile(
   $path: String!
 ) {
   owner(username: $owner) {
-    repository(name: $repo) {
+    repository: repositoryDeprecated(name: $repo) {
       commit(id: $ref) {
         ...CoverageForFile
       }

--- a/src/services/pathContents/pull/dir/constants.js
+++ b/src/services/pathContents/pull/dir/constants.js
@@ -7,7 +7,7 @@ export const query = `
     $filters: PathContentsFilters!
   ) {
     owner(username: $owner) {
-      repository(name: $repo) {
+      repository: repositoryDeprecated(name: $repo) {
         repositoryConfig {
           indicationRange {
             upperRange

--- a/src/services/pull/usePrefetchSingleFileComp.js
+++ b/src/services/pull/usePrefetchSingleFileComp.js
@@ -9,7 +9,7 @@ import { transformImpactedFileData } from './utils'
 const query = `
   query ImpactedFileComparison($owner: String!, $repo: String!, $pullId: Int!, $path: String!, $filters: SegmentsFilters) {
     owner(username: $owner) {
-      repository(name: $repo) {
+      repository: repositoryDeprecated(name: $repo) {
         pull(id: $pullId) {
           ...FileComparisonWithBase
         }

--- a/src/services/pull/usePull.js
+++ b/src/services/pull/usePull.js
@@ -23,7 +23,7 @@ export function usePull({
     query Pull($owner: String!, $repo: String!, $pullId: Int!, $filters: ImpactedFilesFilters!) {
         owner(username: $owner) {
           isCurrentUserPartOfOrg
-          repository(name: $repo) {
+          repository: repositoryDeprecated(name: $repo) {
             defaultBranch
             private
             pull(id: $pullId) {

--- a/src/services/pull/useSingularImpactedFileComparison.js
+++ b/src/services/pull/useSingularImpactedFileComparison.js
@@ -8,7 +8,7 @@ import { transformImpactedFileData } from './utils'
 const query = `
     query ImpactedFileComparison($owner: String!, $repo: String!, $pullId: Int!, $path: String!, $filters: SegmentsFilters) {
       owner(username: $owner) {
-        repository(name: $repo) {
+        repository: repositoryDeprecated(name: $repo) {
           pull(id: $pullId) {
             ...FileComparisonWithBase
           }

--- a/src/services/pulls/usePulls.js
+++ b/src/services/pulls/usePulls.js
@@ -31,7 +31,7 @@ function fetchRepoPulls({ provider, owner, repo, variables, after, signal }) {
   const query = `
       query GetPulls($owner: String!, $repo: String!, $orderingDirection: OrderingDirection, $filters: PullsSetFilters, $after: String){
             owner(username:$owner){
-                repository(name:$repo){
+                repository: repositoryDeprecated(name:$repo){
                     pulls(orderingDirection: $orderingDirection, filters: $filters, first: 20, after: $after){
                         edges{
                             node{

--- a/src/services/repo/useRepo.js
+++ b/src/services/repo/useRepo.js
@@ -9,7 +9,7 @@ function fetchRepoDetails({ provider, owner, repo, signal }) {
         isAdmin
         isCurrentUserPartOfOrg
         isCurrentUserActivated
-        repository(name:$repo){
+        repository: repositoryDeprecated(name:$repo){
           private
           uploadToken
           defaultBranch

--- a/src/services/repo/useRepoBackfilled.js
+++ b/src/services/repo/useRepoBackfilled.js
@@ -10,7 +10,7 @@ function fetchRepoBackfilledContents({ provider, owner, repo, signal }) {
           isTimescaleEnabled
         }
         owner(username:$name){
-          repository(name:$repo){
+          repository: repositoryDeprecated(name:$repo){
             flagsMeasurementsActive
             flagsMeasurementsBackfilled
             flagsCount

--- a/src/services/repo/useRepoConfig.ts
+++ b/src/services/repo/useRepoConfig.ts
@@ -26,7 +26,7 @@ export interface UseRepoConfigArgs {
 const query = `
   query RepoConfig($owner: String!, $repo: String!) {
     owner(username:$owner){
-      repository(name:$repo){
+      repository: repositoryDeprecated(name:$repo){
         repositoryConfig {
           indicationRange {
             lowerRange

--- a/src/services/repo/useRepoCoverage.js
+++ b/src/services/repo/useRepoCoverage.js
@@ -6,7 +6,7 @@ function fetchRepoBranchCoverage({ provider, owner, repo, branch, signal }) {
   const query = `
     query GetRepoCoverage($name: String!, $repo: String!, $branch: String!) {
       owner(username:$name){
-        repository(name:$repo){
+        repository: repositoryDeprecated(name:$repo){
           branch(name:$branch) {
             name
             head {

--- a/src/services/repo/useRepoFlags.js
+++ b/src/services/repo/useRepoFlags.js
@@ -29,7 +29,7 @@ function fetchRepoFlags({
       $after: String
     ) {
       owner(username: $name) {
-        repository(name: $repo) {
+        repository: repositoryDeprecated(name: $repo) {
           flags(filters: $filters, orderingDirection: $orderingDirection, after: $after, first: 15) {
             pageInfo {
               hasNextPage

--- a/src/services/repo/useRepoFlagsSelect.js
+++ b/src/services/repo/useRepoFlagsSelect.js
@@ -21,7 +21,7 @@ function fetchRepoFlags({
       $after: String
     ) {
       owner(username: $name) {
-        repository(name: $repo) {
+        repository: repositoryDeprecated(name: $repo) {
           flags(filters: $filters, after: $after) {
             pageInfo {
               hasNextPage

--- a/src/services/repo/useRepoOverview.js
+++ b/src/services/repo/useRepoOverview.js
@@ -6,7 +6,7 @@ function fetchRepoOverviewInitial({ provider, owner, repo, signal }) {
   const query = `
     query GetRepoOverview($name: String!, $repo: String!) {
       owner(username:$name){
-        repository(name:$repo){
+        repository: repositoryDeprecated(name:$repo){
           private
           defaultBranch
           oldestCommitAt

--- a/src/services/repo/useRepoSettings.js
+++ b/src/services/repo/useRepoSettings.js
@@ -7,7 +7,7 @@ function fetchRepoSettingsDetails({ provider, owner, repo, signal }) {
   const query = `
     query GetRepoSettings($name: String!, $repo: String!){
       owner(username:$name){
-        repository(name:$repo){
+        repository: repositoryDeprecated(name:$repo){
           private
           activated
           uploadToken

--- a/src/shared/api/api.test.js
+++ b/src/shared/api/api.test.js
@@ -227,7 +227,7 @@ describe('when using a graphql request', () => {
       const query = `
         query CoverageForFile($owner: String!, $repo: String!, $ref: String!) {
           owner(username: $owner) {
-            repository(name: $repo){
+            repository: repositoryDeprecated(name: $repo){
               commit(id: $ref) {
                 commitid
               }


### PR DESCRIPTION
https://codecovio.atlassian.net/browse/CODE-3434

Planning to change the return type of the `repository` resolver.  This `repositoryDeprecated` resolver is to maintain backward compat with Gazebo in the meantime.

Don't merge until https://github.com/codecov/codecov-api/pull/1549 is deployed.