### PR TITLE
ref: Remove Trial Flag from Actions Billing

### DIFF
--- a/src/pages/PlanPage/subRoutes/CurrentOrgPlan/CurrentPlanCard/shared/ActionsBilling/ActionsBilling.jsx
+++ b/src/pages/PlanPage/subRoutes/CurrentOrgPlan/CurrentPlanCard/shared/ActionsBilling/ActionsBilling.jsx
@@ -9,7 +9,6 @@ import {
   usePlans,
 } from 'services/account'
 import { useStartTrial } from 'services/trial'
-import { useFlags } from 'shared/featureFlags'
 import {
   canApplySentryUpgrade,
   isFreePlan,
@@ -22,14 +21,10 @@ import Button from 'ui/Button'
 function PlansActionsBilling({ plan }) {
   const { provider, owner } = useParams()
   const { data: plans } = usePlans(provider)
-  const { codecovTrialMvp } = useFlags({
-    codecovTrialMvp: false,
-  })
 
   const { data: planData } = usePlanData({
     provider,
     owner,
-    opts: { enabled: codecovTrialMvp },
   })
 
   const { mutate, isLoading } = useStartTrial()
@@ -45,6 +40,7 @@ function PlansActionsBilling({ plan }) {
           onClick={() => {
             mutate({ owner })
           }}
+          hook="start-trial"
           variant="primary"
           isLoading={isLoading}
         >


### PR DESCRIPTION
# Description

Another day another PR removing the trial flag, this time from the `ActionsBilling` component. I thought I'd also update the test `setup` function to take a object argument so that if we need to add another flag in it's not a positional argument which isn't fun to clean up.

# Notable Changes

- Remove flag from `ActionsBilling` component
- Update tests, including swapping to obj arg for `setup`