### PR TITLE
ref: Remove default branch from badges and graphs 

### DIFF
--- a/src/pages/RepoPage/SettingsTab/tabs/BadgesAndGraphsTab/Badges/Badges.jsx
+++ b/src/pages/RepoPage/SettingsTab/tabs/BadgesAndGraphsTab/Badges/Badges.jsx
@@ -6,11 +6,11 @@ import config from 'config'
 import SettingsDescriptor from 'ui/SettingsDescriptor'
 import TokenWrapper from 'ui/TokenWrapper'
 
-const useBadges = ({ graphToken, defaultBranch }) => {
+const useBadges = ({ graphToken }) => {
   const { provider, owner, repo } = useParams()
 
   const repoPath = `${config.BASE_URL}/${provider}/${owner}/${repo}`
-  const fullPath = `${repoPath}/branch/${defaultBranch}/graph/badge.svg?token=${graphToken}`
+  const fullPath = `${repoPath}/graph/badge.svg?token=${graphToken}`
 
   const BadgesEnum = Object.freeze({
     MARKDOWN: `[![codecov](${fullPath})](${repoPath})`,
@@ -21,8 +21,8 @@ const useBadges = ({ graphToken, defaultBranch }) => {
   return BadgesEnum
 }
 
-function Badges({ graphToken, defaultBranch }) {
-  const BadgesEnum = useBadges({ graphToken, defaultBranch })
+function Badges({ graphToken }) {
+  const BadgesEnum = useBadges({ graphToken })
 
   return (
     <SettingsDescriptor
@@ -49,7 +49,6 @@ function Badges({ graphToken, defaultBranch }) {
 }
 
 Badges.propTypes = {
-  defaultBranch: PropTypes.string,
   graphToken: PropTypes.string.isRequired,
 }
 

--- a/src/pages/RepoPage/SettingsTab/tabs/BadgesAndGraphsTab/Badges/Badges.spec.jsx
+++ b/src/pages/RepoPage/SettingsTab/tabs/BadgesAndGraphsTab/Badges/Badges.spec.jsx
@@ -1,4 +1,3 @@
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { render, screen } from '@testing-library/react'
 import { MemoryRouter, Route } from 'react-router-dom'
 
@@ -8,22 +7,16 @@ import Badges from './Badges'
 
 jest.mock('config')
 
-const queryClient = new QueryClient({
-  defaultOptions: { queries: { retry: false } },
-})
-
 const wrapper = ({ children }) => (
   <MemoryRouter initialEntries={['/gh/codecov/codecov-client/settings/badge']}>
-    <QueryClientProvider client={queryClient}>
-      <Route path="/:provider/:owner/:repo/settings/badge">{children}</Route>
-    </QueryClientProvider>
+    <Route path="/:provider/:owner/:repo/settings/badge">{children}</Route>
   </MemoryRouter>
 )
 
 describe('Badges', () => {
   describe('renders', () => {
     it('renders title', () => {
-      render(<Badges graphToken="WIO9JXFGE" defaultBranch="master" />, {
+      render(<Badges graphToken="WIO9JXFGE" />, {
         wrapper,
       })
 
@@ -32,7 +25,7 @@ describe('Badges', () => {
     })
 
     it('renders body', () => {
-      render(<Badges graphToken="WIO9JXFGE" defaultBranch="master" />, {
+      render(<Badges graphToken="WIO9JXFGE" />, {
         wrapper,
       })
 
@@ -43,19 +36,19 @@ describe('Badges', () => {
     })
 
     it('renders with expected base url', () => {
-      render(<Badges graphToken="WIO9JXFGE" defaultBranch="master" />, {
+      render(<Badges graphToken="WIO9JXFGE" />, {
         wrapper,
       })
       config.BASE_URL = 'https://stage-codecov.io'
 
       const baseUrl = screen.getByText(
-        '[![codecov](https://stage-web.codecov.dev/gh/codecov/codecov-client/branch/master/graph/badge.svg?token=WIO9JXFGE)](https://stage-web.codecov.dev/gh/codecov/codecov-client)'
+        '[![codecov](https://stage-web.codecov.dev/gh/codecov/codecov-client/graph/badge.svg?token=WIO9JXFGE)](https://stage-web.codecov.dev/gh/codecov/codecov-client)'
       )
       expect(baseUrl).toBeInTheDocument()
     })
 
     it('renders tokens', () => {
-      render(<Badges graphToken="WIO9JXFGE" defaultBranch="master" />, {
+      render(<Badges graphToken="WIO9JXFGE" />, {
         wrapper,
       })
 

--- a/src/pages/RepoPage/SettingsTab/tabs/BadgesAndGraphsTab/BadgesAndGraphsTab.jsx
+++ b/src/pages/RepoPage/SettingsTab/tabs/BadgesAndGraphsTab/BadgesAndGraphsTab.jsx
@@ -6,16 +6,11 @@ import Graphs from './Graphs'
 function BadgesAndGraphsTab() {
   const { data } = useRepoSettings()
   const graphToken = data?.repository?.graphToken
-  const defaultBranch = data?.repository?.defaultBranch
 
   return (
     <div className="flex flex-col gap-4">
-      {graphToken && (
-        <Badges graphToken={graphToken} defaultBranch={defaultBranch} />
-      )}
-      {graphToken && (
-        <Graphs graphToken={graphToken} defaultBranch={defaultBranch} />
-      )}
+      {graphToken && <Badges graphToken={graphToken} />}
+      {graphToken && <Graphs graphToken={graphToken} />}
     </div>
   )
 }

--- a/src/pages/RepoPage/SettingsTab/tabs/BadgesAndGraphsTab/BadgesAndGraphsTab.spec.jsx
+++ b/src/pages/RepoPage/SettingsTab/tabs/BadgesAndGraphsTab/BadgesAndGraphsTab.spec.jsx
@@ -1,62 +1,84 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { render, screen } from '@testing-library/react'
+import { graphql } from 'msw'
+import { setupServer } from 'msw/node'
 import { MemoryRouter, Route } from 'react-router-dom'
-
-import { useRepoSettings } from 'services/repo'
 
 import BadgesAndGraphsTab from './BadgesAndGraphsTab'
 
-jest.mock('services/repo')
 const queryClient = new QueryClient({
   defaultOptions: { queries: { retry: false } },
 })
 
+const server = setupServer()
+
+const wrapper = ({ children }) => (
+  <MemoryRouter initialEntries={['/gh/codecov/codecov-client/settings']}>
+    <QueryClientProvider client={queryClient}>
+      <Route path="/:provider/:owner/:repo/settings">{children}</Route>
+    </QueryClientProvider>
+  </MemoryRouter>
+)
+
+beforeAll(() => {
+  server.listen()
+  console.error = () => {}
+})
+afterEach(() => {
+  queryClient.clear()
+  server.resetHandlers()
+})
+afterAll(() => server.close())
+
 describe('BadgesAndGraphsTab', () => {
   function setup({ graphToken }) {
-    useRepoSettings.mockReturnValue({
-      data: {
-        repository: { graphToken },
-      },
-    })
-
-    render(
-      <MemoryRouter initialEntries={['/gh/codecov/codecov-client/settings']}>
-        <QueryClientProvider client={queryClient}>
-          <Route path="/:provider/:owner/:repo/settings">
-            <BadgesAndGraphsTab />
-          </Route>
-        </QueryClientProvider>
-      </MemoryRouter>
+    server.use(
+      graphql.query('GetRepoSettings', (req, res, ctx) => {
+        return res(
+          ctx.status(200),
+          ctx.data({
+            owner: {
+              repository: {
+                graphToken: graphToken,
+              },
+            },
+          })
+        )
+      })
     )
   }
 
   describe('when rendered with graphToken', () => {
-    beforeEach(() => {
+    it('renders badges component', async () => {
       setup({ graphToken: 'WIO9JXFGE3' })
-    })
+      render(<BadgesAndGraphsTab />, { wrapper })
 
-    it('renders badges component', () => {
-      const title = screen.getByText(/Codecov badge/)
+      const title = await screen.findByText(/Codecov badge/)
       expect(title).toBeInTheDocument()
     })
 
-    it('renders graphs component', () => {
-      const title = screen.getByText(/Graphs/)
+    it('renders graphs component', async () => {
+      setup({ graphToken: 'WIO9JXFGE3' })
+      render(<BadgesAndGraphsTab />, { wrapper })
+
+      const title = await screen.findByText(/Graphs/)
       expect(title).toBeInTheDocument()
     })
   })
 
   describe('when rendered with no graphToken', () => {
-    beforeEach(() => {
-      setup({ graphToken: null })
-    })
-
     it('does not render badges component', () => {
+      setup({ graphToken: null })
+      render(<BadgesAndGraphsTab />, { wrapper })
+
       const title = screen.queryByText(/Codecov badge/)
       expect(title).not.toBeInTheDocument()
     })
 
     it('does not render graphs component', () => {
+      setup({ graphToken: null })
+      render(<BadgesAndGraphsTab />, { wrapper })
+
       const title = screen.queryByText(/Graphs/)
       expect(title).not.toBeInTheDocument()
     })

--- a/src/pages/RepoPage/SettingsTab/tabs/BadgesAndGraphsTab/BadgesAndGraphsTab.spec.jsx
+++ b/src/pages/RepoPage/SettingsTab/tabs/BadgesAndGraphsTab/BadgesAndGraphsTab.spec.jsx
@@ -12,10 +12,10 @@ const queryClient = new QueryClient({
 })
 
 describe('BadgesAndGraphsTab', () => {
-  function setup({ defaultBranch, graphToken }) {
+  function setup({ graphToken }) {
     useRepoSettings.mockReturnValue({
       data: {
-        repository: { defaultBranch, graphToken },
+        repository: { graphToken },
       },
     })
 

--- a/src/pages/RepoPage/SettingsTab/tabs/BadgesAndGraphsTab/Graphs/Graphs.jsx
+++ b/src/pages/RepoPage/SettingsTab/tabs/BadgesAndGraphsTab/Graphs/Graphs.jsx
@@ -6,7 +6,7 @@ import TokenWrapper from 'ui/TokenWrapper'
 
 import URLEmbed from './URLEmbed'
 
-function Graphs({ graphToken, defaultBranch }) {
+function Graphs({ graphToken }) {
   return (
     <div className="flex flex-col gap-5">
       <SettingsDescriptor
@@ -22,14 +22,13 @@ function Graphs({ graphToken, defaultBranch }) {
           </>
         }
       />
-      <URLEmbed graphToken={graphToken} defaultBranch={defaultBranch} />
+      <URLEmbed graphToken={graphToken} />
     </div>
   )
 }
 
 Graphs.propTypes = {
   graphToken: PropTypes.string.isRequired,
-  defaultBranch: PropTypes.string,
 }
 
 export default Graphs

--- a/src/pages/RepoPage/SettingsTab/tabs/BadgesAndGraphsTab/Graphs/Graphs.spec.jsx
+++ b/src/pages/RepoPage/SettingsTab/tabs/BadgesAndGraphsTab/Graphs/Graphs.spec.jsx
@@ -1,44 +1,38 @@
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { render, screen } from '@testing-library/react'
 import { MemoryRouter, Route } from 'react-router-dom'
 
 import Graphs from './Graphs'
 
-const queryClient = new QueryClient({
-  defaultOptions: { queries: { retry: false } },
-})
+const wrapper = ({ children }) => (
+  <MemoryRouter initialEntries={['/gh/codecov/codecov-client/settings/badge']}>
+    <Route path="/:provider/:owner/:repo/settings/badge">{children}</Route>
+  </MemoryRouter>
+)
 
 describe('Graphs', () => {
-  function setup() {
-    render(
-      <MemoryRouter
-        initialEntries={['/gh/codecov/codecov-client/settings/badge']}
-      >
-        <QueryClientProvider client={queryClient}>
-          <Route path="/:provider/:owner/:repo/settings/badge">
-            <Graphs graphToken="WIO9JXFGE" defaultBranch="master" />
-          </Route>
-        </QueryClientProvider>
-      </MemoryRouter>
-    )
-  }
-
   describe('renders Graphs component', () => {
-    beforeEach(() => {
-      setup()
-    })
     it('renders title', () => {
+      render(<Graphs graphToken="WIO9JXFGE" />, { wrapper })
+
       const title = screen.getByText(/Graphs/)
       expect(title).toBeInTheDocument()
     })
+
     it('renders Embed via API component', () => {
+      render(<Graphs graphToken="WIO9JXFGE" />, { wrapper })
+
       const p = screen.getByText(
         /Use this token to view graphs and images for third party dashboard usage./
       )
       expect(p).toBeInTheDocument()
-      expect(screen.getAllByText(/WIO9JXFGE/)[0]).toBeInTheDocument()
+
+      const token = screen.getAllByText(/WIO9JXFGE/)[0]
+      expect(token).toBeInTheDocument()
     })
+
     it('renders Embed via URL component', () => {
+      render(<Graphs graphToken="WIO9JXFGE" />, { wrapper })
+
       const p = screen.getByText(
         /Use the URL of the svg to embed a graph of your repository page./
       )
@@ -46,6 +40,8 @@ describe('Graphs', () => {
     })
 
     it('renders three different graphs cards', () => {
+      render(<Graphs graphToken="WIO9JXFGE" />, { wrapper })
+
       expect(screen.getByText(/Sunburst/)).toBeInTheDocument()
       expect(
         screen.getByText(/The inner-most circle is the entire/)
@@ -60,6 +56,18 @@ describe('Graphs', () => {
       expect(
         screen.getByText(/The top section represents the entire/)
       ).toBeInTheDocument()
+    })
+
+    it('renders open SVG', () => {
+      render(<Graphs graphToken="WIO9JXFGE" />, { wrapper })
+
+      const url = screen.getAllByRole('link', { name: /Open SVG/ })
+      expect(url).toHaveLength(3)
+
+      expect(url[0]).toHaveAttribute(
+        'href',
+        'https://stage-web.codecov.dev/gh/codecov/codecov-client/graphs/sunburst.svg?token=WIO9JXFGE'
+      )
     })
   })
 })

--- a/src/pages/RepoPage/SettingsTab/tabs/BadgesAndGraphsTab/Graphs/URLEmbed.jsx
+++ b/src/pages/RepoPage/SettingsTab/tabs/BadgesAndGraphsTab/Graphs/URLEmbed.jsx
@@ -4,8 +4,8 @@ import GraphCard from 'ui/GraphCard'
 
 import useGraphsDetails from './useGraphsDetails'
 
-function URLEmbed({ graphToken, defaultBranch }) {
-  const GraphsDetailsEnum = useGraphsDetails({ defaultBranch, graphToken })
+function URLEmbed({ graphToken }) {
+  const GraphsDetailsEnum = useGraphsDetails({ graphToken })
 
   return (
     <div className="flex flex-col gap-2 border-2 border-ds-gray-primary p-4 xl:w-4/5 2xl:w-3/5">
@@ -30,7 +30,6 @@ function URLEmbed({ graphToken, defaultBranch }) {
 
 URLEmbed.propTypes = {
   graphToken: PropTypes.string.isRequired,
-  defaultBranch: PropTypes.string,
 }
 
 export default URLEmbed

--- a/src/pages/RepoPage/SettingsTab/tabs/BadgesAndGraphsTab/Graphs/useGraphsDetails.js
+++ b/src/pages/RepoPage/SettingsTab/tabs/BadgesAndGraphsTab/Graphs/useGraphsDetails.js
@@ -4,11 +4,11 @@ import config from 'config'
 
 import { icicle, sunburst, tree } from 'assets/svg/graphs'
 
-const useChartsDetails = ({ defaultBranch, graphToken }) => {
+const useChartsDetails = ({ graphToken }) => {
   const { provider, owner, repo } = useParams()
 
   const repoPath = `${config.BASE_URL}/${provider}/${owner}/${repo}`
-  const fullPath = `${repoPath}/branch/${defaultBranch}/graphs`
+  const fullPath = `${repoPath}/graphs`
 
   const ChartDetailsEnum = Object.freeze({
     SUNBURST: {


### PR DESCRIPTION
# Description
People need a way to default urls to default branch without having to hard code it in the URL, we support default to repo.branch in the API so an easy fix was to remove default branch. 

# Notable Changes
Remove default branch from URLs
Fix tests

# Link to Sample Entry
any repo settings.

Issue: https://github.com/codecov/engineering-team/issues/306

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.