### PR TITLE
bug: Pass X-CSRFToken with every API request

### DIFF
--- a/src/shared/api/api.js
+++ b/src/shared/api/api.js
@@ -1,3 +1,4 @@
+import Cookie from 'js-cookie'
 import get from 'lodash/get'
 
 import config from 'config'
@@ -20,6 +21,7 @@ function _fetch({
   const headers = {
     Accept: 'application/json',
     'Content-Type': 'application/json; charset=utf-8',
+    'X-CSRFToken': Cookie.get('csrftoken'),
     ...getHeaders(provider),
     ...extraHeaders,
   }


### PR DESCRIPTION
We're using the Django session mechanism now in the API and it seems to be conflicting in some way with the csrftoken.  i.e. REST API calls are failing with "missing csrf token" (even though there's a `csrftoken` cookie set).  This is an alternative way we can pass the csrftoken.  I'll continue investigating the cookie approach as well.