### PR TITLE
2164 url sanitization

### DIFF
--- a/src/ui/A/A.jsx
+++ b/src/ui/A/A.jsx
@@ -26,12 +26,21 @@ const variantClasses = {
   blueSeptenary: `text-ds-blue-septenary`,
 }
 
+const getHostnameFromRegex = (url) => {
+  // run against regex
+  const matches = url.match(/^https?:\/\/([^/?#]+)(?:[/?#]|$)/i)
+  // extract hostname (will be null if no match is found)
+  return matches && matches[1]
+}
+
 function _adjustPathForGLSubgroups(path) {
   // Adjusts external url's for any gitlab owners who have subgroups. Gitlab subgroups look like
   // this => "user:subgroup", but Gitlab URLs look like this => "user/subgroup". Hence, this function
   // is to detect if we have a gitlab user with a subgroup and adjust it accordingly. The regex identifies the
   // domain + owner (by selecting everything till the next forward slash) and selecting everything else
-  if (!path.includes('gitlab.com')) {
+  const host = getHostnameFromRegex(path)
+  const acceptedPaths = ['gitlab.com']
+  if (!acceptedPaths.includes(host)) {
     return path
   }
 


### PR DESCRIPTION
# Description
Sanitize url in `A` as per https://github.com/codecov/gazebo/issues/2164

# Notable Changes
- Adjusted string evaluation + tests

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.