### PR TITLE
fix: Force All Contents Table Searches to Lower Case

### DIFF
--- a/src/pages/CommitDetailPage/subRoute/CommitDetailFileExplorer/hooks/useRepoCommitContentsTable.js
+++ b/src/pages/CommitDetailPage/subRoute/CommitDetailFileExplorer/hooks/useRepoCommitContentsTable.js
@@ -1,4 +1,5 @@
 import isEqual from 'lodash/isEqual'
+import isString from 'lodash/isString'
 import { useCallback, useMemo } from 'react'
 import { useParams } from 'react-router-dom'
 
@@ -170,6 +171,10 @@ export function useRepoCommitContentsTable() {
   const { params } = useLocationParams(defaultQueryParams)
   const { treePaths } = useCommitTreePaths()
   const [sortBy, setSortBy] = useTableDefaultSort()
+
+  if (isString(params?.search)) {
+    params.search = params.search.toLowerCase()
+  }
 
   const { data: commitData, isLoading: commitIsLoading } =
     useRepoCommitContents({

--- a/src/pages/PullRequestPage/subroute/FileExplorer/hooks/useRepoPullContentsTable.js
+++ b/src/pages/PullRequestPage/subroute/FileExplorer/hooks/useRepoPullContentsTable.js
@@ -1,4 +1,5 @@
 import isEqual from 'lodash/isEqual'
+import isString from 'lodash/isString'
 import { useCallback, useMemo } from 'react'
 import { useParams } from 'react-router-dom'
 
@@ -172,6 +173,10 @@ export function useRepoPullContentsTable() {
   const { params } = useLocationParams(defaultQueryParams)
   const { treePaths } = usePullTreePaths()
   const [sortBy, setSortBy] = useTableDefaultSort()
+
+  if (isString(params?.search)) {
+    params.search = params.search.toLowerCase()
+  }
 
   const { data: pullData, isLoading: pullIsLoading } = useRepoPullContents({
     provider,

--- a/src/pages/RepoPage/CoverageTab/subroute/FileExplorer/hooks/useRepoBranchContentsTable.js
+++ b/src/pages/RepoPage/CoverageTab/subroute/FileExplorer/hooks/useRepoBranchContentsTable.js
@@ -1,4 +1,5 @@
 import isEqual from 'lodash/isEqual'
+import isString from 'lodash/isString'
 import { useCallback, useMemo } from 'react'
 import { useParams } from 'react-router-dom'
 
@@ -167,11 +168,16 @@ const getQueryFilters = ({ params, sortBy }) => {
   }
 }
 
+// eslint-disable-next-line max-statements
 export function useRepoBranchContentsTable() {
   const { provider, owner, repo, path: urlPath, branch } = useParams()
   const { params } = useLocationParams(defaultQueryParams)
   const { treePaths } = useTreePaths()
   const [sortBy, setSortBy] = useTableDefaultSort()
+
+  if (isString(params?.search)) {
+    params.search = params.search.toLowerCase()
+  }
 
   const { data: repoOverview, isLoadingRepo } = useRepoOverview({
     provider,


### PR DESCRIPTION
# Description

This PR closes #2157 by forcing all search param strings to lower case before sending to the API so that if the user so the search value param matches that of the requesting user.

# Notable Changes

- Update all `*ContentsTables` hooks to send search param string to lower case. 