### PR TITLE
ref: Remove Pendo Modal PR Page Flag

### DIFF
--- a/src/pages/PullRequestPage/Header/Header.spec.jsx
+++ b/src/pages/PullRequestPage/Header/Header.spec.jsx
@@ -4,8 +4,6 @@ import { graphql } from 'msw'
 import { setupServer } from 'msw/node'
 import { MemoryRouter, Route } from 'react-router-dom'
 
-import { useFlags } from 'shared/featureFlags'
-
 import Header from './Header'
 
 jest.mock('shared/featureFlags')
@@ -58,8 +56,6 @@ afterAll(() => {
 
 describe('Header', () => {
   function setup() {
-    useFlags.mockReturnValue({ pendoModalPrPage: false })
-
     server.use(
       graphql.query('PullHeadData', (req, res, ctx) =>
         res(ctx.status(200), ctx.data(mockPullData))

--- a/src/pages/PullRequestPage/Header/PendoLink.spec.tsx
+++ b/src/pages/PullRequestPage/Header/PendoLink.spec.tsx
@@ -1,38 +1,14 @@
 import { render, screen } from '@testing-library/react'
 
-import { useFlags } from 'shared/featureFlags'
-
 import PendoLink from './PendoLink'
 
 jest.mock('shared/featureFlags')
 
-const mockedUseFlags = useFlags as jest.Mock<{ pendoModalPrPage: boolean }>
-
 describe('PendoLink', () => {
-  function setup({ flagValue }: { flagValue: boolean }) {
-    mockedUseFlags.mockReturnValue({
-      pendoModalPrPage: flagValue,
-    })
-  }
+  it('displays link', () => {
+    render(<PendoLink />)
 
-  describe('flag is enabled', () => {
-    it('displays link', () => {
-      setup({ flagValue: true })
-
-      render(<PendoLink />)
-
-      const link = screen.getByText('Does this report look accurate?')
-      expect(link).toBeInTheDocument()
-    })
-  })
-
-  describe('flag is disabled', () => {
-    it('does not display anything', () => {
-      setup({ flagValue: false })
-
-      const { container } = render(<PendoLink />)
-
-      expect(container).toBeEmptyDOMElement()
-    })
+    const link = screen.getByText('Does this report look accurate?')
+    expect(link).toBeInTheDocument()
   })
 })

--- a/src/pages/PullRequestPage/Header/PendoLink.tsx
+++ b/src/pages/PullRequestPage/Header/PendoLink.tsx
@@ -1,13 +1,6 @@
-import { useFlags } from 'shared/featureFlags'
 import A from 'ui/A'
 
 const PendoLink: React.FC = () => {
-  const { pendoModalPrPage } = useFlags({ pendoModalPrPage: false })
-
-  if (!pendoModalPrPage) {
-    return null
-  }
-
   return (
     <div className="flex items-end">
       {/* Need this rule here as the href will be handled by pendo */}

--- a/src/pages/PullRequestPage/PullRequestPage.spec.jsx
+++ b/src/pages/PullRequestPage/PullRequestPage.spec.jsx
@@ -5,8 +5,6 @@ import { graphql } from 'msw'
 import { setupServer } from 'msw/node'
 import { MemoryRouter, Route } from 'react-router-dom'
 
-import { useFlags } from 'shared/featureFlags'
-
 import PullRequestPage from './PullRequestPage'
 
 jest.mock('shared/featureFlags')
@@ -79,14 +77,7 @@ afterAll(() => {
 })
 
 describe('PullRequestPage', () => {
-  function setup(
-    { hasAccess = false, pullData = mockPullPageData } = {
-      hasAccess: false,
-      pullData: mockPullPageData,
-    }
-  ) {
-    useFlags.mockReturnValue({ pendoModalPrPage: false })
-
+  function setup({ hasAccess = false, pullData = {} }) {
     server.use(
       graphql.query('PullHeadData', (req, res, ctx) =>
         res(ctx.status(200), ctx.data(mockPullHeadData))

--- a/src/pages/PullRequestPage/PullRequestPage.spec.jsx
+++ b/src/pages/PullRequestPage/PullRequestPage.spec.jsx
@@ -77,7 +77,7 @@ afterAll(() => {
 })
 
 describe('PullRequestPage', () => {
-  function setup({ hasAccess = false, pullData = {} }) {
+  function setup({ hasAccess = false, pullData = mockPullPageData }) {
     server.use(
       graphql.query('PullHeadData', (req, res, ctx) =>
         res(ctx.status(200), ctx.data(mockPullHeadData))


### PR DESCRIPTION
# Description

Quick PR to remove the Pendo modal flag that's located on the PR page as it has been fully rolled out.

# Notable Changes

- Remove flag from `PendoLink` component
- Update tests to remove flag mock