### PR TITLE
Invalidate UseMyOrganizations query

### DIFF
--- a/src/services/user/useResyncUser.js
+++ b/src/services/user/useResyncUser.js
@@ -76,7 +76,7 @@ export function useResyncUser() {
   const prevIsSyncing = usePrevious(isSyncing)
   useEffect(() => {
     if (prevIsSyncing && !isSyncing) {
-      queryClient.refetchQueries(['repos'])
+      queryClient.refetchQueries(['repos', 'UseMyOrganizations'])
     }
   }, [prevIsSyncing, isSyncing, queryClient])
 

--- a/src/services/user/useResyncUser.spec.js
+++ b/src/services/user/useResyncUser.spec.js
@@ -155,7 +155,10 @@ describe('useResyncUser', () => {
       })
 
       await waitFor(() =>
-        expect(refetchQueriesSpy).toHaveBeenCalledWith(['repos'])
+        expect(refetchQueriesSpy).toHaveBeenCalledWith([
+          'repos',
+          'UseMyOrganizations',
+        ])
       )
     })
   })


### PR DESCRIPTION
# Description
For the onboarding page, we want to invalidate the `UseMyOrganizations` query when syncing users.

# Notable Changes
- Adjusted resync user hook + tests

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.