### PR TITLE
CODE-3534-errors-shown-before-selection-in-manage-plan

### DIFF
--- a/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/UpgradeForm.jsx
+++ b/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/UpgradeForm.jsx
@@ -89,7 +89,7 @@ const useUpgradeForm = ({
       sentryPlanYear,
     }),
     resolver: zodResolver(getSchema({ accountDetails, minSeats })),
-    mode: 'onChange',
+    mode: 'onBlur',
   })
 
   const perYearPrice = calculatePrice({


### PR DESCRIPTION
# Description
use `onBlur` instead of `onChange` to validate when the element loses focus.
Link to ticket : https://codecovio.atlassian.net/browse/CODE-3534

# Link to Sample Entry

/plan/gh/{your personal org}

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.