### PR TITLE
ref: Remove Any Mention of Trials on the Upgrade Page (CODE-3651)

### DIFF
--- a/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/UpdateButton/UpdateButton.spec.tsx
+++ b/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/UpdateButton/UpdateButton.spec.tsx
@@ -62,117 +62,20 @@ describe('UpdateButton', () => {
     })
   })
 
-  describe('it is a sentry upgrade', () => {
-    describe('the user has not yet started a trial', () => {
-      describe('subscription details are present', () => {
-        it('displays button with "Start trial" text', () => {
-          const props = {
-            isValid: true,
-            getValues: () => ({ newPlan: Plans.USERS_PR_INAPPY, seats: 10 }),
-            value: Plans.USERS_BASIC,
-            quantity: 2,
-            isSentryUpgrade: true,
-            trialStatus: 'NOT_STARTED',
-          }
+  describe('user is able to start a new plan', () => {
+    it('displays button with "Proceed with plan" text', () => {
+      const props = {
+        isValid: true,
+        getValues: () => ({ newPlan: Plans.USERS_PR_INAPPY, seats: 10 }),
+        value: Plans.USERS_BASIC,
+        quantity: 2,
+      }
 
-          render(<UpdateButton {...props} />)
+      render(<UpdateButton {...props} />)
 
-          const button = screen.getByText('Start trial')
-          expect(button).toBeInTheDocument()
-          expect(button).not.toBeDisabled()
-        })
-
-        it('displays no credit card required text', () => {
-          const props = {
-            isValid: true,
-            getValues: () => ({ newPlan: Plans.USERS_PR_INAPPY, seats: 10 }),
-            value: Plans.USERS_BASIC,
-            quantity: 2,
-            isSentryUpgrade: true,
-            trialStatus: 'NOT_STARTED',
-          }
-
-          render(<UpdateButton {...props} />)
-
-          const text = screen.getByText('No credit card required!')
-          expect(text).toBeInTheDocument()
-        })
-      })
-
-      describe('subscription details are null', () => {
-        it('displays button with "Start trial" text', () => {
-          const props = {
-            isValid: true,
-            getValues: () => ({ newPlan: Plans.USERS_PR_INAPPY, seats: 10 }),
-            value: Plans.USERS_BASIC,
-            quantity: 2,
-            isSentryUpgrade: true,
-            trialStatus: 'NOT_STARTED',
-          }
-
-          render(<UpdateButton {...props} />)
-
-          const button = screen.getByText('Start trial')
-          expect(button).toBeInTheDocument()
-          expect(button).not.toBeDisabled()
-        })
-
-        it('displays no credit card required text', () => {
-          const props = {
-            isValid: true,
-            getValues: () => ({ newPlan: Plans.USERS_PR_INAPPY, seats: 10 }),
-            value: Plans.USERS_BASIC,
-            quantity: 2,
-            isSentryUpgrade: true,
-            trialStatus: 'NOT_STARTED',
-          }
-
-          render(<UpdateButton {...props} />)
-
-          const text = screen.getByText('No credit card required!')
-          expect(text).toBeInTheDocument()
-        })
-      })
-    })
-
-    describe('the user has already started the trial', () => {
-      it('displays button with "Proceed with plan" text', () => {
-        const props = {
-          isValid: true,
-          getValues: () => ({ newPlan: Plans.USERS_PR_INAPPY, seats: 10 }),
-          value: Plans.USERS_BASIC,
-          quantity: 2,
-          isSentryUpgrade: true,
-          trialStatus: 'ONGOING',
-        }
-
-        render(<UpdateButton {...props} />)
-
-        const button = screen.getByText('Proceed with plan')
-        expect(button).toBeInTheDocument()
-        expect(button).not.toBeDisabled()
-      })
-    })
-
-    describe('the user has finished the trial', () => {
-      it('displays button with "Proceed with plan" text', () => {
-        const props = {
-          isValid: true,
-          getValues: () => ({ newPlan: Plans.USERS_PR_INAPPY, seats: 10 }),
-          value: Plans.USERS_BASIC,
-          quantity: 2,
-          isSentryUpgrade: true,
-          disableInputs: false,
-          organizationName: 'codecov',
-          trialStatus: 'EXPIRED',
-        }
-
-        render(<UpdateButton {...props} />)
-
-        const button = screen.getByText('Proceed with plan')
-        expect(button).toBeInTheDocument()
-        expect(button).not.toBeDisabled()
-      })
+      const button = screen.getByText('Proceed with plan')
+      expect(button).toBeInTheDocument()
+      expect(button).not.toBeDisabled()
     })
   })
 })

--- a/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/UpdateButton/UpdateButton.tsx
+++ b/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/UpdateButton/UpdateButton.tsx
@@ -1,6 +1,5 @@
 import PropTypes, { type InferProps } from 'prop-types'
 
-import { TrialStatuses } from 'services/account'
 import { isFreePlan } from 'shared/utils/billing'
 import Button from 'ui/Button'
 
@@ -10,30 +9,10 @@ function UpdateButton({
   getValues,
   value,
   quantity,
-  isSentryUpgrade,
-  trialStatus,
 }: InferProps<typeof UpdateButton.propTypes>) {
   const isSamePlan = getValues()?.newPlan === value
   const noChangeInSeats = getValues()?.seats === quantity
   const disabled = !isValid || (isSamePlan && noChangeInSeats)
-
-  if (isSentryUpgrade && trialStatus === TrialStatuses.NOT_STARTED) {
-    return (
-      <div className="flex items-center gap-2">
-        <Button
-          data-cy="all-orgs-plan-update"
-          disabled={false}
-          type="submit"
-          variant="primary"
-          hook="submit-upgrade"
-          to={undefined}
-        >
-          Start trial
-        </Button>
-        <p>No credit card required!</p>
-      </div>
-    )
-  }
 
   return (
     <Button
@@ -54,8 +33,6 @@ UpdateButton.propTypes = {
   getValues: PropTypes.func.isRequired,
   value: PropTypes.string,
   quantity: PropTypes.number,
-  isSentryUpgrade: PropTypes.bool.isRequired,
-  trialStatus: PropTypes.string.isRequired,
 }
 
 export default UpdateButton

--- a/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/UpgradeForm.jsx
+++ b/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/UpgradeForm.jsx
@@ -6,7 +6,6 @@ import { useHistory, useParams } from 'react-router-dom'
 import {
   accountDetailsPropType,
   planPropType,
-  TrialStatuses,
   usePlanData,
   usePlans,
   useUpgradePlan,
@@ -143,12 +142,7 @@ const PlanDetails = ({ isSentryUpgrade, trialStatus }) => {
   return (
     <div>
       <h3 className="font-semibold">Plan</h3>
-      <p>
-        {trialStatus !== TrialStatuses.EXPIRED && (
-          <span>14 day free trial, then </span>
-        )}
-        $29 monthly includes 5 seats.
-      </p>
+      <p>$29 monthly includes 5 seats.</p>
     </div>
   )
 }
@@ -269,8 +263,6 @@ function UpgradeForm({
           getValues={getValues}
           value={accountDetails?.plan?.value}
           quantity={accountDetails?.plan?.quantity}
-          isSentryUpgrade={isSentryUpgrade}
-          trialStatus={trialStatus}
         />
       </div>
     </form>

--- a/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/UpgradeForm.spec.jsx
+++ b/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/UpgradeForm.spec.jsx
@@ -479,9 +479,6 @@ describe('UpgradeForm', () => {
         })
         expect(planDetails).toBeInTheDocument()
 
-        const trial = await screen.findByText('14 day free trial, then')
-        expect(trial).toBeInTheDocument()
-
         const standardSeats = await screen.findByText(
           '$29 monthly includes 5 seats.'
         )


### PR DESCRIPTION
# Description

Because we're moving the ability to start the trial to the plan page, and also allowing users to start paying right away it was required that we remove any mention of trials from the upgrade page.

# Notable Changes

- Remove trial related stuff from `UpgradeForm`
- Remove trial related stuff from `UpgradeButton`
- Update Tests

# Screenshots

<img width="1205" alt="Screenshot 2023-08-02 at 10 04 23 AM" src="https://github.com/codecov/gazebo/assets/105234307/716387c5-7ec1-41b9-978a-f63eac101e6e">