### PR TITLE
feat: Allowing impersonation to bypass default org selector

### DIFF
--- a/src/layouts/BaseLayout/BaseLayout.jsx
+++ b/src/layouts/BaseLayout/BaseLayout.jsx
@@ -5,6 +5,7 @@ import Header from 'layouts/Header'
 import ErrorBoundary from 'layouts/shared/ErrorBoundary'
 import NetworkErrorBoundary from 'layouts/shared/NetworkErrorBoundary'
 import ToastNotifications from 'layouts/ToastNotifications'
+import { useImpersonate } from 'services/impersonate'
 import { useTracking } from 'services/tracking'
 import GlobalBanners from 'shared/GlobalBanners'
 import GlobalTopBanners from 'shared/GlobalTopBanners'
@@ -27,6 +28,8 @@ const OnboardingOrChildren = ({ children }) => {
   const { isFullExperience, showAgreeToTerms, showDefaultOrgSelector } =
     useUserAccessGate()
 
+  const { isImpersonating } = useImpersonate()
+
   if (showAgreeToTerms && !isFullExperience)
     return (
       <Suspense fallback={null}>
@@ -34,7 +37,7 @@ const OnboardingOrChildren = ({ children }) => {
       </Suspense>
     )
 
-  if (showDefaultOrgSelector && !isFullExperience)
+  if (showDefaultOrgSelector && !isFullExperience && !isImpersonating)
     return (
       <Suspense fallback={null}>
         <DefaultOrgSelector />


### PR DESCRIPTION
# Description
Impersonation accounts are struggling with the default org selector screen; this is a quick fix for that.

# Notable Changes
- Added an impersonation check for codecov users to bypass the default org selector screen

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.