### PR TITLE
re-apply: fix: use API_URL instead of BASE_URL for auth button hrefs

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,4 +1,5 @@
 PROXY_TO=https://stage-api.codecov.dev
+REACT_APP_API_URL=https://stage-api.codecov.dev
 REACT_APP_BASE_URL=https://stage-web.codecov.dev
 REACT_APP_MARKETING_BASE_URL=https://about.codecov.io
 REACT_APP_SEGMENT_KEY=$SEGMENT_KEY

--- a/public/mockServiceWorker.js
+++ b/public/mockServiceWorker.js
@@ -2,7 +2,7 @@
 /* tslint:disable */
 
 /**
- * Mock Service Worker (1.1.0).
+ * Mock Service Worker (1.2.1).
  * @see https://github.com/mswjs/msw
  * - Please do NOT modify this file.
  * - Please do NOT serve this file on production.

--- a/src/layouts/Header/DesktopMenu.spec.jsx
+++ b/src/layouts/Header/DesktopMenu.spec.jsx
@@ -339,9 +339,12 @@ describe('LoginPrompt', () => {
 
       const loginLink = within(loginPrompt).getByText('Log in')
       expect(loginLink).toBeInTheDocument()
+      // This is supposed to have REACT_APP_API_URL in front of it, but a lot
+      // of tests rely on that value being blank in `.env.test` so the test
+      // appears to assert that it is a same-site URL.
       expect(loginLink).toHaveAttribute(
         'href',
-        'https://stage-web.codecov.dev/login/gh?to=http%3A%2F%2Flocalhost%2F'
+        '/login/gh?to=http%3A%2F%2Flocalhost%2F'
       )
 
       const signUpLink = within(loginPrompt).getByText('Sign up')

--- a/src/layouts/Header/Dropdown.spec.jsx
+++ b/src/layouts/Header/Dropdown.spec.jsx
@@ -85,10 +85,10 @@ describe('Dropdown', () => {
 
         const link = screen.getByText('Sign Out')
         expect(link).toBeVisible()
-        expect(link).toHaveAttribute(
-          'href',
-          'https://stage-web.codecov.dev/logout/gh'
-        )
+        // This is supposed to have REACT_APP_API_URL in front of it, but a lot
+        // of tests rely on that value being blank in `.env.test` so the test
+        // appears to assert that it is a same-site URL.
+        expect(link).toHaveAttribute('href', '/logout/gh')
       })
 
       it('shows manage app access link', async () => {
@@ -144,10 +144,10 @@ describe('Dropdown', () => {
 
         const link = screen.getByText('Sign Out')
         expect(link).toBeVisible()
-        expect(link).toHaveAttribute(
-          'href',
-          'https://stage-web.codecov.dev/logout/gl'
-        )
+        // This is supposed to have REACT_APP_API_URL in front of it, but a lot
+        // of tests rely on that value being blank in `.env.test` so the test
+        // appears to assert that it is a same-site URL.
+        expect(link).toHaveAttribute('href', '/logout/gl')
       })
 
       it('does not show manage app access link', async () => {

--- a/src/layouts/Header/Dropdown.spec.jsx
+++ b/src/layouts/Header/Dropdown.spec.jsx
@@ -85,10 +85,10 @@ describe('Dropdown', () => {
 
         const link = screen.getByText('Sign Out')
         expect(link).toBeVisible()
-        // This is supposed to have REACT_APP_API_URL in front of it, but a lot
-        // of tests rely on that value being blank in `.env.test` so the test
-        // appears to assert that it is a same-site URL.
-        expect(link).toHaveAttribute('href', '/logout/gh')
+        expect(link).toHaveAttribute(
+          'href',
+          'https://stage-web.codecov.dev/logout/gh'
+        )
       })
 
       it('shows manage app access link', async () => {
@@ -144,10 +144,10 @@ describe('Dropdown', () => {
 
         const link = screen.getByText('Sign Out')
         expect(link).toBeVisible()
-        // This is supposed to have REACT_APP_API_URL in front of it, but a lot
-        // of tests rely on that value being blank in `.env.test` so the test
-        // appears to assert that it is a same-site URL.
-        expect(link).toHaveAttribute('href', '/logout/gl')
+        expect(link).toHaveAttribute(
+          'href',
+          'https://stage-web.codecov.dev/logout/gl'
+        )
       })
 
       it('does not show manage app access link', async () => {

--- a/src/pages/EnterpriseLandingPage/ProviderCard/ProviderCard.spec.jsx
+++ b/src/pages/EnterpriseLandingPage/ProviderCard/ProviderCard.spec.jsx
@@ -28,7 +28,10 @@ describe('ProviderCard', () => {
           name: 'Login via Bitbucket',
         })
         expect(element).toBeInTheDocument()
-        expect(element).toHaveAttribute('href', `${config.BASE_URL}/login/bb`)
+        // This is supposed to have REACT_APP_API_URL in front of it, but a lot
+        // of tests rely on that value being blank in `.env.test` so the test
+        // appears to assert that it is a same-site URL.
+        expect(element).toHaveAttribute('href', `${config.API_URL}/login/bb`)
       })
 
       it('renders self hosted login link', () => {
@@ -36,7 +39,10 @@ describe('ProviderCard', () => {
           name: 'Login via Bitbucket Server',
         })
         expect(element).toBeInTheDocument()
-        expect(element).toHaveAttribute('href', `${config.BASE_URL}/login/bbs`)
+        // This is supposed to have REACT_APP_API_URL in front of it, but a lot
+        // of tests rely on that value being blank in `.env.test` so the test
+        // appears to assert that it is a same-site URL.
+        expect(element).toHaveAttribute('href', `${config.API_URL}/login/bbs`)
       })
     })
   })
@@ -51,7 +57,10 @@ describe('ProviderCard', () => {
       it('renders external login button', () => {
         const element = screen.getByRole('link', { name: 'Login via GitHub' })
         expect(element).toBeInTheDocument()
-        expect(element).toHaveAttribute('href', `${config.BASE_URL}/login/gh`)
+        // This is supposed to have REACT_APP_API_URL in front of it, but a lot
+        // of tests rely on that value being blank in `.env.test` so the test
+        // appears to assert that it is a same-site URL.
+        expect(element).toHaveAttribute('href', `${config.API_URL}/login/gh`)
       })
 
       it('renders self hosted login link', () => {
@@ -59,7 +68,10 @@ describe('ProviderCard', () => {
           name: 'Login via GitHub Enterprise',
         })
         expect(element).toBeInTheDocument()
-        expect(element).toHaveAttribute('href', `${config.BASE_URL}/login/ghe`)
+        // This is supposed to have REACT_APP_API_URL in front of it, but a lot
+        // of tests rely on that value being blank in `.env.test` so the test
+        // appears to assert that it is a same-site URL.
+        expect(element).toHaveAttribute('href', `${config.API_URL}/login/ghe`)
       })
     })
   })
@@ -74,7 +86,10 @@ describe('ProviderCard', () => {
       it('renders external login button', () => {
         const element = screen.getByRole('link', { name: 'Login via GitLab' })
         expect(element).toBeInTheDocument()
-        expect(element).toHaveAttribute('href', `${config.BASE_URL}/login/gl`)
+        // This is supposed to have REACT_APP_API_URL in front of it, but a lot
+        // of tests rely on that value being blank in `.env.test` so the test
+        // appears to assert that it is a same-site URL.
+        expect(element).toHaveAttribute('href', `${config.API_URL}/login/gl`)
       })
 
       it('renders self hosted login link', () => {
@@ -82,7 +97,10 @@ describe('ProviderCard', () => {
           name: 'Login via GitLab CE/EE',
         })
         expect(element).toBeInTheDocument()
-        expect(element).toHaveAttribute('href', `${config.BASE_URL}/login/gle`)
+        // This is supposed to have REACT_APP_API_URL in front of it, but a lot
+        // of tests rely on that value being blank in `.env.test` so the test
+        // appears to assert that it is a same-site URL.
+        expect(element).toHaveAttribute('href', `${config.API_URL}/login/gle`)
       })
     })
   })

--- a/src/services/navigation/useNavLinks/useNavLinks.js
+++ b/src/services/navigation/useNavLinks/useNavLinks.js
@@ -16,7 +16,7 @@ export function useNavLinks() {
     signOut: {
       text: 'Sign Out',
       path: ({ provider = p } = { provider: p }) =>
-        `${config.BASE_URL}/logout/${provider}`,
+        `${config.API_URL}/logout/${provider}`,
       isExternalLink: true,
     },
     signIn: {
@@ -29,7 +29,7 @@ export function useNavLinks() {
           },
           { addQueryPrefix: true }
         )
-        return `${config.BASE_URL}/login/${provider}${query}`
+        return `${config.API_URL}/login/${provider}${query}`
       },
       isExternalLink: true,
     },

--- a/src/services/navigation/useNavLinks/useNavLinks.js
+++ b/src/services/navigation/useNavLinks/useNavLinks.js
@@ -16,7 +16,7 @@ export function useNavLinks() {
     signOut: {
       text: 'Sign Out',
       path: ({ provider = p } = { provider: p }) =>
-        `${config.API_URL}/logout/${provider}`,
+        `${config.BASE_URL}/logout/${provider}`,
       isExternalLink: true,
     },
     signIn: {

--- a/src/services/navigation/useNavLinks/useNavLinks.spec.js
+++ b/src/services/navigation/useNavLinks/useNavLinks.spec.js
@@ -36,13 +36,19 @@ describe('useNavLinks', () => {
     })
 
     it('Returns the correct link with nothing passed', () => {
+      // This is supposed to have REACT_APP_API_URL in front of it, but a lot
+      // of tests rely on that value being blank in `.env.test` so the test
+      // appears to assert that it is a same-site URL.
       expect(hookData.result.current.signOut.path()).toBe(
-        `${config.BASE_URL}/logout/gl`
+        `${config.API_URL}/logout/gl`
       )
     })
     it('can override the params', () => {
+      // This is supposed to have REACT_APP_API_URL in front of it, but a lot
+      // of tests rely on that value being blank in `.env.test` so the test
+      // appears to assert that it is a same-site URL.
       expect(hookData.result.current.signOut.path({ provider: 'bb' })).toBe(
-        `${config.BASE_URL}/logout/bb`
+        `${config.API_URL}/logout/bb`
       )
     })
   })
@@ -53,24 +59,33 @@ describe('useNavLinks', () => {
     })
 
     it('Returns the correct link with nothing passed', () => {
+      // This is supposed to have REACT_APP_API_URL in front of it, but a lot
+      // of tests rely on that value being blank in `.env.test` so the test
+      // appears to assert that it is a same-site URL.
       expect(hookData.result.current.signIn.path()).toBe(
-        `${config.BASE_URL}/login/gl`
+        `${config.API_URL}/login/gl`
       )
     })
 
     it('can override the params', () => {
+      // This is supposed to have REACT_APP_API_URL in front of it, but a lot
+      // of tests rely on that value being blank in `.env.test` so the test
+      // appears to assert that it is a same-site URL.
       expect(hookData.result.current.signIn.path({ provider: 'bb' })).toBe(
-        `${config.BASE_URL}/login/bb`
+        `${config.API_URL}/login/bb`
       )
     })
 
     it('can add a `to` redirection', () => {
+      // This is supposed to have REACT_APP_API_URL in front of it, but a lot
+      // of tests rely on that value being blank in `.env.test` so the test
+      // appears to assert that it is a same-site URL.
       expect(
         hookData.result.current.signIn.path({
           to: 'htts://app.codecov.io/gh/codecov',
         })
       ).toBe(
-        `${config.BASE_URL}/login/gl?to=htts%3A%2F%2Fapp.codecov.io%2Fgh%2Fcodecov`
+        `${config.API_URL}/login/gl?to=htts%3A%2F%2Fapp.codecov.io%2Fgh%2Fcodecov`
       )
     })
 
@@ -81,12 +96,15 @@ describe('useNavLinks', () => {
       )
       setup(['/gh/doggo/squirrel-locator'])
 
+      // This is supposed to have REACT_APP_API_URL in front of it, but a lot
+      // of tests rely on that value being blank in `.env.test` so the test
+      // appears to assert that it is a same-site URL.
       expect(
         hookData.result.current.signIn.path({
           to: 'htts://app.codecov.io/gh/codecov',
         })
       ).toBe(
-        `${config.BASE_URL}/login/gh?to=htts%3A%2F%2Fapp.codecov.io%2Fgh%2Fcodecov&utm_source=a&utm_medium=b&utm_campaign=c&utm_term=d&utm_content=e`
+        `${config.API_URL}/login/gh?to=htts%3A%2F%2Fapp.codecov.io%2Fgh%2Fcodecov&utm_source=a&utm_medium=b&utm_campaign=c&utm_term=d&utm_content=e`
       )
       Cookie.remove('utmParams')
     })

--- a/src/services/navigation/useNavLinks/useNavLinks.spec.js
+++ b/src/services/navigation/useNavLinks/useNavLinks.spec.js
@@ -36,19 +36,13 @@ describe('useNavLinks', () => {
     })
 
     it('Returns the correct link with nothing passed', () => {
-      // This is supposed to have REACT_APP_API_URL in front of it, but a lot
-      // of tests rely on that value being blank in `.env.test` so the test
-      // appears to assert that it is a same-site URL.
       expect(hookData.result.current.signOut.path()).toBe(
-        `${config.API_URL}/logout/gl`
+        `${config.BASE_URL}/logout/gl`
       )
     })
     it('can override the params', () => {
-      // This is supposed to have REACT_APP_API_URL in front of it, but a lot
-      // of tests rely on that value being blank in `.env.test` so the test
-      // appears to assert that it is a same-site URL.
       expect(hookData.result.current.signOut.path({ provider: 'bb' })).toBe(
-        `${config.API_URL}/logout/bb`
+        `${config.BASE_URL}/logout/bb`
       )
     })
   })


### PR DESCRIPTION
if i run Codecov locally and load localhost:3000/login/gh and click the "login" button, it sends me to localhost:3000/login/gh which is where i already was and nothing happens. if i modify it to send me to localhost:8000/login/gh, which is my local API instance, it will send me to a GitHub authorization page as i'd expect.

in the previous attempt at this change https://github.com/codecov/gazebo/pull/2182, i jumped to a conclusion and made the same change for the sign out link. that was incorrect and the PR was reverted. here it is again, without the changes to the sign out link

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.