### PR TITLE
fix: Remove 0 from source data

### DIFF
--- a/src/pages/PullRequestPage/Summary/CompareSummary.jsx
+++ b/src/pages/PullRequestPage/Summary/CompareSummary.jsx
@@ -50,6 +50,38 @@ function totalsCards({
   ]
 }
 
+function BehindByCommits({ behindByCommit, behindBy, defaultBranch }) {
+  const { owner, repo, provider } = useParams()
+
+  if (!behindBy || !behindByCommit) return null
+
+  return (
+    <p className="text-xs text-ds-gray-quinary">
+      BASE commit is <span>{behindBy}</span> commits behind HEAD on{' '}
+      <span>{defaultBranch}</span>{' '}
+      <A
+        variant="code"
+        href={getProviderCommitURL({
+          provider,
+          owner,
+          repo,
+          commit: behindByCommit,
+        })}
+        hook="provider commit url"
+        isExternal={true}
+      >
+        {behindByCommit?.slice(0, 7)}
+      </A>
+    </p>
+  )
+}
+
+BehindByCommits.propTypes = {
+  behindByCommit: PropTypes.string,
+  behindBy: PropTypes.number,
+  defaultBranch: PropTypes.string,
+}
+
 function CardWithDifferentNumberOfUploads({
   head,
   base,
@@ -59,7 +91,6 @@ function CardWithDifferentNumberOfUploads({
   behindByCommit,
   defaultBranch,
 }) {
-  const { owner, repo, provider } = useParams()
   return (
     <div className="flex flex-col gap-1">
       <p className="text-sm text-ds-gray-octonary">
@@ -93,25 +124,11 @@ function CardWithDifferentNumberOfUploads({
           </A>{' '}
         </p>
       </div>
-      {behindBy && behindByCommit && (
-        <p className="text-xs text-ds-gray-quinary">
-          BASE commit is <span>{behindBy}</span> commits behind HEAD on{' '}
-          <span>{defaultBranch}</span>{' '}
-          <A
-            variant="code"
-            href={getProviderCommitURL({
-              provider,
-              owner,
-              repo,
-              commit: behindByCommit,
-            })}
-            hook="provider commit url"
-            isExternal={true}
-          >
-            {behindByCommit?.slice(0, 7)}
-          </A>
-        </p>
-      )}
+      <BehindByCommits
+        behindByCommit={behindByCommit}
+        behindBy={behindBy}
+        defaultBranch={defaultBranch}
+      />
     </div>
   )
 }
@@ -141,7 +158,6 @@ function CardWithSameNumberOfUploads({
   behindByCommit,
   defaultBranch,
 }) {
-  const { owner, repo, provider } = useParams()
   return (
     <p className="text-sm text-ds-gray-octonary">
       Coverage data is based on{' '}
@@ -153,25 +169,11 @@ function CardWithSameNumberOfUploads({
       <A to={{ pageName: 'commit', options: { commit: baseCommit } }}>
         {baseCommit?.slice(0, 7)}
       </A>{' '}
-      {behindBy && behindByCommit && (
-        <p className="text-xs text-ds-gray-quinary">
-          BASE commit is <span>{behindBy}</span> commits behind HEAD on{' '}
-          <span>{defaultBranch}</span>{' '}
-          <A
-            variant="code"
-            href={getProviderCommitURL({
-              provider,
-              owner,
-              repo,
-              commit: behindByCommit,
-            })}
-            hook="provider commit url"
-            isExternal={true}
-          >
-            {behindByCommit?.slice(0, 7)}
-          </A>
-        </p>
-      )}
+      <BehindByCommits
+        behindByCommit={behindByCommit}
+        behindBy={behindBy}
+        defaultBranch={defaultBranch}
+      />
     </p>
   )
 }

--- a/src/pages/PullRequestPage/Summary/CompareSummary.spec.jsx
+++ b/src/pages/PullRequestPage/Summary/CompareSummary.spec.jsx
@@ -335,4 +335,53 @@ describe('CompareSummary', () => {
       )
     })
   })
+
+  describe('When PR is not behind by the target branch', () => {
+    it('does not render a card with the behind by information', async () => {
+      setup({
+        owner: {
+          repository: {
+            defaultBranch: 'main',
+            pull: {
+              behindBy: 0,
+              behindByCommit: undefined,
+              commits: {
+                edges: [{ node: { state: 'complete', commitid: 'abc' } }],
+              },
+              head: {
+                commitid: 'fc43199b07c52cf3d6c19b7cdb368f74387c38ab',
+                totals: {
+                  percentCovered: 78.33,
+                },
+                uploads: {
+                  totalCount: 4,
+                },
+              },
+              comparedTo: {
+                commitid: '2d6c42fe217c61b007b2c17544a9d85840381857',
+                uploads: {
+                  totalCount: 1,
+                },
+              },
+              compareWithBase: {
+                hasDifferentNumberOfHeadAndBaseReports: true,
+                patchTotals: {
+                  percentCovered: 92.12,
+                },
+                changeCoverage: 38.94,
+              },
+            },
+          },
+        },
+      })
+
+      render(<CompareSummary />, { wrapper: wrapper() })
+
+      const baseCommitText = screen.queryByText(/BASE commit is/)
+      expect(baseCommitText).not.toBeInTheDocument()
+
+      const behindByNumber = screen.queryByText(/0/)
+      expect(behindByNumber).not.toBeInTheDocument()
+    })
+  })
 })


### PR DESCRIPTION
# Description
The compare message displayed an extra 0 'cus of a bad `&&`
<img width="566" alt="258154568-0dcce7aa-5a3d-469a-b1b0-c94d0f639e2b" src="https://github.com/codecov/gazebo/assets/91732700/048df4ec-e2f3-4fb5-a4ec-6da4e0890a79">

# Link to Sample Entry
/gh/codecov/codecov-api/pull/1623

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.