### PR TITLE
ref: Remove ask for credit card when trialing

### DIFF
--- a/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/UpgradeForm.jsx
+++ b/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/UpgradeForm.jsx
@@ -25,8 +25,6 @@ import {
   MIN_SENTRY_SEATS,
   SENTRY_PRICE,
 } from 'shared/utils/upgradeForm'
-import A from 'ui/A'
-import Icon from 'ui/Icon'
 import TextInput from 'ui/TextInput'
 
 import BillingControls from './BillingControls/BillingControls'
@@ -170,8 +168,6 @@ function UpgradeForm({
   })
   const minSeats = isSentryUpgrade ? MIN_SENTRY_SEATS : MIN_NB_SEATS
   const trialStatus = planData?.plan?.trialStatus
-  const hasPaymentMethod =
-    accountDetails?.subscriptionDetail?.defaultPaymentMethod ?? null
 
   const {
     perYearPrice,
@@ -210,140 +206,64 @@ function UpgradeForm({
         isSentryUpgrade={isSentryUpgrade}
         trialStatus={trialStatus}
       />
-      {/* If not on trial, show the plan details without the credit card prompt */}
-      {trialStatus === TrialStatuses.NOT_STARTED ? (
-        <>
-          <div className="flex flex-col gap-2">
-            <BillingControls
-              planString={planString}
-              isSentryUpgrade={isSentryUpgrade}
-              setValue={setValue}
-            />
-          </div>
-          <div className="flex flex-col gap-2 xl:w-5/12">
-            <div className="w-2/6">
-              <TextInput
-                data-cy="seats"
-                dataMarketing="plan-pricing-seats"
-                {...register('seats')}
-                id="nb-seats"
-                size="20"
-                type="number"
-                label="Seat count"
-                min={minSeats}
-              />
-            </div>
-            <UserCount
-              activatedStudentCount={accountDetails?.activatedStudentCount}
-              activatedUserCount={accountDetails?.activatedUserCount}
-              inactiveUserCount={accountDetails?.inactiveUserCount}
-              isSentryUpgrade={isSentryUpgrade}
-            />
-          </div>
-          <TotalBanner
-            isPerYear={isPerYear}
-            perYearPrice={perYearPrice}
-            perMonthPrice={perMonthPrice}
-            setValue={setValue}
-            isSentryUpgrade={isSentryUpgrade}
-            sentryPlanYear={sentryPlanYear}
-            sentryPlanMonth={sentryPlanMonth}
-            seats={watch('seats')}
+      <div className="flex flex-col gap-2">
+        <BillingControls
+          planString={planString}
+          isSentryUpgrade={isSentryUpgrade}
+          setValue={setValue}
+        />
+      </div>
+      <div className="flex flex-col gap-2 xl:w-5/12">
+        <div className="w-2/6">
+          <TextInput
+            data-cy="seats"
+            dataMarketing="plan-pricing-seats"
+            {...register('seats')}
+            id="nb-seats"
+            size="20"
+            type="number"
+            label="Seat count"
+            min={minSeats}
           />
-          {nextBillingDate && (
-            <p className="mt-1 flex">
-              Next Billing Date
-              <span className="ml-auto">{nextBillingDate}</span>
-            </p>
-          )}
-          {errors?.seats && (
-            <p className="rounded-md bg-ds-error-quinary p-3 text-ds-error-nonary">
-              {errors?.seats?.message}
-            </p>
-          )}
-          <div className="w-fit">
-            <UpdateButton
-              isValid={isValid}
-              getValues={getValues}
-              value={accountDetails?.plan?.value}
-              quantity={accountDetails?.plan?.quantity}
-              isSentryUpgrade={isSentryUpgrade}
-              trialStatus={trialStatus}
-            />
-          </div>
-        </>
-      ) : trialStatus === TrialStatuses.ONGOING && !hasPaymentMethod ? (
-        // If on trial, if no credit card, only show the credit card prompt
-        <A
-          href="https://billing.stripe.com/p/login/aEU00i9by3V4caQ6oo"
-          hook="stripe-account-management-portal"
-        >
-          Proceed with plan and input billing information
-          <Icon name="chevronRight" size="sm" variant="solid" />
-        </A>
-      ) : (
-        <>
-          {/* If on trial, if credit card, only show the billing details */}
-          <div className="flex flex-col gap-2">
-            <BillingControls
-              planString={planString}
-              isSentryUpgrade={isSentryUpgrade}
-              setValue={setValue}
-            />
-          </div>
-          <div className="flex flex-col gap-2 xl:w-5/12">
-            <div className="w-2/6">
-              <TextInput
-                data-cy="seats"
-                dataMarketing="plan-pricing-seats"
-                {...register('seats')}
-                id="nb-seats"
-                size="20"
-                type="number"
-                label="Seat count"
-                min={minSeats}
-              />
-            </div>
-            <UserCount
-              activatedStudentCount={accountDetails?.activatedStudentCount}
-              activatedUserCount={accountDetails?.activatedUserCount}
-              inactiveUserCount={accountDetails?.inactiveUserCount}
-              isSentryUpgrade={isSentryUpgrade}
-            />
-          </div>
-          <TotalBanner
-            isPerYear={isPerYear}
-            perYearPrice={perYearPrice}
-            perMonthPrice={perMonthPrice}
-            setValue={setValue}
-            isSentryUpgrade={isSentryUpgrade}
-            sentryPlanYear={sentryPlanYear}
-            sentryPlanMonth={sentryPlanMonth}
-            seats={watch('seats')}
-          />
-          {nextBillingDate && (
-            <p className="mt-1 flex">
-              Next Billing Date
-              <span className="ml-auto">{nextBillingDate}</span>
-            </p>
-          )}
-          {errors?.seats && (
-            <p className="rounded-md bg-ds-error-quinary p-3 text-ds-error-nonary">
-              {errors?.seats?.message}
-            </p>
-          )}
-          <div className="w-fit">
-            <UpdateButton
-              isValid={isValid}
-              getValues={getValues}
-              value={accountDetails?.plan?.value}
-              quantity={accountDetails?.plan?.quantity}
-              isSentryUpgrade={isSentryUpgrade}
-              trialStatus={trialStatus}
-            />
-          </div>
-        </>
+        </div>
+        <UserCount
+          activatedStudentCount={accountDetails?.activatedStudentCount}
+          activatedUserCount={accountDetails?.activatedUserCount}
+          inactiveUserCount={accountDetails?.inactiveUserCount}
+          isSentryUpgrade={isSentryUpgrade}
+        />
+      </div>
+      <TotalBanner
+        isPerYear={isPerYear}
+        perYearPrice={perYearPrice}
+        perMonthPrice={perMonthPrice}
+        setValue={setValue}
+        isSentryUpgrade={isSentryUpgrade}
+        sentryPlanYear={sentryPlanYear}
+        sentryPlanMonth={sentryPlanMonth}
+        seats={watch('seats')}
+      />
+      {nextBillingDate && (
+        <p className="mt-1 flex">
+          Next Billing Date
+          <span className="ml-auto">{nextBillingDate}</span>
+        </p>
       )}
+      {errors?.seats && (
+        <p className="rounded-md bg-ds-error-quinary p-3 text-ds-error-nonary">
+          {errors?.seats?.message}
+        </p>
+      )}
+      <div className="w-fit">
+        <UpdateButton
+          isValid={isValid}
+          getValues={getValues}
+          value={accountDetails?.plan?.value}
+          quantity={accountDetails?.plan?.quantity}
+          isSentryUpgrade={isSentryUpgrade}
+          trialStatus={trialStatus}
+        />
+      </div>
     </form>
   )
 }

--- a/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/UpgradeForm.spec.jsx
+++ b/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/UpgradeForm.spec.jsx
@@ -570,12 +570,6 @@ describe('UpgradeForm', () => {
           inactiveUserCount: 0,
           plan: sentryPlanYear,
           latestInvoice: null,
-          subscriptionDetail: {
-            defaultPaymentMethod: {
-              billingDetails: {},
-              card: { brand: 'visa' },
-            },
-          },
         },
       }
 
@@ -624,50 +618,6 @@ describe('UpgradeForm', () => {
           const price = screen.getByText(/\$120/)
           expect(price).toBeInTheDocument()
         })
-      })
-    })
-
-    describe('when the user have a sentry pro year plan but no billing information during trial', () => {
-      const props = {
-        proPlanMonth,
-        proPlanYear,
-        sentryPlanMonth,
-        sentryPlanYear,
-        accountDetails: {
-          activatedUserCount: 9,
-          inactiveUserCount: 0,
-          plan: sentryPlanYear,
-          latestInvoice: null,
-        },
-      }
-
-      it('does not render annual option to be "selected"', () => {
-        setup({ includeSentryPlans: true, trialStatus: TrialStatuses.ONGOING })
-        render(<UpgradeForm {...props} />, { wrapper: wrapper() })
-
-        const optionBtn = screen.queryByRole('button', { name: 'Annual' })
-        expect(optionBtn).not.toBeInTheDocument()
-      })
-
-      it('does not have the update button', () => {
-        setup({ includeSentryPlans: true })
-        render(<UpgradeForm {...props} />, { wrapper: wrapper() })
-
-        const update = screen.queryByText(/Update/)
-        expect(update).not.toBeInTheDocument()
-      })
-
-      it('prompts the user to input their billing information', async () => {
-        setup({ includeSentryPlans: true, trialStatus: TrialStatuses.ONGOING })
-        render(<UpgradeForm {...props} />, { wrapper: wrapper() })
-
-        const billingInformationAnchor = await screen.findByText(
-          /Proceed with plan and input billing information/
-        )
-        expect(billingInformationAnchor).toBeInTheDocument()
-        expect(billingInformationAnchor.href).toBe(
-          'https://billing.stripe.com/p/login/aEU00i9by3V4caQ6oo'
-        )
       })
     })
 
@@ -758,12 +708,6 @@ describe('UpgradeForm', () => {
               inactiveUserCount: 0,
               plan: null,
               latestInvoice: null,
-              subscriptionDetail: {
-                defaultPaymentMethod: {
-                  billingDetails: {},
-                  card: { brand: 'visa' },
-                },
-              },
             }}
           />,
           { wrapper: wrapper() }
@@ -802,12 +746,6 @@ describe('UpgradeForm', () => {
               inactiveUserCount: 0,
               plan: null,
               latestInvoice: null,
-              subscriptionDetail: {
-                defaultPaymentMethod: {
-                  billingDetails: {},
-                  card: { brand: 'visa' },
-                },
-              },
             }}
           />,
           { wrapper: wrapper() }


### PR DESCRIPTION
# Description
With the introduction of codecov trial, we no longer need to ask for the credit card when you're under our old trial. This Pr removes the need for that.

Caveat: do not merge this until the whole trial initiative is in.

# Notable Changes
- Removed the ask for credit card info in the upgrade page once you're trialing and adjusted the test for it
- Adjusted trialstatuses never_trialed value to cannot_trial as that's the expected API value