### PR TITLE
Revert "fix/rfc: use API_URL instead of BASE_URL for auth button hrefs"

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,5 +1,4 @@
 PROXY_TO=https://stage-api.codecov.dev
-REACT_APP_API_URL=https://stage-api.codecov.dev
 REACT_APP_BASE_URL=https://stage-web.codecov.dev
 REACT_APP_MARKETING_BASE_URL=https://about.codecov.io
 REACT_APP_SEGMENT_KEY=$SEGMENT_KEY

--- a/src/layouts/Header/DesktopMenu.spec.jsx
+++ b/src/layouts/Header/DesktopMenu.spec.jsx
@@ -339,12 +339,9 @@ describe('LoginPrompt', () => {
 
       const loginLink = within(loginPrompt).getByText('Log in')
       expect(loginLink).toBeInTheDocument()
-      // This is supposed to have REACT_APP_API_URL in front of it, but a lot
-      // of tests rely on that value being blank in `.env.test` so the test
-      // appears to assert that it is a same-site URL.
       expect(loginLink).toHaveAttribute(
         'href',
-        '/login/gh?to=http%3A%2F%2Flocalhost%2F'
+        'https://stage-web.codecov.dev/login/gh?to=http%3A%2F%2Flocalhost%2F'
       )
 
       const signUpLink = within(loginPrompt).getByText('Sign up')

--- a/src/layouts/Header/Dropdown.spec.jsx
+++ b/src/layouts/Header/Dropdown.spec.jsx
@@ -85,10 +85,10 @@ describe('Dropdown', () => {
 
         const link = screen.getByText('Sign Out')
         expect(link).toBeVisible()
-        // This is supposed to have REACT_APP_API_URL in front of it, but a lot
-        // of tests rely on that value being blank in `.env.test` so the test
-        // appears to assert that it is a same-site URL.
-        expect(link).toHaveAttribute('href', '/logout/gh')
+        expect(link).toHaveAttribute(
+          'href',
+          'https://stage-web.codecov.dev/logout/gh'
+        )
       })
 
       it('shows manage app access link', async () => {
@@ -144,10 +144,10 @@ describe('Dropdown', () => {
 
         const link = screen.getByText('Sign Out')
         expect(link).toBeVisible()
-        // This is supposed to have REACT_APP_API_URL in front of it, but a lot
-        // of tests rely on that value being blank in `.env.test` so the test
-        // appears to assert that it is a same-site URL.
-        expect(link).toHaveAttribute('href', '/logout/gl')
+        expect(link).toHaveAttribute(
+          'href',
+          'https://stage-web.codecov.dev/logout/gl'
+        )
       })
 
       it('does not show manage app access link', async () => {

--- a/src/pages/EnterpriseLandingPage/ProviderCard/ProviderCard.spec.jsx
+++ b/src/pages/EnterpriseLandingPage/ProviderCard/ProviderCard.spec.jsx
@@ -28,10 +28,7 @@ describe('ProviderCard', () => {
           name: 'Login via Bitbucket',
         })
         expect(element).toBeInTheDocument()
-        // This is supposed to have REACT_APP_API_URL in front of it, but a lot
-        // of tests rely on that value being blank in `.env.test` so the test
-        // appears to assert that it is a same-site URL.
-        expect(element).toHaveAttribute('href', `${config.API_URL}/login/bb`)
+        expect(element).toHaveAttribute('href', `${config.BASE_URL}/login/bb`)
       })
 
       it('renders self hosted login link', () => {
@@ -39,10 +36,7 @@ describe('ProviderCard', () => {
           name: 'Login via Bitbucket Server',
         })
         expect(element).toBeInTheDocument()
-        // This is supposed to have REACT_APP_API_URL in front of it, but a lot
-        // of tests rely on that value being blank in `.env.test` so the test
-        // appears to assert that it is a same-site URL.
-        expect(element).toHaveAttribute('href', `${config.API_URL}/login/bbs`)
+        expect(element).toHaveAttribute('href', `${config.BASE_URL}/login/bbs`)
       })
     })
   })
@@ -57,10 +51,7 @@ describe('ProviderCard', () => {
       it('renders external login button', () => {
         const element = screen.getByRole('link', { name: 'Login via GitHub' })
         expect(element).toBeInTheDocument()
-        // This is supposed to have REACT_APP_API_URL in front of it, but a lot
-        // of tests rely on that value being blank in `.env.test` so the test
-        // appears to assert that it is a same-site URL.
-        expect(element).toHaveAttribute('href', `${config.API_URL}/login/gh`)
+        expect(element).toHaveAttribute('href', `${config.BASE_URL}/login/gh`)
       })
 
       it('renders self hosted login link', () => {
@@ -68,10 +59,7 @@ describe('ProviderCard', () => {
           name: 'Login via GitHub Enterprise',
         })
         expect(element).toBeInTheDocument()
-        // This is supposed to have REACT_APP_API_URL in front of it, but a lot
-        // of tests rely on that value being blank in `.env.test` so the test
-        // appears to assert that it is a same-site URL.
-        expect(element).toHaveAttribute('href', `${config.API_URL}/login/ghe`)
+        expect(element).toHaveAttribute('href', `${config.BASE_URL}/login/ghe`)
       })
     })
   })
