### PR TITLE
Add TS File Types to CircleCI Test Files

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,7 @@ jobs:
       - run:
           name: Run tests
           command: |
-            TESTFILES=$(circleci tests glob "src/**/*.spec.js" "src/**/*.test.js" "src/**/*.spec.jsx" "src/**/*.test.jsx" src/**/*.spec.ts" "src/**/*.test.ts" "src/**/*.spec.tsx" "src/**/*.test.tsx" | circleci tests split --split-by=timings)
+            TESTFILES=$(circleci tests glob "src/**/*.spec.js" "src/**/*.test.js" "src/**/*.spec.jsx" "src/**/*.test.jsx" "src/**/*.spec.ts" "src/**/*.test.ts" "src/**/*.spec.tsx" "src/**/*.test.tsx" | circleci tests split --split-by=timings)
             CI=true npm run test:ci -- --maxWorkers=2 $TESTFILES
           # Set maxWorkers to reflect the number of cores on the Resource Class running this task.
           environment:


### PR DESCRIPTION
# Description

Soooooo this may the solution to all of our problems with our TS test coverage as the files were never being selected. It was just other JS files calling them then running them that gave them any actual test coverage.