### PR TITLE
Copy Updates for Trial

### DIFF
--- a/src/pages/MembersPage/MembersActivation/Activation/Activation.jsx
+++ b/src/pages/MembersPage/MembersActivation/Activation/Activation.jsx
@@ -40,9 +40,9 @@ function Activation() {
             active members
           </p>
           <p className="text-xs">
-            Your org is on trial{' '}
+            Your org is on a free trial.{' '}
             <span className="font-semibold">
-              <A to={{ pageName: 'upgradeOrgPlan' }}>upgrade</A>
+              <A to={{ pageName: 'upgradeOrgPlan' }}>Upgrade to Pro today.</A>
             </span>
           </p>
         </section>

--- a/src/pages/MembersPage/MembersActivation/Activation/Activation.spec.jsx
+++ b/src/pages/MembersPage/MembersActivation/Activation/Activation.spec.jsx
@@ -175,7 +175,9 @@ describe('Activation', () => {
 
         render(<Activation />, { wrapper: wrapper() })
 
-        const trialText = await screen.findByText(/Your org is on trial/)
+        const trialText = await screen.findByText(
+          /Your org is on a free trial./
+        )
         expect(trialText).toBeInTheDocument()
       })
 
@@ -185,7 +187,7 @@ describe('Activation', () => {
         render(<Activation />, { wrapper: wrapper() })
 
         const upgradeLink = await screen.findByRole('link', {
-          name: /upgrade/,
+          name: /Upgrade to Pro today./,
         })
         expect(upgradeLink).toBeInTheDocument()
         expect(upgradeLink).toHaveAttribute(

--- a/src/pages/OwnerPage/Tabs/TrialReminder/TrialReminder.spec.tsx
+++ b/src/pages/OwnerPage/Tabs/TrialReminder/TrialReminder.spec.tsx
@@ -219,8 +219,11 @@ describe('TrialReminder', () => {
 
             render(<TrialReminder />, { wrapper })
 
-            const text = await screen.findByText(/Trial is active/)
-            expect(text).toBeInTheDocument()
+            const link = await screen.findByRole('link', {
+              name: /Upgrade now/,
+            })
+            expect(link).toBeInTheDocument()
+            expect(link).toHaveAttribute('href', '/plan/gh/codecov/upgrade')
           })
         })
 

--- a/src/pages/OwnerPage/Tabs/TrialReminder/TrialReminder.tsx
+++ b/src/pages/OwnerPage/Tabs/TrialReminder/TrialReminder.tsx
@@ -90,11 +90,11 @@ const TrialReminder: React.FC = () => {
     return (
       <div className="flex items-center">
         <p>
-          Trial is active with {dateDiff} days{' '}
+          Trial active for {dateDiff} days.{' '}
           <span className="font-semibold">
             {/* this is required because the A component has this random `[x: string]: any` record type on it */}
             {/* @ts-expect-error */}
-            <A to={{ pageName: 'upgradeOrgPlan' }}>upgrade</A>
+            <A to={{ pageName: 'upgradeOrgPlan' }}>Upgrade now</A>
           </span>
         </p>
       </div>

--- a/src/pages/PlanPage/subRoutes/CurrentOrgPlan/CurrentPlanCard/FreePlanCard/FreePlanCard.jsx
+++ b/src/pages/PlanPage/subRoutes/CurrentOrgPlan/CurrentPlanCard/FreePlanCard/FreePlanCard.jsx
@@ -149,7 +149,7 @@ function FreePlanCard({ plan, scheduledPhase }) {
           <h2 className="font-semibold">{marketingName} plan</h2>
           <span className="text-gray-500">
             {trialOngoing
-              ? "You'll be downgraded to this plan when your trial expires"
+              ? "You'll be downgraded to the Developer plan when your trial expires."
               : 'Current Plan'}
           </span>
         </div>

--- a/src/pages/PlanPage/subRoutes/CurrentOrgPlan/CurrentPlanCard/FreePlanCard/FreePlanCard.spec.jsx
+++ b/src/pages/PlanPage/subRoutes/CurrentOrgPlan/CurrentPlanCard/FreePlanCard/FreePlanCard.spec.jsx
@@ -314,7 +314,7 @@ describe('FreePlanCard', () => {
           })
 
           const text = await screen.findByText(
-            /You'll be downgraded to this plan/
+            /You'll be downgraded to the Developer plan when your trial expires./
           )
           expect(text).toBeInTheDocument()
         })

--- a/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/UpdateButton/UpdateButton.spec.tsx
+++ b/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/UpdateButton/UpdateButton.spec.tsx
@@ -18,7 +18,7 @@ describe('UpdateButton', () => {
 
       render(<UpdateButton {...props} />)
 
-      const button = screen.getByText('Proceed with plan')
+      const button = screen.getByText('Proceed to Checkout')
       expect(button).toBeInTheDocument()
       expect(button).not.toBeDisabled()
     })
@@ -56,14 +56,14 @@ describe('UpdateButton', () => {
 
       render(<UpdateButton {...props} />)
 
-      const button = screen.getByText('Proceed with plan')
+      const button = screen.getByText('Proceed to Checkout')
       expect(button).toBeInTheDocument()
       expect(button).toBeDisabled()
     })
   })
 
   describe('user is able to start a new plan', () => {
-    it('displays button with "Proceed with plan" text', () => {
+    it('displays button with "Proceed to Checkout" text', () => {
       const props = {
         isValid: true,
         getValues: () => ({ newPlan: Plans.USERS_PR_INAPPY, seats: 10 }),
@@ -73,7 +73,7 @@ describe('UpdateButton', () => {
 
       render(<UpdateButton {...props} />)
 
-      const button = screen.getByText('Proceed with plan')
+      const button = screen.getByText('Proceed to Checkout')
       expect(button).toBeInTheDocument()
       expect(button).not.toBeDisabled()
     })

--- a/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/UpdateButton/UpdateButton.tsx
+++ b/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/UpdateButton/UpdateButton.tsx
@@ -23,7 +23,7 @@ function UpdateButton({
       hook="submit-upgrade"
       to={undefined}
     >
-      {isFreePlan(value) ? 'Proceed with plan' : 'Update'}
+      {isFreePlan(value) ? 'Proceed to Checkout' : 'Update'}
     </Button>
   )
 }

--- a/src/shared/GlobalTopBanners/TrialBanner/OngoingBanner.tsx
+++ b/src/shared/GlobalTopBanners/TrialBanner/OngoingBanner.tsx
@@ -24,7 +24,7 @@ const OngoingBanner: React.FC<OngoingBannerProps> = ({ dateDiff }) => {
       <TopBanner.End>
         <p>
           {/* @ts-expect-error */}
-          Need help? view our <A to={{ pageName: 'docs' }}>
+          Need help? View our <A to={{ pageName: 'docs' }}>
             get started docs
           </A>{' '}
           or {/* @ts-expect-error */}


### PR DESCRIPTION
# Description

This PR updates a few pieces of text requested after a walk through of the trial was completed.

Closes: codecov/applications-team#130

# Notable Changes

- Update `UpdateButton` on the upgrade page to show `Proceed to Checkout`
- Update the downgrade message in the `FreePlanCard`
- Update Owner page trial CTA while the trial is ongoing
- Update `OngoingBanner` left and right side text
- Update copy on the members page activation section
- Update tests