@@ -86,10 +74,7 @@ describe('ProviderCard', () => {
       it('renders external login button', () => {
         const element = screen.getByRole('link', { name: 'Login via GitLab' })
         expect(element).toBeInTheDocument()
-        // This is supposed to have REACT_APP_API_URL in front of it, but a lot
-        // of tests rely on that value being blank in `.env.test` so the test
-        // appears to assert that it is a same-site URL.
-        expect(element).toHaveAttribute('href', `${config.API_URL}/login/gl`)
+        expect(element).toHaveAttribute('href', `${config.BASE_URL}/login/gl`)
       })
 
       it('renders self hosted login link', () => {
@@ -97,10 +82,7 @@ describe('ProviderCard', () => {
           name: 'Login via GitLab CE/EE',
         })
         expect(element).toBeInTheDocument()
-        // This is supposed to have REACT_APP_API_URL in front of it, but a lot
-        // of tests rely on that value being blank in `.env.test` so the test
-        // appears to assert that it is a same-site URL.
-        expect(element).toHaveAttribute('href', `${config.API_URL}/login/gle`)
+        expect(element).toHaveAttribute('href', `${config.BASE_URL}/login/gle`)
       })
     })
   })

--- a/src/services/navigation/useNavLinks/useNavLinks.js
+++ b/src/services/navigation/useNavLinks/useNavLinks.js
@@ -16,7 +16,7 @@ export function useNavLinks() {
     signOut: {
       text: 'Sign Out',
       path: ({ provider = p } = { provider: p }) =>
-        `${config.API_URL}/logout/${provider}`,
+        `${config.BASE_URL}/logout/${provider}`,
       isExternalLink: true,
     },
     signIn: {
@@ -29,7 +29,7 @@ export function useNavLinks() {
           },
           { addQueryPrefix: true }
         )
-        return `${config.API_URL}/login/${provider}${query}`
+        return `${config.BASE_URL}/login/${provider}${query}`
       },
       isExternalLink: true,
     },

--- a/src/services/navigation/useNavLinks/useNavLinks.spec.js
+++ b/src/services/navigation/useNavLinks/useNavLinks.spec.js
@@ -36,19 +36,13 @@ describe('useNavLinks', () => {
     })
 
     it('Returns the correct link with nothing passed', () => {
-      // This is supposed to have REACT_APP_API_URL in front of it, but a lot
-      // of tests rely on that value being blank in `.env.test` so the test
-      // appears to assert that it is a same-site URL.
       expect(hookData.result.current.signOut.path()).toBe(
-        `${config.API_URL}/logout/gl`
+        `${config.BASE_URL}/logout/gl`
       )
     })
     it('can override the params', () => {
-      // This is supposed to have REACT_APP_API_URL in front of it, but a lot
-      // of tests rely on that value being blank in `.env.test` so the test
-      // appears to assert that it is a same-site URL.
       expect(hookData.result.current.signOut.path({ provider: 'bb' })).toBe(
-        `${config.API_URL}/logout/bb`
+        `${config.BASE_URL}/logout/bb`
       )
     })
   })
@@ -59,33 +53,24 @@ describe('useNavLinks', () => {
     })
 
     it('Returns the correct link with nothing passed', () => {
-      // This is supposed to have REACT_APP_API_URL in front of it, but a lot
-      // of tests rely on that value being blank in `.env.test` so the test
-      // appears to assert that it is a same-site URL.
       expect(hookData.result.current.signIn.path()).toBe(
-        `${config.API_URL}/login/gl`
+        `${config.BASE_URL}/login/gl`
       )
     })
 
     it('can override the params', () => {
-      // This is supposed to have REACT_APP_API_URL in front of it, but a lot
-      // of tests rely on that value being blank in `.env.test` so the test
-      // appears to assert that it is a same-site URL.
       expect(hookData.result.current.signIn.path({ provider: 'bb' })).toBe(
-        `${config.API_URL}/login/bb`
+        `${config.BASE_URL}/login/bb`
       )
     })
 
     it('can add a `to` redirection', () => {
-      // This is supposed to have REACT_APP_API_URL in front of it, but a lot
-      // of tests rely on that value being blank in `.env.test` so the test
-      // appears to assert that it is a same-site URL.
       expect(
         hookData.result.current.signIn.path({
           to: 'htts://app.codecov.io/gh/codecov',
         })
       ).toBe(
-        `${config.API_URL}/login/gl?to=htts%3A%2F%2Fapp.codecov.io%2Fgh%2Fcodecov`
+        `${config.BASE_URL}/login/gl?to=htts%3A%2F%2Fapp.codecov.io%2Fgh%2Fcodecov`
       )
     })
 
@@ -96,15 +81,12 @@ describe('useNavLinks', () => {
       )
       setup(['/gh/doggo/squirrel-locator'])
 
-      // This is supposed to have REACT_APP_API_URL in front of it, but a lot
-      // of tests rely on that value being blank in `.env.test` so the test
-      // appears to assert that it is a same-site URL.
       expect(
         hookData.result.current.signIn.path({
           to: 'htts://app.codecov.io/gh/codecov',
         })
       ).toBe(
-        `${config.API_URL}/login/gh?to=htts%3A%2F%2Fapp.codecov.io%2Fgh%2Fcodecov&utm_source=a&utm_medium=b&utm_campaign=c&utm_term=d&utm_content=e`
+        `${config.BASE_URL}/login/gh?to=htts%3A%2F%2Fapp.codecov.io%2Fgh%2Fcodecov&utm_source=a&utm_medium=b&utm_campaign=c&utm_term=d&utm_content=e`
       )
       Cookie.remove('utmParams')
     })


### PR DESCRIPTION
Reverts codecov/gazebo#2182