### PR TITLE
feat: Add Configuration Option to Toggle Access Tab

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -19,6 +19,10 @@ export function removeReactAppPrefix(obj) {
     keys['IS_SELF_HOSTED'] = keys['ENV'].toLowerCase() === 'enterprise'
   }
 
+  if ('HIDE_ACCESS_TAB' in keys) {
+    keys['HIDE_ACCESS_TAB'] = keys['HIDE_ACCESS_TAB'].toLowerCase() === 'true'
+  }
+
   if ('SENTRY_TRACING_SAMPLE_RATE' in keys) {
     keys['SENTRY_TRACING_SAMPLE_RATE'] = parseFloat(
       keys['SENTRY_TRACING_SAMPLE_RATE']

--- a/src/config.spec.js
+++ b/src/config.spec.js
@@ -40,6 +40,34 @@ describe('config', () => {
       })
     })
 
+    describe('sets HIDE_ACCESS_TAB to boolean', () => {
+      it('sets to true', () => {
+        const obj = {
+          HIDE_ACCESS_TAB: 'true',
+        }
+
+        expect(removeReactAppPrefix(obj)).toEqual({
+          HIDE_ACCESS_TAB: true,
+        })
+      })
+
+      it('sets to false', () => {
+        const obj = {
+          HIDE_ACCESS_TAB: 'false',
+        }
+
+        expect(removeReactAppPrefix(obj)).toEqual({
+          HIDE_ACCESS_TAB: false,
+        })
+      })
+
+      it('sets skips if undefined', () => {
+        const obj = {}
+
+        expect(removeReactAppPrefix(obj)).toEqual({})
+      })
+    })
+
     describe('sets SENTRY_TRACING_SAMPLE_RATE to float', () => {
       it('sets to float', () => {
         const obj = {

--- a/src/pages/AccountSettings/AccountSettings.jsx
+++ b/src/pages/AccountSettings/AccountSettings.jsx
@@ -51,7 +51,7 @@ function AccountSettings() {
             <SentryRoute path="/account/:provider/:owner/yaml/" exact>
               <YAMLTab provider={provider} owner={owner} />
             </SentryRoute>
-            {(!config.IS_SELF_HOSTED || config.SHOW_ACCESS_TAB) && (
+            {(!config.IS_SELF_HOSTED || !config.HIDE_ACCESS_TAB) && (
               <SentryRoute path="/account/:provider/:owner/access/" exact>
                 <AccessTab provider={provider} />
               </SentryRoute>

--- a/src/pages/AccountSettings/AccountSettings.jsx
+++ b/src/pages/AccountSettings/AccountSettings.jsx
@@ -53,7 +53,7 @@ function AccountSettings() {
             </SentryRoute>
             {(!config.IS_SELF_HOSTED || !config.HIDE_ACCESS_TAB) && (
               <SentryRoute path="/account/:provider/:owner/access/" exact>
-                <AccessTab provider={provider} />
+                <AccessTab />
               </SentryRoute>
             )}
             <SentryRoute

--- a/src/pages/AccountSettings/AccountSettings.jsx
+++ b/src/pages/AccountSettings/AccountSettings.jsx
@@ -51,7 +51,7 @@ function AccountSettings() {
             <SentryRoute path="/account/:provider/:owner/yaml/" exact>
               <YAMLTab provider={provider} owner={owner} />
             </SentryRoute>
-            {!config.IS_SELF_HOSTED && (
+            {(!config.IS_SELF_HOSTED || config.SHOW_ACCESS_TAB) && (
               <SentryRoute path="/account/:provider/:owner/access/" exact>
                 <AccessTab provider={provider} />
               </SentryRoute>

--- a/src/pages/AccountSettings/AccountSettings.spec.jsx
+++ b/src/pages/AccountSettings/AccountSettings.spec.jsx
@@ -67,14 +67,17 @@ describe('AccountSettings', () => {
       owner = 'codecov',
       username = 'codecov',
       isAdmin = false,
+      showAccessTab = false,
     } = {
       isSelfHosted: false,
       owner: 'codecov',
       username: 'codecov',
       isAdmin: false,
+      showAccessTab: false,
     }
   ) {
     config.IS_SELF_HOSTED = isSelfHosted
+    config.SHOW_ACCESS_TAB = showAccessTab
 
     server.use(
       graphql.query('CurrentUser', (req, res, ctx) => {
@@ -178,34 +181,69 @@ describe('AccountSettings', () => {
 
   describe('on the access route', () => {
     describe('is self hosted', () => {
-      it('renders not found tab', async () => {
-        setup({ isSelfHosted: true })
+      describe('show access tab is set to true', () => {
+        it('renders access tab', async () => {
+          setup({ isSelfHosted: true, showAccessTab: true })
 
-        render(<AccountSettings />, {
-          wrapper: wrapper({
-            initialEntries: '/account/gh/codecov/access',
-            path: '/account/:provider/:owner/access',
-          }),
+          render(<AccountSettings />, {
+            wrapper: wrapper({
+              initialEntries: '/account/gh/codecov/access',
+              path: '/account/:provider/:owner/access',
+            }),
+          })
+
+          const accessTab = await screen.findByText('Access')
+          expect(accessTab).toBeInTheDocument()
         })
+      })
 
-        const notFound = await screen.findByText('NotFound')
-        expect(notFound).toBeInTheDocument()
+      describe('show access tab is set to false', () => {
+        it('renders not found tab', async () => {
+          setup({ isSelfHosted: true, showAccessTab: false })
+
+          render(<AccountSettings />, {
+            wrapper: wrapper({
+              initialEntries: '/account/gh/codecov/access',
+              path: '/account/:provider/:owner/access',
+            }),
+          })
+
+          const notFound = await screen.findByText('NotFound')
+          expect(notFound).toBeInTheDocument()
+        })
       })
     })
 
     describe('is not self hosted', () => {
-      it('renders access tab', async () => {
-        setup()
+      describe('show access tab is set to true', () => {
+        it('renders access tab', async () => {
+          setup({ isSelfHosted: false, showAccessTab: true })
 
-        render(<AccountSettings />, {
-          wrapper: wrapper({
-            initialEntries: '/account/gh/codecov/access',
-            path: '/account/:provider/:owner/access',
-          }),
+          render(<AccountSettings />, {
+            wrapper: wrapper({
+              initialEntries: '/account/gh/codecov/access',
+              path: '/account/:provider/:owner/access',
+            }),
+          })
+
+          const accessTab = await screen.findByText('Access')
+          expect(accessTab).toBeInTheDocument()
         })
+      })
+      describe('show access tab is set to false', () => {
+        it('renders access tab', async () => {
+          setup({ isSelfHosted: false, showAccessTab: false })
 
-        const accessTab = await screen.findByText('Access')
-        expect(accessTab).toBeInTheDocument()
+          render(<AccountSettings />, {
+            wrapper: wrapper({
+              initialEntries: '/account/gh/codecov/access',
+              path: '/account/:provider/:owner/access',
+            }),
+          })
+
+          const accessTab = await screen.findByText('Access')
+          expect(accessTab).toBeInTheDocument()
+        })
       })
     })
   })

--- a/src/pages/AccountSettings/AccountSettings.spec.jsx
+++ b/src/pages/AccountSettings/AccountSettings.spec.jsx
@@ -67,17 +67,17 @@ describe('AccountSettings', () => {
       owner = 'codecov',
       username = 'codecov',
       isAdmin = false,
-      showAccessTab = false,
+      hideAccessTab = true,
     } = {
       isSelfHosted: false,
       owner: 'codecov',
       username: 'codecov',
       isAdmin: false,
-      showAccessTab: false,
+      hideAccessTab: true,
     }
   ) {
     config.IS_SELF_HOSTED = isSelfHosted
-    config.SHOW_ACCESS_TAB = showAccessTab
+    config.HIDE_ACCESS_TAB = hideAccessTab
 
     server.use(
       graphql.query('CurrentUser', (req, res, ctx) => {
@@ -181,9 +181,9 @@ describe('AccountSettings', () => {
 
   describe('on the access route', () => {
     describe('is self hosted', () => {
-      describe('show access tab is set to true', () => {
+      describe('hide access tab is set to false', () => {
         it('renders access tab', async () => {
-          setup({ isSelfHosted: true, showAccessTab: true })
+          setup({ isSelfHosted: true, hideAccessTab: false })
 
           render(<AccountSettings />, {
             wrapper: wrapper({
@@ -197,9 +197,9 @@ describe('AccountSettings', () => {
         })
       })
 
-      describe('show access tab is set to false', () => {
+      describe('hide access tab is set to true', () => {
         it('renders not found tab', async () => {
-          setup({ isSelfHosted: true, showAccessTab: false })
+          setup({ isSelfHosted: true, hideAccessTab: true })
 
           render(<AccountSettings />, {
             wrapper: wrapper({
@@ -215,9 +215,9 @@ describe('AccountSettings', () => {
     })
 
     describe('is not self hosted', () => {
-      describe('show access tab is set to true', () => {
+      describe('hide access tab is set to false', () => {
         it('renders access tab', async () => {
-          setup({ isSelfHosted: false, showAccessTab: true })
+          setup({ isSelfHosted: false, hideAccessTab: false })
 
           render(<AccountSettings />, {
             wrapper: wrapper({
@@ -230,9 +230,9 @@ describe('AccountSettings', () => {
           expect(accessTab).toBeInTheDocument()
         })
       })
-      describe('show access tab is set to false', () => {
+      describe('hide access tab is set to true', () => {
         it('renders access tab', async () => {
-          setup({ isSelfHosted: false, showAccessTab: false })
+          setup({ isSelfHosted: false, hideAccessTab: true })
 
           render(<AccountSettings />, {
             wrapper: wrapper({

--- a/src/pages/AccountSettings/AccountSettingsSideMenu.jsx
+++ b/src/pages/AccountSettings/AccountSettingsSideMenu.jsx
@@ -14,8 +14,12 @@ function defaultLinks({ internalAccessTab }) {
 }
 
 function selfHostedOverrideLinks({ isPersonalSettings }) {
+  let internalAccessTab =
+    !config.HIDE_ACCESS_TAB && isPersonalSettings ? 'internalAccessTab' : null
+
   return [
     { pageName: isPersonalSettings ? 'profile' : '', exact: true },
+    ...(internalAccessTab ? [{ pageName: internalAccessTab }] : []),
     { pageName: 'yamlTab' },
   ]
 }

--- a/src/pages/AccountSettings/AccountSettingsSideMenu.spec.jsx
+++ b/src/pages/AccountSettings/AccountSettingsSideMenu.spec.jsx
@@ -55,16 +55,19 @@ describe('AccountSettingsSideMenu', () => {
     {
       isAdmin = false,
       username = 'codecov',
-      isSelfHosted = false,
       owner = 'codecov',
+      isSelfHosted = false,
+      hideAccessTab = false,
     } = {
       isAdmin: false,
       username: 'codecov',
       isSelfHosted: false,
       owner: 'codecov',
+      hideAccessTab: false,
     }
   ) {
     config.IS_SELF_HOSTED = isSelfHosted
+    config.HIDE_ACCESS_TAB = hideAccessTab
 
     server.use(
       graphql.query('CurrentUser', (req, res, ctx) => {
@@ -91,6 +94,37 @@ describe('AccountSettingsSideMenu', () => {
         const link = await screen.findByRole('link', { name: 'Profile' })
         expect(link).toBeInTheDocument()
         expect(link).toHaveAttribute('href', '/account/gh/codecov')
+      })
+
+      describe('hide access tab is set to false', () => {
+        it('renders access tab link', async () => {
+          setup({ isSelfHosted: true })
+
+          render(<AccountSettingsSideMenu />, { wrapper: wrapper() })
+
+          const link = await screen.findByRole('link', { name: 'Access' })
+          expect(link).toBeInTheDocument()
+          expect(link).toHaveAttribute('href', '/account/gh/codecov/access')
+        })
+      })
+
+      describe('hide access tab is set to true', () => {
+        it('does not render access tab link', async () => {
+          setup({ isSelfHosted: true, hideAccessTab: true })
+
+          render(<AccountSettingsSideMenu />, { wrapper: wrapper() })
+
+          const suspense = await screen.findByText('Loading')
+          expect(suspense).toBeInTheDocument()
+          await waitFor(() =>
+            expect(screen.queryByText('Loading')).not.toBeInTheDocument()
+          )
+
+          const link = screen.queryByRole('link', {
+            name: 'Access',
+          })
+          expect(link).not.toBeInTheDocument()
+        })
       })
     })
 

--- a/src/pages/AccountSettings/tabs/Access/Access.jsx
+++ b/src/pages/AccountSettings/tabs/Access/Access.jsx
@@ -1,28 +1,38 @@
-import PropTypes from 'prop-types'
 import { useState } from 'react'
+import { Redirect, useParams } from 'react-router-dom'
 
 import { useSessions } from 'services/access'
+import { useUser } from 'services/user'
 import Button from 'ui/Button'
 
 import CreateTokenModal from './CreateTokenModal'
 import SessionsTable from './SessionsTable'
 import TokensTable from './TokensTable'
 
-function Access({ provider }) {
-  const { data } = useSessions({
+function Access() {
+  const { provider, owner } = useParams()
+  const [showModal, setShowModal] = useState(false)
+
+  const { data: sessionData } = useSessions({
     provider,
   })
 
-  const [showModal, setShowModal] = useState(false)
+  const { data: currentUser } = useUser()
+
+  const isViewingPersonalSettings =
+    currentUser?.user?.username?.toLowerCase() === owner?.toLowerCase()
+
+  if (!isViewingPersonalSettings) {
+    return <Redirect to={`/account/${provider}/${owner}`} />
+  }
 
   return (
     <div className="flex flex-col">
       <h2 className="text-lg font-semibold">API Tokens</h2>
       <div className="flex items-center justify-between">
-        <p data-testid="tokens-summary">
-          Tokens created to access Codecov’s API as an authenticated user{' '}
+        <p>
+          Tokens created to access Codecov&apos;s API as an authenticated user{' '}
           <a
-            data-testid="tokens-docs-link"
             rel="noreferrer"
             target="_blank"
             href="https://docs.codecov.com/reference/overview"
@@ -42,17 +52,13 @@ function Access({ provider }) {
           />
         )}
       </div>
-      <TokensTable tokens={data?.tokens} />
+      <TokensTable tokens={sessionData?.tokens} />
       <h2 className="mb-4 mt-8 text-lg font-semibold">Login Sessions</h2>
       <div className="max-w-screen-md">
-        <SessionsTable sessions={data?.sessions} />
+        <SessionsTable sessions={sessionData?.sessions} />
       </div>
     </div>
   )
-}
-
-Access.propTypes = {
-  provider: PropTypes.string.isRequired,
 }
 
 export default Access

--- a/src/pages/AccountSettings/tabs/Access/Access.spec.jsx
+++ b/src/pages/AccountSettings/tabs/Access/Access.spec.jsx
@@ -1,35 +1,34 @@
-import { render, screen } from 'custom-testing-library'
-
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { subDays } from 'date-fns'
+import { graphql } from 'msw'
+import { setupServer } from 'msw/node'
+import { Suspense } from 'react'
 import { MemoryRouter, Route } from 'react-router-dom'
-
-import {
-  useDeleteSession,
-  useGenerateUserToken,
-  useRevokeUserToken,
-  useSessions,
-} from 'services/access'
 
 import Access from './Access'
 
-jest.mock('services/access')
-
 window.confirm = jest.fn(() => true)
 
-const wrapper = ({ children }) => (
-  <MemoryRouter initialEntries={['/bb/critical-role/bells-hells']}>
-    <Route path="/:provider/:owner/:repo">{children}</Route>
-  </MemoryRouter>
-)
-describe('AccessTab', () => {
-  function setup() {
-    const user = userEvent.setup()
+const mockSignedInUser = {
+  me: {
+    owner: {
+      defaultOrgUsername: 'codecov',
+    },
+    user: {
+      username: 'codecov-user',
+      avatarUrl: 'https://github.com/morri.png?size=40',
+    },
+  },
+}
 
-    useSessions.mockReturnValue({
-      data: {
-        sessions: [
-          {
+const mockSessionInfo = {
+  me: {
+    sessions: {
+      edges: [
+        {
+          node: {
             sessionid: 32,
             ip: '172.21.0.1',
             lastseen: subDays(new Date(), 3).toISOString(),
@@ -38,80 +37,173 @@ describe('AccessTab', () => {
             type: 'login',
             name: null,
           },
-        ],
-        tokens: [],
-      },
-    })
-    useDeleteSession.mockReturnValue({})
-    useRevokeUserToken.mockReturnValue({})
-    useGenerateUserToken.mockReturnValue({})
+        },
+      ],
+    },
+    tokens: {
+      edges: [],
+    },
+  },
+}
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      suspense: true,
+    },
+  },
+})
+const server = setupServer()
+
+let testLocation
+const wrapper =
+  (initialEntries = '/account/gh/codecov-user/access') =>
+  ({ children }) =>
+    (
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter initialEntries={[initialEntries]}>
+          <Suspense fallback={<p>loading</p>}>
+            <Route path="/account/:provider/:owner/access">{children}</Route>
+            <Route
+              path="*"
+              render={({ location }) => {
+                testLocation = location
+                return null
+              }}
+            />
+          </Suspense>
+        </MemoryRouter>
+      </QueryClientProvider>
+    )
+
+beforeAll(() => {
+  server.listen()
+})
+
+afterEach(() => {
+  queryClient.clear()
+  server.resetHandlers()
+})
+
+afterAll(() => {
+  server.close()
+})
+
+describe('AccessTab', () => {
+  function setup() {
+    const user = userEvent.setup()
+
+    server.use(
+      graphql.query('MySessions', (req, res, ctx) => {
+        return res(ctx.status(200), ctx.data(mockSessionInfo))
+      }),
+      graphql.query('CurrentUser', (req, res, ctx) => {
+        return res(ctx.status(200), ctx.data(mockSignedInUser))
+      })
+    )
 
     return { user }
   }
 
   describe('when rendering on base url', () => {
-    beforeEach(() => {
-      setup()
-    })
-
     describe('renders elements', () => {
-      it('renders title', () => {
-        render(<Access provider="gh" owner="codecov" />, { wrapper })
+      it('renders title', async () => {
+        setup()
+        render(<Access />, { wrapper: wrapper() })
 
-        const title = screen.getByText(/API Tokens/)
+        const title = await screen.findByText(/API Tokens/)
         expect(title).toBeInTheDocument()
       })
-      it('renders button', () => {
-        render(<Access provider="gh" owner="codecov" />, { wrapper })
 
-        const button = screen.getByText(/Generate Token/)
+      it('renders button', async () => {
+        setup()
+        render(<Access />, { wrapper: wrapper() })
+
+        const button = await screen.findByText(/Generate Token/)
         expect(button).toBeInTheDocument()
       })
-      it('renders sessions title', () => {
-        render(<Access provider="gh" owner="codecov" />, { wrapper })
 
-        const sessionsTitle = screen.getByText(/Login Sessions/)
+      it('renders sessions title', async () => {
+        setup()
+        render(<Access />, { wrapper: wrapper() })
+
+        const sessionsTitle = await screen.findByText(/Login Sessions/)
         expect(sessionsTitle).toBeInTheDocument()
       })
-      it('renders tokens summary', () => {
-        render(<Access provider="gh" owner="codecov" />, { wrapper })
 
-        expect(screen.getByTestId('tokens-summary')).toBeInTheDocument()
+      it('renders tokens summary', async () => {
+        setup()
+        render(<Access />, { wrapper: wrapper() })
+
+        const tokenSummary = await screen.findByText(
+          /Tokens created to access Codecov/
+        )
+        expect(tokenSummary).toBeInTheDocument()
       })
-      it('renders tokens docs link', () => {
-        render(<Access provider="gh" owner="codecov" />, { wrapper })
 
-        expect(screen.getByTestId('tokens-docs-link')).toBeInTheDocument()
+      it('renders tokens docs link', async () => {
+        setup()
+        render(<Access />, { wrapper: wrapper() })
+
+        const tokenDocsLink = await screen.findByRole('link', {
+          name: 'learn more',
+        })
+        expect(tokenDocsLink).toBeInTheDocument()
       })
-      it('renders no tokens message', () => {
-        render(<Access provider="gh" owner="codecov" />, { wrapper })
 
-        const sessionsTitle = screen.getByText(/No tokens created yet/)
+      it('renders no tokens message', async () => {
+        setup()
+        render(<Access />, { wrapper: wrapper() })
+
+        const sessionsTitle = await screen.findByText(/No tokens created yet/)
         expect(sessionsTitle).toBeInTheDocument()
       })
     })
+
     describe('on revoke', () => {
       it('triggers confirmation Modal', async () => {
         const { user } = setup()
-        render(<Access provider="gh" owner="codecov" />, { wrapper })
+        render(<Access />, { wrapper: wrapper() })
 
-        await user.click(screen.getAllByText(/Revoke/)[0])
-        expect(window.confirm).toBeCalled()
+        const revokeButtons = await screen.findAllByText(/Revoke/)
+
+        await user.click(revokeButtons[0])
+
+        await waitFor(() => expect(window.confirm).toBeCalled())
       })
     })
+
     describe('on open modal', () => {
       it('opens create token modal', async () => {
         const { user } = setup()
-        render(<Access provider="gh" owner="codecov" />, { wrapper })
+        render(<Access />, { wrapper: wrapper() })
 
-        await user.click(screen.getByText(/Generate Token/))
-        expect(
-          screen.getByText('Generate new API access token')
-        ).toBeInTheDocument()
+        const generateToken = await screen.findByText(/Generate Token/)
+        await user.click(generateToken)
 
-        await user.click(screen.getByText(/Cancel/))
-        expect(screen.getByText('Generate Token')).toBeInTheDocument()
+        const modalText = await screen.findByText(
+          'Generate new API access token'
+        )
+        expect(modalText).toBeInTheDocument()
+
+        const cancelBtn = await screen.findByText(/Cancel/)
+        await user.click(cancelBtn)
+
+        const generateToken_2 = await screen.findByText('Generate Token')
+        expect(generateToken_2).toBeInTheDocument()
       })
+    })
+  })
+
+  describe('user is not viewing their own settings', () => {
+    it('redirects the user', async () => {
+      setup()
+
+      render(<Access />, { wrapper: wrapper('/account/gh/codecov/access') })
+
+      await waitFor(() =>
+        expect(testLocation.pathname).toBe('/account/gh/codecov')
+      )
     })
   })
 })


### PR DESCRIPTION
# Description

Currently when running in self hosted mode the access tab on the account settings page is currently hidden, some customers are looking to use this access tab while others are looking to keep it hidden so this is an option that will allow it to be toggled per customer.

Closes #2199 

# Notable Changes

- Add check for `config.HIDE_ACCESS_TAB` in `AccountSettings`
- Update tests.
