### PR TITLE
Update global upload token `learn more` to point to correct link 

### DIFF
--- a/src/pages/AccountSettings/tabs/OrgUploadToken/GenerateOrgUploadToken.jsx
+++ b/src/pages/AccountSettings/tabs/OrgUploadToken/GenerateOrgUploadToken.jsx
@@ -38,7 +38,7 @@ function GenerateOrgUploadToken() {
         </div>
       )}
       <div className="flex gap-1">
-        <A to={{ pageName: 'orgUploadToken' }}>Learn more</A>
+        <A to={{ pageName: 'orgUploadTokenDoc' }}>Learn more</A>
         <p>how to generate and use the global upload token.</p>
       </div>
     </div>

--- a/src/pages/AccountSettings/tabs/OrgUploadToken/OrgUploadToken.spec.jsx
+++ b/src/pages/AccountSettings/tabs/OrgUploadToken/OrgUploadToken.spec.jsx
@@ -130,6 +130,17 @@ describe('OrgUploadToken', () => {
       const genBtn = await screen.findByRole('button', { name: /Generate/ })
       expect(genBtn).toBeInTheDocument()
     })
+
+    it('renders link to codecov uploader', async () => {
+      render(<OrgUploadToken />, { wrapper })
+
+      const link = await screen.findByRole('link', { name: /Learn more/ })
+      expect(link).toBeInTheDocument()
+      expect(link).toHaveAttribute(
+        'href',
+        'https://docs.codecov.com/docs/codecov-uploader#organization-upload-token'
+      )
+    })
   })
 
   describe('when user clicks on Generate button', () => {


### PR DESCRIPTION
# Description
Use orgUploadTokenDoc instead of orgUploadToken 
Add a quick test 

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.