### PR TITLE
fix: Flaky tests found in desktop menu

### DIFF
--- a/src/layouts/Header/DesktopMenu.spec.jsx
+++ b/src/layouts/Header/DesktopMenu.spec.jsx
@@ -135,12 +135,15 @@ describe('DesktopMenu', () => {
           }),
         })
 
-        await waitFor(() => queryClient.isFetching)
-        await waitFor(() => !queryClient.isFetching)
-
-        const link = await screen.findByTestId('homepage-link')
-        expect(link).toBeInTheDocument()
-        expect(link).toHaveAttribute('href', '/gh/penny')
+        await waitFor(async () =>
+          expect(await screen.findByTestId('homepage-link')).toBeInTheDocument()
+        )
+        await waitFor(async () =>
+          expect(await screen.findByTestId('homepage-link')).toHaveAttribute(
+            'href',
+            '/gh/penny'
+          )
+        )
       })
     })
 
@@ -167,12 +170,15 @@ describe('DesktopMenu', () => {
           }),
         })
 
-        await waitFor(() => queryClient.isFetching)
-        await waitFor(() => !queryClient.isFetching)
-
-        const link = await screen.findByTestId('homepage-link')
-        expect(link).toBeInTheDocument()
-        expect(link).toHaveAttribute('href', '/gh/penny-org')
+        await waitFor(async () =>
+          expect(await screen.findByTestId('homepage-link')).toBeInTheDocument()
+        )
+        await waitFor(async () =>
+          expect(await screen.findByTestId('homepage-link')).toHaveAttribute(
+            'href',
+            '/gh/penny-org'
+          )
+        )
       })
     })
   })


### PR DESCRIPTION
# Description
Fixing default org tests in desktop menu component, hopefully 

# Link to Sample Entry

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.