### PR TITLE
fix: Adjust Upgrade Plan Form Resolver When Seat Count is Lower then Activated Members (CODE-3642)

### DIFF
--- a/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/UpgradeForm.jsx
+++ b/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/UpgradeForm.jsx
@@ -89,7 +89,13 @@ const useUpgradeForm = ({
       sentryPlanYear,
       trialStatus: planData?.plan?.trialStatus,
     }),
-    resolver: zodResolver(getSchema({ accountDetails, minSeats })),
+    resolver: zodResolver(
+      getSchema({
+        accountDetails,
+        minSeats,
+        trialStatus: planData?.plan?.trialStatus,
+      })
+    ),
     mode: 'onChange',
   })
 

--- a/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/UpgradeForm.spec.jsx
+++ b/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/UpgradeForm.spec.jsx
@@ -730,45 +730,47 @@ describe('UpgradeForm', () => {
       })
     })
 
-    describe('when the user chooses less than the number of active users', () => {
-      it('does not display an error', async () => {
-        const { user } = setup({
-          includeSentryPlans: true,
-          trialStatus: TrialStatuses.ONGOING,
+    describe('user is currently on a trial', () => {
+      describe('user chooses less than the number of active users', () => {
+        it('does not display an error', async () => {
+          const { user } = setup({
+            includeSentryPlans: true,
+            trialStatus: TrialStatuses.ONGOING,
+          })
+
+          render(
+            <UpgradeForm
+              proPlanMonth={proPlanMonth}
+              proPlanYear={proPlanYear}
+              sentryPlanMonth={sentryPlanMonth}
+              sentryPlanYear={sentryPlanYear}
+              accountDetails={{
+                activatedUserCount: 9,
+                inactiveUserCount: 0,
+                plan: { value: Plans.USERS_TRIAL },
+                latestInvoice: null,
+              }}
+            />,
+            { wrapper: wrapper() }
+          )
+
+          const input = await screen.findByRole('spinbutton')
+          await user.type(input, '{backspace}{backspace}{backspace}')
+          await user.type(input, '8')
+
+          const updateButton = await screen.findByRole('button', {
+            name: 'Update',
+          })
+          await user.click(updateButton)
+
+          await waitFor(() => queryClient.isMutating)
+          await waitFor(() => !queryClient.isMutating)
+
+          const error = screen.queryByText(
+            /deactivate more users before downgrading plans/i
+          )
+          expect(error).not.toBeInTheDocument()
         })
-
-        render(
-          <UpgradeForm
-            proPlanMonth={proPlanMonth}
-            proPlanYear={proPlanYear}
-            sentryPlanMonth={sentryPlanMonth}
-            sentryPlanYear={sentryPlanYear}
-            accountDetails={{
-              activatedUserCount: 9,
-              inactiveUserCount: 0,
-              plan: { value: Plans.USERS_TRIAL },
-              latestInvoice: null,
-            }}
-          />,
-          { wrapper: wrapper() }
-        )
-
-        const input = await screen.findByRole('spinbutton')
-        await user.type(input, '{backspace}{backspace}{backspace}')
-        await user.type(input, '8')
-
-        const updateButton = await screen.findByRole('button', {
-          name: 'Update',
-        })
-        await user.click(updateButton)
-
-        await waitFor(() => queryClient.isMutating)
-        await waitFor(() => !queryClient.isMutating)
-
-        const error = screen.queryByText(
-          /deactivate more users before downgrading plans/i
-        )
-        expect(error).not.toBeInTheDocument()
       })
     })
   })

--- a/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/UpgradeForm.spec.jsx
+++ b/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/UpgradeForm.spec.jsx
@@ -8,6 +8,7 @@ import { MemoryRouter, Route } from 'react-router-dom'
 
 import { TrialStatuses } from 'services/account'
 import { useAddNotification } from 'services/toastNotification'
+import { Plans } from 'shared/utils/billing'
 
 import UpgradeForm from './UpgradeForm'
 
@@ -730,11 +731,12 @@ describe('UpgradeForm', () => {
     })
 
     describe('when the user chooses less than the number of active users', () => {
-      it('displays an error', async () => {
+      it('does not display an error', async () => {
         const { user } = setup({
           includeSentryPlans: true,
           trialStatus: TrialStatuses.ONGOING,
         })
+
         render(
           <UpgradeForm
             proPlanMonth={proPlanMonth}
@@ -744,7 +746,7 @@ describe('UpgradeForm', () => {
             accountDetails={{
               activatedUserCount: 9,
               inactiveUserCount: 0,
-              plan: null,
+              plan: { value: Plans.USERS_TRIAL },
               latestInvoice: null,
             }}
           />,
@@ -760,10 +762,13 @@ describe('UpgradeForm', () => {
         })
         await user.click(updateButton)
 
-        const error = await screen.findByText(
+        await waitFor(() => queryClient.isMutating)
+        await waitFor(() => !queryClient.isMutating)
+
+        const error = screen.queryByText(
           /deactivate more users before downgrading plans/i
         )
-        expect(error).toBeInTheDocument()
+        expect(error).not.toBeInTheDocument()
       })
     })
   })

--- a/src/shared/utils/upgradeForm.js
+++ b/src/shared/utils/upgradeForm.js
@@ -67,7 +67,7 @@ export const getInitialDataForm = ({
   }
 }
 
-export const getSchema = ({ accountDetails, minSeats }) =>
+export const getSchema = ({ accountDetails, minSeats, trialStatus }) =>
   z.object({
     seats: z.coerce
       .number({
@@ -79,6 +79,13 @@ export const getSchema = ({ accountDetails, minSeats }) =>
         message: `You cannot purchase a per user plan for less than ${minSeats} users`,
       })
       .transform((val, ctx) => {
+        if (
+          trialStatus === TrialStatuses.ONGOING &&
+          accountDetails?.plan?.value === Plans.USERS_TRIAL
+        ) {
+          return val
+        }
+
         if (val < accountDetails?.activatedUserCount) {
           ctx.addIssue({
             code: z.ZodIssueCode.custom,

--- a/src/shared/utils/upgradeForm.spec.js
+++ b/src/shared/utils/upgradeForm.spec.js
@@ -162,7 +162,10 @@ describe('getSchema', () => {
     }
     const schema = getSchema({ accountDetails, minSeats: 5 })
 
-    const response = schema.safeParse({ seats: 10, newPlan: 'users-inappy' })
+    const response = schema.safeParse({
+      seats: 10,
+      newPlan: Plans.USERS_PR_INAPPY,
+    })
     expect(response.success).toEqual(true)
     expect(response.error).toBeUndefined()
   })
@@ -233,6 +236,27 @@ describe('getSchema', () => {
         message: 'Must deactivate more users before downgrading plans',
       })
     )
+  })
+
+  it('passes when seats are below activated seats and user is on trial', () => {
+    const accountDetails = {
+      activatedUserCount: 2,
+      plan: {
+        value: Plans.USERS_TRIAL,
+      },
+    }
+    const schema = getSchema({
+      accountDetails,
+      minSeats: 5,
+      trialStatus: TrialStatuses.ONGOING,
+    })
+
+    const response = schema.safeParse({
+      seats: 10,
+      newPlan: Plans.USERS_PR_INAPPY,
+    })
+    expect(response.success).toEqual(true)
+    expect(response.error).toBeUndefined()
   })
 })
 


### PR DESCRIPTION
# Description

Since we're giving a vast amount of seats when users are trialing we can't block them from upgrading to an amount of seats that is lower then the current activated amount so this bypasses that check in the form resolver.

# Notable Changes

- Update `getSchema` function to return bypass the seat count vs activated member check if the current plan is on trial and trial is currently ongoing.
- Update `UpgradeForm` to pass along `trialStatus` value
- Update tests