### PR TITLE
feat, fix: Add New Trial Logic to Plan Page (CODE-3587)

### DIFF
--- a/src/pages/PlanPage/hooks/usePlanPageData.js
+++ b/src/pages/PlanPage/hooks/usePlanPageData.js
@@ -23,7 +23,7 @@ export function usePlanPageData(opts) {
     queryKey: ['PlanPageData', variables, provider, query],
     queryFn: ({ signal }) =>
       Api.graphql({ provider, query, variables, signal }).then(
-        (res) => res?.data?.owner
+        (res) => res?.data?.owner ?? {}
       ),
     ...opts,
   })

--- a/src/pages/PlanPage/subRoutes/CurrentOrgPlan/CurrentPlanCard/CurrentPlanCard.jsx
+++ b/src/pages/PlanPage/subRoutes/CurrentOrgPlan/CurrentPlanCard/CurrentPlanCard.jsx
@@ -5,12 +5,14 @@ import {
   CollectionMethods,
   isEnterprisePlan,
   isFreePlan,
+  isTrialPlan,
 } from 'shared/utils/billing'
 
 import EnterprisePlanCard from './EnterprisePlanCard'
 import FreePlanCard from './FreePlanCard'
 import ProPlanCard from './ProPlanCard'
 
+// eslint-disable-next-line complexity
 function CurrentPlanCard() {
   const { provider, owner } = useParams()
   const { data: accountDetails } = useAccountDetails({ provider, owner })
@@ -18,7 +20,7 @@ function CurrentPlanCard() {
   const scheduledPhase = accountDetails?.scheduleDetail?.scheduledPhase
   const collectionMethod = accountDetails?.subscriptionDetail?.collectionMethod
 
-  if (isFreePlan(plan?.value)) {
+  if (isFreePlan(plan?.value) || isTrialPlan(plan?.value)) {
     return <FreePlanCard plan={plan} scheduledPhase={scheduledPhase} />
   }
 

--- a/src/pages/PlanPage/subRoutes/CurrentOrgPlan/CurrentPlanCard/CurrentPlanCard.spec.jsx
+++ b/src/pages/PlanPage/subRoutes/CurrentOrgPlan/CurrentPlanCard/CurrentPlanCard.spec.jsx
@@ -14,7 +14,7 @@ const proPlanDetails = {
   plan: {
     marketingName: 'Pro Team',
     baseUnitPrice: 12,
-    benefits: ['Configureable # of users', 'Unlimited repos'],
+    benefits: ['Configurable # of users', 'Unlimited repos'],
     quantity: 5,
     value: 'users-inappm',
   },
@@ -48,6 +48,16 @@ const enterprisePlan = {
   },
 }
 
+const trialPlanDetails = {
+  plan: {
+    marketingName: 'Pro Trial Team',
+    baseUnitPrice: 12,
+    benefits: ['Configurable # of users', 'Unlimited repos'],
+    quantity: 5,
+    value: 'users-trial',
+  },
+}
+
 const queryClient = new QueryClient({
   defaultOptions: { queries: { retry: false } },
 })
@@ -78,44 +88,55 @@ describe('CurrentPlanCard', () => {
     )
   }
 
-  describe('When rendered with free plan', () => {
-    beforeEach(() => {
+  describe('rendered with free plan', () => {
+    it('renders the correct plan card', async () => {
       setup()
-    })
-    it('renders the correct plan card', async () => {
+
       render(<CurrentPlanCard />, {
         wrapper,
       })
 
-      expect(await screen.findByText(/Free plan card/)).toBeInTheDocument()
+      const freePlanCard = await screen.findByText(/Free plan card/)
+      expect(freePlanCard).toBeInTheDocument()
     })
   })
 
-  describe('When rendered with pro plan', () => {
-    beforeEach(() => {
+  describe('rendered with trial plan', () => {
+    it('renders the correct plan card', async () => {
+      setup(trialPlanDetails)
+
+      render(<CurrentPlanCard />, {
+        wrapper,
+      })
+
+      const freePlanCard = await screen.findByText(/Free plan card/)
+      expect(freePlanCard).toBeInTheDocument()
+    })
+  })
+
+  describe('rendered with pro plan', () => {
+    it('renders the correct plan card', async () => {
       setup(proPlanDetails)
-    })
-    it('renders the correct plan card', async () => {
+
       render(<CurrentPlanCard />, {
         wrapper,
       })
 
-      expect(await screen.findByText(/Pro plan card/)).toBeInTheDocument()
+      const proPlanCard = await screen.findByText(/Pro plan card/)
+      expect(proPlanCard).toBeInTheDocument()
     })
   })
 
-  describe('When rendered with enterprise plan', () => {
-    beforeEach(() => {
-      setup(enterprisePlan)
-    })
+  describe('rendered with enterprise plan', () => {
     it('renders the correct plan card', async () => {
+      setup(enterprisePlan)
+
       render(<CurrentPlanCard />, {
         wrapper,
       })
 
-      expect(
-        await screen.findByText(/Enterprise plan card/)
-      ).toBeInTheDocument()
+      const enterpriseCard = await screen.findByText(/Enterprise plan card/)
+      expect(enterpriseCard).toBeInTheDocument()
     })
   })
 })

--- a/src/pages/PlanPage/subRoutes/CurrentOrgPlan/CurrentPlanCard/FreePlanCard/ProPlanSubheading/ProPlanSubheading.spec.tsx
+++ b/src/pages/PlanPage/subRoutes/CurrentOrgPlan/CurrentPlanCard/FreePlanCard/ProPlanSubheading/ProPlanSubheading.spec.tsx
@@ -1,0 +1,182 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { render, screen, waitFor } from '@testing-library/react'
+import { graphql } from 'msw'
+import { setupServer } from 'msw/node'
+import { MemoryRouter, Route } from 'react-router-dom'
+
+import { TrialStatuses } from 'services/account'
+import { useFlags } from 'shared/featureFlags'
+
+import ProPlanSubheading from './ProPlanSubheading'
+
+jest.mock('shared/featureFlags')
+
+const mockedUseFlags = useFlags as jest.Mock<{ codecovTrialMvp: boolean }>
+
+const mockResponse = {
+  baseUnitPrice: 10,
+  benefits: [],
+  billingRate: 'monthly',
+  marketingName: 'Users Basic',
+  monthlyUploadLimit: 250,
+  planName: 'users-basic',
+  trialStatus: TrialStatuses.NOT_STARTED,
+  trialStartDate: '',
+  trialEndDate: '',
+}
+
+const server = setupServer()
+const queryClient = new QueryClient({
+  defaultOptions: { queries: { retry: false } },
+})
+
+const wrapper: React.FC<React.PropsWithChildren> = ({ children }) => (
+  <QueryClientProvider client={queryClient}>
+    <MemoryRouter initialEntries={['/plan/gh/codecov']}>
+      <Route path="/plan/:provider/:owner">{children}</Route>
+    </MemoryRouter>
+  </QueryClientProvider>
+)
+
+beforeAll(() => {
+  server.listen()
+})
+
+afterEach(() => {
+  queryClient.clear()
+  server.resetHandlers()
+})
+
+afterAll(() => {
+  server.close()
+})
+
+interface SetupArgs {
+  trialFlag?: boolean
+  trialStatus?: string | null
+  planValue?: string
+}
+
+describe('ProPlanSubheading', () => {
+  function setup({
+    trialFlag = false,
+    trialStatus = TrialStatuses.NOT_STARTED,
+    planValue = 'users-basic',
+  }: SetupArgs) {
+    mockedUseFlags.mockReturnValue({
+      codecovTrialMvp: trialFlag,
+    })
+
+    server.use(
+      graphql.query('GetPlanData', (req, res, ctx) =>
+        res(
+          ctx.status(200),
+          ctx.data({
+            owner: {
+              plan: {
+                ...mockResponse,
+                trialStatus,
+                planName: planValue,
+              },
+            },
+          })
+        )
+      )
+    )
+  }
+
+  describe('flag is set to false', () => {
+    it('renders nothing', () => {
+      setup({ trialFlag: false })
+
+      const { container } = render(<ProPlanSubheading />, { wrapper })
+
+      expect(container).toBeEmptyDOMElement()
+    })
+  })
+
+  describe('flag is set to true', () => {
+    describe('user is not eligible for a trial', () => {
+      it('renders nothing', async () => {
+        setup({ trialFlag: true, trialStatus: TrialStatuses.CANNOT_TRIAL })
+
+        const { container } = render(<ProPlanSubheading />, { wrapper })
+
+        await waitFor(() => queryClient.isFetching)
+        await waitFor(() => !queryClient.isFetching)
+
+        expect(container).toBeEmptyDOMElement()
+      })
+    })
+
+    describe('user is on a free plan', () => {
+      it('renders correct text', async () => {
+        setup({ trialFlag: true, trialStatus: TrialStatuses.NOT_STARTED })
+
+        render(<ProPlanSubheading />, { wrapper })
+
+        const text = await screen.findByText(/Includes 14-day free trial/)
+        expect(text).toBeInTheDocument()
+      })
+
+      it('renders faq link', async () => {
+        setup({ trialFlag: true, trialStatus: TrialStatuses.NOT_STARTED })
+
+        render(<ProPlanSubheading />, { wrapper })
+
+        const faqLink = await screen.findByRole('link', { name: /FAQ/ })
+        expect(faqLink).toBeInTheDocument()
+        expect(faqLink).toHaveAttribute(
+          'href',
+          'https://docs.codecov.com/docs/free-trial-faqs'
+        )
+      })
+    })
+
+    describe('user is currently on a trial', () => {
+      it('renders correct text', async () => {
+        setup({
+          trialFlag: true,
+          trialStatus: TrialStatuses.ONGOING,
+          planValue: 'users-trial',
+        })
+
+        render(<ProPlanSubheading />, { wrapper })
+
+        const text = await screen.findByText(/Current trial/)
+        expect(text).toBeInTheDocument()
+      })
+
+      it('renders link to faqs', async () => {
+        setup({
+          trialFlag: true,
+          trialStatus: TrialStatuses.ONGOING,
+          planValue: 'users-trial',
+        })
+
+        render(<ProPlanSubheading />, { wrapper })
+
+        const faqLink = await screen.findByRole('link', { name: /FAQ/ })
+        expect(faqLink).toBeInTheDocument()
+        expect(faqLink).toHaveAttribute(
+          'href',
+          'https://docs.codecov.com/docs/free-trial-faqs'
+        )
+      })
+    })
+
+    describe('users trial has expired', () => {
+      it('renders correct text', async () => {
+        setup({
+          trialFlag: true,
+          trialStatus: TrialStatuses.EXPIRED,
+        })
+
+        render(<ProPlanSubheading />, { wrapper })
+
+        const text = await screen.findByText(/Your org trialed this plan/)
+        expect(text).toBeInTheDocument()
+      })
+    })
+  })
+})

--- a/src/pages/PlanPage/subRoutes/CurrentOrgPlan/CurrentPlanCard/FreePlanCard/ProPlanSubheading/ProPlanSubheading.tsx
+++ b/src/pages/PlanPage/subRoutes/CurrentOrgPlan/CurrentPlanCard/FreePlanCard/ProPlanSubheading/ProPlanSubheading.tsx
@@ -1,0 +1,71 @@
+import { useParams } from 'react-router-dom'
+
+import { TrialStatuses, usePlanData } from 'services/account'
+import { useFlags } from 'shared/featureFlags'
+import { isFreePlan, isTrialPlan } from 'shared/utils/billing'
+import A from 'ui/A'
+
+interface Params {
+  provider: string
+  owner: string
+}
+
+// eslint-disable-next-line max-statements, complexity
+function ProPlanSubheading() {
+  const { provider, owner } = useParams<Params>()
+  const { codecovTrialMvp } = useFlags({
+    codecovTrialMvp: false,
+  })
+
+  const { data: planData } = usePlanData({
+    provider,
+    owner,
+    opts: { enabled: codecovTrialMvp },
+  })
+
+  if (!codecovTrialMvp) return null
+
+  // user can start a trial
+  // - user on a free plan
+  // - trial status is not started
+  if (
+    isFreePlan(planData?.plan?.planName) &&
+    planData?.plan?.trialStatus === TrialStatuses.NOT_STARTED
+  ) {
+    return (
+      <p className="text-ds-gray-quinary">
+        {/* @ts-expect-error */}
+        Includes 14-day free trial <A to={{ pageName: 'freeTrialFaqs' }}>FAQ</A>
+      </p>
+    )
+  }
+
+  // user currently is on trial
+  // - user is on a trial plan
+  // - trial status is currently ongoing
+  if (
+    isTrialPlan(planData?.plan?.planName) &&
+    planData?.plan?.trialStatus === TrialStatuses.ONGOING
+  ) {
+    return (
+      <p className="text-ds-gray-quinary">
+        {/* @ts-expect-error */}
+        Current trial <A to={{ pageName: 'freeTrialFaqs' }}>FAQ</A>
+      </p>
+    )
+  }
+
+  // user has an expired trial
+  // - user is currently on a free plan
+  // - trial status is expired
+  if (
+    isFreePlan(planData?.plan?.planName) &&
+    planData?.plan?.trialStatus === TrialStatuses.EXPIRED
+  ) {
+    return <p className="text-ds-gray-quinary">Your org trialed this plan</p>
+  }
+
+  return null
+}
+
+export default ProPlanSubheading

--- a/src/pages/PlanPage/subRoutes/CurrentOrgPlan/CurrentPlanCard/FreePlanCard/ProPlanSubheading/index.ts
+++ b/src/pages/PlanPage/subRoutes/CurrentOrgPlan/CurrentPlanCard/FreePlanCard/ProPlanSubheading/index.ts
@@ -1,0 +1,1 @@
+export { default } from './ProPlanSubheading'

--- a/src/pages/PlanPage/subRoutes/CurrentOrgPlan/CurrentPlanCard/shared/ActionsBilling/ActionsBilling.jsx
+++ b/src/pages/PlanPage/subRoutes/CurrentOrgPlan/CurrentPlanCard/shared/ActionsBilling/ActionsBilling.jsx
@@ -8,6 +8,7 @@ import {
   usePlanData,
   usePlans,
 } from 'services/account'
+import { useStartTrial } from 'services/trial'
 import { useFlags } from 'shared/featureFlags'
 import {
   canApplySentryUpgrade,
@@ -18,7 +19,7 @@ import {
 import A from 'ui/A/A'
 import Button from 'ui/Button'
 
-// eslint-disable-next-line complexity
+// eslint-disable-next-line complexity, max-statements
 function PlansActionsBilling({ plan }) {
   const { provider, owner } = useParams()
   const { data: plans } = usePlans(provider)
@@ -32,6 +33,8 @@ function PlansActionsBilling({ plan }) {
     opts: { enabled: codecovTrialMvp },
   })
 
+  const { mutate, isLoading } = useStartTrial({ owner })
+
   const canStartTrial =
     planData?.plan?.trialStatus === TrialStatuses.NOT_STARTED &&
     isFreePlan(planData?.plan?.planName)
@@ -41,10 +44,10 @@ function PlansActionsBilling({ plan }) {
       <div className="flex items-center gap-4 self-start">
         <Button
           onClick={() => {
-            // call mutate depending on condition
-            // redirect if no error
+            mutate()
           }}
           variant="primary"
+          isLoading={isLoading}
         >
           Start trial
         </Button>

--- a/src/pages/PlanPage/subRoutes/CurrentOrgPlan/CurrentPlanCard/shared/ActionsBilling/ActionsBilling.jsx
+++ b/src/pages/PlanPage/subRoutes/CurrentOrgPlan/CurrentPlanCard/shared/ActionsBilling/ActionsBilling.jsx
@@ -1,17 +1,58 @@
 import { useParams } from 'react-router-dom'
 
 import githubLogo from 'assets/githublogo.png'
-import { planPropType, useAccountDetails, usePlans } from 'services/account'
+import {
+  planPropType,
+  TrialStatuses,
+  useAccountDetails,
+  usePlanData,
+  usePlans,
+} from 'services/account'
+import { useFlags } from 'shared/featureFlags'
 import {
   canApplySentryUpgrade,
   isFreePlan,
   isSentryPlan,
+  isTrialPlan,
 } from 'shared/utils/billing'
+import A from 'ui/A/A'
 import Button from 'ui/Button'
 
+// eslint-disable-next-line complexity
 function PlansActionsBilling({ plan }) {
-  const { provider } = useParams()
+  const { provider, owner } = useParams()
   const { data: plans } = usePlans(provider)
+  const { codecovTrialMvp } = useFlags({
+    codecovTrialMvp: false,
+  })
+
+  const { data: planData } = usePlanData({
+    provider,
+    owner,
+    opts: { enabled: codecovTrialMvp },
+  })
+
+  const canStartTrial =
+    planData?.plan?.trialStatus === TrialStatuses.NOT_STARTED &&
+    isFreePlan(planData?.plan?.planName)
+
+  if (canStartTrial) {
+    return (
+      <div className="flex items-center gap-4 self-start">
+        <Button
+          onClick={() => {
+            // call mutate depending on condition
+            // redirect if no error
+          }}
+          variant="primary"
+        >
+          Start trial
+        </Button>
+        <p className="font-semibold">OR</p>
+        <A to={{ pageName: 'upgradeOrgPlan' }}>upgrade now</A>
+      </div>
+    )
+  }
 
   if (canApplySentryUpgrade({ plan, plans })) {
     return (
@@ -28,7 +69,9 @@ function PlansActionsBilling({ plan }) {
   return (
     <div className="flex self-start">
       <Button to={{ pageName: 'upgradeOrgPlan' }} variant="primary">
-        {isFreePlan(plan?.value) ? 'Upgrade to Pro Team plan' : 'Manage plan'}
+        {isFreePlan(plan?.value) || isTrialPlan(plan?.value)
+          ? 'Upgrade to Pro Team plan'
+          : 'Manage plan'}
       </Button>
     </div>
   )
@@ -68,7 +111,7 @@ function ActionsBilling() {
       <div className="flex flex-col gap-4">
         <hr />
         <p className="text-sm">
-          This subgroup’s billing is managed by {username}.
+          This subgroup&apos;s billing is managed by {username}.
         </p>
         <div className="flex self-start">
           <Button

--- a/src/pages/PlanPage/subRoutes/CurrentOrgPlan/CurrentPlanCard/shared/ActionsBilling/ActionsBilling.jsx
+++ b/src/pages/PlanPage/subRoutes/CurrentOrgPlan/CurrentPlanCard/shared/ActionsBilling/ActionsBilling.jsx
@@ -33,7 +33,7 @@ function PlansActionsBilling({ plan }) {
     opts: { enabled: codecovTrialMvp },
   })
 
-  const { mutate, isLoading } = useStartTrial({ owner })
+  const { mutate, isLoading } = useStartTrial()
 
   const canStartTrial =
     planData?.plan?.trialStatus === TrialStatuses.NOT_STARTED &&
@@ -44,7 +44,7 @@ function PlansActionsBilling({ plan }) {
       <div className="flex items-center gap-4 self-start">
         <Button
           onClick={() => {
-            mutate()
+            mutate({ owner })
           }}
           variant="primary"
           isLoading={isLoading}

--- a/src/pages/PlanPage/subRoutes/CurrentOrgPlan/CurrentPlanCard/shared/ActionsBilling/ActionsBilling.spec.jsx
+++ b/src/pages/PlanPage/subRoutes/CurrentOrgPlan/CurrentPlanCard/shared/ActionsBilling/ActionsBilling.spec.jsx
@@ -1,11 +1,15 @@
-import { render, screen } from 'custom-testing-library'
-
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { rest } from 'msw'
+import { render, screen, waitFor } from '@testing-library/react'
+import { graphql, rest } from 'msw'
 import { setupServer } from 'msw/node'
 import { MemoryRouter, Route } from 'react-router-dom'
 
+import { TrialStatuses } from 'services/account'
+import { useFlags } from 'shared/featureFlags'
+
 import ActionsBilling from './ActionsBilling'
+
+jest.mock('shared/featureFlags')
 
 const allPlans = [
   {
@@ -119,152 +123,331 @@ const sentryMockedAccountDetails = {
   inactiveUserCount: 1,
 }
 
+const mockTrialAccountDetails = {
+  plan: {
+    marketingName: 'Trial plan',
+    baseUnitPrice: 12,
+    benefits: ['Configurable # of users', 'Unlimited repos'],
+    quantity: 9,
+    value: 'users-trial',
+  },
+  activatedUserCount: 5,
+  inactiveUserCount: 1,
+}
+
+const mockTrialData = {
+  plan: {
+    baseUnitPrice: 10,
+    benefits: [],
+    billingRate: 'monthly',
+    marketingName: 'Users Basic',
+    monthlyUploadLimit: 250,
+    planName: 'users-basic',
+    trialStatus: 'ONGOING',
+    trialStartDate: '2023-01-01T08:55:25',
+    trialEndDate: '2023-01-10T08:55:25',
+  },
+}
+
 const server = setupServer()
 
-beforeAll(() => server.listen())
+beforeAll(() => {
+  server.listen()
+})
+
 afterEach(() => {
   queryClient.clear()
   server.resetHandlers()
 })
-afterAll(() => server.close())
+
+afterAll(() => {
+  server.close()
+})
 
 const wrapper = ({ children }) => (
   <QueryClientProvider client={queryClient}>
-    <MemoryRouter initialEntries={['/members/gh/critical-role']}>
-      <Route path="/:provider/:owner/:repo">{children}</Route>
+    <MemoryRouter initialEntries={['/plan/gh/critical-role']}>
+      <Route path="/plan/:provider/:owner">{children}</Route>
     </MemoryRouter>
   </QueryClientProvider>
 )
 
 describe('Actions Billing', () => {
-  function setup(accountDetails = mockedFreeAccountDetails, plans = allPlans) {
+  function setup(
+    accountDetails = mockedFreeAccountDetails,
+    plans = allPlans,
+    codecovTrialFlag = false,
+    trialPlanData = mockTrialData
+  ) {
+    useFlags.mockReturnValue({
+      codecovTrialMvp: codecovTrialFlag,
+    })
+
     server.use(
-      rest.get('/internal/members/gh/account-details/', (req, res, ctx) =>
+      rest.get('/internal/gh/critical-role/account-details/', (req, res, ctx) =>
         res(ctx.status(200), ctx.json(accountDetails))
       ),
       rest.get('/internal/plans', (req, res, ctx) =>
         res(ctx.status(200), ctx.json(plans))
-      )
+      ),
+      graphql.query('GetPlanData', (req, res, ctx) => {
+        return res(ctx.status(200), ctx.data({ owner: trialPlanData }))
+      })
     )
   }
 
-  describe('Renders Component', () => {
-    beforeEach(() => setup())
+  describe('rendering component', () => {
+    describe('user has a free plan', () => {
+      describe('flag is false', () => {
+        it('renders upgrade to pro plan', async () => {
+          setup()
 
-    describe('For the free plan', () => {
-      it('Displays upgrade pro team plan', async () => {
-        render(<ActionsBilling />, { wrapper })
+          render(<ActionsBilling />, { wrapper })
 
-        expect(
-          await screen.findByRole('link', { name: /Upgrade to Pro Team plan/ })
-        ).toBeInTheDocument()
+          const upgradeLink = await screen.findByRole('link', {
+            name: /Upgrade to Pro Team plan/,
+          })
+          expect(upgradeLink).toBeInTheDocument()
+          expect(upgradeLink).toHaveAttribute(
+            'href',
+            '/plan/gh/critical-role/upgrade'
+          )
+        })
+      })
 
-        expect(
-          await screen.findByRole('link', { name: /Upgrade to Pro Team plan/ })
-        ).toHaveAttribute('href', '/plan/members/gh/upgrade')
+      describe('flag is true', () => {
+        it('renders start trial button', async () => {
+          setup(mockedFreeAccountDetails, allPlans, true, {
+            plan: {
+              ...mockTrialData.plan,
+              trialStatus: TrialStatuses.NOT_STARTED,
+            },
+          })
+
+          render(<ActionsBilling />, { wrapper })
+
+          const startTrialButton = await screen.findByRole('button', {
+            name: 'Start trial',
+          })
+          expect(startTrialButton).toBeInTheDocument()
+        })
+
+        it('renders upgrade now link', async () => {
+          setup(mockedFreeAccountDetails, allPlans, true, {
+            plan: {
+              ...mockTrialData.plan,
+              trialStatus: TrialStatuses.NOT_STARTED,
+            },
+          })
+
+          render(<ActionsBilling />, { wrapper })
+
+          const upgradeNowLink = await screen.findByRole('link', {
+            name: 'upgrade now',
+          })
+          expect(upgradeNowLink).toBeInTheDocument()
+          expect(upgradeNowLink).toHaveAttribute(
+            'href',
+            '/plan/gh/critical-role/upgrade'
+          )
+        })
       })
     })
-  })
 
-  describe('For the pro plan', () => {
-    beforeEach(() => setup(mockedProAccountDetails))
+    describe('user has a trial plan', () => {
+      it('renders upgrade link', async () => {
+        setup(mockTrialAccountDetails, allPlans, true, {
+          plan: {
+            ...mockTrialData.plan,
+            trialStatus: TrialStatuses.ONGOING,
+          },
+        })
 
-    it('Displays manage plan link', async () => {
-      render(<ActionsBilling />, { wrapper })
+        render(<ActionsBilling />, { wrapper })
 
-      expect(
-        await screen.findByRole('link', { name: /Manage plan/ })
-      ).toBeInTheDocument()
-
-      expect(
-        await screen.findByRole('link', { name: /Manage plan/ })
-      ).toHaveAttribute('href', '/plan/members/gh/upgrade')
-    })
-  })
-
-  describe('If the root org has a username', () => {
-    beforeEach(() => setup({ rootOrganization: { username: 'critical-role' } }))
-
-    it('Displays view billing', async () => {
-      render(<ActionsBilling />, { wrapper })
-
-      expect(
-        await screen.findByRole('link', { name: /View Billing/ })
-      ).toBeInTheDocument()
-
-      expect(
-        await screen.findByRole('link', { name: /View Billing/ })
-      ).toHaveAttribute('href', '/account/members/critical-role/billing')
+        const upgradeLink = await screen.findByRole('link', {
+          name: /Upgrade to Pro Team plan/,
+        })
+        expect(upgradeLink).toBeInTheDocument()
+        expect(upgradeLink).toHaveAttribute(
+          'href',
+          '/plan/gh/critical-role/upgrade'
+        )
+      })
     })
 
-    it('Displays the description', async () => {
-      render(<ActionsBilling />, { wrapper })
+    describe('user has a pro plan', () => {
+      it('renders manage plan link', async () => {
+        setup(mockedProAccountDetails)
 
-      expect(
-        await screen.findByText(/This subgroup’s billing is managed by/)
-      ).toBeInTheDocument()
+        render(<ActionsBilling />, { wrapper })
+
+        const managePlanLink = await screen.findByRole('link', {
+          name: /Manage plan/,
+        })
+        expect(managePlanLink).toBeInTheDocument()
+        expect(managePlanLink).toHaveAttribute(
+          'href',
+          '/plan/gh/critical-role/upgrade'
+        )
+      })
     })
-  })
 
-  describe('If the plan is managed by github', () => {
-    beforeEach(() => setup({ planProvider: 'github' }))
+    describe('owner is a user', () => {
+      it('renders view billing', async () => {
+        setup({ rootOrganization: { username: 'critical-role' } })
 
-    it('Displays the description', async () => {
-      render(<ActionsBilling />, { wrapper })
+        render(<ActionsBilling />, { wrapper })
 
-      expect(
-        await screen.findByText(
+        const viewBillingLink = await screen.findByRole('link', {
+          name: /View Billing/,
+        })
+        expect(viewBillingLink).toBeInTheDocument()
+        expect(viewBillingLink).toHaveAttribute(
+          'href',
+          '/account/gh/critical-role/billing'
+        )
+      })
+
+      it('renders the description', async () => {
+        setup({ rootOrganization: { username: 'critical-role' } })
+
+        render(<ActionsBilling />, { wrapper })
+
+        const description = await screen.findByText(
+          /This subgroup's billing is managed by/
+        )
+        expect(description).toBeInTheDocument()
+      })
+    })
+
+    describe('plan is managed by github', () => {
+      it('renders the description', async () => {
+        setup({ planProvider: 'github' })
+
+        render(<ActionsBilling />, { wrapper })
+
+        const githubText = await screen.findByText(
           /Your account is configured via GitHub Marketplace/
         )
-      ).toBeInTheDocument()
-    })
+        expect(githubText).toBeInTheDocument()
+      })
 
-    it('Displays manage billing in GitHub link', async () => {
-      render(<ActionsBilling />, { wrapper })
+      it('renders manage billing in GitHub link', async () => {
+        setup({ planProvider: 'github' })
 
-      expect(
-        await screen.findByRole('link', { name: /Manage billing in GitHub/ })
-      ).toBeInTheDocument()
+        render(<ActionsBilling />, { wrapper })
 
-      expect(
-        await screen.findByRole('link', { name: /Manage billing in GitHub/ })
-      ).toHaveAttribute('href', 'https://github.com/marketplace/codecov')
-    })
-  })
-
-  describe('If can upgrade to sentry plan', () => {
-    beforeEach(() => setup(mockedProAccountDetails, sentryPlans))
-
-    it('Displays upgrade to sentry plan', async () => {
-      render(<ActionsBilling />, { wrapper })
-
-      expect(
-        await screen.findByRole('link', {
-          name: /Upgrade to Sentry Pro Team plan/,
+        const githubLink = await screen.findByRole('link', {
+          name: /Manage billing in GitHub/,
         })
-      ).toBeInTheDocument()
-
-      expect(
-        await screen.findByRole('link', {
-          name: /Upgrade to Sentry Pro Team plan/,
-        })
-      ).toHaveAttribute('href', '/plan/members/gh/upgrade')
+        expect(githubLink).toBeInTheDocument()
+        expect(githubLink).toHaveAttribute(
+          'href',
+          'https://github.com/marketplace/codecov'
+        )
+      })
     })
-  })
 
-  describe('If current plan is sentry plan', () => {
-    beforeEach(() => setup(sentryMockedAccountDetails, sentryPlans))
+    describe('user can upgrade to sentry plan', () => {
+      describe('flag is false', () => {
+        it('renders upgrade to sentry plan', async () => {
+          setup(mockedProAccountDetails, sentryPlans)
 
-    it('Displays manage plan', async () => {
-      render(<ActionsBilling />, { wrapper })
+          render(<ActionsBilling />, { wrapper })
 
-      expect(
-        await screen.findByRole('link', { name: /Manage plan/ })
-      ).toBeInTheDocument()
+          const upgradeLink = await screen.findByRole('link', {
+            name: /Upgrade to Sentry Pro Team plan/,
+          })
+          expect(upgradeLink).toBeInTheDocument()
+          expect(upgradeLink).toHaveAttribute(
+            'href',
+            '/plan/gh/critical-role/upgrade'
+          )
+        })
+      })
 
-      expect(
-        await screen.findByRole('link', { name: /Manage plan/ })
-      ).toHaveAttribute('href', '/plan/members/gh/upgrade')
+      describe('flag is true', () => {
+        describe('user is on a free plan', () => {
+          it('renders start trial link', async () => {
+            setup(mockedFreeAccountDetails, sentryPlans, true, {
+              plan: {
+                ...mockTrialData.plan,
+                trialStatus: TrialStatuses.NOT_STARTED,
+              },
+            })
+
+            render(<ActionsBilling />, { wrapper })
+
+            const startTrialBtn = await screen.findByRole('button', {
+              name: /Start trial/,
+            })
+            expect(startTrialBtn).toBeInTheDocument()
+          })
+
+          it('renders upgrade now link', async () => {
+            setup(mockedFreeAccountDetails, sentryPlans, true, {
+              plan: {
+                ...mockTrialData.plan,
+                trialStatus: TrialStatuses.NOT_STARTED,
+              },
+            })
+
+            render(<ActionsBilling />, { wrapper })
+
+            const upgradeLink = await screen.findByRole('link', {
+              name: /upgrade now/,
+            })
+            expect(upgradeLink).toBeInTheDocument()
+            expect(upgradeLink).toHaveAttribute(
+              'href',
+              '/plan/gh/critical-role/upgrade'
+            )
+          })
+        })
+
+        describe('user has a trial ongoing', () => {
+          it('renders upgrade link', async () => {
+            setup(mockTrialAccountDetails, sentryPlans, true, {
+              plan: {
+                ...mockTrialData.plan,
+                trialStatus: TrialStatuses.ONGOING,
+              },
+            })
+
+            render(<ActionsBilling />, { wrapper })
+
+            const upgradeLink = await screen.findByRole('link', {
+              name: /Upgrade to Sentry Pro Team plan/,
+            })
+            expect(upgradeLink).toBeInTheDocument()
+            expect(upgradeLink).toHaveAttribute(
+              'href',
+              '/plan/gh/critical-role/upgrade'
+            )
+          })
+        })
+      })
+    })
+
+    describe('user has a sentry plan', () => {
+      it('renders manage plan', async () => {
+        setup(sentryMockedAccountDetails, sentryPlans)
+
+        render(<ActionsBilling />, { wrapper })
+
+        await waitFor(() => queryClient.isFetching)
+        await waitFor(() => !queryClient.isFetching)
+
+        const manageLink = await screen.findByRole('link', {
+          name: /Manage plan/,
+        })
+        expect(manageLink).toBeInTheDocument()
+        expect(manageLink).toHaveAttribute(
+          'href',
+          '/plan/gh/critical-role/upgrade'
+        )
+      })
     })
   })
 })

--- a/src/services/navigation/useNavLinks/useStaticNavLinks.js
+++ b/src/services/navigation/useNavLinks/useStaticNavLinks.js
@@ -272,5 +272,11 @@ export function useStaticNavLinks() {
       isExternalLink: true,
       openNewTab: true,
     },
+    freeTrialFaqs: {
+      text: 'Free Trial FAQ',
+      path: () => 'https://docs.codecov.com/docs/free-trial-faqs',
+      isExternalLink: true,
+      openNewTab: true,
+    },
   }
 }

--- a/src/services/navigation/useNavLinks/useStatickNavLinks.spec.js
+++ b/src/services/navigation/useNavLinks/useStatickNavLinks.spec.js
@@ -66,6 +66,7 @@ describe('useStaticNavLinks', () => {
       ${links.repoConfigFeedback}      | ${'https://github.com/codecov/Codecov-user-feedback/issues/18'}
       ${links.staticAnalysisDoc}       | ${'https://docs.codecov.com/docs/automated-test-selection'}
       ${links.circleCIOrbs}            | ${'https://circleci.com/developer/orbs/orb/codecov/codecov'}
+      ${links.freeTrialFaqs}           | ${'https://docs.codecov.com/docs/free-trial-faqs'}
     `('static links return path', ({ link, outcome }) => {
       it(`${link.text}: Returns the correct link`, () => {
         expect(link.path()).toBe(outcome)

--- a/src/ui/Button/Button.jsx
+++ b/src/ui/Button/Button.jsx
@@ -81,7 +81,7 @@ const variantClasses = {
 
 const loadingVariantClasses = {
   default: `disabled:bg-ds-gray-secondary disabled:text-ds-gray-octonary disabled:border-ds-gray-quaternary`,
-  primary: `disabled:bg-ds-blue-darker disabled:bg-ds-blue-medium text-white disabled:border-ds-blue-quinary`,
+  primary: `justify-center border border-solid font-semibold text-white shadow disabled:border-ds-blue-quinary disabled:bg-ds-blue-quinary`,
   danger: `disabled:text-white disabled:border-ds-primary-red disabled:bg-ds-primary-red`,
   secondary: `disabled:text-white disabled:border-ds-pink-tertiary disabled:bg-ds-pink`,
 }


### PR DESCRIPTION
# Description

To make it easier for users to start trials, or directly upgrade to a pro version we're making some slight changes to the base plan, and if the user is eligible for a trial they will now see a `Start Trial` button, or a link `upgrade now` which they can directly upgrade to a pro version. While the user is on a trial they will also be able to upgrade right away if they wish to do so. If the users trial expires they will be informed of the plan that they trialed.

# Notable Changes

- Display `FreePlanCard` if user is on a trial plan
- Create new `ProPlanSubheading` component that handles the variety of states that the sub-heading may be in
- Update `FreePlanCard` to use new `ProPlanSubheading` 
- Update free plan card sub-heading text if the user is currently on trial in `FreePlanCard`
- Update `ActionsBilling` to handle various new trial states with `Start Trial` button and `upgrade now` link
- Add link to trial FAQ docs
- Fix loading styles of primary button
- Update tests accordingly

# Screenshots

Pro plan trial:

![Screenshot 2023-07-26 at 9 10 27 AM](https://github.com/codecov/gazebo/assets/105234307/26c40c76-aacf-46b0-af81-293897015695)

Sentry bundle trial:

![Screenshot 2023-07-26 at 9 10 47 AM](https://github.com/codecov/gazebo/assets/105234307/c84cfc07-920c-4a31-b084-eb8ba9694115)

Ongoing trial:

![Screenshot 2023-07-26 at 9 10 04 AM](https://github.com/codecov/gazebo/assets/105234307/1f258f15-56bf-4269-99b9-c2f0d487b7ef)

Expired trial:

![Screenshot 2023-07-26 at 9 09 30 AM](https://github.com/codecov/gazebo/assets/105234307/2b5f991e-9de5-4ab0-bcc0-4f3788347049)