### PR TITLE
Setup a fileviewer list to replace old table

### DIFF
--- a/src/ui/CodeRenderer/CodeRenderer.css
+++ b/src/ui/CodeRenderer/CodeRenderer.css
@@ -1,18 +1,18 @@
-tbody,
-tr,
-td {
+.coderenderer tbody,
+.coderenderer tr,
+.coderenderer td {
   tab-size: 8;
 }
 
-tbody tr:first-child td {
+.coderenderer tbody tr:first-child td {
   @apply pt-2;
 }
 
-tbody tr:last-child td {
+.coderenderer tbody tr:last-child td {
   @apply pb-2;
 }
 
-/* I inspected the page took the selectors and overode the background to be transparent */
+/* I inspected the page took the selectors and overrode the background to be transparent */
 .token.operator,
 .token.entity,
 .token.url,

--- a/src/ui/CodeRenderer/CodeRenderer.tsx
+++ b/src/ui/CodeRenderer/CodeRenderer.tsx
@@ -1,14 +1,25 @@
 import Highlight, { defaultProps } from 'prism-react-renderer'
-import PropTypes from 'prop-types'
 
 import 'shared/utils/prisimTheme.css'
 import { CODE_RENDERER_TYPE } from 'shared/utils/fileviewer'
 import { prismLanguageMapper } from 'shared/utils/prismLanguageMapper'
 import './CodeRenderer.css'
 
-function CodeRenderer({ code, fileName, LineComponent, rendererType }) {
+type CodeRendererProps = {
+  code: string
+  fileName: string
+  rendererType: keyof typeof CODE_RENDERER_TYPE
+  LineComponent: React.FC<{}>
+}
+
+function CodeRenderer({
+  code,
+  fileName,
+  LineComponent,
+  rendererType,
+}: CodeRendererProps) {
   return (
-    <table className="box-border w-full table-auto border-collapse whitespace-pre-wrap border border-solid border-ds-gray-tertiary font-mono">
+    <table className="coderenderer box-border w-full table-auto border-collapse whitespace-pre-wrap border border-solid border-ds-gray-tertiary font-mono">
       <colgroup>
         <col width="40" />
         {rendererType === CODE_RENDERER_TYPE.DIFF && <col width="40" />}
@@ -30,16 +41,6 @@ function CodeRenderer({ code, fileName, LineComponent, rendererType }) {
       </tbody>
     </table>
   )
-}
-
-CodeRenderer.propTypes = {
-  code: PropTypes.string.isRequired,
-  fileName: PropTypes.string.isRequired,
-  rendererType: PropTypes.oneOf([
-    CODE_RENDERER_TYPE.DIFF,
-    CODE_RENDERER_TYPE.SINGLE_LINE,
-  ]),
-  LineComponent: PropTypes.func.isRequired,
 }
 
 export default CodeRenderer

--- a/src/ui/CodeRenderer/CoverageLineIndicator/CoverageLineIndicator.jsx
+++ b/src/ui/CodeRenderer/CoverageLineIndicator/CoverageLineIndicator.jsx
@@ -41,7 +41,7 @@ function CoverageHitCounter({ coverage, hitCount }) {
     return (
       <span
         className={cs(
-          'text-white flex justify-center content-center items-center px-1.5 rounded-full text-center',
+          'text-white flex justify-center content-center items-center px-1.5 rounded-full text-center whitespace-nowrap',
           {
             'bg-ds-primary-red': coverage === LINE_STATE.UNCOVERED,
             'bg-ds-primary-yellow': coverage === LINE_STATE.PARTIAL,

--- a/src/ui/FileList/FileList.css
+++ b/src/ui/FileList/FileList.css
@@ -1,0 +1,73 @@
+.filelistui {
+  @apply @container/filelist text-ds-gray-octonary overflow-auto;
+}
+
+.filelistui > div {
+  @apply flex-1 w-full min-w-full divide-y divide-ds-gray-tertiary;
+}
+
+.filelistui .filelistui-thead,
+.filelistui .filelistui-row {
+  @apply flex gap-2 items-center;
+}
+
+.filelistui .filelistui-thead {
+  @apply whitespace-nowrap;
+}
+
+.filelistui .filelistui-thead > div {
+  @apply font-sans text-sm font-semibold text-ds-gray-quinary py-2 px-3.5;
+}
+
+.filelistui .filelistui-row > div {
+  @apply py-3 @sm/filelist:px-4;
+}
+
+.filelistui .filelistui-row {
+  @apply border-t border-ds-gray-tertiary;
+}
+
+/* <element data-highlight-row="onHover"> */
+/* <element className="filelistui-row"> */
+.filelistui[data-highlight-row='onHover'] .filelistui-row,
+.filelistui .filelistui-row[data-highlight-row='onHover'],
+.filelistui [data-highlight-row='onHover'] {
+  @apply hover:bg-ds-gray-primary;
+}
+
+/* <element data-type="numeric"> */
+.filelistui .filelistui-thead [data-type='numeric'] {
+  @apply text-right justify-end;
+}
+
+/* <element data-type="numeric"> */
+.filelistui [data-type='numeric'] {
+  @apply font-mono text-right justify-end;
+}
+
+/* <element data-sortable="true"> */
+.filelistui [data-sortable='true'] {
+  @apply cursor-pointer select-none;
+}
+
+.filelistui [data-sort-direction] {
+  @apply transform opacity-0 transition-opacity ease-in duration-100;
+}
+
+.filelistui [data-sort-direction='asc'] {
+  @apply opacity-100;
+}
+
+.filelistui [data-sort-direction='desc'] {
+  @apply opacity-100 rotate-180;
+}
+
+/* <element data-expanded="false"> */
+.filelistui [data-expanded='false'] {
+  @apply hidden;
+}
+
+/* <element data-action="clickable"> */
+.filelistui [data-action='clickable'] {
+  @apply cursor-pointer;
+}

--- a/src/ui/FileList/FileList.stories.tsx
+++ b/src/ui/FileList/FileList.stories.tsx
@@ -1,0 +1,316 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import {
+  createColumnHelper,
+  flexRender,
+  getCoreRowModel,
+  getExpandedRowModel,
+  getSortedRowModel,
+  useReactTable,
+} from '@tanstack/react-table'
+import type { ExpandedState, SortingState } from '@tanstack/react-table'
+import cs from 'classnames'
+import { createBrowserHistory } from 'history'
+import { Fragment, useState } from 'react'
+import { Route, Router, Switch } from 'react-router-dom'
+
+import { CODE_RENDERER_TYPE } from 'shared/utils/fileviewer'
+
+import A from '../A'
+import CodeRenderer from '../CodeRenderer'
+import CodeRendererInfoRow from '../CodeRenderer/CodeRendererInfoRow'
+import DiffLine from '../CodeRenderer/DiffLine'
+import Icon from '../Icon'
+import TotalsNumber from '../TotalsNumber'
+
+import './FileList.css'
+
+const history = createBrowserHistory()
+const coverage = ['H', 'M', 'P'] as const
+
+interface Segment {
+  path: string
+  missed: number
+  head: number
+  patch: number
+  change: number
+  contents: string
+}
+
+const files: Segment[] = [
+  {
+    path: 'src/ui/Table/Table.stories.tsx',
+    missed: 680,
+    head: 89,
+    patch: 45,
+    change: 34,
+    contents: `const AnalyticsPage = lazy(() => import('./pages/AnalyticsPage'))
+      const CommitDetailPage = lazy(() => import('./pages/CommitDetailPage'))`,
+  },
+  {
+    path: 'src/ui/Table/TableSorting.stories.tsx',
+    missed: 176,
+    head: 65,
+    patch: 67,
+    change: -8,
+    contents: `
+function SortingExampleWithReactTable() {
+  const [sorting, setSorting] = React.useState<SortingState>([])
+  const columns = [
+    columnHelper.accessor('name', {
+      header: () => 'Name',
+      cell: (info) => info.renderValue(),
+    }),
+    columnHelper.accessor('title', {
+      header: () => 'Title',
+      cell: (info) => info.renderValue(),
+    }),
+`,
+  },
+]
+
+const columnHelper = createColumnHelper<Segment>()
+
+const isNumericColumn = (cellId: string) =>
+  cellId === 'missed' ||
+  cellId === 'head' ||
+  cellId === 'patch' ||
+  cellId === 'change'
+
+function Example() {
+  const [expanded, setExpanded] = useState<ExpandedState>({})
+  const [sorting, setSorting] = useState<SortingState>([])
+
+  const columns = [
+    columnHelper.accessor('path', {
+      header: () => 'Name',
+      cell: ({ row, getValue }) => (
+        <span
+          className="inline-flex cursor-pointer items-center gap-1 font-sans text-ds-blue hover:underline focus:ring-2"
+          {...{
+            onClick: row.getToggleExpandedHandler(),
+          }}
+        >
+          {row.getCanExpand() ? (
+            <Icon
+              size="md"
+              name={row.getIsExpanded() ? 'chevron-down' : 'chevron-right'}
+              variant="solid"
+            />
+          ) : (
+            '🔵'
+          )}
+          {getValue()}
+        </span>
+      ),
+    }),
+    columnHelper.accessor('missed', {
+      header: () => 'Missed lines',
+      cell: (info) => info.renderValue(),
+    }),
+    columnHelper.accessor('head', {
+      header: () => 'HEAD %',
+      cell: (info) => (
+        /* @ts-expect-error */
+        <TotalsNumber value={info.renderValue()} plain />
+      ),
+    }),
+    columnHelper.accessor('patch', {
+      header: () => 'Patch %',
+      cell: (info) => (
+        /* @ts-expect-error */
+        <TotalsNumber value={info.renderValue()} plain />
+      ),
+    }),
+    columnHelper.accessor('change', {
+      header: () => 'Change',
+      cell: (info) => (
+        /* @ts-expect-error */
+        <TotalsNumber value={info.renderValue()} />
+      ),
+    }),
+  ]
+
+  const table = useReactTable({
+    data: files,
+    columns,
+    state: {
+      expanded,
+      sorting,
+    },
+    onSortingChange: setSorting,
+    onExpandedChange: setExpanded,
+    getCoreRowModel: getCoreRowModel(),
+    getSortedRowModel: getSortedRowModel(),
+    getExpandedRowModel: getExpandedRowModel(),
+    getRowCanExpand: (row) => row.original.contents.length > 0,
+  })
+
+  return (
+    <div className="filelistui" data-highlight-row="onHover">
+      <div>
+        {table.getHeaderGroups().map((headerGroup) => (
+          <div
+            key={headerGroup.id}
+            className="filelistui-thead"
+            data-highlight-row="onHover"
+          >
+            {headerGroup.headers.map((header) => (
+              <div
+                key={header.id}
+                data-sortable="true"
+                {...{
+                  onClick: header.column.getToggleSortingHandler(),
+                }}
+                // define column widths, must be done in the body as well.
+                className={cs({
+                  'w-full @4xl/w-4/12': header.id === 'path',
+                  'w-2/12 hidden @4xl/filelist:block':
+                    header.id === 'change' ||
+                    header.id === 'patch' ||
+                    header.id === 'head' ||
+                    header.id === 'missed',
+                })}
+              >
+                <div
+                  className={cs('flex gap-1', {
+                    // reverse the order of the icon and text so the text is aligned well when not active.
+                    'flex-row-reverse justify-end': header.id === 'path',
+                  })}
+                  {...(isNumericColumn(header.id)
+                    ? {
+                        'data-type': 'numeric',
+                      }
+                    : {})}
+                >
+                  <span
+                    className="text-ds-blue-darker"
+                    data-sort-direction={header.column.getIsSorted()}
+                  >
+                    <Icon name="arrowUp" size="sm" />
+                  </span>
+                  {flexRender(
+                    header.column.columnDef.header,
+                    header.getContext()
+                  )}
+                </div>
+              </div>
+            ))}
+          </div>
+        ))}
+        <div>
+          {table.getRowModel().rows.map((row, i) => (
+            <Fragment key={i}>
+              <div className="filelistui-row">
+                {row.getVisibleCells().map((cell) => (
+                  <div
+                    key={cell.id}
+                    {...(isNumericColumn(cell.column.id)
+                      ? {
+                          'data-type': 'numeric',
+                        }
+                      : {})}
+                    className={cs({
+                      'w-full @4xl/w-4/12': cell.column.id === 'path',
+                      'w-2/12 hidden @4xl/filelist:block':
+                        cell.column.id === 'change' ||
+                        cell.column.id === 'patch' ||
+                        cell.column.id === 'head' ||
+                        cell.column.id === 'missed',
+                    })}
+                  >
+                    {/* start: Responsive example */}
+                    <div className="mb-6 flex justify-between gap-8 @md/filelist:justify-start @4xl/filelist:hidden">
+                      <div>
+                        Missed lines:{' '}
+                        <div className="font-mono">{row.original.missed}</div>
+                      </div>
+                      <div>
+                        {/* @ts-expect-error */}
+                        head: <TotalsNumber value={row.original.head} plain />
+                      </div>
+                      <div>
+                        {' '}
+                        {/* @ts-expect-error */}
+                        patch: <TotalsNumber value={row.original.patch} plain />
+                      </div>
+                      <div>
+                        {' '}
+                        {/* @ts-expect-error */}
+                        Change: <TotalsNumber value={row.original.change} />
+                      </div>
+                    </div>
+                    {/* end: Responsive example */}
+
+                    {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                  </div>
+                ))}
+              </div>
+              <div data-expanded={row.getIsExpanded()}>
+                {/*  Start: Not part of filelistui, just for example */}
+                <CodeRendererInfoRow>
+                  <div className="flex w-full justify-between">
+                    <div className="flex gap-1">
+                      <span data-testid="patch">{row.original.patch}</span>
+                      <span className="border-l-2 pl-2">
+                        {row.original.path}
+                      </span>
+                    </div>
+                    {/* @ts-expect-error */}
+                    <A href="#" isExternal hook="commit full file">
+                      View full file
+                    </A>
+                  </div>
+                </CodeRendererInfoRow>
+                <CodeRenderer
+                  code={row.original.contents}
+                  fileName={row.original.path}
+                  rendererType={CODE_RENDERER_TYPE.DIFF}
+                  /* @ts-expect-error */
+                  LineComponent={({ i, line, ...props }) => (
+                    <DiffLine
+                      key={i + 1}
+                      lineContent={line}
+                      edgeOfFile={i <= 2 || i >= 6}
+                      path={row.original.path}
+                      hitCount={
+                        Math.random() > 0.5
+                          ? Math.floor(Math.random() * 100)
+                          : null
+                      }
+                      headNumber={i + 1}
+                      baseNumber={i}
+                      headCoverage={coverage[Math.floor(Math.random() * 3) % 3]}
+                      baseCoverage={coverage[Math.floor(Math.random() * 3) % 3]}
+                      {...props}
+                    />
+                  )}
+                />
+                {/*  End: Not part of filelistui, just for example */}
+              </div>
+            </Fragment>
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+const meta: Meta<typeof Example> = {
+  title: 'Components/FileList',
+  component: Example,
+}
+
+export default meta
+type Story = StoryObj<typeof Example>
+
+export const BasicExample: Story = {
+  render: () => (
+    <Router history={history}>
+      <Switch>
+        <Route path="*">
+          <Example />
+        </Route>
+      </Switch>
+    </Router>
+  ),
+}

--- a/src/ui/Table/Table.css
+++ b/src/ui/Table/Table.css
@@ -23,7 +23,7 @@
 }
 
 .tableui td {
-  @apply py-3 sm:px-4;
+  @apply py-3 @sm/table:px-4;
 }
 
 /* <div className="tableui" data-highlight-row="onHover"> */
@@ -52,7 +52,6 @@
   @apply cursor-pointer select-none;
 }
 
-/* TODO make hover whole th */
 .tableui [data-sort-direction] {
   @apply transform opacity-0 transition-opacity ease-in duration-100;
 }
@@ -63,4 +62,9 @@
 
 .tableui [data-sort-direction='desc'] {
   @apply opacity-100 rotate-180;
+}
+
+/* <element data-expanded="false"> */
+.tableui [data-expanded='false'] {
+  @apply hidden;
 }

--- a/src/ui/Table/TableSorting.stories.tsx
+++ b/src/ui/Table/TableSorting.stories.tsx
@@ -4,11 +4,11 @@ import {
   flexRender,
   getCoreRowModel,
   getSortedRowModel,
-  SortingState,
   useReactTable,
 } from '@tanstack/react-table'
+import type { SortingState } from '@tanstack/react-table'
 import cs from 'classnames'
-import React from 'react'
+import { useState } from 'react'
 
 import Icon from '../Icon'
 
@@ -45,7 +45,7 @@ const people: Person[] = [
 const columnHelper = createColumnHelper<Person>()
 
 function SortingExampleWithReactTable() {
-  const [sorting, setSorting] = React.useState<SortingState>([])
+  const [sorting, setSorting] = useState<SortingState>([])
   const columns = [
     columnHelper.accessor('name', {
       header: () => 'Name',
@@ -93,7 +93,11 @@ function SortingExampleWithReactTable() {
                   {...{
                     onClick: header.column.getToggleSortingHandler(),
                   }}
-                  data-type={header.id === 'seatNumber' ? 'numeric' : ''}
+                  {...(header.id === 'seatNumber'
+                    ? {
+                        'data-type': 'numeric',
+                      }
+                    : {})}
                 >
                   <div
                     className={cs('flex gap-1', {
@@ -124,7 +128,11 @@ function SortingExampleWithReactTable() {
               {row.getVisibleCells().map((cell) => (
                 <td
                   key={cell.id}
-                  data-type={cell.column.id === 'seatNumber' ? 'numeric' : ''}
+                  {...(cell.column.id === 'seatNumber'
+                    ? {
+                        'data-type': 'numeric',
+                      }
+                    : {})}
                 >
                   {flexRender(cell.column.columnDef.cell, cell.getContext())}
                 </td>


### PR DESCRIPTION
# Description
Less documentation then the Tableui, migration/DX is more or less identical, different HTML markup requirements (not using a proper table). I made a fairly polished demo in storybook.

# Notable Changes
* Converted CodeRenderer to typescript
* Tweaked/improved TableUI style/examples if I found something better.
* Code renderer styles were affecting things outside of itself, added a classname to scope it down to only it.
* Added expanded support to table + file list

# Screenshots
![image](https://github.com/codecov/gazebo/assets/87824812/f04be4c1-2dd1-450e-820c-95fa8bc9a5e2)


# Link to Sample Entry

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.