### PR TITLE
Added fix to excape meta characters

### DIFF
--- a/src/pages/RepoPage/NewRepoTab/OtherCI/TerminalInstructions/InstructionBox.spec.jsx
+++ b/src/pages/RepoPage/NewRepoTab/OtherCI/TerminalInstructions/InstructionBox.spec.jsx
@@ -1,9 +1,10 @@
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import { graphql } from 'msw'
 
 import config from 'config'
 
-import { useOnboardingTracking, useUser } from 'services/user'
+import { useOnboardingTracking } from 'services/user'
 
 import InstructionBox from '.'
 
@@ -30,14 +31,18 @@ describe('InstructionBox', () => {
         })
       },
     })
-    useUser.mockReturnValue({
-      data: {
-        username: "Patia Por'co",
-        trackingMetadata: {
-          ownerid: 12345,
-        },
-      },
-    })
+
+    graphql.query('CurrentUser', (_, res, ctx) =>
+      res(
+        ctx.status(200),
+        ctx.data({
+          me: {
+            user: { username: "Patia Por'co" },
+            trackingMetadata: { ownerid: 12345 },
+          },
+        })
+      )
+    )
 
     return {
       terminalUploaderCommandClicked: mockTerminalUploaderCommandClicked,
@@ -123,7 +128,7 @@ describe('InstructionBox', () => {
 
       await user.click(screen.getByRole('button', { name: 'Windows' }))
 
-      const baseUrl = screen.getByText(/https:\/\/app.codecov.io\/uploader/)
+      const baseUrl = screen.getByText(/https:\/\/app\.codecov\.io\/uploader/)
       expect(baseUrl).toBeInTheDocument()
     })
 
@@ -134,7 +139,7 @@ describe('InstructionBox', () => {
       await user.click(screen.getByRole('button', { name: 'Windows' }))
 
       const selfHostedInstruction = screen.getByText(
-        /\/codecov -u https:\/\/app.codecov.io/
+        /\/codecov -u https:\/\/app\.codecov\.io/
       )
       expect(selfHostedInstruction).toBeInTheDocument()
     })
@@ -147,7 +152,7 @@ describe('InstructionBox', () => {
 
       await user.click(screen.getByRole('button', { name: 'Linux' }))
       const instruction = screen.queryByText(
-        /curl -Os https:\/\/uploader.codecov.io\/latest\/linux\/codecov/
+        /curl -Os https:\/\/uploader\.codecov\.io\/latest\/linux\/codecov/
       )
       expect(instruction).toBeInTheDocument()
     })
@@ -160,7 +165,7 @@ describe('InstructionBox', () => {
 
       await user.click(screen.getByRole('button', { name: 'Alpine Linux' }))
       const instruction = screen.queryByText(
-        /curl -Os https:\/\/uploader.codecov.io\/latest\/alpine\/codecov/
+        /curl -Os https:\/\/uploader\.codecov\.io\/latest\/alpine\/codecov/
       )
       expect(instruction).toBeInTheDocument()
     })


### PR DESCRIPTION
# Description
This PR addresses the security vuln found here, https://github.com/codecov/gazebo/security/code-scanning/1. This tweaks the regex to escape meta-characters based of this list https://www.ibm.com/docs/en/rational-clearquest/9.0.1?topic=tags-meta-characters-in-regular-expressions

# Notable Changes
- Adjusted test file to account for regex meta-character escape

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.