### PR TITLE
Setting up sentry config for releases in other envs

### DIFF
--- a/.github/workflows/alpha.yml
+++ b/.github/workflows/alpha.yml
@@ -19,6 +19,8 @@ jobs:
       gcp_sa: ${{ secrets.CODECOV_GCP_WIDSA }}
       gcp_idp: ${{ secrets.CODECOV_GCP_WIDP }}
       sentry_dsn: ${{ secrets.sentry_dsn_alpha }}
+      sentry_release_token: ${{ secrets.CODECOV_SENTRY_RELEASE_TOKEN }}
+      sentry_project: ${{ secrets.CODECOV_SENTRY_CLIENT_PROJECT }}
     permissions:
       pull-requests: 'write'
       contents: 'read'

--- a/.github/workflows/client-release.yml
+++ b/.github/workflows/client-release.yml
@@ -21,6 +21,10 @@ on:
         required: true
       sentry_dsn:
         required: true
+      sentry_project:
+        required: true
+      sentry_release_token:
+        required: true
 jobs:
   release:
     name: Release
@@ -56,5 +60,7 @@ jobs:
           REACT_APP_ENTERPRISE_DEFAULT_PROVIDER: ${{ secrets.default_provider }}
           REACT_APP_SENTRY_DSN: ${{ secrets.sentry_dsn }}
           REACT_APP_SENTRY_ENVIRONMENT: ${{ secrets.client_name }}
+          REACT_APP_SENTRY_AUTH_TOKEN: ${{ secrets.sentry_release_token }}
+          REACT_APP_SENTRY_PROJECT: ${{ secrets.sentry_project }}
 
       - run: gsutil -m rsync -d -c -r build gs://${{ secrets.bucket }}

--- a/craco.config.js
+++ b/craco.config.js
@@ -5,8 +5,8 @@ const SentryWebpackPlugin = require('@sentry/webpack-plugin')
 const { resolve } = require('path')
 
 const SentryPlugin = new SentryWebpackPlugin({
-  org: 'codecov',
-  project: 'gazebo',
+  org: process.env.SENTRY_ORG || 'codecov',
+  project: process.env.SENTRY_PROJECT || 'gazebo',
   include: './build/static/js',
   authToken: process.env.SENTRY_AUTH_TOKEN,
   urlPrefix: '~/static/js',


### PR DESCRIPTION
# Description
Setting up sentry config for releases in other envs


<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.