### PR TITLE
Update eslint rules

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -23,8 +23,8 @@
     "testing-library/prefer-user-event": "warn",
     "testing-library/prefer-wait-for": "warn",
     "testing-library/prefer-explicit-assert": "warn",
-    "complexity": ["error", 5],
-    "max-statements": ["error", 10],
+    "complexity": "off",
+    "max-statements": "off",
     "max-nested-callbacks": ["error", 2],
     "react/prefer-stateless-function": ["error"],
     "react/prop-types": [
@@ -237,6 +237,14 @@
         ]
       }
     },
+    // TypeScript rules
+    {
+      "files": ["src/**/*.ts", "src/**/*.tsx"],
+      "rules": {
+        // No prop-types definitions required for typed React components
+        "react/prop-types": "off"
+      }
+    },
     // Testing Rules
     {
       "files": [
@@ -255,8 +263,6 @@
       ],
       "rules": {
         "max-nested-callbacks": "off",
-        "max-statements": "off",
-        "complexity": "off",
         "react/display-name": "off",
         "camelcase": "off"
       }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -38,7 +38,6 @@ const HomePageRedirect = () => {
   return <Redirect to={`/${provider}/${defaultOrg}`} />
 }
 
-// eslint-disable-next-line complexity
 const MainAppRoutes = () => (
   <Switch>
     <SentryRoute path="/login/:provider">

--- a/src/layouts/BaseLayout/hooks/useUserAccessGate.js
+++ b/src/layouts/BaseLayout/hooks/useUserAccessGate.js
@@ -29,7 +29,6 @@ function useOnboardingRedirect({ username }) {
   }
 }
 
-// eslint-disable-next-line complexity, max-statements
 const useUserAccessGate = () => {
   const { provider } = useParams()
   const { termsOfServicePage, defaultOrgSelectorPage } = useFlags({

--- a/src/pages/AccountSettings/AccountSettings.jsx
+++ b/src/pages/AccountSettings/AccountSettings.jsx
@@ -25,7 +25,6 @@ const Loader = () => (
   </div>
 )
 
-// eslint-disable-next-line complexity
 function AccountSettings() {
   const { provider, owner } = useParams()
   const isAdmin = useIsCurrentUserAnAdmin({ owner })

--- a/src/pages/AdminSettings/AdminMembers/MemberList/MemberTable.jsx
+++ b/src/pages/AdminSettings/AdminMembers/MemberList/MemberTable.jsx
@@ -1,4 +1,3 @@
-/* eslint-disable complexity */
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { useMemo } from 'react'
 import { useParams } from 'react-router-dom'

--- a/src/pages/CommitDetailPage/Header/hooks/useCommitHeaderData.tsx
+++ b/src/pages/CommitDetailPage/Header/hooks/useCommitHeaderData.tsx
@@ -96,7 +96,6 @@ export const useCommitHeaderData = ({
           repo,
           commitId,
         },
-        // eslint-disable-next-line max-statements
       }).then((res) => {
         const parsedData = CommitHeaderDataSchema.safeParse(res?.data?.owner)
 

--- a/src/pages/CommitDetailPage/hooks/useCommitPageData.tsx
+++ b/src/pages/CommitDetailPage/hooks/useCommitPageData.tsx
@@ -76,7 +76,6 @@ export const useCommitPageData = ({
           repo,
           commitId,
         },
-        // eslint-disable-next-line max-statements, complexity
       }).then((res) => {
         const parsedData = CommitPageDataSchema.safeParse(res?.data?.owner)
 

--- a/src/pages/CommitDetailPage/subRoute/IndirectChangesTab/IndirectChangesTable/CommitFileDiff/CommitFileDiff.jsx
+++ b/src/pages/CommitDetailPage/subRoute/IndirectChangesTab/IndirectChangesTable/CommitFileDiff/CommitFileDiff.jsx
@@ -30,7 +30,6 @@ const Loader = () => (
   </div>
 )
 
-// eslint-disable-next-line max-statements
 function CommitFileDiff({ path }) {
   const { owner, repo, provider, commit } = useParams()
   const { commitFileDiff } = useNavLinks()

--- a/src/pages/DefaultOrgSelector/DefaultOrgSelector.jsx
+++ b/src/pages/DefaultOrgSelector/DefaultOrgSelector.jsx
@@ -46,7 +46,6 @@ const renderItem = ({ item }) => {
   )
 }
 
-// eslint-disable-next-line max-statements
 function DefaultOrgSelector() {
   const { register, control, setValue, handleSubmit } = useForm({
     resolver: zodResolver(FormSchema),

--- a/src/pages/LoginPage/LoginButton.jsx
+++ b/src/pages/LoginPage/LoginButton.jsx
@@ -10,7 +10,7 @@ import {
 } from 'shared/utils/loginProviders'
 
 // temp disabling because of flag
-// eslint-disable-next-line max-statements
+
 function LoginButton({ provider }) {
   const { sentryLoginProvider } = useFlags({
     sentryLoginProvider: false,

--- a/src/pages/MembersPage/MembersActivation/Activation/Activation.jsx
+++ b/src/pages/MembersPage/MembersActivation/Activation/Activation.jsx
@@ -7,7 +7,6 @@ import A from 'ui/A/A'
 
 import ChangePlanLink from './ChangePlanLink'
 
-// eslint-disable-next-line complexity, max-statements
 function Activation() {
   const { owner, provider } = useParams()
   const { data: accountDetails } = useAccountDetails({ owner, provider })

--- a/src/pages/MembersPage/MembersList/MembersList.jsx
+++ b/src/pages/MembersPage/MembersList/MembersList.jsx
@@ -52,7 +52,6 @@ const handleActivate = (accountDetails, activate, setIsOpen) => (user) => {
   }
 }
 
-// eslint-disable-next-line max-statements
 function MembersList() {
   const { owner, provider } = useParams()
   const { params, updateParams } = useLocationParams({

--- a/src/pages/MembersPage/MembersList/MembersTable/MembersTable.jsx
+++ b/src/pages/MembersPage/MembersList/MembersTable/MembersTable.jsx
@@ -131,7 +131,6 @@ LoadMoreTrigger.propTypes = {
   intersectionRef: PropTypes.func,
 }
 
-// eslint-disable-next-line max-statements
 function MembersTable({ handleActivate, params }) {
   const [sortBy, setSortBy] = useState([])
   const { owner, provider } = useParams()

--- a/src/pages/OwnerPage/Header/HeaderBanners/HeaderBanners.jsx
+++ b/src/pages/OwnerPage/Header/HeaderBanners/HeaderBanners.jsx
@@ -49,7 +49,6 @@ AlertBanners.propTypes = {
   hasGhApp: PropTypes.bool.isRequired,
 }
 
-// eslint-disable-next-line complexity
 export default function HeaderBanners() {
   const { owner, provider } = useParams()
   // TODO: refactor this to add a gql field for the integration id used to determine if the org has a GH app

--- a/src/pages/OwnerPage/Tabs/TrialReminder/TrialReminder.tsx
+++ b/src/pages/OwnerPage/Tabs/TrialReminder/TrialReminder.tsx
@@ -35,7 +35,6 @@ const determineDateDiff = ({
   return dateDiff
 }
 
-// eslint-disable-next-line max-statements, complexity
 const TrialReminder: React.FC = () => {
   const { provider, owner } = useParams<{ provider: string; owner: string }>()
 

--- a/src/pages/PlanPage/subRoutes/CancelPlanPage/CancelPlanPage.jsx
+++ b/src/pages/PlanPage/subRoutes/CancelPlanPage/CancelPlanPage.jsx
@@ -21,7 +21,6 @@ const Loader = () => (
   </div>
 )
 
-// eslint-disable-next-line max-statements, complexity
 function CancelPlanPage() {
   const { provider, owner } = useParams()
   const { data: accountDetailsData } = useAccountDetails({ provider, owner })

--- a/src/pages/PlanPage/subRoutes/CancelPlanPage/subRoutes/DowngradePlan/CancelButton/utils.js
+++ b/src/pages/PlanPage/subRoutes/CancelPlanPage/subRoutes/DowngradePlan/CancelButton/utils.js
@@ -7,7 +7,6 @@ export function getEndPeriod(unixPeriodEnd) {
   )
 }
 
-/* eslint-disable max-statements */
 export function loadBaremetrics() {
   return new Promise((resolve) => {
     if (window.barecancel && window.barecancel.created) {

--- a/src/pages/PlanPage/subRoutes/CurrentOrgPlan/CurrentPlanCard/CurrentPlanCard.jsx
+++ b/src/pages/PlanPage/subRoutes/CurrentOrgPlan/CurrentPlanCard/CurrentPlanCard.jsx
@@ -12,7 +12,6 @@ import EnterprisePlanCard from './EnterprisePlanCard'
 import FreePlanCard from './FreePlanCard'
 import ProPlanCard from './ProPlanCard'
 
-// eslint-disable-next-line complexity
 function CurrentPlanCard() {
   const { provider, owner } = useParams()
   const { data: accountDetails } = useAccountDetails({ provider, owner })

--- a/src/pages/PlanPage/subRoutes/CurrentOrgPlan/CurrentPlanCard/FreePlanCard/FreePlanCard.jsx
+++ b/src/pages/PlanPage/subRoutes/CurrentOrgPlan/CurrentPlanCard/FreePlanCard/FreePlanCard.jsx
@@ -111,7 +111,6 @@ PlanUpgrade.propTypes = {
   plans: PropType.arrayOf(planPropType).isRequired,
 }
 
-// eslint-disable-next-line complexity, max-statements
 function FreePlanCard({ plan, scheduledPhase }) {
   const { provider, owner } = useParams()
   const { codecovTrialMvp } = useFlags({

--- a/src/pages/PlanPage/subRoutes/CurrentOrgPlan/CurrentPlanCard/FreePlanCard/ProPlanSubheading/ProPlanSubheading.tsx
+++ b/src/pages/PlanPage/subRoutes/CurrentOrgPlan/CurrentPlanCard/FreePlanCard/ProPlanSubheading/ProPlanSubheading.tsx
@@ -10,7 +10,6 @@ interface Params {
   owner: string
 }
 
-// eslint-disable-next-line max-statements, complexity
 function ProPlanSubheading() {
   const { provider, owner } = useParams<Params>()
   const { codecovTrialMvp } = useFlags({

--- a/src/pages/PlanPage/subRoutes/CurrentOrgPlan/CurrentPlanCard/shared/ActionsBilling/ActionsBilling.jsx
+++ b/src/pages/PlanPage/subRoutes/CurrentOrgPlan/CurrentPlanCard/shared/ActionsBilling/ActionsBilling.jsx
@@ -19,7 +19,6 @@ import {
 import A from 'ui/A/A'
 import Button from 'ui/Button'
 
-// eslint-disable-next-line complexity, max-statements
 function PlansActionsBilling({ plan }) {
   const { provider, owner } = useParams()
   const { data: plans } = usePlans(provider)

--- a/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/BillingControls/BillingControls.tsx
+++ b/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/BillingControls/BillingControls.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/prop-types */
 import { useEffect, useState } from 'react'
 import { useParams } from 'react-router-dom'
 
@@ -17,7 +16,6 @@ interface BillingTextProps {
   isSentryUpgrade: boolean
 }
 
-// eslint-disable-next-line max-statements
 const BillingText: React.FC<BillingTextProps> = ({
   isSentryUpgrade,
   option,

--- a/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/UpdateButton/UpdateButton.tsx
+++ b/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/UpdateButton/UpdateButton.tsx
@@ -3,7 +3,6 @@ import PropTypes, { type InferProps } from 'prop-types'
 import { isFreePlan } from 'shared/utils/billing'
 import Button from 'ui/Button'
 
-// eslint-disable-next-line complexity
 function UpdateButton({
   isValid,
   getValues,

--- a/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/UpgradeForm.jsx
+++ b/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/UpgradeForm.jsx
@@ -31,7 +31,6 @@ import TotalBanner from './TotalBanner'
 import UpdateButton from './UpdateButton'
 import UserCount from './UserCount'
 
-// eslint-disable-next-line max-statements
 const useUpgradeForm = ({
   proPlanYear,
   proPlanMonth,
@@ -152,7 +151,6 @@ PlanDetails.propTypes = {
   trialStatus: PropTypes.string,
 }
 
-// eslint-disable-next-line complexity, max-statements
 function UpgradeForm({
   proPlanYear,
   proPlanMonth,

--- a/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradePlanPage.jsx
+++ b/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradePlanPage.jsx
@@ -14,7 +14,6 @@ import UpgradeForm from './UpgradeForm'
 
 import { useSetCrumbs } from '../../context'
 
-// eslint-disable-next-line max-statements
 function UpgradePlanPage() {
   const { provider, owner } = useParams()
   const setCrumbs = useSetCrumbs()

--- a/src/pages/PullRequestPage/Header/hooks/usePullHeadData.tsx
+++ b/src/pages/PullRequestPage/Header/hooks/usePullHeadData.tsx
@@ -96,7 +96,6 @@ export const usePullHeadData = ({
           repo,
           pullId: parseInt(pullId, 10),
         },
-        // eslint-disable-next-line max-statements
       }).then((res) => {
         const parsedData = PullHeadDataSchema.safeParse(
           res?.data?.owner?.repository

--- a/src/pages/PullRequestPage/PullRequestPageContent/ErrorBanner/ErrorBanner.jsx
+++ b/src/pages/PullRequestPage/PullRequestPageContent/ErrorBanner/ErrorBanner.jsx
@@ -5,7 +5,6 @@ import Banner from 'ui/Banner'
 
 import { ComparisonReturnType } from './constants'
 
-// eslint-disable-next-line complexity, max-statements
 function BannerContent({ errorType }) {
   if (errorType === ComparisonReturnType.MISSING_BASE_COMMIT) {
     return (

--- a/src/pages/RepoPage/CommitsTab/CommitsTable/CommitsTable.jsx
+++ b/src/pages/RepoPage/CommitsTab/CommitsTable/CommitsTable.jsx
@@ -121,7 +121,6 @@ const Loader = () => (
   </div>
 )
 
-// eslint-disable-next-line complexity
 function CommitsTable({ branch, states, search }) {
   const { provider, owner, repo } = useParams()
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading } =

--- a/src/pages/RepoPage/CommitsTab/hooks/useCommitsTabBranchSelector.ts
+++ b/src/pages/RepoPage/CommitsTab/hooks/useCommitsTabBranchSelector.ts
@@ -10,7 +10,6 @@ interface URLParams {
   provider: string
 }
 
-// eslint-disable-next-line max-statements, complexity
 export const useCommitsTabBranchSelector = ({
   passedBranch,
   defaultBranch,

--- a/src/pages/RepoPage/CoverageTab/subroute/CoverageChart/CoverageChart.jsx
+++ b/src/pages/RepoPage/CoverageTab/subroute/CoverageChart/CoverageChart.jsx
@@ -1,4 +1,3 @@
-/* eslint-disable complexity */
 import { format } from 'date-fns'
 import { useParams } from 'react-router-dom'
 

--- a/src/pages/RepoPage/RepoPage.jsx
+++ b/src/pages/RepoPage/RepoPage.jsx
@@ -59,7 +59,6 @@ const Loader = () => (
   </div>
 )
 
-// eslint-disable-next-line max-statements, complexity
 function RepoPage() {
   const { provider, owner, repo } = useParams()
   const [refetchEnabled, setRefetchEnabled] = useState(false)

--- a/src/pages/TermsOfService/TermsOfService.jsx
+++ b/src/pages/TermsOfService/TermsOfService.jsx
@@ -25,7 +25,6 @@ function isDisabled({ isValid, isDirty }) {
   return (!isValid && isDirty) || !isDirty
 }
 
-// eslint-disable-next-line complexity
 export default function TermsOfService() {
   const { register, control, handleSubmit, formState, setValue, setError } =
     useForm({

--- a/src/services/file/utils.js
+++ b/src/services/file/utils.js
@@ -1,7 +1,6 @@
 import keyBy from 'lodash/keyBy'
 import mapValues from 'lodash/mapValues'
 
-// eslint-disable-next-line complexity
 export function extractCoverageFromResponse(res) {
   const commit = res?.data?.owner?.repository?.commit
   const branch = res?.data?.owner?.repository?.branch?.head

--- a/src/services/pathContents/utils.js
+++ b/src/services/pathContents/utils.js
@@ -1,7 +1,6 @@
 import keyBy from 'lodash/keyBy'
 import mapValues from 'lodash/mapValues'
 
-// eslint-disable-next-line complexity
 export function extractCoverageFromResponse(res) {
   const commit = res?.data?.owner?.repository?.commit
   const branch = res?.data?.owner?.repository?.branch?.head

--- a/src/services/toast/ErrorToast/ErrorToast.tsx
+++ b/src/services/toast/ErrorToast/ErrorToast.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/prop-types */
 import type { ToastProps } from '../renderToast'
 
 const ErrorToast: React.FC<ToastProps> = ({ title, content }) => (

--- a/src/services/toast/GenericToast/GenericToast.tsx
+++ b/src/services/toast/GenericToast/GenericToast.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/prop-types */
 import type { ToastProps } from '../renderToast'
 
 const GenericToast: React.FC<ToastProps> = ({ title, content }) => (

--- a/src/services/toast/renderToast.spec.tsx
+++ b/src/services/toast/renderToast.spec.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/prop-types */
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { toast, Toaster } from 'react-hot-toast'

--- a/src/services/toast/renderToast.tsx
+++ b/src/services/toast/renderToast.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/prop-types */
 import { toast, type ToastOptions } from 'react-hot-toast'
 
 import ErrorToast from './ErrorToast'

--- a/src/shared/GlobalTopBanners/RequestInstallBanner/RequestInstallBanner.jsx
+++ b/src/shared/GlobalTopBanners/RequestInstallBanner/RequestInstallBanner.jsx
@@ -8,7 +8,6 @@ import { providerToName } from 'shared/utils'
 import Icon from 'ui/Icon'
 import TopBanner from 'ui/TopBanner'
 
-// eslint-disable-next-line complexity
 function RequestInstallBanner() {
   const { provider } = useParams()
   const { params } = useLocationParams()

--- a/src/shared/GlobalTopBanners/TrialBanner/TrialBanner.tsx
+++ b/src/shared/GlobalTopBanners/TrialBanner/TrialBanner.tsx
@@ -30,7 +30,6 @@ interface UrlParams {
   owner?: string
 }
 
-// eslint-disable-next-line complexity, max-statements
 const TrialBanner: React.FC = () => {
   const { provider, owner } = useParams<UrlParams>()
 

--- a/src/shared/ListRepo/ReposTable/RepoTitleLink.jsx
+++ b/src/shared/ListRepo/ReposTable/RepoTitleLink.jsx
@@ -14,7 +14,6 @@ function Badge({ children }) {
 const getRepoIconName = ({ activated, isRepoPrivate, active }) =>
   !activated && active ? 'ban' : isRepoPrivate ? 'lock-closed' : 'globe-alt'
 
-// eslint-disable-next-line complexity
 function RepoTitleLink({ repo, showRepoOwner, pageName, disabledLink }) {
   const options = {
     owner: repo.author.username,

--- a/src/shared/ListRepo/ReposTable/ReposTable.jsx
+++ b/src/shared/ListRepo/ReposTable/ReposTable.jsx
@@ -75,7 +75,6 @@ const tableInactive = [
   },
 ]
 
-// eslint-disable-next-line complexity
 function transformRepoToTable({ repos, owner, isCurrentUserPartOfOrg }) {
   // if there are no repos show empty message
   if (!repos?.length || repos?.length <= 0) {
@@ -130,7 +129,6 @@ function transformRepoToTable({ repos, owner, isCurrentUserPartOfOrg }) {
   })
 }
 
-// eslint-disable-next-line complexity
 function ReposTable({ searchValue, owner, sortItem, filterValues = [] }) {
   const { data: userData } = useUser()
   const { data: ownerData } = useOwner({

--- a/src/shared/treePaths/useTreePaths.js
+++ b/src/shared/treePaths/useTreePaths.js
@@ -8,7 +8,6 @@ function getTreeLocation(paths, location, index) {
   return dropRight(paths, paths.length - index - 1).join('/')
 }
 
-// eslint-disable-next-line max-statements, complexity
 export function useTreePaths(passedPath) {
   const {
     provider,

--- a/src/shared/utils/extractUploads.js
+++ b/src/shared/utils/extractUploads.js
@@ -3,7 +3,6 @@ import groupBy from 'lodash/groupBy'
 
 import { UploadStateEnum, UploadTypeEnum } from 'shared/utils/commit'
 
-// eslint-disable-next-line complexity
 function humanReadableOverview(state, count) {
   const plural = (count) => (count > 1 ? 'are' : 'is')
   if (state === UploadStateEnum.error) return 'errored'

--- a/src/shared/utils/legacyCharts.js
+++ b/src/shared/utils/legacyCharts.js
@@ -34,7 +34,6 @@ export function getTrendEnum(trend) {
   return Trend.THREE_MONTHS
 }
 
-// eslint-disable-next-line complexity
 const calculateTrendDate = ({ today, trend }) => {
   if (trend === Trend.TWENTY_FOUR_HOURS) return subDays(today, 1)
   if (trend === Trend.SEVEN_DAYS) return subDays(today, 7)

--- a/src/shared/utils/timeseriesCharts.js
+++ b/src/shared/utils/timeseriesCharts.js
@@ -39,7 +39,6 @@ export function getTrendEnum(trend) {
   return Trend.THREE_MONTHS
 }
 
-// eslint-disable-next-line complexity
 const calculateTrendDate = ({ today, trend }) => {
   if (trend === Trend.SEVEN_DAYS) return subDays(today, 7)
   if (trend === Trend.THIRTY_DAYS) return subDays(today, 30)
@@ -75,7 +74,6 @@ function analyticsGroupingUnit({ dayDifference }) {
   return GroupingUnit.WEEK
 }
 
-// eslint-disable-next-line complexity
 export function analyticsQuery({ endDate, startDate, repositories }) {
   const dayDifference = calculateDayDifference({
     end: endDate,

--- a/src/shared/utils/upgradeForm.js
+++ b/src/shared/utils/upgradeForm.js
@@ -14,7 +14,6 @@ export const MIN_NB_SEATS = 2
 export const MIN_SENTRY_SEATS = 5
 export const SENTRY_PRICE = 29
 
-// eslint-disable-next-line complexity
 export function extractSeats({
   quantity,
   value,

--- a/src/ui/CodeRenderer/hooks/useScrollToLine.js
+++ b/src/ui/CodeRenderer/hooks/useScrollToLine.js
@@ -26,7 +26,6 @@ const handleClick =
 const useTarget = ({ location, idString }) => {
   const [targeted, setTargeted] = useState(false)
 
-  // eslint-disable-next-line complexity
   useEffect(() => {
     if (location?.hash === idString) {
       if (!targeted) {
@@ -73,7 +72,6 @@ export const useScrollToLine = ({
 
   const [resizeObs] = useState(() => new ResizeObserver(handleResize))
 
-  // eslint-disable-next-line complexity, max-statements
   useEffect(() => {
     if (!resizeObs) return
 

--- a/src/ui/MultiSelect/MultiSelect.jsx
+++ b/src/ui/MultiSelect/MultiSelect.jsx
@@ -68,7 +68,6 @@ LoadMoreTrigger.propTypes = {
   intersectionRef: PropTypes.shape({ current: PropTypes.instanceOf(Element) }),
 }
 
-// eslint-disable-next-line complexity
 function DropdownList({
   ariaName,
   isOpen,

--- a/src/ui/Select/Select.jsx
+++ b/src/ui/Select/Select.jsx
@@ -59,7 +59,6 @@ LoadMoreTrigger.propTypes = {
 }
 
 const Select = forwardRef(
-  // eslint-disable-next-line complexity
   (
     {
       placeholder = 'Select',

--- a/src/ui/SunburstChart/SunburstChart.jsx
+++ b/src/ui/SunburstChart/SunburstChart.jsx
@@ -1,4 +1,3 @@
-/* eslint-disable max-statements */
 import { interpolate } from 'd3-interpolate'
 import { scaleSequential } from 'd3-scale'
 import { select } from 'd3-selection'


### PR DESCRIPTION
# Description

This work disables the complexity and max-lines eslint rules and disables prop-types (the library) requirement for TypeScript React components. Disabled lines or files have also been cleaned up for the associated rule changes.

# Notable Changes
Cleans up all disabled lines/files of associated rules.
You no longer need to disable the `prop-types` rule with TypeScript files, properly typing components replaces the necessity of using the library.

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.