### PR TITLE
ref: Hide Cancel Link While User is On a Trial (CODE-3645)

### DIFF
--- a/src/pages/PlanPage/subRoutes/CancelPlanPage/CancelPlanPage.jsx
+++ b/src/pages/PlanPage/subRoutes/CancelPlanPage/CancelPlanPage.jsx
@@ -3,8 +3,12 @@ import { Redirect, Switch, useParams } from 'react-router-dom'
 
 import { SentryRoute } from 'sentry'
 
-import { useAccountDetails } from 'services/account'
-import { isEnterprisePlan, isMonthlyPlan } from 'shared/utils/billing'
+import { TrialStatuses, useAccountDetails, usePlanData } from 'services/account'
+import {
+  isEnterprisePlan,
+  isMonthlyPlan,
+  isTrialPlan,
+} from 'shared/utils/billing'
 import Spinner from 'ui/Spinner'
 
 import SpecialOffer from './subRoutes/SpecialOffer'
@@ -17,12 +21,18 @@ const Loader = () => (
   </div>
 )
 
+// eslint-disable-next-line max-statements, complexity
 function CancelPlanPage() {
   const { provider, owner } = useParams()
   const { data: accountDetailsData } = useAccountDetails({ provider, owner })
+  const { data: planData } = usePlanData({ provider, owner })
+
+  const isOnTrial =
+    isTrialPlan(planData?.plan?.planName) &&
+    planData?.plan?.trialStatus === TrialStatuses.ONGOING
 
   // redirect right away if the user is on an enterprise plan
-  if (isEnterprisePlan(accountDetailsData?.plan?.value)) {
+  if (isEnterprisePlan(accountDetailsData?.plan?.value) || isOnTrial) {
     return <Redirect to={`/plan/${provider}/${owner}`} />
   }
 

--- a/src/pages/PlanPage/subRoutes/CancelPlanPage/CancelPlanPage.spec.jsx
+++ b/src/pages/PlanPage/subRoutes/CancelPlanPage/CancelPlanPage.spec.jsx
@@ -1,16 +1,29 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { render, screen, waitFor } from '@testing-library/react'
-import { rest } from 'msw'
+import { graphql, rest } from 'msw'
 import { setupServer } from 'msw/node'
 import { Suspense } from 'react'
 import { MemoryRouter, Route } from 'react-router-dom'
 
+import { TrialStatuses } from 'services/account'
 import { Plans } from 'shared/utils/billing'
 
 import CancelPlanPage from './CancelPlanPage'
 
 jest.mock('./subRoutes/SpecialOffer', () => () => 'SpecialOffer')
 jest.mock('./subRoutes/DowngradePlan', () => () => 'DowngradePlan')
+
+const mockPlanData = {
+  baseUnitPrice: 10,
+  benefits: [],
+  billingRate: 'monthly',
+  marketingName: 'Users Basic',
+  monthlyUploadLimit: 250,
+  planName: 'users-basic',
+  trialStatus: TrialStatuses.NOT_STARTED,
+  trialStartDate: '',
+  trialEndDate: '',
+}
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -56,9 +69,14 @@ afterAll(() => {
 
 describe('CancelPlanPage', () => {
   function setup(
-    { hasDiscount = false, planValue = Plans.USERS_PR_INAPPM } = {
+    {
+      hasDiscount = false,
+      planValue = Plans.USERS_PR_INAPPM,
+      trialStatus = TrialStatuses.NOT_STARTED,
+    } = {
       hasDiscount: false,
       planValue: Plans.USERS_PR_INAPPM,
+      trialStatus: TrialStatuses.NOT_STARTED,
     }
   ) {
     server.use(
@@ -72,6 +90,20 @@ describe('CancelPlanPage', () => {
             subscriptionDetail: {
               customer: {
                 discount: hasDiscount,
+              },
+            },
+          })
+        )
+      ),
+      graphql.query('GetPlanData', (req, res, ctx) =>
+        res(
+          ctx.status(200),
+          ctx.data({
+            owner: {
+              plan: {
+                ...mockPlanData,
+                trialStatus,
+                planName: planValue,
               },
             },
           })
@@ -212,6 +244,23 @@ describe('CancelPlanPage', () => {
     beforeEach(() => setup({ planValue: Plans.USERS_ENTERPRISEM }))
 
     it('directs them directly to plan page', async () => {
+      render(<CancelPlanPage />, {
+        wrapper: wrapper('/plan/gh/codecov/cancel'),
+      })
+
+      await waitFor(() =>
+        expect(testLocation.pathname).toBe('/plan/gh/codecov')
+      )
+    })
+  })
+
+  describe('user is on a trial', () => {
+    it('directs them directly to plan page', async () => {
+      setup({
+        planValue: Plans.USERS_TRIAL,
+        trialStatus: TrialStatuses.ONGOING,
+      })
+
       render(<CancelPlanPage />, {
         wrapper: wrapper('/plan/gh/codecov/cancel'),
       })

--- a/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeDetails/UpgradeDetails.jsx
+++ b/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeDetails/UpgradeDetails.jsx
@@ -1,7 +1,12 @@
 import PropTypes from 'prop-types'
+import { useParams } from 'react-router-dom'
 
 import sentryCodecov from 'assets/plan/sentry_codecov.svg'
-import { accountDetailsPropType, planPropType } from 'services/account'
+import {
+  accountDetailsPropType,
+  planPropType,
+  usePlanData,
+} from 'services/account'
 import BenefitList from 'shared/plan/BenefitList'
 import ScheduledPlanDetails from 'shared/plan/ScheduledPlanDetails'
 import { canApplySentryUpgrade } from 'shared/utils/billing'
@@ -14,6 +19,7 @@ function SentryPlanDetails({
   sentryPlanMonth,
   sentryPlanYear,
   cancelAtPeriodEnd,
+  trialStatus,
 }) {
   return (
     <div className="flex flex-col gap-4 border p-4">
@@ -33,7 +39,7 @@ function SentryPlanDetails({
       <p className="text-ds-gray-quaternary">
         ${sentryPlanMonth?.baseUnitPrice} per user / month if paid monthly
       </p>
-      {shouldRenderCancelLink(cancelAtPeriodEnd, plan) && (
+      {shouldRenderCancelLink(cancelAtPeriodEnd, plan, trialStatus) && (
         <A
           to={{ pageName: 'cancelOrgPlan' }}
           variant="black"
@@ -54,6 +60,7 @@ SentryPlanDetails.propTypes = {
   }),
   sentryPlanMonth: planPropType,
   sentryPlanYear: planPropType,
+  trialStatus: PropTypes.string,
 }
 
 function UpgradeDetails({
@@ -66,8 +73,12 @@ function UpgradeDetails({
   accountDetails,
   scheduledPhase,
 }) {
+  const { provider, owner } = useParams()
+  const { data: planData } = usePlanData({ provider, owner })
+
   const cancelAtPeriodEnd =
     accountDetails?.subscriptionDetail?.cancelAtPeriodEnd
+  const trialStatus = planData?.plan?.trialStatus
 
   if (canApplySentryUpgrade({ plan, plans })) {
     return (
@@ -76,6 +87,7 @@ function UpgradeDetails({
         plan={plan}
         sentryPlanMonth={sentryPlanMonth}
         sentryPlanYear={sentryPlanYear}
+        trialStatus={trialStatus}
       />
     )
   }
@@ -103,7 +115,7 @@ function UpgradeDetails({
         {scheduledPhase && (
           <ScheduledPlanDetails scheduledPhase={scheduledPhase} />
         )}
-        {shouldRenderCancelLink(cancelAtPeriodEnd, plan) && (
+        {shouldRenderCancelLink(cancelAtPeriodEnd, plan, trialStatus) && (
           <A
             to={{ pageName: 'cancelOrgPlan' }}
             variant="graySenary"

--- a/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradePlanPage.spec.jsx
+++ b/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradePlanPage.spec.jsx
@@ -1,10 +1,16 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { render, screen, waitFor } from '@testing-library/react'
-import { rest } from 'msw'
+import {
+  render,
+  screen,
+  waitFor,
+  waitForElementToBeRemoved,
+} from '@testing-library/react'
+import { graphql, rest } from 'msw'
 import { setupServer } from 'msw/node'
 import { Suspense } from 'react'
 import { MemoryRouter, Route } from 'react-router-dom'
 
+import { TrialStatuses } from 'services/account'
 import { Plans } from 'shared/utils/billing'
 
 import UpgradePlanPage from './UpgradePlanPage'
@@ -101,6 +107,18 @@ const sentryPlanYear = {
   trialDays: 14,
 }
 
+const mockPlanData = {
+  baseUnitPrice: 10,
+  benefits: [],
+  billingRate: 'monthly',
+  marketingName: 'Users Basic',
+  monthlyUploadLimit: 250,
+  planName: 'users-basic',
+  trialStatus: TrialStatuses.NOT_STARTED,
+  trialStartDate: '',
+  trialEndDate: '',
+}
+
 const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
@@ -119,7 +137,7 @@ const wrapper =
       <QueryClientProvider client={queryClient}>
         <MemoryRouter initialEntries={[initialWrappers]}>
           <Route path="/plan/:provider/:owner/upgrade">
-            <Suspense fallback={null}>{children}</Suspense>
+            <Suspense fallback={<p>Loading...</p>}>{children}</Suspense>
           </Route>
           <Route
             path="*"
@@ -154,6 +172,18 @@ describe('UpgradePlanPage', () => {
     }
   ) {
     server.use(
+      graphql.query('GetPlanData', (req, res, ctx) =>
+        res(
+          ctx.status(200),
+          ctx.data({
+            owner: {
+              plan: {
+                ...mockPlanData,
+              },
+            },
+          })
+        )
+      ),
       rest.get('/internal/plans', (req, res, ctx) =>
         res(
           ctx.status(200),
@@ -185,10 +215,10 @@ describe('UpgradePlanPage', () => {
               value: planValue,
               baseUnitPrice: 12,
               benefits: [
-                'Configureable # of users',
+                'Configurable # of users',
                 'Unlimited public repositories',
                 'Unlimited private repositories',
-                'Priorty Support',
+                'Priority Support',
               ],
             },
             subscriptionDetail: {
@@ -223,8 +253,40 @@ describe('UpgradePlanPage', () => {
     it('does not render upgrade banner', async () => {
       render(<UpgradePlanPage />, { wrapper: wrapper() })
 
-      await waitFor(() => queryClient.isFetching)
-      await waitFor(() => !queryClient.isFetching)
+      await waitForElementToBeRemoved(screen.queryByText('Loading...'))
+
+      const banner = screen.queryByText(/You are choosing to upgrade/)
+      expect(banner).not.toBeInTheDocument()
+    })
+  })
+
+  describe('when rendered with a free plan', () => {
+    it('renders the basic plan title', async () => {
+      setup({ planValue: Plans.USERS_BASIC })
+
+      render(<UpgradePlanPage />, { wrapper: wrapper() })
+
+      const title = await screen.findByText(/Pro Team/)
+      expect(title).toBeInTheDocument()
+    })
+
+    it('does not render a cancel plan link', async () => {
+      setup({ planValue: Plans.USERS_BASIC })
+
+      render(<UpgradePlanPage />, { wrapper: wrapper() })
+
+      await waitForElementToBeRemoved(screen.queryByText('Loading...'))
+
+      const cancelLink = screen.queryByText('Cancel')
+      expect(cancelLink).not.toBeInTheDocument()
+    })
+
+    it('does not render upgrade banner', async () => {
+      setup({ planValue: Plans.USERS_BASIC })
+
+      render(<UpgradePlanPage />, { wrapper: wrapper() })
+
+      await waitForElementToBeRemoved(screen.queryByText('Loading...'))
 
       const banner = screen.queryByText(/You are choosing to upgrade/)
       expect(banner).not.toBeInTheDocument()
@@ -253,8 +315,7 @@ describe('UpgradePlanPage', () => {
     it('does not render cancel plan link', async () => {
       render(<UpgradePlanPage />, { wrapper: wrapper() })
 
-      const title = await screen.findByText(/Pro Team/)
-      expect(title).toBeInTheDocument()
+      await waitForElementToBeRemoved(screen.queryByText('Loading...'))
 
       const cancelLink = screen.queryByText('Cancel plan')
       expect(cancelLink).not.toBeInTheDocument()

--- a/src/shared/utils/upgradeForm.js
+++ b/src/shared/utils/upgradeForm.js
@@ -6,6 +6,7 @@ import {
   isFreePlan,
   isPaidPlan,
   isSentryPlan,
+  isTrialPlan,
   Plans,
 } from 'shared/utils/billing'
 
@@ -122,12 +123,21 @@ export const calculatePrice = ({
 export const calculateNonBundledCost = ({ baseUnitPrice }) =>
   MIN_SENTRY_SEATS * baseUnitPrice * 12 - SENTRY_PRICE * 12
 
-export function shouldRenderCancelLink(accountDetails, plan) {
+export function shouldRenderCancelLink(accountDetails, plan, trialStatus) {
   // cant cancel a free plan
-  if (isFreePlan(plan?.value)) return false
+  if (isFreePlan(plan?.value)) {
+    return false
+  }
+
+  // if user is on trial can't cancel plan
+  if (isTrialPlan(plan?.value) && trialStatus === TrialStatuses.ONGOING) {
+    return false
+  }
 
   // plan is already set for cancellation
-  if (accountDetails?.subscriptionDetail?.cancelAtPeriodEnd) return false
+  if (accountDetails?.subscriptionDetail?.cancelAtPeriodEnd) {
+    return false
+  }
 
   return true
 }

--- a/src/shared/utils/upgradeForm.spec.js
+++ b/src/shared/utils/upgradeForm.spec.js
@@ -7,6 +7,7 @@ import {
   extractSeats,
   getInitialDataForm,
   getSchema,
+  shouldRenderCancelLink,
 } from './upgradeForm'
 
 describe('calculatePrice', () => {
@@ -393,6 +394,54 @@ describe('extractSeats', () => {
 
         expect(seats).toEqual(2)
       })
+    })
+  })
+})
+
+describe('shouldRenderCancelLink', () => {
+  it('returns true', () => {
+    // eslint-disable-next-line testing-library/render-result-naming-convention
+    const value = shouldRenderCancelLink(
+      {},
+      { value: Plans.USERS_PR_INAPPY },
+      ''
+    )
+
+    expect(value).toBeTruthy()
+  })
+
+  describe('user is on a free plan', () => {
+    it('returns false', () => {
+      // eslint-disable-next-line testing-library/render-result-naming-convention
+      const value = shouldRenderCancelLink({}, { value: Plans.USERS_BASIC }, '')
+
+      expect(value).toBeFalsy()
+    })
+  })
+
+  describe('user is currently on a trial', () => {
+    it('returns false', () => {
+      // eslint-disable-next-line testing-library/render-result-naming-convention
+      const value = shouldRenderCancelLink(
+        {},
+        { value: Plans.USERS_TRIAL },
+        TrialStatuses.ONGOING
+      )
+
+      expect(value).toBeFalsy()
+    })
+  })
+
+  describe('user has already cancelled their plan', () => {
+    it('returns false', () => {
+      // eslint-disable-next-line testing-library/render-result-naming-convention
+      const value = shouldRenderCancelLink(
+        { subscriptionDetail: { cancelAtPeriodEnd: true } },
+        { value: Plans.USERS_PR_INAPPY },
+        ''
+      )
+
+      expect(value).toBeFalsy()
     })
   })
 })


### PR DESCRIPTION
# Description

We've decided that users should not be able to access the cancel

# Notable Changes

- Update `shouldRenderCancelLink` to return `false` when user is on a trial
- Update `UpgradeDetails` to fetch trial status and pass values through to `shouldRenderCancelLink`
- Update `CancelPlanPage` to redirect users away when on trial
- Update tests