### PR TITLE
fix: Display Pre-Trial Benefits on Downgrade Card (CODE-3647)

### DIFF
--- a/src/pages/MembersPage/MembersActivation/Activation/Activation.spec.jsx
+++ b/src/pages/MembersPage/MembersActivation/Activation/Activation.spec.jsx
@@ -35,6 +35,8 @@ const mockPlanData = {
   trialStatus: TrialStatuses.NOT_STARTED,
   trialStartDate: '',
   trialEndDate: '',
+  trialTotalDays: 0,
+  pretrialUsersCount: 0,
 }
 
 const queryClient = new QueryClient({

--- a/src/pages/MembersPage/MembersActivation/MembersActivation.spec.jsx
+++ b/src/pages/MembersPage/MembersActivation/MembersActivation.spec.jsx
@@ -35,6 +35,8 @@ const mockPlanData = {
   trialStatus: TrialStatuses.NOT_STARTED,
   trialStartDate: '',
   trialEndDate: '',
+  trialTotalDays: 0,
+  pretrialUsersCount: 0,
 }
 
 const server = setupServer()

--- a/src/pages/OwnerPage/Tabs/TrialReminder/TrialReminder.spec.tsx
+++ b/src/pages/OwnerPage/Tabs/TrialReminder/TrialReminder.spec.tsx
@@ -38,6 +38,8 @@ const mockResponse = {
   trialStatus: TrialStatuses.NOT_STARTED,
   trialStartDate: '',
   trialEndDate: '',
+  trialTotalDays: 0,
+  pretrialUsersCount: 0,
 }
 
 const wrapper: React.FC<React.PropsWithChildren> = ({ children }) => {
@@ -79,7 +81,7 @@ describe('TrialReminder', () => {
   function setup({
     flagValue = true,
     planValue = Plans.USERS_BASIC,
-    trialStatus = undefined,
+    trialStatus = TrialStatuses.CANNOT_TRIAL,
     trialStartDate = '2023-01-01T08:55:25',
     trialEndDate = '2023-01-01T08:55:25',
     userPartOfOrg = true,

--- a/src/pages/PlanPage/subRoutes/CancelPlanPage/CancelPlanPage.spec.jsx
+++ b/src/pages/PlanPage/subRoutes/CancelPlanPage/CancelPlanPage.spec.jsx
@@ -23,6 +23,8 @@ const mockPlanData = {
   trialStatus: TrialStatuses.NOT_STARTED,
   trialStartDate: '',
   trialEndDate: '',
+  trialTotalDays: 0,
+  pretrialUsersCount: 0,
 }
 
 const queryClient = new QueryClient({

--- a/src/pages/PlanPage/subRoutes/CurrentOrgPlan/CurrentPlanCard/FreePlanCard/FreePlanCard.jsx
+++ b/src/pages/PlanPage/subRoutes/CurrentOrgPlan/CurrentPlanCard/FreePlanCard/FreePlanCard.jsx
@@ -131,20 +131,22 @@ function FreePlanCard({ plan, scheduledPhase }) {
     isTrialPlan(planData?.plan?.planName) &&
     planData?.plan.trialStatus === TrialStatuses.ONGOING
 
-  console.debug(trialOngoing)
-
   let benefits = plan?.benefits
+  let planName = plan?.value
+  let baseUnitPrice = plan?.baseUnitPrice
+  let marketingName = plan?.marketingName
   if (trialOngoing) {
     benefits = planData?.pretrialPlan?.benefits
+    planName = planData?.pretrialPlan?.planName
+    baseUnitPrice = planData?.pretrialPlan?.baseUnitPrice
+    marketingName = planData?.pretrialPlan?.marketingName
   }
-
-  console.debug(benefits)
 
   return (
     <div className="flex flex-col gap-4">
       <div className="flex flex-col border">
         <div className="p-4">
-          <h2 className="font-semibold">{plan?.marketingName} plan</h2>
+          <h2 className="font-semibold">{marketingName} plan</h2>
           <span className="text-gray-500">
             {trialOngoing
               ? "You'll be downgraded to this plan when your trial expires"
@@ -163,10 +165,7 @@ function FreePlanCard({ plan, scheduledPhase }) {
           </div>
           <div className="flex flex-col gap-3 border-t pt-2 sm:border-0 sm:p-0">
             <p className="text-xs font-semibold">Pricing</p>
-            <PlanPricing
-              value={plan?.value}
-              baseUnitPrice={plan?.baseUnitPrice}
-            />
+            <PlanPricing value={planName} baseUnitPrice={baseUnitPrice} />
             <div>
               {isNumber(uploadsNumber) && (
                 <p className="mt-4 text-xs text-ds-gray-senary">

--- a/src/pages/PlanPage/subRoutes/CurrentOrgPlan/CurrentPlanCard/FreePlanCard/FreePlanCard.jsx
+++ b/src/pages/PlanPage/subRoutes/CurrentOrgPlan/CurrentPlanCard/FreePlanCard/FreePlanCard.jsx
@@ -111,6 +111,7 @@ PlanUpgrade.propTypes = {
   plans: PropType.arrayOf(planPropType).isRequired,
 }
 
+// eslint-disable-next-line complexity, max-statements
 function FreePlanCard({ plan, scheduledPhase }) {
   const { provider, owner } = useParams()
   const { codecovTrialMvp } = useFlags({
@@ -123,12 +124,21 @@ function FreePlanCard({ plan, scheduledPhase }) {
     opts: { enabled: codecovTrialMvp },
   })
 
+  const { data: plans } = usePlans(provider)
+
   const uploadsNumber = ownerData?.numberOfUploads
   const trialOngoing =
     isTrialPlan(planData?.plan?.planName) &&
     planData?.plan.trialStatus === TrialStatuses.ONGOING
 
-  const { data: plans } = usePlans(provider)
+  console.debug(trialOngoing)
+
+  let benefits = plan?.benefits
+  if (trialOngoing) {
+    benefits = planData?.pretrialPlan?.benefits
+  }
+
+  console.debug(benefits)
 
   return (
     <div className="flex flex-col gap-4">
@@ -146,7 +156,7 @@ function FreePlanCard({ plan, scheduledPhase }) {
           <div className="flex flex-col gap-2">
             <p className="text-xs font-semibold">Includes</p>
             <BenefitList
-              benefits={plan?.benefits}
+              benefits={benefits}
               iconName="check"
               iconColor="text-ds-pink-quinary"
             />

--- a/src/pages/PlanPage/subRoutes/CurrentOrgPlan/CurrentPlanCard/FreePlanCard/FreePlanCard.spec.jsx
+++ b/src/pages/PlanPage/subRoutes/CurrentOrgPlan/CurrentPlanCard/FreePlanCard/FreePlanCard.spec.jsx
@@ -122,6 +122,8 @@ const mockPlanData = {
   trialStatus: TrialStatuses.NOT_STARTED,
   trialStartDate: '',
   trialEndDate: '',
+  trialTotalDays: 0,
+  pretrialUsersCount: 0,
 }
 
 const server = setupServer()

--- a/src/pages/PlanPage/subRoutes/CurrentOrgPlan/CurrentPlanCard/FreePlanCard/FreePlanCard.spec.jsx
+++ b/src/pages/PlanPage/subRoutes/CurrentOrgPlan/CurrentPlanCard/FreePlanCard/FreePlanCard.spec.jsx
@@ -32,7 +32,7 @@ const allPlans = [
       'Configurable # of users',
       'Unlimited public repositories',
       'Unlimited private repositories',
-      'Priorty Support',
+      'Priority Support',
     ],
   },
   {
@@ -44,7 +44,7 @@ const allPlans = [
       'Configurable # of users',
       'Unlimited public repositories',
       'Unlimited private repositories',
-      'Priorty Support',
+      'Priority Support',
     ],
   },
   {
@@ -56,7 +56,7 @@ const allPlans = [
       'Configurable # of users',
       'Unlimited public repositories',
       'Unlimited private repositories',
-      'Priorty Support',
+      'Priority Support',
     ],
   },
   {
@@ -68,7 +68,7 @@ const allPlans = [
       'Configurable # of users',
       'Unlimited public repositories',
       'Unlimited private repositories',
-      'Priorty Support',
+      'Priority Support',
     ],
   },
 ]
@@ -114,7 +114,7 @@ const scheduledPhase = {
 
 const mockPlanData = {
   baseUnitPrice: 10,
-  benefits: [],
+  benefits: ['Up to # user', 'Unlimited public repositories'],
   billingRate: 'monthly',
   marketingName: 'Users Basic',
   monthlyUploadLimit: 250,
@@ -124,6 +124,15 @@ const mockPlanData = {
   trialEndDate: '',
   trialTotalDays: 0,
   pretrialUsersCount: 0,
+}
+
+const mockPreTrialPlanInfo = {
+  baseUnitPrice: 0,
+  benefits: ['Up to 1 user', 'Pre Trial benefits'],
+  billingRate: 'monthly',
+  marketingName: 'Users Basic',
+  monthlyUploadLimit: 250,
+  planName: 'users-basic',
 }
 
 const server = setupServer()
@@ -155,7 +164,13 @@ const wrapper = ({ children }) => (
 
 describe('FreePlanCard', () => {
   function setup(
-    { owner, plans, trialStatus, planValue, trialFlag } = {
+    {
+      owner,
+      plans,
+      trialStatus = TrialStatuses.CANNOT_TRIAL,
+      planValue = 'users-basic',
+      trialFlag,
+    } = {
       owner: {
         username: 'codecov',
         isCurrentUserPartOfOrg: true,
@@ -183,6 +198,7 @@ describe('FreePlanCard', () => {
                 trialStatus,
                 planName: planValue,
               },
+              pretrialPlan: mockPreTrialPlanInfo,
             },
           })
         )
@@ -303,6 +319,27 @@ describe('FreePlanCard', () => {
             /You'll be downgraded to this plan/
           )
           expect(text).toBeInTheDocument()
+        })
+
+        it('renders the pretrial benefits', async () => {
+          setup({
+            planValue: 'users-trial',
+            trialStatus: TrialStatuses.ONGOING,
+            trialFlag: true,
+            plans: allPlans,
+          })
+
+          // ['Up to 1 user', 'Unlimited public repositories'],
+
+          render(<FreePlanCard plan={freePlan} />, {
+            wrapper,
+          })
+
+          const benefitOne = await screen.findByText(/Up to 1 user/)
+          expect(benefitOne).toBeInTheDocument()
+
+          const benefitTwo = await screen.findByText(/Pre Trial benefits/)
+          expect(benefitTwo).toBeInTheDocument()
         })
       })
     })

--- a/src/pages/PlanPage/subRoutes/CurrentOrgPlan/CurrentPlanCard/FreePlanCard/ProPlanSubheading/ProPlanSubheading.spec.tsx
+++ b/src/pages/PlanPage/subRoutes/CurrentOrgPlan/CurrentPlanCard/FreePlanCard/ProPlanSubheading/ProPlanSubheading.spec.tsx
@@ -23,6 +23,8 @@ const mockResponse = {
   trialStatus: TrialStatuses.NOT_STARTED,
   trialStartDate: '',
   trialEndDate: '',
+  trialTotalDays: 0,
+  pretrialUsersCount: 0,
 }
 
 const server = setupServer()

--- a/src/pages/PlanPage/subRoutes/CurrentOrgPlan/CurrentPlanCard/shared/ActionsBilling/ActionsBilling.spec.jsx
+++ b/src/pages/PlanPage/subRoutes/CurrentOrgPlan/CurrentPlanCard/shared/ActionsBilling/ActionsBilling.spec.jsx
@@ -143,6 +143,8 @@ const mockTrialData = {
     trialStatus: 'ONGOING',
     trialStartDate: '2023-01-01T08:55:25',
     trialEndDate: '2023-01-10T08:55:25',
+    trialTotalDays: 0,
+    pretrialUsersCount: 0,
   },
 }
 

--- a/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeDetails/UpgradeDetails.spec.jsx
+++ b/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeDetails/UpgradeDetails.spec.jsx
@@ -92,6 +92,8 @@ const mockPlanData = {
   trialStatus: TrialStatuses.NOT_STARTED,
   trialStartDate: '',
   trialEndDate: '',
+  trialTotalDays: 0,
+  pretrialUsersCount: 0,
 }
 
 const trialPlan = {

--- a/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/UpgradeForm.spec.jsx
+++ b/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/UpgradeForm.spec.jsx
@@ -96,6 +96,8 @@ const mockPlanData = {
   trialStatus: TrialStatuses.NOT_STARTED,
   trialStartDate: '',
   trialEndDate: '',
+  trialTotalDays: 0,
+  pretrialUsersCount: 0,
 }
 
 const queryClient = new QueryClient({

--- a/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradePlanPage.spec.jsx
+++ b/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradePlanPage.spec.jsx
@@ -117,6 +117,8 @@ const mockPlanData = {
   trialStatus: TrialStatuses.NOT_STARTED,
   trialStartDate: '',
   trialEndDate: '',
+  trialTotalDays: 0,
+  pretrialUsersCount: 0,
 }
 
 const queryClient = new QueryClient({

--- a/src/services/account/usePlanData.spec.tsx
+++ b/src/services/account/usePlanData.spec.tsx
@@ -16,6 +16,16 @@ const mockTrialData = {
     trialStatus: 'ONGOING',
     trialStartDate: '2023-01-01T08:55:25',
     trialEndDate: '2023-01-10T08:55:25',
+    trialTotalDays: 0,
+    pretrialUsersCount: 0,
+  },
+  pretrialPlan: {
+    baseUnitPrice: 10,
+    benefits: [],
+    billingRate: 'monthly',
+    marketingName: 'Users Basic',
+    monthlyUploadLimit: 250,
+    planName: 'users-basic',
   },
 }
 
@@ -52,9 +62,9 @@ describe('usePlanData', () => {
 
   describe('calling hook', () => {
     describe('there is plan data', () => {
-      beforeEach(() => setup({ trialData: mockTrialData }))
-
       it('returns the plan data', async () => {
+        setup({ trialData: mockTrialData })
+
         const { result } = renderHook(
           () =>
             usePlanData({
@@ -76,6 +86,16 @@ describe('usePlanData', () => {
               trialStatus: 'ONGOING',
               trialStartDate: '2023-01-01T08:55:25',
               trialEndDate: '2023-01-10T08:55:25',
+              trialTotalDays: 0,
+              pretrialUsersCount: 0,
+            },
+            pretrialPlan: {
+              baseUnitPrice: 10,
+              benefits: [],
+              billingRate: 'monthly',
+              marketingName: 'Users Basic',
+              monthlyUploadLimit: 250,
+              planName: 'users-basic',
             },
           })
         )

--- a/src/services/account/usePlanData.ts
+++ b/src/services/account/usePlanData.ts
@@ -91,7 +91,6 @@ export const usePlanData = ({ provider, owner, opts }: UseTrialArgs) => {
         const parsedRes = PlanDataSchema?.safeParse(res?.data?.owner)
 
         if (!parsedRes.success) {
-          console.debug(parsedRes.error.errors)
           return {}
         }
 

--- a/src/services/account/usePlanData.ts
+++ b/src/services/account/usePlanData.ts
@@ -20,21 +20,27 @@ const PlanDataSchema = z
         marketingName: z.string(),
         monthlyUploadLimit: z.number().nullable(),
         planName: z.string(),
+        pretrialUsersCount: z.number().nullable(),
+        trialEndDate: z.string().nullable(),
         trialStatus: z.nativeEnum(TrialStatuses),
         trialStartDate: z.string().nullable(),
-        trialEndDate: z.string().nullable(),
+        trialTotalDays: z.number().nullable(),
+      })
+      .nullish(),
+    pretrialPlan: z
+      .object({
+        baseUnitPrice: z.number(),
+        benefits: z.array(z.string()),
+        billingRate: z.string().nullable(),
+        marketingName: z.string(),
+        monthlyUploadLimit: z.number().nullable(),
+        planName: z.string(),
       })
       .nullish(),
   })
   .nullish()
 
 type TPlanData = z.infer<typeof PlanDataSchema>
-
-export interface UseTrialArgs {
-  provider: string
-  owner: string
-  opts?: UseQueryOptions<TPlanData>
-}
 
 export const query = `
   query GetPlanData($owner: String!) {
@@ -46,16 +52,32 @@ export const query = `
         marketingName
         monthlyUploadLimit
         planName
+        pretrialUsersCount
+        trialEndDate
         trialStatus
         trialStartDate
-        trialEndDate
+        trialTotalDays
+      }
+      pretrialPlan {
+        baseUnitPrice
+        benefits
+        billingRate
+        marketingName
+        monthlyUploadLimit
+        planName
       }
     }
   }
 `
 
-export const usePlanData = ({ provider, owner, opts }: UseTrialArgs) =>
-  useQuery({
+export interface UseTrialArgs {
+  provider: string
+  owner: string
+  opts?: UseQueryOptions<TPlanData>
+}
+
+export const usePlanData = ({ provider, owner, opts }: UseTrialArgs) => {
+  return useQuery({
     queryKey: ['GetPlanData', provider, owner, query],
     queryFn: ({ signal }) =>
       Api.graphql({
@@ -69,6 +91,7 @@ export const usePlanData = ({ provider, owner, opts }: UseTrialArgs) =>
         const parsedRes = PlanDataSchema?.safeParse(res?.data?.owner)
 
         if (!parsedRes.success) {
+          console.debug(parsedRes.error.errors)
           return {}
         }
 
@@ -76,3 +99,4 @@ export const usePlanData = ({ provider, owner, opts }: UseTrialArgs) =>
       }),
     ...(!!opts && opts),
   })
+}

--- a/src/shared/GlobalTopBanners/TrialBanner/TrialBanner.spec.tsx
+++ b/src/shared/GlobalTopBanners/TrialBanner/TrialBanner.spec.tsx
@@ -30,6 +30,8 @@ const proPlanMonth = {
     'Priority Support',
   ],
   quantity: 10,
+  trialTotalDays: 0,
+  pretrialUsersCount: 0,
 }
 
 const trialPlan = {
@@ -44,6 +46,8 @@ const trialPlan = {
     'Priority Support',
   ],
   quantity: 10,
+  trialTotalDays: 0,
+  pretrialUsersCount: 0,
 }
 
 const basicPlan = {
@@ -57,6 +61,8 @@ const basicPlan = {
     'Unlimited private repositories',
   ],
   quantity: 1,
+  trialTotalDays: 0,
+  pretrialUsersCount: 0,
 }
 
 const queryClient = new QueryClient()
@@ -146,6 +152,8 @@ describe('TrialBanner', () => {
                 trialStatus,
                 trialStartDate,
                 trialEndDate,
+                trialTotalDays: plan.trialTotalDays,
+                pretrialUsersCount: plan.pretrialUsersCount,
               },
             },
           })


### PR DESCRIPTION
# Description

Because the free plan card currently displays the current benefits the user has on their account this would display the trial plan benefits but that's not whats supposed to be displayed. So the API will have a new field introduced that will allow us to get the information for the plan the user had previously.

# Notable Changes

- Update `usePlanData` to fetch the pre-trial info
- Update `FreePlanCard` to display the pre-trial benefits if the user is currently on a trial
- Update tests

Closes codecov/applications-team#66