### PR TITLE
ref: Remove Trial Flag from Activation

### DIFF
--- a/src/pages/MembersPage/MembersActivation/Activation/Activation.jsx
+++ b/src/pages/MembersPage/MembersActivation/Activation/Activation.jsx
@@ -1,7 +1,6 @@
 import { useParams } from 'react-router-dom'
 
 import { TrialStatuses, useAccountDetails, usePlanData } from 'services/account'
-import { useFlags } from 'shared/featureFlags'
 import { isFreePlan, isTrialPlan } from 'shared/utils/billing'
 import A from 'ui/A/A'
 
@@ -11,16 +10,9 @@ function Activation() {
   const { owner, provider } = useParams()
   const { data: accountDetails } = useAccountDetails({ owner, provider })
 
-  const { codecovTrialMvp } = useFlags({
-    codecovTrialMvp: false,
-  })
-
   const { data: planData } = usePlanData({
     provider,
     owner,
-    opts: {
-      enabled: codecovTrialMvp,
-    },
   })
 
   const activatedUserCount = accountDetails?.activatedUserCount || 0

--- a/src/pages/MembersPage/MembersActivation/Activation/Activation.spec.jsx
+++ b/src/pages/MembersPage/MembersActivation/Activation/Activation.spec.jsx
@@ -6,11 +6,9 @@ import { setupServer } from 'msw/node'
 import { MemoryRouter, Route } from 'react-router-dom'
 
 import { TrialStatuses } from 'services/account'
-import { useFlags } from 'shared/featureFlags'
 
 import Activation from './Activation'
 
-jest.mock('shared/featureFlags')
 jest.mock('./ChangePlanLink', () => () => 'ChangePlanLink')
 
 const mockedAccountDetails = {
@@ -73,13 +71,8 @@ describe('Activation', () => {
   function setup(
     accountDetails = mockedAccountDetails,
     trialStatus = TrialStatuses.NOT_STARTED,
-    planValue = mockedAccountDetails.plan.value,
-    trialFlag = false
+    planValue = mockedAccountDetails.plan.value
   ) {
-    useFlags.mockReturnValue({
-      codecovTrialMvp: trialFlag,
-    })
-
     server.use(
       rest.get('/internal/gh/:owner/account-details/', (req, res, ctx) =>
         res(ctx.status(200), ctx.json(accountDetails))
@@ -148,7 +141,7 @@ describe('Activation', () => {
 
     describe('user is currently on a trial', () => {
       it('displays title', async () => {
-        setup(mockedAccountDetails, TrialStatuses.ONGOING, 'users-trial', true)
+        setup(mockedAccountDetails, TrialStatuses.ONGOING, 'users-trial')
 
         render(<Activation />, { wrapper: wrapper() })
 
@@ -159,7 +152,7 @@ describe('Activation', () => {
       })
 
       it('displays number of active users', async () => {
-        setup(mockedAccountDetails, TrialStatuses.ONGOING, 'users-trial', true)
+        setup(mockedAccountDetails, TrialStatuses.ONGOING, 'users-trial')
 
         render(<Activation />, { wrapper: wrapper() })
 
@@ -171,7 +164,7 @@ describe('Activation', () => {
       })
 
       it('displays on trial notice', async () => {
-        setup(mockedAccountDetails, TrialStatuses.ONGOING, 'users-trial', true)
+        setup(mockedAccountDetails, TrialStatuses.ONGOING, 'users-trial')
 
         render(<Activation />, { wrapper: wrapper() })
 
@@ -182,7 +175,7 @@ describe('Activation', () => {
       })
 
       it('displays upgrade plan link', async () => {
-        setup(mockedAccountDetails, TrialStatuses.ONGOING, 'users-trial', true)
+        setup(mockedAccountDetails, TrialStatuses.ONGOING, 'users-trial')
 
         render(<Activation />, { wrapper: wrapper() })
 
@@ -199,7 +192,7 @@ describe('Activation', () => {
 
     describe('user has an expired trial', () => {
       it('displays title', async () => {
-        setup(mockedAccountDetails, TrialStatuses.EXPIRED, 'users-basic', true)
+        setup(mockedAccountDetails, TrialStatuses.EXPIRED, 'users-basic')
 
         render(<Activation />, { wrapper: wrapper() })
 
@@ -210,7 +203,7 @@ describe('Activation', () => {
       })
 
       it('displays number of activated users', async () => {
-        setup(mockedAccountDetails, TrialStatuses.EXPIRED, 'users-basic', true)
+        setup(mockedAccountDetails, TrialStatuses.EXPIRED, 'users-basic')
 
         render(<Activation />, { wrapper: wrapper() })
 
@@ -222,7 +215,7 @@ describe('Activation', () => {
       })
 
       it('displays number of plan quantity', async () => {
-        setup(mockedAccountDetails, TrialStatuses.EXPIRED, 'users-basic', true)
+        setup(mockedAccountDetails, TrialStatuses.EXPIRED, 'users-basic')
 
         render(<Activation />, { wrapper: wrapper() })
 
@@ -234,7 +227,7 @@ describe('Activation', () => {
       })
 
       it('displays org trialed text', async () => {
-        setup(mockedAccountDetails, TrialStatuses.EXPIRED, 'users-basic', true)
+        setup(mockedAccountDetails, TrialStatuses.EXPIRED, 'users-basic')
 
         render(<Activation />, { wrapper: wrapper() })
 
@@ -245,7 +238,7 @@ describe('Activation', () => {
       })
 
       it('displays change plan link', async () => {
-        setup(mockedAccountDetails, TrialStatuses.EXPIRED, 'users-basic', true)
+        setup(mockedAccountDetails, TrialStatuses.EXPIRED, 'users-basic')
 
         render(<Activation />, { wrapper: wrapper() })
 


### PR DESCRIPTION
# Description

Trials seemed to have been rolled out smoothly so it's a good idea to remove the flags while the context is fresh in the mind. This PR removes the flags usage in the `Activation` component and related tests.

# Notable Changes

- Remove use of flag in `Activation`
- Remove tests checking flag values