### PR TITLE
fix: Map to Correct Enterprise Internal Providers (#2142)

### DIFF
--- a/src/services/charts/useLegacyRepoCoverage.js
+++ b/src/services/charts/useLegacyRepoCoverage.js
@@ -1,12 +1,11 @@
 import { useQuery } from '@tanstack/react-query'
 
 import Api from 'shared/api'
-import { providerToName } from 'shared/utils'
+import { providerToInternalProvider } from 'shared/utils'
 
 function getRepoCoverage({ provider, owner }) {
-  return `/charts/${providerToName(
-    provider
-  ).toLowerCase()}/${owner}/coverage/repository`
+  const internalProvider = providerToInternalProvider(provider)
+  return `/charts/${internalProvider}/${owner}/coverage/repository`
 }
 
 function fetchRepoCoverage({ provider, owner, body, signal }) {

--- a/src/services/charts/useSunburstCoverage.js
+++ b/src/services/charts/useSunburstCoverage.js
@@ -1,12 +1,11 @@
 import { useQuery } from '@tanstack/react-query'
 
 import Api from 'shared/api'
-import { providerToName } from 'shared/utils'
+import { providerToInternalProvider } from 'shared/utils'
 
 function getSunburstCoverage({ provider, owner, repo }) {
-  return `/${providerToName(
-    provider
-  )?.toLowerCase()}/${owner}/${repo}/coverage/tree`
+  const internalProvider = providerToInternalProvider(provider)
+  return `/${internalProvider}/${owner}/${repo}/coverage/tree`
 }
 
 function fetchSunburstCoverage({ provider, owner, query, repo, signal }) {

--- a/src/services/repo/useEncodeString.js
+++ b/src/services/repo/useEncodeString.js
@@ -2,14 +2,14 @@ import { useMutation } from '@tanstack/react-query'
 import { useParams } from 'react-router-dom'
 
 import Api from 'shared/api'
-import { providerToName } from 'shared/utils'
+import { providerToInternalProvider } from 'shared/utils'
 
 function getEncodeStringPath({ provider, owner, repo }) {
   return `/${provider}/${owner}/repos/${repo}/encode/`
 }
 
 function encodeString({ provider, owner, repo, value }) {
-  const refactoredProvider = providerToName(provider).toLowerCase()
+  const refactoredProvider = providerToInternalProvider(provider)
   const path = getEncodeStringPath({
     provider: refactoredProvider,
     owner,

--- a/src/services/repo/useEraseRepoContent.js
+++ b/src/services/repo/useEraseRepoContent.js
@@ -2,7 +2,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { useParams } from 'react-router-dom'
 
 import Api from 'shared/api'
-import { providerToName } from 'shared/utils'
+import { providerToInternalProvider } from 'shared/utils'
 
 function getPathEraseRepo({ provider, owner, repo }) {
   return `/${provider}/${owner}/repos/${repo}/erase/`
@@ -11,7 +11,7 @@ function getPathEraseRepo({ provider, owner, repo }) {
 export function useEraseRepoContent() {
   const { provider, owner, repo } = useParams()
   const queryClient = useQueryClient()
-  const refactoredProvider = providerToName(provider).toLowerCase()
+  const refactoredProvider = providerToInternalProvider(provider)
   return useMutation({
     mutationFn: () => {
       const path = getPathEraseRepo({

--- a/src/services/repo/useUpdateRepo.js
+++ b/src/services/repo/useUpdateRepo.js
@@ -2,14 +2,14 @@ import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { useParams } from 'react-router-dom'
 
 import Api from 'shared/api'
-import { providerToName } from 'shared/utils'
+import { providerToInternalProvider } from 'shared/utils'
 
 function getRepoPath({ provider, owner, repo }) {
   return `/${provider}/${owner}/repos/${repo}/`
 }
 
 function updateRepo({ provider, owner, repo, body }) {
-  const refactoredProvider = providerToName(provider).toLowerCase()
+  const refactoredProvider = providerToInternalProvider(provider)
   const path = getRepoPath({
     provider: refactoredProvider,
     owner,

--- a/src/services/repoUploadToken/useRegenerateRepoUploadToken.js
+++ b/src/services/repoUploadToken/useRegenerateRepoUploadToken.js
@@ -2,15 +2,15 @@ import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { useParams } from 'react-router-dom/cjs/react-router-dom.min'
 
 import Api from 'shared/api'
-import { providerToName } from 'shared/utils'
+import { providerToInternalProvider } from 'shared/utils'
 
-function getRegenrateRepoTokenPath({ provider, owner, repo }) {
+function getRegenerateRepoTokenPath({ provider, owner, repo }) {
   return `/${provider}/${owner}/repos/${repo}/regenerate-upload-token/`
 }
 
 function regenerateRepoUploadToken({ provider, owner, repo }) {
-  const refactoredProvider = providerToName(provider).toLowerCase()
-  const path = getRegenrateRepoTokenPath({
+  const refactoredProvider = providerToInternalProvider(provider)
+  const path = getRegenerateRepoTokenPath({
     provider: refactoredProvider,
     owner,
     repo,

--- a/src/shared/treePaths/useTreePaths.js
+++ b/src/shared/treePaths/useTreePaths.js
@@ -8,8 +8,20 @@ function getTreeLocation(paths, location, index) {
   return dropRight(paths, paths.length - index - 1).join('/')
 }
 
+// eslint-disable-next-line max-statements, complexity
 export function useTreePaths(passedPath) {
-  const { provider, owner, branch, path, repo, ref } = useParams()
+  const {
+    provider,
+    owner,
+    branch: urlBranch,
+    path: urlPath,
+    repo,
+    ref: urlRef,
+  } = useParams()
+  const branch = urlBranch && decodeURIComponent(urlBranch)
+  const ref = urlRef && decodeURIComponent(urlRef)
+  const path = urlPath && decodeURIComponent(urlPath)
+
   const filePaths = getFilePathParts(passedPath || path)
   const { data: repoOverview } = useRepoOverview(
     {

--- a/src/shared/utils/provider.js
+++ b/src/shared/utils/provider.js
@@ -22,6 +22,23 @@ export function providerToName(provider) {
   }[provider.toLowerCase()]
 }
 
+export function providerToInternalProvider(provider) {
+  return {
+    gh: 'github',
+    bb: 'bitbucket',
+    gl: 'gitlab',
+    ghe: 'github_enterprise',
+    gle: 'gitlab_enterprise',
+    bbs: 'bitbucket_server',
+    github: 'github',
+    bitbucket: 'bitbucket',
+    gitlab: 'gitlab',
+    github_enterprise: 'github_enterprise',
+    gitlab_enterprise: 'gitlab_enterprise',
+    bitbucket_server: 'bitbucket_server',
+  }[provider.toLowerCase()]
+}
+
 export function providerImage(providerName) {
   return {
     Github: githubLogo,

--- a/src/shared/utils/provider.spec.js
+++ b/src/shared/utils/provider.spec.js
@@ -5,6 +5,7 @@ import {
   getProviderPullURL,
   providerFeedback,
   providerImage,
+  providerToInternalProvider,
   providerToName,
 } from './provider'
 
@@ -242,5 +243,85 @@ describe('getProviderPullURL', () => {
     expect(getProviderPullURL({ provider: 'bbs', owner, repo, pullId })).toBe(
       'https://bitbucket.mycompany.org/codecov/python/pull-requests/aebf'
     )
+  })
+})
+
+describe('providerToInternalProvider', () => {
+  describe('when called with gh', () => {
+    it('returns github', () => {
+      expect(providerToInternalProvider('gh')).toBe('github')
+    })
+  })
+
+  describe('when called with gl', () => {
+    it('returns gitlab', () => {
+      expect(providerToInternalProvider('gl')).toBe('gitlab')
+    })
+  })
+
+  describe('when called with bb', () => {
+    it('returns bitbucket', () => {
+      expect(providerToInternalProvider('bb')).toBe('bitbucket')
+    })
+  })
+
+  describe('when called with ghe', () => {
+    it('returns github_enterprise', () => {
+      expect(providerToInternalProvider('ghe')).toBe('github_enterprise')
+    })
+  })
+
+  describe('when called with gle', () => {
+    it('returns gitlab_enterprise', () => {
+      expect(providerToInternalProvider('gle')).toBe('gitlab_enterprise')
+    })
+  })
+
+  describe('when called with bbs', () => {
+    it('returns bitbucket_server', () => {
+      expect(providerToInternalProvider('bbs')).toBe('bitbucket_server')
+    })
+  })
+
+  describe('when called with Github', () => {
+    it('returns github', () => {
+      expect(providerToInternalProvider('github')).toBe('github')
+    })
+  })
+
+  describe('when called with Gitlab', () => {
+    it('returns gitlab', () => {
+      expect(providerToInternalProvider('gitlab')).toBe('gitlab')
+    })
+  })
+
+  describe('when called with BitBucket', () => {
+    it('returns bitbucket', () => {
+      expect(providerToInternalProvider('BitBucket')).toBe('bitbucket')
+    })
+  })
+
+  describe('when called with github_enterprise', () => {
+    it('returns github_enterprise', () => {
+      expect(providerToInternalProvider('github_enterprise')).toBe(
+        'github_enterprise'
+      )
+    })
+  })
+
+  describe('when called with gitlab-enterprise', () => {
+    it('returns gitlab_enterprise', () => {
+      expect(providerToInternalProvider('gitlab_enterprise')).toBe(
+        'gitlab_enterprise'
+      )
+    })
+  })
+
+  describe('when called with bitbucket_server', () => {
+    it('returns bitbucket_server', () => {
+      expect(providerToInternalProvider('bitbucket_server')).toBe(
+        'bitbucket_server'
+      )
+    })
   })
 })


### PR DESCRIPTION
fix: Map to Correct Enterprise Internal Providers (#2142)

Add new providerToInternalProvider function and swap from providerToName to new function.

Fixes CODE-3620

(cherry picked from commit 3fcbf2de0e6c9c49f8e8006a9aa119abd0072a20)

# Description

# Code Example

# Notable Changes

# Screenshots

# Link to Sample Entry

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.