### PR TITLE
feat: Branch dropdown search merged + unmerged branches

### DIFF
--- a/src/pages/RepoPage/SettingsTab/tabs/GeneralTab/DefaultBranch/DefaultBranch.spec.jsx
+++ b/src/pages/RepoPage/SettingsTab/tabs/GeneralTab/DefaultBranch/DefaultBranch.spec.jsx
@@ -333,6 +333,7 @@ describe('DefaultBranch', () => {
       await waitFor(() =>
         expect(fetchFilters).toBeCalledWith({
           searchValue: 'cool branch name',
+          mergedBranches: true,
         })
       )
     })

--- a/src/services/branches/useBranches.js
+++ b/src/services/branches/useBranches.js
@@ -40,6 +40,15 @@ export function useBranches({ provider, owner, repo, filters, opts = {} }) {
     filters,
   }
 
+  if (
+    filters &&
+    !!filters.searchValue &&
+    filters.mergedBranches === undefined
+  ) {
+    // include merged branches when we're searching
+    filters.mergedBranches = true
+  }
+
   const { data, ...rest } = useInfiniteQuery({
     queryKey: ['GetBranches', provider, owner, repo, variables, query],
     queryFn: ({ pageParam, signal }) =>


### PR DESCRIPTION
The API returns only unmerged branches by default which is nice in that it keeps the branch selector fairly tidy and relevant to current work.  When we're searching for a specific branch we'd like to search across merged branches as well.  This passes the necessary GraphQL resolver filter in that case.

From https://github.com/codecov/codecov-api/issues/96