### PR TITLE
feat: Update useRepoBranchContentsTable to Pull Pass Along Flags Filter

### DIFF
--- a/src/pages/RepoPage/CoverageTab/subroute/FileExplorer/CodeTreeTable/CodeTreeTable.jsx
+++ b/src/pages/RepoPage/CoverageTab/subroute/FileExplorer/CodeTreeTable/CodeTreeTable.jsx
@@ -11,6 +11,7 @@ function CodeTreeTable() {
     isSearching,
     isMissingHeadReport,
     isLoading,
+    hasFlagsSelected,
   } = useRepoBranchContentsTable()
 
   return (
@@ -23,12 +24,13 @@ function CodeTreeTable() {
         defaultSort={[{ id: 'name', desc: false }]}
       />
       <Loader isLoading={isLoading} />
-      {data?.length === 0 && !isLoading && (
+      {data?.length === 0 && !isLoading ? (
         <RepoContentsResult
           isSearching={isSearching}
           isMissingHeadReport={isMissingHeadReport}
+          hasFlagsSelected={hasFlagsSelected}
         />
-      )}
+      ) : null}
     </div>
   )
 }

--- a/src/pages/RepoPage/CoverageTab/subroute/FileExplorer/CodeTreeTable/CodeTreeTable.spec.jsx
+++ b/src/pages/RepoPage/CoverageTab/subroute/FileExplorer/CodeTreeTable/CodeTreeTable.spec.jsx
@@ -3,6 +3,7 @@ import { render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { graphql } from 'msw'
 import { setupServer } from 'msw/node'
+import qs from 'qs'
 import { MemoryRouter, Route } from 'react-router-dom'
 
 import CodeTreeTable from './CodeTreeTable'
@@ -84,11 +85,11 @@ const mockOverview = {
 }
 
 const wrapper =
-  (initialEntries = ['/gh/codecov/cool-repo/tree/main/a/b/c']) =>
+  (initialEntries = '/gh/codecov/cool-repo/tree/main/a/b/c') =>
   ({ children }) => {
     return (
       <QueryClientProvider client={queryClient}>
-        <MemoryRouter initialEntries={initialEntries}>
+        <MemoryRouter initialEntries={[initialEntries]}>
           <Route path="/:provider/:owner/:repo/tree/:branch/:path+">
             {children}
           </Route>
@@ -100,16 +101,24 @@ const wrapper =
 beforeAll(() => {
   server.listen()
 })
+
 afterEach(() => {
   queryClient.clear()
   server.resetHandlers()
 })
+
 afterAll(() => {
   server.close()
 })
 
 describe('CodeTreeTable', () => {
-  function setup(noFiles = false, noHeadReport = false) {
+  function setup(
+    { noFiles = false, noHeadReport = false, noFlagCoverage = false } = {
+      noFiles: false,
+      noHeadReport: false,
+      noFlagCoverage: false,
+    }
+  ) {
     const user = userEvent.setup()
     const requestFilters = jest.fn()
 
@@ -127,6 +136,10 @@ describe('CodeTreeTable', () => {
           return res(ctx.status(200), ctx.data({ owner: mockNoFiles }))
         }
 
+        if (noFlagCoverage) {
+          return res(ctx.status(200), ctx.data({ owner: mockNoFiles }))
+        }
+
         return res(ctx.status(200), ctx.data({ owner: mockTreeData }))
       }),
       graphql.query('GetRepoOverview', (req, res, ctx) => {
@@ -139,9 +152,8 @@ describe('CodeTreeTable', () => {
 
   describe('rendering table', () => {
     describe('displaying the table head', () => {
-      beforeEach(() => setup())
-
       it('has a files column', async () => {
+        setup()
         render(<CodeTreeTable />, { wrapper: wrapper() })
 
         const files = await screen.findByText('Files')
@@ -149,6 +161,7 @@ describe('CodeTreeTable', () => {
       })
 
       it('has a tracked lines column', async () => {
+        setup()
         render(<CodeTreeTable />, { wrapper: wrapper() })
 
         const trackedLines = await screen.findByText('Tracked lines')
@@ -156,6 +169,7 @@ describe('CodeTreeTable', () => {
       })
 
       it('has a covered column', async () => {
+        setup()
         render(<CodeTreeTable />, { wrapper: wrapper() })
 
         const covered = await screen.findByText('Covered')
@@ -163,6 +177,7 @@ describe('CodeTreeTable', () => {
       })
 
       it('has a partial column', async () => {
+        setup()
         render(<CodeTreeTable />, { wrapper: wrapper() })
 
         const partial = await screen.findByText('Partial')
@@ -170,6 +185,7 @@ describe('CodeTreeTable', () => {
       })
 
       it('has a missed column', async () => {
+        setup()
         render(<CodeTreeTable />, { wrapper: wrapper() })
 
         const missed = await screen.findByText('Missed')
@@ -177,6 +193,7 @@ describe('CodeTreeTable', () => {
       })
 
       it('has a coverage column', async () => {
+        setup()
         render(<CodeTreeTable />, { wrapper: wrapper() })
 
         const coverage = await screen.findByText('Coverage %')
@@ -196,17 +213,18 @@ describe('CodeTreeTable', () => {
           await waitFor(() => expect(queryClient.isFetching()).toBe(0))
 
           await waitFor(() =>
-            expect(requestFilters).toBeCalledWith({
-              ordering: { direction: 'ASC', parameter: 'NAME' },
-            })
+            expect(requestFilters).toBeCalledWith(
+              expect.objectContaining({
+                ordering: { direction: 'ASC', parameter: 'NAME' },
+              })
+            )
           )
         })
       })
 
       describe('displaying a directory', () => {
-        beforeEach(() => setup())
-
         it('has the correct url', async () => {
+          setup()
           render(<CodeTreeTable />, { wrapper: wrapper() })
 
           expect(await screen.findByText('src')).toBeTruthy()
@@ -224,9 +242,8 @@ describe('CodeTreeTable', () => {
       })
 
       describe('displaying a file', () => {
-        beforeEach(() => setup())
-
         it('has the correct url', async () => {
+          setup()
           render(<CodeTreeTable />, { wrapper: wrapper() })
 
           expect(await screen.findByText('file.js')).toBeTruthy()
@@ -245,11 +262,8 @@ describe('CodeTreeTable', () => {
     })
 
     describe('there is no results found', () => {
-      beforeEach(() => {
-        setup(true)
-      })
-
       it('displays error fetching data message', async () => {
+        setup({ noFiles: true })
         render(<CodeTreeTable />, { wrapper: wrapper() })
 
         expect(
@@ -265,11 +279,8 @@ describe('CodeTreeTable', () => {
     })
 
     describe('when head commit has no reports', () => {
-      beforeEach(() => {
-        setup(false, true)
-      })
-
       it('renders no report uploaded message', async () => {
+        setup({ noHeadReport: true })
         render(<CodeTreeTable />, { wrapper: wrapper() })
 
         expect(
@@ -279,6 +290,25 @@ describe('CodeTreeTable', () => {
         ).toBeTruthy()
         const message = screen.getByText(
           'No coverage report uploaded for this branch head commit'
+        )
+        expect(message).toBeInTheDocument()
+      })
+    })
+
+    describe('when flags are selected with no coverage', () => {
+      it('renders no flag coverage message', async () => {
+        setup({ noFlagCoverage: true })
+        render(<CodeTreeTable />, {
+          wrapper: wrapper(
+            `/gh/codecov/cool-repo/tree/main/a/b/c${qs.stringify(
+              { flags: ['flag-1'] },
+              { addQueryPrefix: true }
+            )}`
+          ),
+        })
+
+        const message = await screen.findByText(
+          'No coverage report uploaded for the selected flags'
         )
         expect(message).toBeInTheDocument()
       })
@@ -298,9 +328,11 @@ describe('CodeTreeTable', () => {
           await user.click(files)
 
           await waitFor(() =>
-            expect(requestFilters).toHaveBeenCalledWith({
-              ordering: { direction: 'ASC', parameter: 'NAME' },
-            })
+            expect(requestFilters).toHaveBeenCalledWith(
+              expect.objectContaining({
+                ordering: { direction: 'ASC', parameter: 'NAME' },
+              })
+            )
           )
         })
       })
@@ -319,9 +351,11 @@ describe('CodeTreeTable', () => {
           await user.click(files)
 
           await waitFor(() => {
-            expect(requestFilters).toHaveBeenCalledWith({
-              ordering: { direction: 'DESC', parameter: 'NAME' },
-            })
+            expect(requestFilters).toHaveBeenCalledWith(
+              expect.objectContaining({
+                ordering: { direction: 'DESC', parameter: 'NAME' },
+              })
+            )
           })
         })
       })
@@ -338,9 +372,11 @@ describe('CodeTreeTable', () => {
           await user.click(trackedLines)
 
           await waitFor(() =>
-            expect(requestFilters).toHaveBeenCalledWith({
-              ordering: { direction: 'ASC', parameter: 'LINES' },
-            })
+            expect(requestFilters).toHaveBeenCalledWith(
+              expect.objectContaining({
+                ordering: { direction: 'ASC', parameter: 'LINES' },
+              })
+            )
           )
         })
       })
@@ -359,9 +395,11 @@ describe('CodeTreeTable', () => {
           await user.click(trackedLines)
 
           await waitFor(() => {
-            expect(requestFilters).toHaveBeenCalledWith({
-              ordering: { direction: 'DESC', parameter: 'LINES' },
-            })
+            expect(requestFilters).toHaveBeenCalledWith(
+              expect.objectContaining({
+                ordering: { direction: 'DESC', parameter: 'LINES' },
+              })
+            )
           })
         })
       })
@@ -378,9 +416,11 @@ describe('CodeTreeTable', () => {
           await user.click(covered)
 
           await waitFor(() =>
-            expect(requestFilters).toHaveBeenCalledWith({
-              ordering: { direction: 'ASC', parameter: 'HITS' },
-            })
+            expect(requestFilters).toHaveBeenCalledWith(
+              expect.objectContaining({
+                ordering: { direction: 'ASC', parameter: 'HITS' },
+              })
+            )
           )
         })
       })
@@ -399,9 +439,11 @@ describe('CodeTreeTable', () => {
           await user.click(covered)
 
           await waitFor(() => {
-            expect(requestFilters).toHaveBeenCalledWith({
-              ordering: { direction: 'DESC', parameter: 'HITS' },
-            })
+            expect(requestFilters).toHaveBeenCalledWith(
+              expect.objectContaining({
+                ordering: { direction: 'DESC', parameter: 'HITS' },
+              })
+            )
           })
         })
       })
@@ -418,9 +460,11 @@ describe('CodeTreeTable', () => {
           await user.click(partial)
 
           await waitFor(() =>
-            expect(requestFilters).toHaveBeenCalledWith({
-              ordering: { direction: 'ASC', parameter: 'PARTIALS' },
-            })
+            expect(requestFilters).toHaveBeenCalledWith(
+              expect.objectContaining({
+                ordering: { direction: 'ASC', parameter: 'PARTIALS' },
+              })
+            )
           )
         })
       })
@@ -439,9 +483,11 @@ describe('CodeTreeTable', () => {
           await user.click(partial)
 
           await waitFor(() => {
-            expect(requestFilters).toHaveBeenCalledWith({
-              ordering: { direction: 'DESC', parameter: 'PARTIALS' },
-            })
+            expect(requestFilters).toHaveBeenCalledWith(
+              expect.objectContaining({
+                ordering: { direction: 'DESC', parameter: 'PARTIALS' },
+              })
+            )
           })
         })
       })
@@ -457,9 +503,11 @@ describe('CodeTreeTable', () => {
           const missed = screen.getByText('Missed')
           await user.click(missed)
 
-          expect(requestFilters).toHaveBeenCalledWith({
-            ordering: { direction: 'ASC', parameter: 'MISSES' },
-          })
+          expect(requestFilters).toHaveBeenCalledWith(
+            expect.objectContaining({
+              ordering: { direction: 'ASC', parameter: 'MISSES' },
+            })
+          )
         })
       })
 
@@ -477,9 +525,11 @@ describe('CodeTreeTable', () => {
           await user.click(missed)
 
           await waitFor(() => {
-            expect(requestFilters).toHaveBeenCalledWith({
-              ordering: { direction: 'DESC', parameter: 'MISSES' },
-            })
+            expect(requestFilters).toHaveBeenCalledWith(
+              expect.objectContaining({
+                ordering: { direction: 'DESC', parameter: 'MISSES' },
+              })
+            )
           })
         })
       })

--- a/src/pages/RepoPage/CoverageTab/subroute/FileExplorer/FileListTable/FileListTable.jsx
+++ b/src/pages/RepoPage/CoverageTab/subroute/FileExplorer/FileListTable/FileListTable.jsx
@@ -11,6 +11,7 @@ function FileListTable() {
     isSearching,
     isMissingHeadReport,
     isLoading,
+    hasFlagsSelected,
   } = useRepoBranchContentsTable()
 
   return (
@@ -23,12 +24,13 @@ function FileListTable() {
         defaultSort={[{ id: 'misses', desc: true }]}
       />
       <Loader isLoading={isLoading} />
-      {data?.length === 0 && !isLoading && (
+      {data?.length === 0 && !isLoading ? (
         <RepoContentsResult
           isSearching={isSearching}
           isMissingHeadReport={isMissingHeadReport}
+          hasFlagsSelected={hasFlagsSelected}
         />
-      )}
+      ) : null}
     </div>
   )
 }

--- a/src/pages/RepoPage/CoverageTab/subroute/FileExplorer/FileListTable/FileListTable.spec.jsx
+++ b/src/pages/RepoPage/CoverageTab/subroute/FileExplorer/FileListTable/FileListTable.spec.jsx
@@ -3,6 +3,7 @@ import { render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { graphql } from 'msw'
 import { setupServer } from 'msw/node'
+import qs from 'qs'
 import { MemoryRouter, Route } from 'react-router-dom'
 
 import FileListTable from './FileListTable'
@@ -74,11 +75,11 @@ const mockOverview = {
 }
 
 const wrapper =
-  (initialEntries = ['/gh/codecov/cool-repo/tree/main/a/b/c']) =>
+  (initialEntries = '/gh/codecov/cool-repo/tree/main/a/b/c') =>
   ({ children }) => {
     return (
       <QueryClientProvider client={queryClient}>
-        <MemoryRouter initialEntries={initialEntries}>
+        <MemoryRouter initialEntries={[initialEntries]}>
           <Route path="/:provider/:owner/:repo/tree/:branch/:path+">
             {children}
           </Route>
@@ -99,7 +100,13 @@ afterAll(() => {
 })
 
 describe('FileListTable', () => {
-  function setup(noFiles = false, noHeadReport = false) {
+  function setup(
+    { noFiles = false, noHeadReport = false, noFlagCoverage = false } = {
+      noFiles: false,
+      noHeadReport: false,
+      noFlagCoverage: false,
+    }
+  ) {
     const user = userEvent.setup()
     const requestFilters = jest.fn()
 
@@ -117,6 +124,10 @@ describe('FileListTable', () => {
           return res(ctx.status(200), ctx.data({ owner: mockNoFiles }))
         }
 
+        if (noFlagCoverage) {
+          return res(ctx.status(200), ctx.data({ owner: mockNoFiles }))
+        }
+
         return res(ctx.status(200), ctx.data({ owner: mockListData }))
       }),
       graphql.query('GetRepoOverview', (req, res, ctx) => {
@@ -129,9 +140,8 @@ describe('FileListTable', () => {
 
   describe('rendering table', () => {
     describe('displaying the table head', () => {
-      beforeEach(() => setup())
-
       it('has a files column', async () => {
+        setup()
         render(<FileListTable />, { wrapper: wrapper() })
 
         const files = await screen.findByText('Files')
@@ -139,6 +149,7 @@ describe('FileListTable', () => {
       })
 
       it('has a tracked lines column', async () => {
+        setup()
         render(<FileListTable />, { wrapper: wrapper() })
 
         const trackedLines = await screen.findByText('Tracked lines')
@@ -146,6 +157,7 @@ describe('FileListTable', () => {
       })
 
       it('has a covered column', async () => {
+        setup()
         render(<FileListTable />, { wrapper: wrapper() })
 
         const covered = await screen.findByText('Covered')
@@ -153,6 +165,7 @@ describe('FileListTable', () => {
       })
 
       it('has a partial column', async () => {
+        setup()
         render(<FileListTable />, { wrapper: wrapper() })
 
         const partial = await screen.findByText('Partial')
@@ -160,6 +173,7 @@ describe('FileListTable', () => {
       })
 
       it('has a missed column', async () => {
+        setup()
         render(<FileListTable />, { wrapper: wrapper() })
 
         const missed = await screen.findByText('Missed')
@@ -167,6 +181,7 @@ describe('FileListTable', () => {
       })
 
       it('has a coverage column', async () => {
+        setup()
         render(<FileListTable />, { wrapper: wrapper() })
 
         const coverage = await screen.findByText('Coverage %')
@@ -179,28 +194,35 @@ describe('FileListTable', () => {
         it('set to list', async () => {
           const { requestFilters } = setup()
           render(<FileListTable />, {
-            wrapper: wrapper([
-              '/gh/codecov/cool-repo/tree/main/a/b/c?displayType=list',
-            ]),
+            wrapper: wrapper(
+              `/gh/codecov/cool-repo/tree/main/a/b/c${qs.stringify(
+                { displayType: 'list' },
+                { addQueryPrefix: true }
+              )}`
+            ),
           })
 
           await waitFor(() =>
-            expect(requestFilters).toBeCalledWith({
-              displayType: 'LIST',
-              ordering: { direction: 'DESC', parameter: 'MISSES' },
-            })
+            expect(requestFilters).toBeCalledWith(
+              expect.objectContaining({
+                displayType: 'LIST',
+                ordering: { direction: 'DESC', parameter: 'MISSES' },
+              })
+            )
           )
         })
       })
 
       describe('displaying a file', () => {
-        beforeEach(() => setup())
-
         it('has the correct url', async () => {
+          setup()
           render(<FileListTable />, {
-            wrapper: wrapper([
-              '/gh/codecov/cool-repo/tree/main/a/b/c?displayType=list',
-            ]),
+            wrapper: wrapper(
+              `/gh/codecov/cool-repo/tree/main/a/b/c${qs.stringify(
+                { displayType: 'list' },
+                { addQueryPrefix: true }
+              )}`
+            ),
           })
 
           const links = await within(
@@ -215,11 +237,8 @@ describe('FileListTable', () => {
     })
 
     describe('there is no results found', () => {
-      beforeEach(() => {
-        setup(true)
-      })
-
       it('displays error fetching data message', async () => {
+        setup({ noFiles: true })
         render(<FileListTable />, { wrapper: wrapper() })
 
         const message = await screen.findByText(
@@ -230,15 +249,31 @@ describe('FileListTable', () => {
     })
 
     describe('when head commit has no reports', () => {
-      beforeEach(() => {
-        setup(false, true)
-      })
-
       it('renders no report uploaded message', async () => {
+        setup({ noHeadReport: true })
         render(<FileListTable />, { wrapper: wrapper() })
 
         const message = await screen.findByText(
           'No coverage report uploaded for this branch head commit'
+        )
+        expect(message).toBeInTheDocument()
+      })
+    })
+
+    describe('when there is no flag coverage', () => {
+      it('renders no flag coverage message', async () => {
+        setup({ noFlagCoverage: true })
+        render(<FileListTable />, {
+          wrapper: wrapper(
+            `/gh/codecov/cool-repo/tree/main/a/b/c${qs.stringify(
+              { displayType: 'list', flags: ['flag-1'] },
+              { addQueryPrefix: true }
+            )}`
+          ),
+        })
+
+        const message = await screen.findByText(
+          'No coverage report uploaded for the selected flags'
         )
         expect(message).toBeInTheDocument()
       })
@@ -256,9 +291,11 @@ describe('FileListTable', () => {
           let files = await screen.findByText('Files')
           await user.click(files)
 
-          expect(requestFilters).toHaveBeenCalledWith({
-            ordering: { direction: 'ASC', parameter: 'NAME' },
-          })
+          expect(requestFilters).toHaveBeenCalledWith(
+            expect.objectContaining({
+              ordering: { direction: 'ASC', parameter: 'NAME' },
+            })
+          )
         })
       })
 
@@ -273,9 +310,11 @@ describe('FileListTable', () => {
           await user.click(files)
 
           await waitFor(() => {
-            expect(requestFilters).toHaveBeenCalledWith({
-              ordering: { direction: 'DESC', parameter: 'NAME' },
-            })
+            expect(requestFilters).toHaveBeenCalledWith(
+              expect.objectContaining({
+                ordering: { direction: 'DESC', parameter: 'NAME' },
+              })
+            )
           })
         })
       })
@@ -293,9 +332,11 @@ describe('FileListTable', () => {
           trackedLines = await screen.findByText('Tracked lines')
           await user.click(trackedLines)
 
-          expect(requestFilters).toHaveBeenCalledWith({
-            ordering: { direction: 'ASC', parameter: 'LINES' },
-          })
+          expect(requestFilters).toHaveBeenCalledWith(
+            expect.objectContaining({
+              ordering: { direction: 'ASC', parameter: 'LINES' },
+            })
+          )
         })
       })
 
@@ -311,9 +352,11 @@ describe('FileListTable', () => {
           await user.click(trackedLines)
 
           await waitFor(() => {
-            expect(requestFilters).toHaveBeenCalledWith({
-              ordering: { direction: 'DESC', parameter: 'LINES' },
-            })
+            expect(requestFilters).toHaveBeenCalledWith(
+              expect.objectContaining({
+                ordering: { direction: 'DESC', parameter: 'LINES' },
+              })
+            )
           })
         })
       })
@@ -329,9 +372,11 @@ describe('FileListTable', () => {
           await user.click(covered)
 
           await waitFor(() =>
-            expect(requestFilters).toHaveBeenCalledWith({
-              ordering: { direction: 'ASC', parameter: 'HITS' },
-            })
+            expect(requestFilters).toHaveBeenCalledWith(
+              expect.objectContaining({
+                ordering: { direction: 'ASC', parameter: 'HITS' },
+              })
+            )
           )
         })
       })
@@ -348,9 +393,11 @@ describe('FileListTable', () => {
           await user.click(covered)
 
           await waitFor(() => {
-            expect(requestFilters).toHaveBeenCalledWith({
-              ordering: { direction: 'DESC', parameter: 'HITS' },
-            })
+            expect(requestFilters).toHaveBeenCalledWith(
+              expect.objectContaining({
+                ordering: { direction: 'DESC', parameter: 'HITS' },
+              })
+            )
           })
         })
       })
@@ -368,9 +415,11 @@ describe('FileListTable', () => {
           partial = await screen.findByText('Partial')
           await user.click(partial)
 
-          expect(requestFilters).toHaveBeenCalledWith({
-            ordering: { direction: 'ASC', parameter: 'PARTIALS' },
-          })
+          expect(requestFilters).toHaveBeenCalledWith(
+            expect.objectContaining({
+              ordering: { direction: 'ASC', parameter: 'PARTIALS' },
+            })
+          )
         })
       })
 
@@ -386,9 +435,11 @@ describe('FileListTable', () => {
           await user.click(partial)
 
           await waitFor(() => {
-            expect(requestFilters).toHaveBeenCalledWith({
-              ordering: { direction: 'DESC', parameter: 'PARTIALS' },
-            })
+            expect(requestFilters).toHaveBeenCalledWith(
+              expect.objectContaining({
+                ordering: { direction: 'DESC', parameter: 'PARTIALS' },
+              })
+            )
           })
         })
       })
@@ -407,9 +458,11 @@ describe('FileListTable', () => {
           await user.click(missed)
 
           await waitFor(() => {
-            expect(requestFilters).toHaveBeenCalledWith({
-              ordering: { direction: 'DESC', parameter: 'MISSES' },
-            })
+            expect(requestFilters).toHaveBeenCalledWith(
+              expect.objectContaining({
+                ordering: { direction: 'DESC', parameter: 'MISSES' },
+              })
+            )
           })
         })
       })

--- a/src/pages/RepoPage/CoverageTab/subroute/FileExplorer/hooks/useRepoBranchContentsTable.js
+++ b/src/pages/RepoPage/CoverageTab/subroute/FileExplorer/hooks/useRepoBranchContentsTable.js
@@ -156,7 +156,8 @@ const sortingParameter = Object.freeze({
 const getQueryFilters = ({ params, sortBy }) => {
   return {
     ...(params?.search && { searchValue: params.search }),
-    ...(params?.flags && { flags: params.flags }),
+    // doing a ternary here because it's an array and arrays + && do not go well
+    ...(params?.flags ? { flags: params.flags } : {}),
     ...(params?.displayType && {
       displayType: displayTypeParameter[params?.displayType],
     }),

--- a/src/pages/RepoPage/CoverageTab/subroute/FileExplorer/hooks/useRepoBranchContentsTable.js
+++ b/src/pages/RepoPage/CoverageTab/subroute/FileExplorer/hooks/useRepoBranchContentsTable.js
@@ -141,6 +141,7 @@ const headers = [
 const defaultQueryParams = {
   search: '',
   displayType: '',
+  flags: [],
 }
 
 const sortingParameter = Object.freeze({
@@ -155,6 +156,7 @@ const sortingParameter = Object.freeze({
 const getQueryFilters = ({ params, sortBy }) => {
   return {
     ...(params?.search && { searchValue: params.search }),
+    ...(params?.flags && { flags: params.flags }),
     ...(params?.displayType && {
       displayType: displayTypeParameter[params?.displayType],
     }),
@@ -168,7 +170,13 @@ const getQueryFilters = ({ params, sortBy }) => {
 }
 
 export function useRepoBranchContentsTable() {
-  const { provider, owner, repo, path: urlPath, branch } = useParams()
+  const {
+    provider,
+    owner,
+    repo,
+    path: pathParam,
+    branch: branchParam,
+  } = useParams()
   const { params } = useLocationParams(defaultQueryParams)
   const { treePaths } = useTreePaths()
   const [sortBy, setSortBy] = useTableDefaultSort()
@@ -179,13 +187,17 @@ export function useRepoBranchContentsTable() {
     owner,
   })
 
+  const branch = branchParam || repoOverview?.defaultBranch
+  const filters = getQueryFilters({ params, sortBy: sortBy[0] })
+  const urlPath = pathParam || ''
+
   const { data: branchData, isLoading } = useRepoBranchContents({
     provider,
     owner,
     repo,
-    branch: branch || repoOverview?.defaultBranch,
-    path: urlPath || '',
-    filters: getQueryFilters({ params, sortBy: sortBy[0] }),
+    filters,
+    branch,
+    path: urlPath,
     suspense: false,
   })
 
@@ -193,20 +205,20 @@ export function useRepoBranchContentsTable() {
     () =>
       createTableData({
         tableData: branchData?.results,
-        branch: branch || repoOverview?.defaultBranch,
-        urlPath: urlPath || '',
+        branch,
+        urlPath,
         isSearching: !!params?.search,
-        filters: getQueryFilters({ params, sortBy: sortBy[0] }),
+        filters,
         treePaths,
         indicationRange: branchData?.indicationRange,
       }),
     [
-      branchData,
+      branchData?.results,
+      branchData?.indicationRange,
       branch,
-      repoOverview?.defaultBranch,
       urlPath,
-      params,
-      sortBy,
+      params?.search,
+      filters,
       treePaths,
     ]
   )

--- a/src/pages/RepoPage/CoverageTab/subroute/FileExplorer/hooks/useRepoBranchContentsTable.js
+++ b/src/pages/RepoPage/CoverageTab/subroute/FileExplorer/hooks/useRepoBranchContentsTable.js
@@ -237,6 +237,7 @@ export function useRepoBranchContentsTable() {
     data,
     headers,
     handleSort,
+    hasFlagsSelected: params?.flags ? params?.flags?.length > 0 : false,
     isLoading: isLoadingRepo || isLoading,
     isSearching: !!params?.search,
     isMissingHeadReport:

--- a/src/pages/RepoPage/CoverageTab/subroute/FileExplorer/hooks/useRepoBranchContentsTable.spec.js
+++ b/src/pages/RepoPage/CoverageTab/subroute/FileExplorer/hooks/useRepoBranchContentsTable.spec.js
@@ -265,6 +265,40 @@ describe('useRepoBranchContentsTable', () => {
     })
   })
 
+  describe('when there is a flags param', () => {
+    beforeEach(() => {
+      useLocationParams.mockReturnValue({
+        params: { flags: ['flag-1'] },
+      })
+
+      setup()
+    })
+
+    it('makes a gql request with the flags param', async () => {
+      renderHook(() => useRepoBranchContentsTable(), {
+        wrapper: wrapper(),
+      })
+
+      await waitFor(() => expect(queryClient.isFetching()).toBeGreaterThan(0))
+      await waitFor(() => expect(queryClient.isFetching()).toBe(0))
+
+      expect(calledCommitContents).toHaveBeenCalled()
+      expect(calledCommitContents).toHaveBeenCalledWith({
+        branch: 'main',
+        filters: {
+          flags: ['flag-1'],
+          ordering: {
+            direction: 'ASC',
+            parameter: 'NAME',
+          },
+        },
+        name: 'test-org',
+        repo: 'test-repo',
+        path: '',
+      })
+    })
+  })
+
   describe('when handleSort is triggered', () => {
     beforeEach(() => {
       useLocationParams.mockReturnValue({

--- a/src/pages/RepoPage/CoverageTab/subroute/FileExplorer/hooks/useRepoBranchContentsTable.spec.js
+++ b/src/pages/RepoPage/CoverageTab/subroute/FileExplorer/hooks/useRepoBranchContentsTable.spec.js
@@ -2,17 +2,11 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { renderHook, waitFor } from '@testing-library/react'
 import { graphql } from 'msw'
 import { setupServer } from 'msw/node'
+import qs from 'qs'
 import { MemoryRouter, Route } from 'react-router-dom'
 import { act } from 'react-test-renderer'
 
-import { useLocationParams } from 'services/navigation'
-
 import { useRepoBranchContentsTable } from './useRepoBranchContentsTable'
-
-jest.mock('services/navigation', () => ({
-  ...jest.requireActual('services/navigation'),
-  useLocationParams: jest.fn(),
-}))
 
 const mockCommitContentData = {
   owner: {
@@ -73,11 +67,11 @@ const queryClient = new QueryClient({
 const server = setupServer()
 
 const wrapper =
-  (initialEntries = ['/gh/test-org/test-repo/tree/main']) =>
+  (initialEntries = '/gh/test-org/test-repo/tree/main') =>
   ({ children }) =>
     (
       <QueryClientProvider client={queryClient}>
-        <MemoryRouter initialEntries={initialEntries}>
+        <MemoryRouter initialEntries={[initialEntries]}>
           <Route path={'/:provider/:owner/:repo/tree/:branch'}>
             {children}
           </Route>
@@ -104,9 +98,9 @@ const mockOverview = {
 }
 
 describe('useRepoBranchContentsTable', () => {
-  const calledCommitContents = jest.fn()
-
   function setup({ noData } = { noData: false }) {
+    const calledCommitContents = jest.fn()
+
     server.use(
       graphql.query('BranchContents', (req, res, ctx) => {
         calledCommitContents(req?.variables)
@@ -121,20 +115,15 @@ describe('useRepoBranchContentsTable', () => {
         return res(ctx.status(200), ctx.data(mockOverview))
       })
     )
+
+    return { calledCommitContents }
   }
 
   describe('calling the hook', () => {
     describe('when there is data to be returned', () => {
-      beforeEach(() => {
-        useLocationParams.mockReturnValue({
-          params: {},
-        })
-
-        setup()
-      })
-
       describe('on root path', () => {
         it('returns directory contents', async () => {
+          setup()
           const { result } = renderHook(() => useRepoBranchContentsTable(), {
             wrapper: wrapper(),
           })
@@ -150,8 +139,9 @@ describe('useRepoBranchContentsTable', () => {
 
       describe('on child path', () => {
         it('returns directory contents', async () => {
+          setup()
           const { result } = renderHook(() => useRepoBranchContentsTable(), {
-            wrapper: wrapper(['/gh/test-org/test-repo/tree/main/src/dir']),
+            wrapper: wrapper('/gh/test-org/test-repo/tree/main/src/dir'),
           })
 
           await waitFor(() =>
@@ -164,6 +154,7 @@ describe('useRepoBranchContentsTable', () => {
       })
 
       it('sets the correct headers', async () => {
+        setup()
         const { result } = renderHook(() => useRepoBranchContentsTable(), {
           wrapper: wrapper(),
         })
@@ -176,15 +167,8 @@ describe('useRepoBranchContentsTable', () => {
     })
 
     describe('when there is no data', () => {
-      beforeEach(() => {
-        useLocationParams.mockReturnValue({
-          params: {},
-        })
-
-        setup({ noData: true })
-      })
-
       it('returns an empty array', async () => {
+        setup({ noData: true })
         const { result } = renderHook(() => useRepoBranchContentsTable(), {
           wrapper: wrapper(),
         })
@@ -198,17 +182,15 @@ describe('useRepoBranchContentsTable', () => {
   })
 
   describe('when there is a search param', () => {
-    beforeEach(() => {
-      useLocationParams.mockReturnValue({
-        params: { search: 'file.js' },
-      })
-
-      setup()
-    })
-
     it('makes a gql request with the search value', async () => {
+      const { calledCommitContents } = setup()
       renderHook(() => useRepoBranchContentsTable(), {
-        wrapper: wrapper(),
+        wrapper: wrapper(
+          `/gh/test-org/test-repo/tree/main${qs.stringify(
+            { search: 'file.js' },
+            { addQueryPrefix: true }
+          )}`
+        ),
       })
 
       await waitFor(() => expect(queryClient.isFetching()).toBeGreaterThan(0))
@@ -219,6 +201,7 @@ describe('useRepoBranchContentsTable', () => {
         branch: 'main',
         filters: {
           searchValue: 'file.js',
+          flags: [],
           ordering: {
             direction: 'ASC',
             parameter: 'NAME',
@@ -232,17 +215,15 @@ describe('useRepoBranchContentsTable', () => {
   })
 
   describe('when called with the list param', () => {
-    beforeEach(() => {
-      useLocationParams.mockReturnValue({
-        params: { displayType: 'list' },
-      })
-
-      setup()
-    })
-
     it('makes a gql request with the list param', async () => {
+      const { calledCommitContents } = setup()
       renderHook(() => useRepoBranchContentsTable(), {
-        wrapper: wrapper(),
+        wrapper: wrapper(
+          `/gh/test-org/test-repo/tree/main${qs.stringify(
+            { displayType: 'list' },
+            { addQueryPrefix: true }
+          )}`
+        ),
       })
 
       await waitFor(() => expect(queryClient.isFetching()).toBeGreaterThan(0))
@@ -253,6 +234,7 @@ describe('useRepoBranchContentsTable', () => {
         branch: 'main',
         filters: {
           displayType: 'LIST',
+          flags: [],
           ordering: {
             direction: 'DESC',
             parameter: 'MISSES',
@@ -266,17 +248,15 @@ describe('useRepoBranchContentsTable', () => {
   })
 
   describe('when there is a flags param', () => {
-    beforeEach(() => {
-      useLocationParams.mockReturnValue({
-        params: { flags: ['flag-1'] },
-      })
-
-      setup()
-    })
-
     it('makes a gql request with the flags param', async () => {
+      const { calledCommitContents } = setup()
       renderHook(() => useRepoBranchContentsTable(), {
-        wrapper: wrapper(),
+        wrapper: wrapper(
+          `/gh/test-org/test-repo/tree/main${qs.stringify(
+            { flags: ['flag-1'] },
+            { addQueryPrefix: true }
+          )}`
+        ),
       })
 
       await waitFor(() => expect(queryClient.isFetching()).toBeGreaterThan(0))
@@ -300,15 +280,8 @@ describe('useRepoBranchContentsTable', () => {
   })
 
   describe('when handleSort is triggered', () => {
-    beforeEach(() => {
-      useLocationParams.mockReturnValue({
-        params: {},
-      })
-
-      setup()
-    })
-
     it('makes a gql request with the updated params', async () => {
+      const { calledCommitContents } = setup()
       const { result } = renderHook(() => useRepoBranchContentsTable(), {
         wrapper: wrapper(),
       })
@@ -327,6 +300,7 @@ describe('useRepoBranchContentsTable', () => {
       expect(calledCommitContents).toHaveBeenNthCalledWith(2, {
         branch: 'main',
         filters: {
+          flags: [],
           ordering: {
             direction: 'DESC',
             parameter: 'NAME',

--- a/src/pages/RepoPage/CoverageTab/subroute/FileExplorer/shared/RepoContentsResult.jsx
+++ b/src/pages/RepoPage/CoverageTab/subroute/FileExplorer/shared/RepoContentsResult.jsx
@@ -2,11 +2,23 @@ import PropType from 'prop-types'
 
 import MissingFileData from 'shared/ContentsTable/MissingFileData'
 
-function RepoContentsResult({ isSearching, isMissingHeadReport }) {
+function RepoContentsResult({
+  isSearching,
+  isMissingHeadReport,
+  hasFlagsSelected,
+}) {
   if (isMissingHeadReport) {
     return (
       <p className="flex flex-1 justify-center">
         No coverage report uploaded for this branch head commit
+      </p>
+    )
+  }
+
+  if (hasFlagsSelected) {
+    return (
+      <p className="flex flex-1 justify-center">
+        No coverage report uploaded for the selected flags
       </p>
     )
   }
@@ -17,6 +29,7 @@ function RepoContentsResult({ isSearching, isMissingHeadReport }) {
 RepoContentsResult.propTypes = {
   isSearching: PropType.bool,
   isMissingHeadReport: PropType.bool,
+  hasFlagsSelected: PropType.bool,
 }
 
 export default RepoContentsResult


### PR DESCRIPTION
# Description

Small PR updating the `useRepoBranchContentsTable` to pull out the flags param if present and pass it along with the API request.

Closes codecov/engineering-team#424
Closes codecov/engineering-team#469

# Notable Changes

- Update `useRepoBranchContentsTable` to pull flags from URL params
- Update `useRepoBranchContentsTable` tests
- Update `FileExplorer` tests adding in missing call to `setup` function
- Add in Error message when no results are returned and flags have been selected