### PR TITLE
style: Pluralize Trial Days Message

### DIFF
--- a/src/shared/GlobalTopBanners/TrialBanner/OngoingBanner.spec.tsx
+++ b/src/shared/GlobalTopBanners/TrialBanner/OngoingBanner.spec.tsx
@@ -20,18 +20,29 @@ describe('OngoingBanner', () => {
   }
 
   describe('rendering banner', () => {
-    it('renders left side text', () => {
-      render(<OngoingBanner dateDiff={3} />, { wrapper })
+    describe('date diff greater then 1', () => {
+      it('renders left side text', () => {
+        render(<OngoingBanner dateDiff={3} />, { wrapper })
 
-      const leftText = screen.getByText(/Your trial ends in 3 day\(s\)/)
-      expect(leftText).toBeInTheDocument()
+        const leftText = screen.getByText('Your trial ends in 3 days.')
+        expect(leftText).toBeInTheDocument()
+      })
+    })
+
+    describe('date diff lt or eq to 1', () => {
+      it('renders left side text', () => {
+        render(<OngoingBanner dateDiff={1} />, { wrapper })
+
+        const leftText = screen.getByText('Your trial ends in 1 day.')
+        expect(leftText).toBeInTheDocument()
+      })
     })
 
     it('renders link to upgrade', () => {
       render(<OngoingBanner dateDiff={3} />, { wrapper })
 
       const upgradeLink = screen.getByRole('link', {
-        name: /upgrade/,
+        name: /Upgrade now/,
       })
       expect(upgradeLink).toBeInTheDocument()
       expect(upgradeLink).toHaveAttribute('href', '/plan/gh/codecov/upgrade')
@@ -55,7 +66,7 @@ describe('OngoingBanner', () => {
     it('renders button to upgrade', () => {
       render(<OngoingBanner dateDiff={3} />, { wrapper })
 
-      const btn = screen.getByRole('link', { name: /Upgrade/ })
+      const btn = screen.getByRole('link', { name: /Upgrade now/ })
       expect(btn).toBeInTheDocument()
       expect(btn).toHaveAttribute('href', '/plan/gh/codecov/upgrade')
     })

--- a/src/shared/GlobalTopBanners/TrialBanner/OngoingBanner.tsx
+++ b/src/shared/GlobalTopBanners/TrialBanner/OngoingBanner.tsx
@@ -5,6 +5,18 @@ import Button from 'ui/Button/Button'
 import Icon from 'ui/Icon/Icon'
 import TopBanner from 'ui/TopBanner'
 
+interface DayCountProps {
+  dateDiff: number
+}
+
+const DayCount: React.FC<DayCountProps> = ({ dateDiff }) => {
+  if (dateDiff <= 1) {
+    return <span>Your trial ends in {dateDiff} day.</span>
+  }
+
+  return <span>Your trial ends in {dateDiff} days.</span>
+}
+
 interface OngoingBannerProps {
   dateDiff: number
 }
@@ -16,8 +28,9 @@ const OngoingBanner: React.FC<OngoingBannerProps> = ({ dateDiff }) => {
         <p>
           <span className="pr-2 text-xl">&#128075;</span>
           <span className="font-semibold">
-            Your trial ends in {dateDiff} day(s) {/* @ts-expect-error */}
-            <A to={{ pageName: 'upgradeOrgPlan' }}>upgrade</A>.
+            <DayCount dateDiff={dateDiff} />
+            {/* @ts-expect-error */}
+            <A to={{ pageName: 'upgradeOrgPlan' }}>Upgrade now</A>.
           </span>
         </p>
       </TopBanner.Start>

--- a/src/shared/GlobalTopBanners/TrialBanner/TrialBanner.spec.tsx
+++ b/src/shared/GlobalTopBanners/TrialBanner/TrialBanner.spec.tsx
@@ -242,9 +242,7 @@ describe('TrialBanner', () => {
               wrapper: wrapper(),
             })
 
-            const text = await screen.findByText(
-              /Your trial ends in 1 day\(s\)/
-            )
+            const text = await screen.findByText(/Your trial ends in 1 day/)
             expect(text).toBeInTheDocument()
           })
         })


### PR DESCRIPTION
# Description

Quick copy change to the ongoing trial banner. 

Closes codecov/engineering-team#399

# Notable Changes

- Update `OngoingBanner` to render different text based on `dateDiff` being `<= 1`.
- Update `OngoingBanner` to say `Upgrade now` instead of just `upgrade`
- Update tests.
