### PR TITLE
fix: Hide Ongoing Banner if Date Diff is Less Then 0 (CODE-3649)

### DIFF
--- a/src/pages/OwnerPage/Tabs/TrialReminder/TrialReminder.spec.tsx
+++ b/src/pages/OwnerPage/Tabs/TrialReminder/TrialReminder.spec.tsx
@@ -123,6 +123,14 @@ describe('TrialReminder', () => {
 
   describe('flag is enabled', () => {
     describe('user has not started a trial', () => {
+      beforeEach(() => {
+        jest.useFakeTimers().setSystemTime(new Date('2023-01-01'))
+      })
+
+      afterEach(() => {
+        jest.useRealTimers()
+      })
+
       describe('user is on a free plan', () => {
         describe('user is part of org', () => {
           it('displays trial upgrade link', async () => {
@@ -190,6 +198,14 @@ describe('TrialReminder', () => {
 
     describe('user is currently on a trial', () => {
       describe('it is within 4 days remaining on the trial', () => {
+        beforeEach(() => {
+          jest.useFakeTimers().setSystemTime(new Date('2023-01-01'))
+        })
+
+        afterEach(() => {
+          jest.useRealTimers()
+        })
+
         describe('user is part of org', () => {
           it('displays trial upgrade link', async () => {
             setup({
@@ -229,6 +245,14 @@ describe('TrialReminder', () => {
       })
 
       describe('it is within 3 days remaining on the trial', () => {
+        beforeEach(() => {
+          jest.useFakeTimers().setSystemTime(new Date('2023-01-02'))
+        })
+
+        afterEach(() => {
+          jest.useRealTimers()
+        })
+
         it('does not display the trial upgrade link', async () => {
           setup({
             planValue: Plans.USERS_BASIC,
@@ -250,6 +274,14 @@ describe('TrialReminder', () => {
     })
 
     describe('user has finished the trial', () => {
+      beforeEach(() => {
+        jest.useFakeTimers().setSystemTime(new Date('2023-01-01'))
+      })
+
+      afterEach(() => {
+        jest.useRealTimers()
+      })
+
       describe('the user is on a free plan', () => {
         describe('user is part of the org', () => {
           it('displays the upgrade link', async () => {
@@ -315,6 +347,14 @@ describe('TrialReminder', () => {
     })
 
     describe('user cannot trial', () => {
+      beforeEach(() => {
+        jest.useFakeTimers().setSystemTime(new Date('2023-01-01'))
+      })
+
+      afterEach(() => {
+        jest.useRealTimers()
+      })
+
       it('does not display upgrade link', async () => {
         setup({
           planValue: Plans.USERS_PR_INAPPY,
@@ -333,6 +373,14 @@ describe('TrialReminder', () => {
     })
 
     describe('API returns no information', () => {
+      beforeEach(() => {
+        jest.useFakeTimers().setSystemTime(new Date('2023-01-01'))
+      })
+
+      afterEach(() => {
+        jest.useRealTimers()
+      })
+
       it('returns nothing', async () => {
         setup({
           planValue: Plans.USERS_BASIC,
@@ -350,6 +398,14 @@ describe('TrialReminder', () => {
     })
 
     describe('app is running in self hosted', () => {
+      beforeEach(() => {
+        jest.useFakeTimers().setSystemTime(new Date('2023-01-01'))
+      })
+
+      afterEach(() => {
+        jest.useRealTimers()
+      })
+
       it('renders nothing', async () => {
         setup({
           planValue: Plans.USERS_BASIC,
@@ -371,6 +427,14 @@ describe('TrialReminder', () => {
   })
 
   describe('flag is disabled', () => {
+    beforeEach(() => {
+      jest.useFakeTimers().setSystemTime(new Date('2023-01-01'))
+    })
+
+    afterEach(() => {
+      jest.useRealTimers()
+    })
+
     it('displays nothing', async () => {
       setup({ flagValue: false })
 

--- a/src/pages/OwnerPage/Tabs/TrialReminder/TrialReminder.tsx
+++ b/src/pages/OwnerPage/Tabs/TrialReminder/TrialReminder.tsx
@@ -23,18 +23,13 @@ const determineTrialStates = ({
 }
 
 const determineDateDiff = ({
-  trialStartDate,
   trialEndDate,
 }: {
-  trialStartDate?: string | null
   trialEndDate?: string | null
 }) => {
   let dateDiff = 0
-  if (trialStartDate && trialEndDate) {
-    dateDiff = differenceInCalendarDays(
-      new Date(trialEndDate),
-      new Date(trialStartDate)
-    )
+  if (trialEndDate) {
+    dateDiff = differenceInCalendarDays(new Date(trialEndDate), new Date())
   }
 
   return dateDiff
@@ -69,10 +64,8 @@ const TrialReminder: React.FC = () => {
     })
 
   const dateDiff = determineDateDiff({
-    trialStartDate: planData?.plan?.trialStartDate,
     trialEndDate: planData?.plan?.trialEndDate,
   })
-
   if (
     (!isFreePlan(planValue) && !trialOngoing) ||
     cannotTrial ||

--- a/src/shared/GlobalTopBanners/TrialBanner/TrialBanner.spec.tsx
+++ b/src/shared/GlobalTopBanners/TrialBanner/TrialBanner.spec.tsx
@@ -239,6 +239,30 @@ describe('TrialBanner', () => {
             expect(container).toBeEmptyDOMElement()
           })
         })
+
+        describe('date diff is less then 0', () => {
+          it('renders nothing', async () => {
+            setup({
+              flagValue: true,
+              trialStatus: TrialStatuses.ONGOING,
+              isCurrentUserPartOfOrg: true,
+              isTrialPlan: true,
+              trialStartDate: '2021-01-02',
+              trialEndDate: '2021-01-01',
+            })
+
+            const { container } = render(<TrialBanner />, {
+              wrapper: wrapper(),
+            })
+
+            await waitFor(() =>
+              expect(queryClient.isFetching()).toBeGreaterThan(0)
+            )
+            await waitFor(() => expect(queryClient.isFetching()).toBe(0))
+
+            expect(container).toBeEmptyDOMElement()
+          })
+        })
       })
     })
 

--- a/src/shared/GlobalTopBanners/TrialBanner/TrialBanner.spec.tsx
+++ b/src/shared/GlobalTopBanners/TrialBanner/TrialBanner.spec.tsx
@@ -166,6 +166,14 @@ describe('TrialBanner', () => {
 
   describe('when flag is enabled', () => {
     describe('owner is undefined', () => {
+      beforeAll(() => {
+        jest.useFakeTimers().setSystemTime(new Date('2021-01-01'))
+      })
+
+      afterAll(() => {
+        jest.useRealTimers()
+      })
+
       it('renders nothing', async () => {
         setup({ flagValue: true })
 
@@ -178,6 +186,14 @@ describe('TrialBanner', () => {
     })
 
     describe('owner does not belong to org', () => {
+      beforeAll(() => {
+        jest.useFakeTimers().setSystemTime(new Date('2021-01-01'))
+      })
+
+      afterAll(() => {
+        jest.useRealTimers()
+      })
+
       it('renders nothing', async () => {
         setup({ flagValue: true, isCurrentUserPartOfOrg: false })
 
@@ -195,6 +211,15 @@ describe('TrialBanner', () => {
     describe('trial is ongoing', () => {
       describe('trial is ongoing', () => {
         describe('date diff is less then 4', () => {
+          beforeAll(() => {
+            jest.useFakeTimers().setSystemTime(new Date('2021-01-01'))
+          })
+
+          afterEach(() => {
+            jest.runOnlyPendingTimers()
+            jest.useRealTimers()
+          })
+
           it('renders ongoing banner', async () => {
             setup({
               flagValue: true,
@@ -217,6 +242,14 @@ describe('TrialBanner', () => {
         })
 
         describe('date diff is greater then 4', () => {
+          beforeAll(() => {
+            jest.useFakeTimers().setSystemTime(new Date('2021-01-01'))
+          })
+
+          afterAll(() => {
+            jest.useRealTimers()
+          })
+
           it('renders nothing', async () => {
             setup({
               flagValue: true,
@@ -241,6 +274,14 @@ describe('TrialBanner', () => {
         })
 
         describe('date diff is less then 0', () => {
+          beforeAll(() => {
+            jest.useFakeTimers().setSystemTime(new Date('2021-01-02'))
+          })
+
+          afterAll(() => {
+            jest.useRealTimers()
+          })
+
           it('renders nothing', async () => {
             setup({
               flagValue: true,
@@ -267,6 +308,14 @@ describe('TrialBanner', () => {
     })
 
     describe('trial is expired', () => {
+      beforeAll(() => {
+        jest.useFakeTimers().setSystemTime(new Date('2021-01-01'))
+      })
+
+      afterAll(() => {
+        jest.useRealTimers()
+      })
+
       describe('user is on a free plan', () => {
         it('renders expired banner', async () => {
           setup({
@@ -310,6 +359,14 @@ describe('TrialBanner', () => {
     })
 
     describe('running in self hosted mode', () => {
+      beforeAll(() => {
+        jest.useFakeTimers().setSystemTime(new Date('2021-01-01'))
+      })
+
+      afterAll(() => {
+        jest.useRealTimers()
+      })
+
       it('renders nothing', async () => {
         setup({
           flagValue: true,
@@ -331,6 +388,14 @@ describe('TrialBanner', () => {
   })
 
   describe('when flag is disabled', () => {
+    beforeAll(() => {
+      jest.useFakeTimers().setSystemTime(new Date('2021-01-01'))
+    })
+
+    afterAll(() => {
+      jest.useRealTimers()
+    })
+
     it('displays nothing', async () => {
       setup({ flagValue: false })
 

--- a/src/shared/GlobalTopBanners/TrialBanner/TrialBanner.tsx
+++ b/src/shared/GlobalTopBanners/TrialBanner/TrialBanner.tsx
@@ -13,18 +13,13 @@ import ExpiredBanner from './ExpiredBanner'
 import OngoingBanner from './OngoingBanner'
 
 const determineDateDiff = ({
-  trialStartDate,
   trialEndDate,
 }: {
-  trialStartDate?: string | null
   trialEndDate?: string | null
 }) => {
   let dateDiff = 0
-  if (trialStartDate && trialEndDate) {
-    dateDiff = differenceInCalendarDays(
-      new Date(trialEndDate),
-      new Date(trialStartDate)
-    )
+  if (trialEndDate) {
+    dateDiff = differenceInCalendarDays(new Date(trialEndDate), new Date())
   }
 
   return dateDiff
@@ -59,7 +54,6 @@ const TrialBanner: React.FC = () => {
   const planName = planData?.plan?.planName
   const trialStatus = planData?.plan?.trialStatus
   const dateDiff = determineDateDiff({
-    trialStartDate: planData?.plan?.trialStartDate,
     trialEndDate: planData?.plan?.trialEndDate,
   })
 

--- a/src/shared/GlobalTopBanners/TrialBanner/TrialBanner.tsx
+++ b/src/shared/GlobalTopBanners/TrialBanner/TrialBanner.tsx
@@ -78,7 +78,8 @@ const TrialBanner: React.FC = () => {
   if (
     isTrialPlan(planName) &&
     trialStatus === TrialStatuses.ONGOING &&
-    dateDiff < 4
+    dateDiff < 4 &&
+    dateDiff >= 0
   ) {
     return <OngoingBanner dateDiff={dateDiff} />
   }


### PR DESCRIPTION
# Description

Quick fix to make sure ongoing banner does not display when the date difference is less then zero

# Notable Changes

- Add check for `dateDiff >= 0` in `TrialBanner`
- Update tests