### PR TITLE
Update useStartTrial to take Owner as Mutation Arg (CODE-3625)

### DIFF
--- a/src/services/trial/useStartTrial.spec.tsx
+++ b/src/services/trial/useStartTrial.spec.tsx
@@ -78,12 +78,9 @@ describe('useStartTrial', () => {
       it('passes the correct args', async () => {
         const { variablesPassed } = setup({})
 
-        const { result } = renderHook(
-          () => useStartTrial({ owner: 'codecov' }),
-          { wrapper }
-        )
+        const { result } = renderHook(() => useStartTrial(), { wrapper })
 
-        result.current.mutate()
+        result.current.mutate({ owner: 'codecov' })
 
         await waitFor(() =>
           expect(variablesPassed).toBeCalledWith({
@@ -95,12 +92,9 @@ describe('useStartTrial', () => {
       it('triggers render toast', async () => {
         const { mockRenderToast } = setup({})
 
-        const { result } = renderHook(
-          () => useStartTrial({ owner: 'codecov' }),
-          { wrapper }
-        )
+        const { result } = renderHook(() => useStartTrial(), { wrapper })
 
-        result.current.mutate()
+        result.current.mutate({ owner: 'codecov' })
 
         await waitFor(() =>
           expect(mockRenderToast).not.toBeCalledWith({
@@ -137,12 +131,9 @@ describe('useStartTrial', () => {
         it('triggers render toast', async () => {
           const { mockRenderToast } = setup({ isOtherError: true })
 
-          const { result } = renderHook(
-            () => useStartTrial({ owner: 'codecov' }),
-            { wrapper }
-          )
+          const { result } = renderHook(() => useStartTrial(), { wrapper })
 
-          result.current.mutate()
+          result.current.mutate({ owner: 'codecov' })
 
           await waitFor(() =>
             expect(mockRenderToast).toBeCalledWith({
@@ -174,12 +165,9 @@ describe('useStartTrial', () => {
         it('triggers toast', async () => {
           const { mockRenderToast } = setup({ isServerError: true })
 
-          const { result } = renderHook(
-            () => useStartTrial({ owner: 'codecov' }),
-            { wrapper }
-          )
+          const { result } = renderHook(() => useStartTrial(), { wrapper })
 
-          result.current.mutate()
+          result.current.mutate({ owner: 'codecov' })
 
           await waitFor(() =>
             expect(mockRenderToast).toBeCalledWith({

--- a/src/services/trial/useStartTrial.ts
+++ b/src/services/trial/useStartTrial.ts
@@ -40,18 +40,18 @@ interface Params {
   provider: string
 }
 
-interface UseStartTrialArgs {
+interface StarTrialMutationArgs {
   owner: string
 }
 
 // need to take owner as an arg here because
 // onboarding won't have it in the url
-export const useStartTrial = ({ owner }: UseStartTrialArgs) => {
+export const useStartTrial = () => {
   const { provider } = useParams<Params>()
   const queryClient = useQueryClient()
 
   const mutation = useMutation({
-    mutationFn: () => {
+    mutationFn: ({ owner }: StarTrialMutationArgs) => {
       const variables = {
         input: { orgUsername: owner },
       }


### PR DESCRIPTION
# Description

Small little update to change location where `owner` comes from.

# Notable Changes

- Quick update to `useStartTrial` to take `owner` as arg for `mutate` function
- Update tests