### PR TITLE
feat: Use API_URL Instead of BASE_URL

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,4 +1,5 @@
 PROXY_TO=https://stage-api.codecov.dev
+REACT_APP_API_URL=https://stage-api.codecov.dev
 REACT_APP_BASE_URL=https://stage-web.codecov.dev
 REACT_APP_MARKETING_BASE_URL=https://about.codecov.io
 REACT_APP_SEGMENT_KEY=$SEGMENT_KEY

--- a/src/layouts/Header/DesktopMenu.spec.jsx
+++ b/src/layouts/Header/DesktopMenu.spec.jsx
@@ -316,7 +316,7 @@ describe('LoginPrompt', () => {
       expect(loginLink).toBeInTheDocument()
       expect(loginLink).toHaveAttribute(
         'href',
-        'https://stage-web.codecov.dev/login/gh?to=http%3A%2F%2Flocalhost%2F'
+        '/login/gh?to=http%3A%2F%2Flocalhost%2F'
       )
 
       const signUpLink = within(loginPrompt).getByText('Sign up')

--- a/src/layouts/Header/Dropdown.jsx
+++ b/src/layouts/Header/Dropdown.jsx
@@ -14,8 +14,6 @@ function Dropdown({ currentUser }) {
   const { provider } = useParams()
   const isGh = providerToName(provider) === 'Github'
 
-  const to = `${window.location.protocol}//${window.location.host}/${provider}`
-
   const items =
     !config.IS_SELF_HOSTED && isGh
       ? [
@@ -37,7 +35,9 @@ function Dropdown({ currentUser }) {
       children: 'Settings',
     },
     {
-      props: { to: { pageName: 'signOut', options: { to } } },
+      props: {
+        to: { pageName: 'signOut', options: { to: config.MARKETING_BASE_URL } },
+      },
       children: 'Sign Out',
     }
   )

--- a/src/layouts/Header/Dropdown.jsx
+++ b/src/layouts/Header/Dropdown.jsx
@@ -14,6 +14,8 @@ function Dropdown({ currentUser }) {
   const { provider } = useParams()
   const isGh = providerToName(provider) === 'Github'
 
+  const to = `${window.location.protocol}//${window.location.host}/${provider}`
+
   const items =
     !config.IS_SELF_HOSTED && isGh
       ? [
@@ -34,7 +36,10 @@ function Dropdown({ currentUser }) {
       },
       children: 'Settings',
     },
-    { props: { to: { pageName: 'signOut' } }, children: 'Sign Out' }
+    {
+      props: { to: { pageName: 'signOut', options: { to } } },
+      children: 'Sign Out',
+    }
   )
 
   const {

--- a/src/layouts/Header/Dropdown.spec.jsx
+++ b/src/layouts/Header/Dropdown.spec.jsx
@@ -87,7 +87,7 @@ describe('Dropdown', () => {
         expect(link).toBeVisible()
         expect(link).toHaveAttribute(
           'href',
-          '/logout/gh?to=http%3A%2F%2Flocalhost%2Fgh'
+          '/logout/gh?to=https%3A%2F%2Fabout.codecov.io'
         )
       })
 
@@ -146,7 +146,7 @@ describe('Dropdown', () => {
         expect(link).toBeVisible()
         expect(link).toHaveAttribute(
           'href',
-          '/logout/gl?to=http%3A%2F%2Flocalhost%2Fgl'
+          '/logout/gl?to=https%3A%2F%2Fabout.codecov.io'
         )
       })
 

--- a/src/layouts/Header/Dropdown.spec.jsx
+++ b/src/layouts/Header/Dropdown.spec.jsx
@@ -87,7 +87,7 @@ describe('Dropdown', () => {
         expect(link).toBeVisible()
         expect(link).toHaveAttribute(
           'href',
-          'https://stage-web.codecov.dev/logout/gh'
+          '/logout/gh?to=http%3A%2F%2Flocalhost%2Fgh'
         )
       })
 
@@ -146,7 +146,7 @@ describe('Dropdown', () => {
         expect(link).toBeVisible()
         expect(link).toHaveAttribute(
           'href',
-          'https://stage-web.codecov.dev/logout/gl'
+          '/logout/gl?to=http%3A%2F%2Flocalhost%2Fgl'
         )
       })
 

--- a/src/pages/EnterpriseLandingPage/ProviderCard/ProviderCard.spec.jsx
+++ b/src/pages/EnterpriseLandingPage/ProviderCard/ProviderCard.spec.jsx
@@ -1,7 +1,5 @@
 import { render, screen } from '@testing-library/react'
 
-import config from 'config'
-
 import { LoginProvidersEnum } from 'services/loginProviders'
 
 import ProviderCard from './ProviderCard'
@@ -28,7 +26,7 @@ describe('ProviderCard', () => {
           name: 'Login via Bitbucket',
         })
         expect(element).toBeInTheDocument()
-        expect(element).toHaveAttribute('href', `${config.BASE_URL}/login/bb`)
+        expect(element).toHaveAttribute('href', '/login/bb')
       })
 
       it('renders self hosted login link', () => {
@@ -36,7 +34,7 @@ describe('ProviderCard', () => {
           name: 'Login via Bitbucket Server',
         })
         expect(element).toBeInTheDocument()
-        expect(element).toHaveAttribute('href', `${config.BASE_URL}/login/bbs`)
+        expect(element).toHaveAttribute('href', '/login/bbs')
       })
     })
   })
@@ -51,7 +49,7 @@ describe('ProviderCard', () => {
       it('renders external login button', () => {
         const element = screen.getByRole('link', { name: 'Login via GitHub' })
         expect(element).toBeInTheDocument()
-        expect(element).toHaveAttribute('href', `${config.BASE_URL}/login/gh`)
+        expect(element).toHaveAttribute('href', '/login/gh')
       })
 
       it('renders self hosted login link', () => {
@@ -59,7 +57,7 @@ describe('ProviderCard', () => {
           name: 'Login via GitHub Enterprise',
         })
         expect(element).toBeInTheDocument()
-        expect(element).toHaveAttribute('href', `${config.BASE_URL}/login/ghe`)
+        expect(element).toHaveAttribute('href', '/login/ghe')
       })
     })
   })
@@ -74,7 +72,7 @@ describe('ProviderCard', () => {
       it('renders external login button', () => {
         const element = screen.getByRole('link', { name: 'Login via GitLab' })
         expect(element).toBeInTheDocument()
-        expect(element).toHaveAttribute('href', `${config.BASE_URL}/login/gl`)
+        expect(element).toHaveAttribute('href', '/login/gl')
       })
 
       it('renders self hosted login link', () => {
@@ -82,7 +80,7 @@ describe('ProviderCard', () => {
           name: 'Login via GitLab CE/EE',
         })
         expect(element).toBeInTheDocument()
-        expect(element).toHaveAttribute('href', `${config.BASE_URL}/login/gle`)
+        expect(element).toHaveAttribute('href', '/login/gle')
       })
     })
   })

--- a/src/services/navigation/useNavLinks/useNavLinks.js
+++ b/src/services/navigation/useNavLinks/useNavLinks.js
@@ -15,8 +15,11 @@ export function useNavLinks() {
   return {
     signOut: {
       text: 'Sign Out',
-      path: ({ provider = p } = { provider: p }) =>
-        `${config.BASE_URL}/logout/${provider}`,
+      path: ({ provider = p, to } = { provider: p }) => {
+        const query = qs.stringify({ to }, { addQueryPrefix: true })
+
+        return `${config.API_URL}/logout/${provider}${query}`
+      },
       isExternalLink: true,
     },
     signIn: {
@@ -29,7 +32,7 @@ export function useNavLinks() {
           },
           { addQueryPrefix: true }
         )
-        return `${config.BASE_URL}/login/${provider}${query}`
+        return `${config.API_URL}/login/${provider}${query}`
       },
       isExternalLink: true,
     },

--- a/src/services/navigation/useNavLinks/useNavLinks.spec.js
+++ b/src/services/navigation/useNavLinks/useNavLinks.spec.js
@@ -6,71 +6,89 @@ import config from 'config'
 
 import { useNavLinks } from './useNavLinks'
 
+const wrapper =
+  (location) =>
+  ({ children }) =>
+    (
+      <MemoryRouter initialEntries={[location]} initialIndex={0}>
+        <Route path="/:provider">{children}</Route>
+        <Route path="/:provider/:owner">{children}</Route>
+        <Route path="/:provider/:owner/:repo">{children}</Route>
+        <Route path="/:provider/:owner/:repo/:id">{children}</Route>
+        <Route path="/:provider/:owner/:repo/commit/:commit/file/:path">
+          {children}
+        </Route>
+        <Route path="/:provider/:owner/:repo/pull/:pullId">{children}</Route>
+        <Route path="/admin/:provider/access">{children}</Route>
+        <Route path="/admin/:provider/users">{children}</Route>
+        <Route path="/admin/:provider/:owner/access">{children}</Route>
+        <Route path="/admin/:provider/:owner/users">{children}</Route>
+      </MemoryRouter>
+    )
+
 describe('useNavLinks', () => {
-  let hookData
-
-  function setup(location) {
-    hookData = renderHook(() => useNavLinks(), {
-      wrapper: ({ children }) => (
-        <MemoryRouter initialEntries={location} initialIndex={0}>
-          <Route path="/:provider">{children}</Route>
-          <Route path="/:provider/:owner">{children}</Route>
-          <Route path="/:provider/:owner/:repo">{children}</Route>
-          <Route path="/:provider/:owner/:repo/:id">{children}</Route>
-          <Route path="/:provider/:owner/:repo/commit/:commit/file/:path">
-            {children}
-          </Route>
-          <Route path="/:provider/:owner/:repo/pull/:pullId">{children}</Route>
-          <Route path="/admin/:provider/access">{children}</Route>
-          <Route path="/admin/:provider/users">{children}</Route>
-          <Route path="/admin/:provider/:owner/access">{children}</Route>
-          <Route path="/admin/:provider/:owner/users">{children}</Route>
-        </MemoryRouter>
-      ),
-    })
-  }
-
   describe('Sign Out', () => {
-    beforeAll(() => {
-      setup(['/gl/doggo/squirrel-locator'])
+    it('returns the correct link with nothing passed', () => {
+      const { result } = renderHook(() => useNavLinks(), {
+        wrapper: wrapper('/gl/doggo/squirrel-locator'),
+      })
+
+      const path = result.current.signOut.path()
+      expect(path).toBe('/logout/gl')
     })
 
-    it('Returns the correct link with nothing passed', () => {
-      expect(hookData.result.current.signOut.path()).toBe(
-        `${config.BASE_URL}/logout/gl`
-      )
-    })
     it('can override the params', () => {
-      expect(hookData.result.current.signOut.path({ provider: 'bb' })).toBe(
-        `${config.BASE_URL}/logout/bb`
+      const { result } = renderHook(() => useNavLinks(), {
+        wrapper: wrapper('/gl/doggo/squirrel-locator'),
+      })
+
+      const path = result.current.signOut.path({ provider: 'bb' })
+      expect(path).toBe('/logout/bb')
+    })
+
+    it('can add a `to` redirection', () => {
+      const { result } = renderHook(() => useNavLinks(), {
+        wrapper: wrapper('/gl/doggo/squirrel-locator'),
+      })
+
+      const path = result.current.signOut.path({
+        to: 'https://app.codecov.io/gh/codecov',
+      })
+      expect(path).toBe(
+        '/logout/gl?to=https%3A%2F%2Fapp.codecov.io%2Fgh%2Fcodecov'
       )
     })
   })
 
   describe('Sign In', () => {
-    beforeAll(() => {
-      setup(['/gl/doggo/squirrel-locator'])
-    })
+    it('returns the correct link with nothing passed', () => {
+      const { result } = renderHook(() => useNavLinks(), {
+        wrapper: wrapper('/gl/doggo/squirrel-locator'),
+      })
 
-    it('Returns the correct link with nothing passed', () => {
-      expect(hookData.result.current.signIn.path()).toBe(
-        `${config.BASE_URL}/login/gl`
-      )
+      const path = result.current.signIn.path()
+      expect(path).toBe('/login/gl')
     })
 
     it('can override the params', () => {
-      expect(hookData.result.current.signIn.path({ provider: 'bb' })).toBe(
-        `${config.BASE_URL}/login/bb`
-      )
+      const { result } = renderHook(() => useNavLinks(), {
+        wrapper: wrapper('/gl/doggo/squirrel-locator'),
+      })
+
+      const path = result.current.signIn.path({ provider: 'bb' })
+      expect(path).toBe('/login/bb')
     })
 
     it('can add a `to` redirection', () => {
-      expect(
-        hookData.result.current.signIn.path({
-          to: 'htts://app.codecov.io/gh/codecov',
-        })
-      ).toBe(
-        `${config.BASE_URL}/login/gl?to=htts%3A%2F%2Fapp.codecov.io%2Fgh%2Fcodecov`
+      const { result } = renderHook(() => useNavLinks(), {
+        wrapper: wrapper('/gl/doggo/squirrel-locator'),
+      })
+
+      const path = result.current.signIn.path({
+        to: 'https://app.codecov.io/gh/codecov',
+      })
+      expect(path).toBe(
+        '/login/gl?to=https%3A%2F%2Fapp.codecov.io%2Fgh%2Fcodecov'
       )
     })
 
@@ -79,811 +97,907 @@ describe('useNavLinks', () => {
         'utmParams',
         'utm_source=a&utm_medium=b&utm_campaign=c&utm_term=d&utm_content=e'
       )
-      setup(['/gh/doggo/squirrel-locator'])
 
-      expect(
-        hookData.result.current.signIn.path({
-          to: 'htts://app.codecov.io/gh/codecov',
-        })
-      ).toBe(
-        `${config.BASE_URL}/login/gh?to=htts%3A%2F%2Fapp.codecov.io%2Fgh%2Fcodecov&utm_source=a&utm_medium=b&utm_campaign=c&utm_term=d&utm_content=e`
+      const { result } = renderHook(() => useNavLinks(), {
+        wrapper: wrapper('/gh/doggo/squirrel-locator'),
+      })
+
+      const path = result.current.signIn.path({
+        to: 'https://app.codecov.io/gh/codecov',
+      })
+
+      expect(path).toBe(
+        '/login/gh?to=https%3A%2F%2Fapp.codecov.io%2Fgh%2Fcodecov&utm_source=a&utm_medium=b&utm_campaign=c&utm_term=d&utm_content=e'
       )
+
       Cookie.remove('utmParams')
     })
   })
 
   describe('owner link', () => {
-    beforeAll(() => {
-      setup(['/gl/doggo/squirrel-locator'])
+    it('returns the correct link with nothing passed', () => {
+      const { result } = renderHook(() => useNavLinks(), {
+        wrapper: wrapper('/gl/doggo/squirrel-locator'),
+      })
+
+      const path = result.current.owner.path()
+      expect(path).toBe('/gl/doggo')
     })
 
-    it('Returns the correct link with nothing passed', () => {
-      expect(hookData.result.current.owner.path()).toBe('/gl/doggo')
-    })
     it('can override the params', () => {
-      expect(hookData.result.current.owner.path({ provider: 'bb' })).toBe(
-        '/bb/doggo'
-      )
-      expect(hookData.result.current.owner.path({ owner: 'cat' })).toBe(
-        '/gl/cat'
-      )
+      const { result } = renderHook(() => useNavLinks(), {
+        wrapper: wrapper('/gl/doggo/squirrel-locator'),
+      })
+
+      const path = result.current.owner.path({
+        provider: 'bb',
+        owner: 'test-owner',
+      })
+      expect(path).toBe('/bb/test-owner')
     })
   })
 
   describe('owner internal link', () => {
-    beforeAll(() => {
-      setup(['/gl/doggo/squirrel-locator'])
+    it('returns the correct link with nothing passed', () => {
+      const { result } = renderHook(() => useNavLinks(), {
+        wrapper: wrapper('/gl/doggo/squirrel-locator'),
+      })
+
+      const path = result.current.owner.path()
+      expect(path).toBe('/gl/doggo')
     })
 
-    it('Returns the correct link with nothing passed', () => {
-      expect(hookData.result.current.owner.path()).toBe('/gl/doggo')
-    })
     it('can override the params', () => {
-      expect(hookData.result.current.owner.path({ provider: 'bb' })).toBe(
-        '/bb/doggo'
-      )
-      expect(hookData.result.current.owner.path({ owner: 'cat' })).toBe(
-        '/gl/cat'
-      )
+      const { result } = renderHook(() => useNavLinks(), {
+        wrapper: wrapper('/gl/doggo/squirrel-locator'),
+      })
+
+      const path = result.current.owner.path({
+        provider: 'bb',
+        owner: 'test-owner',
+      })
+      expect(path).toBe('/bb/test-owner')
     })
   })
 
   describe('analytics', () => {
-    beforeAll(() => {
-      setup(['/gl/doggo/squirrel-locator'])
+    it('returns the correct link with nothing passed', () => {
+      const { result } = renderHook(() => useNavLinks(), {
+        wrapper: wrapper('/gl/doggo/squirrel-locator'),
+      })
+
+      const path = result.current.analytics.path()
+      expect(path).toBe('/analytics/gl/doggo')
     })
 
-    it('Returns the correct link with nothing passed', () => {
-      expect(hookData.result.current.analytics.path()).toBe(
-        `/analytics/gl/doggo`
-      )
-    })
     it('can override the params', () => {
-      expect(hookData.result.current.analytics.path({ provider: 'bb' })).toBe(
-        `/analytics/bb/doggo`
-      )
-      expect(hookData.result.current.analytics.path({ owner: 'cat' })).toBe(
-        `/analytics/gl/cat`
-      )
+      const { result } = renderHook(() => useNavLinks(), {
+        wrapper: wrapper('/gl/doggo/squirrel-locator'),
+      })
+
+      const path = result.current.analytics.path({
+        provider: 'bb',
+        owner: 'test-owner',
+      })
+      expect(path).toBe('/analytics/bb/test-owner')
     })
   })
 
   describe('Plan', () => {
-    beforeAll(() => {
-      setup(['/gl/doggo/squirrel-locator'])
+    it('returns the correct link with nothing passed', () => {
+      const { result } = renderHook(() => useNavLinks(), {
+        wrapper: wrapper('/gl/doggo/squirrel-locator'),
+      })
+
+      const path = result.current.planTab.path()
+      expect(path).toBe('/plan/gl/doggo')
     })
 
-    it('Returns the correct link with nothing passed', () => {
-      expect(hookData.result.current.planTab.path()).toBe(`/plan/gl/doggo`)
-    })
     it('can override the params', () => {
-      expect(hookData.result.current.planTab.path({ provider: 'bb' })).toBe(
-        `/plan/bb/doggo`
-      )
-      expect(hookData.result.current.planTab.path({ owner: 'cat' })).toBe(
-        `/plan/gl/cat`
-      )
+      const { result } = renderHook(() => useNavLinks(), {
+        wrapper: wrapper('/gl/doggo/squirrel-locator'),
+      })
+
+      const path = result.current.planTab.path({
+        provider: 'bb',
+        owner: 'test-owner',
+      })
+      expect(path).toBe('/plan/bb/test-owner')
     })
   })
 
   describe('Members', () => {
-    beforeAll(() => {
-      setup(['/gh/critical-role/calloway'])
+    it('returns the correct link with nothing passed', () => {
+      const { result } = renderHook(() => useNavLinks(), {
+        wrapper: wrapper('/gh/critical-role/calloway'),
+      })
+
+      const path = result.current.membersTab.path()
+      expect(path).toBe('/members/gh/critical-role')
     })
 
-    it('Returns the correct link with nothing passed', () => {
-      expect(hookData.result.current.membersTab.path()).toBe(
-        `/members/gh/critical-role`
-      )
-    })
     it('can override the params', () => {
-      expect(hookData.result.current.membersTab.path({ provider: 'bb' })).toBe(
-        `/members/bb/critical-role`
-      )
-      expect(
-        hookData.result.current.membersTab.path({ owner: 'skirmisher' })
-      ).toBe(`/members/gh/skirmisher`)
+      const { result } = renderHook(() => useNavLinks(), {
+        wrapper: wrapper('/gh/critical-role/calloway'),
+      })
+
+      const path = result.current.membersTab.path({
+        provider: 'bb',
+        owner: 'skirmisher',
+      })
+      expect(path).toBe('/members/bb/skirmisher')
     })
   })
 
   describe('Upgrade Plan', () => {
-    beforeAll(() => {
-      setup(['/gl/doggo/squirrel-locator'])
+    it('returns the correct link with nothing passed', () => {
+      const { result } = renderHook(() => useNavLinks(), {
+        wrapper: wrapper('/gl/doggo/squirrel-locator'),
+      })
+
+      const path = result.current.upgradeOrgPlan.path()
+      expect(path).toBe('/plan/gl/doggo/upgrade')
     })
 
-    it('Returns the correct link with nothing passed', () => {
-      expect(hookData.result.current.upgradeOrgPlan.path()).toBe(
-        `/plan/gl/doggo/upgrade`
-      )
-    })
     it('can override the params', () => {
-      expect(
-        hookData.result.current.upgradeOrgPlan.path({ provider: 'bb' })
-      ).toBe(`/plan/bb/doggo/upgrade`)
-      expect(
-        hookData.result.current.upgradeOrgPlan.path({ owner: 'cat' })
-      ).toBe(`/plan/gl/cat/upgrade`)
+      const { result } = renderHook(() => useNavLinks(), {
+        wrapper: wrapper('/gl/doggo/squirrel-locator'),
+      })
+
+      const path = result.current.upgradeOrgPlan.path({
+        provider: 'bb',
+        owner: 'test-owner',
+      })
+      expect(path).toBe('/plan/bb/test-owner/upgrade')
     })
   })
 
   describe('Cancel Plan', () => {
-    beforeAll(() => {
-      setup(['/gl/doggo/squirrel-locator'])
+    it('returns the correct link with nothing passed', () => {
+      const { result } = renderHook(() => useNavLinks(), {
+        wrapper: wrapper('/gl/doggo/squirrel-locator'),
+      })
+
+      const path = result.current.cancelOrgPlan.path()
+      expect(path).toBe('/plan/gl/doggo/cancel')
     })
 
-    it('Returns the correct link with nothing passed', () => {
-      expect(hookData.result.current.cancelOrgPlan.path()).toBe(
-        `/plan/gl/doggo/cancel`
-      )
-    })
     it('can override the params', () => {
-      expect(
-        hookData.result.current.cancelOrgPlan.path({ provider: 'bb' })
-      ).toBe(`/plan/bb/doggo/cancel`)
-      expect(hookData.result.current.cancelOrgPlan.path({ owner: 'cat' })).toBe(
-        `/plan/gl/cat/cancel`
-      )
+      const { result } = renderHook(() => useNavLinks(), {
+        wrapper: wrapper('/gl/doggo/squirrel-locator'),
+      })
+
+      const path = result.current.cancelOrgPlan.path({
+        provider: 'bb',
+        owner: 'test-owner',
+      })
+      expect(path).toBe('/plan/bb/test-owner/cancel')
     })
   })
 
   describe('InvoicesPage', () => {
-    beforeAll(() => {
-      setup(['/gl/doggo/squirrel-locator'])
+    it('returns the correct link with nothing passed', () => {
+      const { result } = renderHook(() => useNavLinks(), {
+        wrapper: wrapper('/gl/doggo/squirrel-locator'),
+      })
+
+      const path = result.current.invoicesPage.path()
+      expect(path).toBe('/plan/gl/doggo/invoices')
     })
 
-    it('Returns the correct link with nothing passed', () => {
-      expect(hookData.result.current.invoicesPage.path()).toBe(
-        `/plan/gl/doggo/invoices`
-      )
-    })
     it('can override the params', () => {
-      expect(
-        hookData.result.current.invoicesPage.path({ provider: 'bb' })
-      ).toBe(`/plan/bb/doggo/invoices`)
-      expect(hookData.result.current.invoicesPage.path({ owner: 'cat' })).toBe(
-        `/plan/gl/cat/invoices`
-      )
+      const { result } = renderHook(() => useNavLinks(), {
+        wrapper: wrapper('/gl/doggo/squirrel-locator'),
+      })
+
+      const path = result.current.invoicesPage.path({
+        provider: 'bb',
+        owner: 'test-owner',
+      })
+      expect(path).toBe('/plan/bb/test-owner/invoices')
     })
   })
 
   describe('invoiceDetailsPage', () => {
-    beforeAll(() => {
-      setup(['/gl/doggo/squirrel-locator/9'])
+    it('returns the correct link with nothing passed', () => {
+      const { result } = renderHook(() => useNavLinks(), {
+        wrapper: wrapper('/gl/doggo/squirrel-locator/9'),
+      })
+
+      const path = result.current.invoiceDetailsPage.path()
+      expect(path).toBe('/plan/gl/doggo/invoices/9')
     })
 
-    it('Returns the correct link with nothing passed', () => {
-      expect(hookData.result.current.invoiceDetailsPage.path()).toBe(
-        `/plan/gl/doggo/invoices/9`
-      )
-    })
     it('can override the params', () => {
-      expect(
-        hookData.result.current.invoiceDetailsPage.path({ provider: 'bb' })
-      ).toBe(`/plan/bb/doggo/invoices/9`)
-      expect(
-        hookData.result.current.invoiceDetailsPage.path({ owner: 'cat' })
-      ).toBe(`/plan/gl/cat/invoices/9`)
+      const { result } = renderHook(() => useNavLinks(), {
+        wrapper: wrapper('/gl/doggo/squirrel-locator/9'),
+      })
+
+      const path = result.current.invoiceDetailsPage.path({
+        provider: 'bb',
+        owner: 'test-owner',
+      })
+
+      expect(path).toBe('/plan/bb/test-owner/invoices/9')
     })
   })
 
   describe('downgradePlanPage', () => {
-    beforeAll(() => {
-      setup(['/gl/doggo/squirrel-locator/9'])
+    it('returns the correct link with nothing passed', () => {
+      const { result } = renderHook(() => useNavLinks(), {
+        wrapper: wrapper('/gl/doggo/squirrel-locator/9'),
+      })
+
+      const path = result.current.downgradePlanPage.path()
+      expect(path).toBe('/plan/gl/doggo/cancel/downgrade')
     })
 
-    it('Returns the correct link with nothing passed', () => {
-      expect(hookData.result.current.downgradePlanPage.path()).toBe(
-        `/plan/gl/doggo/cancel/downgrade`
-      )
-    })
     it('can override the params', () => {
-      expect(
-        hookData.result.current.downgradePlanPage.path({ provider: 'bb' })
-      ).toBe(`/plan/bb/doggo/cancel/downgrade`)
-      expect(
-        hookData.result.current.downgradePlanPage.path({ owner: 'cat' })
-      ).toBe(`/plan/gl/cat/cancel/downgrade`)
+      const { result } = renderHook(() => useNavLinks(), {
+        wrapper: wrapper('/gl/doggo/squirrel-locator/9'),
+      })
+
+      const path = result.current.downgradePlanPage.path({
+        provider: 'bb',
+        owner: 'test-owner',
+      })
+      expect(path).toBe('/plan/bb/test-owner/cancel/downgrade')
     })
   })
 
   describe('repo link', () => {
-    beforeAll(() => {
-      setup(['/gl/doggo/squirrel-locator'])
+    it('returns the correct link with nothing passed', () => {
+      const { result } = renderHook(() => useNavLinks(), {
+        wrapper: wrapper('/gl/doggo/squirrel-locator'),
+      })
+
+      const path = result.current.repo.path()
+      expect(path).toBe('/gl/doggo/squirrel-locator')
     })
 
-    it('Returns the correct link with nothing passed', () => {
-      expect(hookData.result.current.repo.path()).toBe(
-        '/gl/doggo/squirrel-locator'
-      )
-    })
     it('can override the params', () => {
-      expect(hookData.result.current.repo.path({ provider: 'bb' })).toBe(
-        '/bb/doggo/squirrel-locator'
-      )
-      expect(hookData.result.current.repo.path({ owner: 'cat' })).toBe(
-        '/gl/cat/squirrel-locator'
-      )
-      expect(hookData.result.current.repo.path({ repo: 'no-cats' })).toBe(
-        '/gl/doggo/no-cats'
-      )
+      const { result } = renderHook(() => useNavLinks(), {
+        wrapper: wrapper('/gl/doggo/squirrel-locator'),
+      })
+
+      const path = result.current.repo.path({
+        provider: 'bb',
+        owner: 'test-owner',
+        repo: 'no-cats',
+      })
+      expect(path).toBe('/bb/test-owner/no-cats')
     })
   })
 
   describe('account link', () => {
-    beforeAll(() => {
-      setup(['/gl/doggo/squirrel-locator'])
+    it('returns the correct link with nothing passed', () => {
+      const { result } = renderHook(() => useNavLinks(), {
+        wrapper: wrapper('/gl/doggo/squirrel-locator'),
+      })
+
+      const path = result.current.account.path()
+      expect(path).toBe('/account/gl/doggo')
     })
 
-    it('Returns the correct link with nothing passed', () => {
-      expect(hookData.result.current.account.path()).toBe('/account/gl/doggo')
-    })
     it('can override the params', () => {
-      expect(hookData.result.current.account.path({ provider: 'bb' })).toBe(
-        '/account/bb/doggo'
-      )
-      expect(hookData.result.current.account.path({ owner: 'cat' })).toBe(
-        '/account/gl/cat'
-      )
+      const { result } = renderHook(() => useNavLinks(), {
+        wrapper: wrapper('/gl/doggo/squirrel-locator'),
+      })
+
+      const path = result.current.account.path({
+        provider: 'bb',
+        owner: 'test-owner',
+      })
+      expect(path).toBe('/account/bb/test-owner')
     })
   })
 
   describe('accountAdmin link', () => {
-    beforeAll(() => {
-      setup(['/gl/doggo/squirrel-locator'])
+    it('returns the correct link with nothing passed', () => {
+      const { result } = renderHook(() => useNavLinks(), {
+        wrapper: wrapper('/gl/doggo/squirrel-locator'),
+      })
+
+      const path = result.current.accountAdmin.path()
+      expect(path).toBe('/account/gl/doggo')
     })
 
-    it('Returns the correct link with nothing passed', () => {
-      expect(hookData.result.current.accountAdmin.path()).toBe(
-        '/account/gl/doggo'
-      )
-    })
     it('can override the params', () => {
-      expect(
-        hookData.result.current.accountAdmin.path({ provider: 'bb' })
-      ).toBe('/account/bb/doggo')
-      expect(hookData.result.current.accountAdmin.path({ owner: 'cat' })).toBe(
-        '/account/gl/cat'
-      )
+      const { result } = renderHook(() => useNavLinks(), {
+        wrapper: wrapper('/gl/doggo/squirrel-locator'),
+      })
+
+      const path = result.current.accountAdmin.path({
+        provider: 'bb',
+        owner: 'test-owner',
+      })
+      expect(path).toBe('/account/bb/test-owner')
     })
   })
 
   describe('yamlTab link', () => {
-    beforeAll(() => {
-      setup(['/gl/doggo/squirrel-locator'])
+    it('returns the correct link with nothing passed', () => {
+      const { result } = renderHook(() => useNavLinks(), {
+        wrapper: wrapper('/gl/doggo/squirrel-locator'),
+      })
+
+      const path = result.current.yamlTab.path()
+      expect(path).toBe('/account/gl/doggo/yaml')
     })
 
-    it('Returns the correct link with nothing passed', () => {
-      expect(hookData.result.current.yamlTab.path()).toBe(
-        '/account/gl/doggo/yaml'
-      )
-    })
     it('can override the params', () => {
-      expect(hookData.result.current.yamlTab.path({ provider: 'bb' })).toBe(
-        '/account/bb/doggo/yaml'
-      )
-      expect(hookData.result.current.yamlTab.path({ owner: 'cat' })).toBe(
-        '/account/gl/cat/yaml'
-      )
+      const { result } = renderHook(() => useNavLinks(), {
+        wrapper: wrapper('/gl/doggo/squirrel-locator'),
+      })
+
+      const path = result.current.yamlTab.path({
+        provider: 'bb',
+        owner: 'test-owner',
+      })
+      expect(path).toBe('/account/bb/test-owner/yaml')
     })
   })
 
   describe('accessTab link', () => {
-    beforeAll(() => {
-      setup(['/gl/doggo/squirrel-locator'])
+    it('returns the correct link with nothing passed', () => {
+      const { result } = renderHook(() => useNavLinks(), {
+        wrapper: wrapper('/gl/doggo/squirrel-locator'),
+      })
+
+      const path = result.current.accessTab.path()
+      expect(path).toBe('/account/gl/doggo/access')
     })
 
-    it('Returns the correct link with nothing passed', () => {
-      expect(hookData.result.current.accessTab.path()).toBe(
-        '/account/gl/doggo/access'
-      )
-    })
     it('can override the params', () => {
-      expect(hookData.result.current.accessTab.path({ provider: 'bb' })).toBe(
-        '/account/bb/doggo/access'
-      )
-      expect(hookData.result.current.accessTab.path({ owner: 'cat' })).toBe(
-        '/account/gl/cat/access'
-      )
+      const { result } = renderHook(() => useNavLinks(), {
+        wrapper: wrapper('/gl/doggo/squirrel-locator'),
+      })
+
+      const path = result.current.accessTab.path({
+        provider: 'bb',
+        owner: 'test-owner',
+      })
+      expect(path).toBe('/account/bb/test-owner/access')
     })
   })
 
   describe('internalAccessTab link', () => {
-    beforeAll(() => {
-      setup(['/gl/doggo/squirrel-locator'])
+    it('returns the correct link with nothing passed', () => {
+      const { result } = renderHook(() => useNavLinks(), {
+        wrapper: wrapper('/gl/doggo/squirrel-locator'),
+      })
+
+      const path = result.current.internalAccessTab.path()
+      expect(path).toBe('/account/gl/doggo/access')
     })
 
-    it('Returns the correct link with nothing passed', () => {
-      expect(hookData.result.current.internalAccessTab.path()).toBe(
-        '/account/gl/doggo/access'
-      )
-    })
     it('can override the params', () => {
-      expect(
-        hookData.result.current.internalAccessTab.path({ provider: 'bb' })
-      ).toBe('/account/bb/doggo/access')
-      expect(
-        hookData.result.current.internalAccessTab.path({ owner: 'cat' })
-      ).toBe('/account/gl/cat/access')
+      const { result } = renderHook(() => useNavLinks(), {
+        wrapper: wrapper('/gl/doggo/squirrel-locator'),
+      })
+
+      const path = result.current.internalAccessTab.path({
+        provider: 'bb',
+        owner: 'test-owner',
+      })
+      expect(path).toBe('/account/bb/test-owner/access')
     })
   })
 
   describe('commits link', () => {
-    beforeAll(() => {
-      setup(['/gl/doggo/squirrel-locator'])
+    it('returns the correct link with nothing passed', () => {
+      const { result } = renderHook(() => useNavLinks(), {
+        wrapper: wrapper('/gl/doggo/squirrel-locator'),
+      })
+
+      const path = result.current.commits.path()
+      expect(path).toBe('/gl/doggo/squirrel-locator/commits')
     })
 
-    it('Returns the correct link with nothing passed', () => {
-      expect(hookData.result.current.commits.path()).toBe(
-        '/gl/doggo/squirrel-locator/commits'
-      )
-    })
     it('can override the params', () => {
-      expect(hookData.result.current.commits.path({ provider: 'bb' })).toBe(
-        '/bb/doggo/squirrel-locator/commits'
-      )
-      expect(hookData.result.current.commits.path({ owner: 'cat' })).toBe(
-        '/gl/cat/squirrel-locator/commits'
-      )
-      expect(hookData.result.current.commits.path({ repo: 'test' })).toBe(
-        '/gl/doggo/test/commits'
-      )
+      const { result } = renderHook(() => useNavLinks(), {
+        wrapper: wrapper('/gl/doggo/squirrel-locator'),
+      })
+
+      const path = result.current.commits.path({
+        provider: 'bb',
+        owner: 'test-owner',
+        repo: 'test-repo',
+      })
+      expect(path).toBe('/bb/test-owner/test-repo/commits')
     })
   })
 
   describe('commitFile link', () => {
-    beforeAll(() => {
-      setup(['/gh/test/test-repo/commit/abcd/index.js'])
+    it('returns the correct link with nothing passed', () => {
+      const { result } = renderHook(() => useNavLinks(), {
+        wrapper: wrapper('/gh/test/test-repo/commit/abcd/index.js'),
+      })
+
+      const path = result.current.commitFile.path({
+        commit: 'abcd',
+        path: 'index.js',
+      })
+      expect(path).toBe('/gh/test/test-repo/commit/abcd/index.js')
     })
 
-    it('Returns the correct link with nothing passed', () => {
-      expect(
-        hookData.result.current.commitFile.path({
-          commit: 'abcd',
-          path: 'index.js',
-        })
-      ).toBe('/gh/test/test-repo/commit/abcd/index.js')
-    })
     it('can override the params', () => {
-      expect(
-        hookData.result.current.commitFile.path({
-          provider: 'bb',
-          commit: 'abcd',
-          path: 'index.js',
-        })
-      ).toBe('/bb/test/test-repo/commit/abcd/index.js')
-      expect(
-        hookData.result.current.commitFile.path({
-          owner: 'cat',
-          commit: 'abcd',
-          path: 'index.js',
-        })
-      ).toBe('/gh/cat/test-repo/commit/abcd/index.js')
-      expect(
-        hookData.result.current.commitFile.path({
-          repo: 'test',
-          commit: 'abcd',
-          path: 'index.js',
-        })
-      ).toBe('/gh/test/test/commit/abcd/index.js')
+      const { result } = renderHook(() => useNavLinks(), {
+        wrapper: wrapper('/gh/test/test-repo/commit/abcd/index.js'),
+      })
+
+      const path = result.current.commitFile.path({
+        provider: 'bb',
+        owner: 'test-owner',
+        repo: 'test',
+        commit: 'abcd',
+        path: 'index.js',
+      })
+      expect(path).toBe('/bb/test-owner/test/commit/abcd/index.js')
     })
   })
 
   describe('treeView link', () => {
-    beforeAll(() => {
-      setup(['/gl/doggo/watch/src/view/catWatch.php'])
+    it('returns the correct link with nothing passed', () => {
+      const { result } = renderHook(() => useNavLinks(), {
+        wrapper: wrapper('/gl/doggo/watch/src/view/catWatch.php'),
+      })
+
+      const path = result.current.treeView.path()
+      expect(path).toBe('/gl/doggo/watch/tree/')
     })
 
-    it('Returns the correct link with nothing passed', () => {
-      expect(hookData.result.current.treeView.path()).toBe(
-        '/gl/doggo/watch/tree/'
-      )
-    })
     it('can override the params', () => {
-      expect(hookData.result.current.treeView.path({ provider: 'bb' })).toBe(
-        '/bb/doggo/watch/tree/'
-      )
-      expect(hookData.result.current.treeView.path({ owner: 'cat' })).toBe(
-        '/gl/cat/watch/tree/'
-      )
-      expect(hookData.result.current.treeView.path({ repo: 'sleep' })).toBe(
-        '/gl/doggo/sleep/tree/'
-      )
+      const { result } = renderHook(() => useNavLinks(), {
+        wrapper: wrapper('/gl/doggo/watch/src/view/catWatch.php'),
+      })
+
+      const path = result.current.treeView.path({
+        provider: 'bb',
+        owner: 'test-owner',
+        repo: 'test-repo',
+      })
+      expect(path).toBe('/bb/test-owner/test-repo/tree/')
     })
+
     it('accepts a ref option', () => {
-      expect(
-        hookData.result.current.treeView.path({
-          ref: 'main',
-        })
-      ).toBe('/gl/doggo/watch/tree/main/')
+      const { result } = renderHook(() => useNavLinks(), {
+        wrapper: wrapper('/gl/doggo/watch/src/view/catWatch.php'),
+      })
+
+      const path = result.current.treeView.path({
+        ref: 'main',
+      })
+      expect(path).toBe('/gl/doggo/watch/tree/main/')
     })
+
     it('accepts a tree option', () => {
-      expect(
-        hookData.result.current.treeView.path({
-          tree: 'src/view/catWatch.php',
-          ref: 'ref',
-        })
-      ).toBe('/gl/doggo/watch/tree/ref/src%2Fview%2FcatWatch.php')
-      expect(
-        hookData.result.current.treeView.path({ tree: 'src', ref: 'ref' })
-      ).toBe('/gl/doggo/watch/tree/ref/src')
-      expect(
-        hookData.result.current.treeView.path({
-          tree: 'src/view',
-          ref: 'ref',
-        })
-      ).toBe('/gl/doggo/watch/tree/ref/src%2Fview')
+      const { result } = renderHook(() => useNavLinks(), {
+        wrapper: wrapper('/gl/doggo/watch/src/view/catWatch.php'),
+      })
+
+      const filePath = result.current.treeView.path({
+        tree: 'src/view/catWatch.php',
+        ref: 'ref',
+      })
+      expect(filePath).toBe(
+        '/gl/doggo/watch/tree/ref/src%2Fview%2FcatWatch.php'
+      )
+
+      const topLevelDirPath = result.current.treeView.path({
+        tree: 'src',
+        ref: 'ref',
+      })
+      expect(topLevelDirPath).toBe('/gl/doggo/watch/tree/ref/src')
+
+      const dirPath = result.current.treeView.path({
+        tree: 'src/view',
+        ref: 'ref',
+      })
+      expect(dirPath).toBe('/gl/doggo/watch/tree/ref/src%2Fview')
     })
   })
 
   describe('fileViewer link', () => {
-    beforeAll(() => {
-      setup(['/gh/codecov-owner/another-test/blob/main/index.js'])
-    })
+    it('returns the correct link with nothing passed', () => {
+      const { result } = renderHook(() => useNavLinks(), {
+        wrapper: wrapper('/gh/codecov-owner/another-test/blob/main/index.js'),
+      })
 
-    it('Returns the correct link with nothing passed', () => {
-      expect(
-        hookData.result.current.fileViewer.path({
-          ref: 'main',
-          tree: 'index.js',
-        })
-      ).toBe('/gh/codecov-owner/another-test/blob/main/index.js')
+      const path = result.current.fileViewer.path({
+        ref: 'main',
+        tree: 'index.js',
+      })
+      expect(path).toBe('/gh/codecov-owner/another-test/blob/main/index.js')
     })
 
     it('can override the params', () => {
-      expect(
-        hookData.result.current.fileViewer.path({
-          provider: 'bb',
-          ref: 'main',
-          tree: 'index.js',
-        })
-      ).toBe('/bb/codecov-owner/another-test/blob/main/index.js')
+      const { result } = renderHook(() => useNavLinks(), {
+        wrapper: wrapper('/gh/codecov-owner/another-test/blob/main/index.js'),
+      })
 
-      expect(
-        hookData.result.current.fileViewer.path({
-          owner: 'cat',
-          ref: 'main',
-          tree: 'index.js',
-        })
-      ).toBe('/gh/cat/another-test/blob/main/index.js')
+      const path1 = result.current.fileViewer.path({
+        provider: 'bb',
+        ref: 'main',
+        tree: 'index.js',
+      })
+      expect(path1).toBe('/bb/codecov-owner/another-test/blob/main/index.js')
 
-      expect(
-        hookData.result.current.fileViewer.path({
-          ref: 'main',
-          tree: 'flags1/mafs.js',
-        })
-      ).toBe('/gh/codecov-owner/another-test/blob/main/flags1%2Fmafs.js')
+      const path2 = result.current.fileViewer.path({
+        owner: 'test-owner',
+        ref: 'main',
+        tree: 'index.js',
+      })
+      expect(path2).toBe('/gh/test-owner/another-test/blob/main/index.js')
 
-      expect(
-        hookData.result.current.fileViewer.path({
-          ref: 'test-br',
-          tree: 'index.js',
-        })
-      ).toBe('/gh/codecov-owner/another-test/blob/test-br/index.js')
+      const path3 = result.current.fileViewer.path({
+        ref: 'main',
+        tree: 'flags1/mafs.js',
+      })
+      expect(path3).toBe(
+        '/gh/codecov-owner/another-test/blob/main/flags1%2Fmafs.js'
+      )
+
+      const path4 = result.current.fileViewer.path({
+        ref: 'test-br',
+        tree: 'index.js',
+      })
+      expect(path4).toBe('/gh/codecov-owner/another-test/blob/test-br/index.js')
     })
   })
 
   describe('commitTreeView link', () => {
-    beforeAll(() => {
-      setup(['/gl/doggo/watch/src/view/catWatch.php'])
-    })
+    it('returns the correct link with only commit passed', () => {
+      const { result } = renderHook(() => useNavLinks(), {
+        wrapper: wrapper('/gl/doggo/watch/src/view/catWatch.php'),
+      })
 
-    it('Returns the correct link with only commit passed', () => {
-      expect(
-        hookData.result.current.commitTreeView.path({ commit: 'sha256' })
-      ).toBe('/gl/doggo/watch/commit/sha256/tree')
+      const path = result.current.commitTreeView.path({ commit: 'sha256' })
+      expect(path).toBe('/gl/doggo/watch/commit/sha256/tree')
     })
 
     it('can override the params', () => {
-      expect(
-        hookData.result.current.commitTreeView.path({
-          provider: 'bb',
-          commit: 'sha256',
-        })
-      ).toBe('/bb/doggo/watch/commit/sha256/tree')
-      expect(
-        hookData.result.current.commitTreeView.path({
-          owner: 'cat',
-          commit: 'sha256',
-        })
-      ).toBe('/gl/cat/watch/commit/sha256/tree')
-      expect(
-        hookData.result.current.commitTreeView.path({
-          repo: 'sleep',
-          commit: 'sha256',
-        })
-      ).toBe('/gl/doggo/sleep/commit/sha256/tree')
+      const { result } = renderHook(() => useNavLinks(), {
+        wrapper: wrapper('/gl/doggo/watch/src/view/catWatch.php'),
+      })
+
+      const path = result.current.commitTreeView.path({
+        provider: 'bb',
+        commit: 'sha256',
+      })
+      expect(path).toBe('/bb/doggo/watch/commit/sha256/tree')
     })
 
     it('accepts a commit option', () => {
-      expect(
-        hookData.result.current.commitTreeView.path({
-          commit: 'sha256',
-        })
-      ).toBe('/gl/doggo/watch/commit/sha256/tree')
+      const { result } = renderHook(() => useNavLinks(), {
+        wrapper: wrapper('/gl/doggo/watch/src/view/catWatch.php'),
+      })
+
+      const path = result.current.commitTreeView.path({
+        commit: 'sha256',
+      })
+      expect(path).toBe('/gl/doggo/watch/commit/sha256/tree')
     })
 
     it('accepts a tree option', () => {
-      expect(
-        hookData.result.current.commitTreeView.path({
-          tree: 'src/view/catWatch.php',
-          commit: 'sha128',
-        })
-      ).toBe('/gl/doggo/watch/commit/sha128/tree/src/view/catWatch.php')
+      const { result } = renderHook(() => useNavLinks(), {
+        wrapper: wrapper('/gl/doggo/watch/src/view/catWatch.php'),
+      })
 
-      expect(
-        hookData.result.current.commitTreeView.path({
-          tree: 'src',
-          commit: 'sha128',
-        })
-      ).toBe('/gl/doggo/watch/commit/sha128/tree/src')
+      const filePath = result.current.commitTreeView.path({
+        tree: 'src/view/catWatch.php',
+        commit: 'sha128',
+      })
+      expect(filePath).toBe(
+        '/gl/doggo/watch/commit/sha128/tree/src/view/catWatch.php'
+      )
 
-      expect(
-        hookData.result.current.commitTreeView.path({
-          tree: 'src/view',
-          commit: 'sha128',
-        })
-      ).toBe('/gl/doggo/watch/commit/sha128/tree/src/view')
+      const rootPath = result.current.commitTreeView.path({
+        tree: 'src',
+        commit: 'sha128',
+      })
+      expect(rootPath).toBe('/gl/doggo/watch/commit/sha128/tree/src')
+
+      const subPath = result.current.commitTreeView.path({
+        tree: 'src/view',
+        commit: 'sha128',
+      })
+      expect(subPath).toBe('/gl/doggo/watch/commit/sha128/tree/src/view')
     })
   })
 
   describe('commitFileDiff link', () => {
-    beforeAll(() => {
-      setup(['/gh/codecov-owner/another-test/blob/main/index.js'])
-    })
+    it('returns the correct link with nothing passed', () => {
+      const { result } = renderHook(() => useNavLinks(), {
+        wrapper: wrapper('/gh/codecov-owner/another-test/blob/main/index.js'),
+      })
 
-    it('Returns the correct link with nothing passed', () => {
-      expect(
-        hookData.result.current.commitFileDiff.path({
-          commit: 'sha256',
-          tree: 'index.js',
-        })
-      ).toBe('/gh/codecov-owner/another-test/commit/sha256/blob/index.js')
+      const path = result.current.commitFileDiff.path({
+        commit: 'sha256',
+        tree: 'index.js',
+      })
+      expect(path).toBe(
+        '/gh/codecov-owner/another-test/commit/sha256/blob/index.js'
+      )
     })
 
     it('can override the params', () => {
-      expect(
-        hookData.result.current.commitFileDiff.path({
-          provider: 'bb',
-          commit: 'sha256',
-          tree: 'index.js',
-        })
-      ).toBe('/bb/codecov-owner/another-test/commit/sha256/blob/index.js')
+      const { result } = renderHook(() => useNavLinks(), {
+        wrapper: wrapper('/gh/codecov-owner/another-test/blob/main/index.js'),
+      })
 
-      expect(
-        hookData.result.current.commitFileDiff.path({
-          owner: 'cat',
-          commit: 'sha256',
-          tree: 'index.js',
-        })
-      ).toBe('/gh/cat/another-test/commit/sha256/blob/index.js')
-
-      expect(
-        hookData.result.current.commitFileDiff.path({
-          repo: 'cool-new-repo',
-          commit: 'sha256',
-          tree: 'flags1/mafs.js',
-        })
-      ).toBe(
-        '/gh/codecov-owner/cool-new-repo/commit/sha256/blob/flags1/mafs.js'
+      const path = result.current.commitFileDiff.path({
+        provider: 'bb',
+        owner: 'test-owner',
+        repo: 'test-repo',
+        commit: 'sha256',
+        tree: 'flags1/mafs.js',
+      })
+      expect(path).toBe(
+        '/bb/test-owner/test-repo/commit/sha256/blob/flags1/mafs.js'
       )
     })
   })
 
   describe('repo overview link', () => {
-    beforeAll(() => {
-      setup(['/gh/RulaKhaled/test'])
+    it('returns the correct link with nothing passed', () => {
+      const { result } = renderHook(() => useNavLinks(), {
+        wrapper: wrapper('/gh/codecov/test'),
+      })
+
+      const path = result.current.overview.path()
+      expect(path).toBe('/gh/codecov/test')
     })
 
-    it('Returns the correct link with nothing passed', () => {
-      expect(hookData.result.current.overview.path()).toBe(
-        '/gh/RulaKhaled/test'
-      )
-    })
     it('can override the params', () => {
-      expect(hookData.result.current.overview.path({ provider: 'bb' })).toBe(
-        '/bb/RulaKhaled/test'
-      )
-      expect(hookData.result.current.overview.path({ owner: 'cat' })).toBe(
-        '/gh/cat/test'
-      )
+      const { result } = renderHook(() => useNavLinks(), {
+        wrapper: wrapper('/gh/codecov/test'),
+      })
+
+      const path = result.current.overview.path({
+        provider: 'bb',
+        owner: 'test-owner',
+      })
+      expect(path).toBe('/bb/test-owner/test')
     })
   })
 
   describe('repo flags tab link', () => {
-    beforeAll(() => {
-      setup(['/gh/codecov/gazebo/flags'])
+    it('returns the correct link with nothing passed', () => {
+      const { result } = renderHook(() => useNavLinks(), {
+        wrapper: wrapper('/gh/codecov/gazebo/flags'),
+      })
+
+      const path = result.current.flagsTab.path()
+      expect(path).toBe('/gh/codecov/gazebo/flags')
     })
 
-    it('Returns the correct link with nothing passed', () => {
-      expect(hookData.result.current.flagsTab.path()).toBe(
-        '/gh/codecov/gazebo/flags'
-      )
-    })
     it('can override the params', () => {
-      expect(hookData.result.current.flagsTab.path({ provider: 'bb' })).toBe(
-        '/bb/codecov/gazebo/flags'
-      )
-      expect(hookData.result.current.flagsTab.path({ owner: 'cat' })).toBe(
-        '/gh/cat/gazebo/flags'
-      )
+      const { result } = renderHook(() => useNavLinks(), {
+        wrapper: wrapper('/gh/codecov/gazebo/flags'),
+      })
+
+      const path = result.current.flagsTab.path({
+        provider: 'bb',
+        owner: 'test-owner',
+      })
+      expect(path).toBe('/bb/test-owner/gazebo/flags')
     })
   })
 
   describe('repo branches link', () => {
-    beforeAll(() => {
-      setup(['/gh/RulaKhaled/test/branches'])
+    it('returns the correct link with nothing passed', () => {
+      const { result } = renderHook(() => useNavLinks(), {
+        wrapper: wrapper('/gh/codecov/test/branches'),
+      })
+
+      const path = result.current.branches.path()
+      expect(path).toBe('/gh/codecov/test/branches')
     })
 
-    it('Returns the correct link with nothing passed', () => {
-      expect(hookData.result.current.branches.path()).toBe(
-        '/gh/RulaKhaled/test/branches'
-      )
-    })
     it('can override the params', () => {
-      expect(hookData.result.current.branches.path({ provider: 'bb' })).toBe(
-        '/bb/RulaKhaled/test/branches'
-      )
-      expect(hookData.result.current.branches.path({ owner: 'cat' })).toBe(
-        '/gh/cat/test/branches'
-      )
+      const { result } = renderHook(() => useNavLinks(), {
+        wrapper: wrapper('/gh/codecov/test/branches'),
+      })
+
+      const path = result.current.branches.path({
+        provider: 'bb',
+        owner: 'test-owner',
+      })
+      expect(path).toBe('/bb/test-owner/test/branches')
     })
   })
 
   describe('repo pulls link', () => {
-    beforeAll(() => {
-      setup(['/gh/RulaKhaled/test/pulls'])
+    it('returns the correct link with nothing passed', () => {
+      const { result } = renderHook(() => useNavLinks(), {
+        wrapper: wrapper('/gh/codecov/test/pulls'),
+      })
+
+      const path = result.current.pulls.path()
+      expect(path).toBe('/gh/codecov/test/pulls')
     })
 
-    it('Returns the correct link with nothing passed', () => {
-      expect(hookData.result.current.pulls.path()).toBe(
-        '/gh/RulaKhaled/test/pulls'
-      )
-    })
     it('can override the params', () => {
-      expect(hookData.result.current.pulls.path({ provider: 'bb' })).toBe(
-        '/bb/RulaKhaled/test/pulls'
-      )
-      expect(hookData.result.current.pulls.path({ repo: 'cat' })).toBe(
-        '/gh/RulaKhaled/cat/pulls'
-      )
+      const { result } = renderHook(() => useNavLinks(), {
+        wrapper: wrapper('/gh/codecov/test/pulls'),
+      })
+
+      const path = result.current.pulls.path({
+        provider: 'bb',
+        owner: 'test-owner',
+        repo: 'test-repo',
+      })
+      expect(path).toBe('/bb/test-owner/test-repo/pulls')
     })
   })
 
   describe('repo settings link', () => {
-    beforeAll(() => {
-      setup(['/gh/RulaKhaled/test/settings'])
+    it('returns the correct link with nothing passed', () => {
+      const { result } = renderHook(() => useNavLinks(), {
+        wrapper: wrapper('/gh/codecov/test/settings'),
+      })
+
+      const path = result.current.settings.path()
+      expect(path).toBe('/gh/codecov/test/settings')
     })
 
-    it('Returns the correct link with nothing passed', () => {
-      expect(hookData.result.current.settings.path()).toBe(
-        '/gh/RulaKhaled/test/settings'
-      )
-    })
     it('can override the params', () => {
-      expect(hookData.result.current.settings.path({ provider: 'bb' })).toBe(
-        '/bb/RulaKhaled/test/settings'
-      )
-      expect(hookData.result.current.settings.path({ repo: 'cat' })).toBe(
-        '/gh/RulaKhaled/cat/settings'
-      )
+      const { result } = renderHook(() => useNavLinks(), {
+        wrapper: wrapper('/gh/codecov/test/pulls'),
+      })
+
+      const path = result.current.settings.path({
+        provider: 'bb',
+        owner: 'test-owner',
+        repo: 'test-repo',
+      })
+      expect(path).toBe('/bb/test-owner/test-repo/settings')
     })
   })
 
   describe('repo new link', () => {
-    beforeAll(() => {
-      setup(['/gh/RulaKhaled/test/new'])
+    it('returns the correct link with nothing passed', () => {
+      const { result } = renderHook(() => useNavLinks(), {
+        wrapper: wrapper('/gh/codecov/test/new'),
+      })
+
+      const path = result.current.new.path()
+      expect(path).toBe('/gh/codecov/test/new')
     })
 
-    it('Returns the correct link with nothing passed', () => {
-      expect(hookData.result.current.new.path()).toBe('/gh/RulaKhaled/test/new')
-    })
     it('can override the params', () => {
-      expect(hookData.result.current.new.path({ provider: 'bb' })).toBe(
-        '/bb/RulaKhaled/test/new'
-      )
-      expect(hookData.result.current.new.path({ repo: 'cat' })).toBe(
-        '/gh/RulaKhaled/cat/new'
-      )
+      const { result } = renderHook(() => useNavLinks(), {
+        wrapper: wrapper('/gh/codecov/test/pulls'),
+      })
+
+      const path = result.current.new.path({
+        provider: 'bb',
+        owner: 'test-owner',
+        repo: 'test-repo',
+      })
+      expect(path).toBe('/bb/test-owner/test-repo/new')
     })
   })
 
   describe('repo new other link', () => {
-    beforeAll(() => {
-      setup(['/gh/RulaKhaled/test/new/other'])
+    it('returns the correct link with nothing passed', () => {
+      const { result } = renderHook(() => useNavLinks(), {
+        wrapper: wrapper('/gh/codecov/test/new/other'),
+      })
+
+      const path = result.current.newOtherCI.path()
+      expect(path).toBe('/gh/codecov/test/new/other-ci')
     })
 
-    it('Returns the correct link with nothing passed', () => {
-      expect(hookData.result.current.newOtherCI.path()).toBe(
-        '/gh/RulaKhaled/test/new/other-ci'
-      )
-    })
     it('can override the params', () => {
-      expect(hookData.result.current.newOtherCI.path({ provider: 'bb' })).toBe(
-        '/bb/RulaKhaled/test/new/other-ci'
-      )
-      expect(hookData.result.current.newOtherCI.path({ repo: 'cat' })).toBe(
-        '/gh/RulaKhaled/cat/new/other-ci'
-      )
+      const { result } = renderHook(() => useNavLinks(), {
+        wrapper: wrapper('/gh/codecov/test/new/other'),
+      })
+
+      const path = result.current.newOtherCI.path({
+        provider: 'bb',
+        owner: 'test-owner',
+        repo: 'test-repo',
+      })
+      expect(path).toBe('/bb/test-owner/test-repo/new/other-ci')
     })
   })
 
   describe('repo new circle ci link', () => {
-    beforeAll(() => {
-      setup(['/gh/RulaKhaled/test/new/circle-ci'])
+    it('returns the correct link with nothing passed', () => {
+      const { result } = renderHook(() => useNavLinks(), {
+        wrapper: wrapper('/gh/codecov/test/new/circle-ci'),
+      })
+
+      const path = result.current.circleCI.path()
+      expect(path).toBe('/gh/codecov/test/new/circle-ci')
     })
 
-    it('Returns the correct link with nothing passed', () => {
-      expect(hookData.result.current.circleCI.path()).toBe(
-        '/gh/RulaKhaled/test/new/circle-ci'
-      )
-    })
     it('can override the params', () => {
-      expect(hookData.result.current.circleCI.path({ provider: 'bb' })).toBe(
-        '/bb/RulaKhaled/test/new/circle-ci'
-      )
-      expect(hookData.result.current.circleCI.path({ repo: 'cat' })).toBe(
-        '/gh/RulaKhaled/cat/new/circle-ci'
-      )
+      const { result } = renderHook(() => useNavLinks(), {
+        wrapper: wrapper('/gh/codecov/test/new/circle-ci'),
+      })
+
+      const path = result.current.circleCI.path({
+        provider: 'bb',
+        owner: 'test-owner',
+        repo: 'test-repo',
+      })
+
+      expect(path).toBe('/bb/test-owner/test-repo/new/circle-ci')
     })
   })
 
   describe('general repo settings link', () => {
-    beforeAll(() => {
-      setup(['/gh/RulaKhaled/test/settings'])
+    it('returns the correct link with nothing passed', () => {
+      const { result } = renderHook(() => useNavLinks(), {
+        wrapper: wrapper('/gh/codecov/test/settings'),
+      })
+
+      const path = result.current.settingsGeneral.path()
+      expect(path).toBe('/gh/codecov/test/settings')
     })
 
-    it('Returns the correct link with nothing passed', () => {
-      expect(hookData.result.current.settingsGeneral.path()).toBe(
-        '/gh/RulaKhaled/test/settings'
-      )
-    })
     it('can override the params', () => {
-      expect(
-        hookData.result.current.settingsGeneral.path({ provider: 'bb' })
-      ).toBe('/bb/RulaKhaled/test/settings')
-      expect(
-        hookData.result.current.settingsGeneral.path({ repo: 'cat' })
-      ).toBe('/gh/RulaKhaled/cat/settings')
+      const { result } = renderHook(() => useNavLinks(), {
+        wrapper: wrapper('/gh/codecov/test/settings'),
+      })
+
+      const path = result.current.settingsGeneral.path({
+        provider: 'bb',
+        owner: 'test-owner',
+        repo: 'test-repo',
+      })
+      expect(path).toBe('/bb/test-owner/test-repo/settings')
     })
   })
 
   describe('repo yaml link', () => {
-    beforeAll(() => {
-      setup(['/gh/RulaKhaled/test/settings/yaml'])
+    it('returns the correct link with nothing passed', () => {
+      const { result } = renderHook(() => useNavLinks(), {
+        wrapper: wrapper('/gh/codecov/test/settings/yaml'),
+      })
+
+      const path = result.current.settingsYaml.path()
+      expect(path).toBe('/gh/codecov/test/settings/yaml')
     })
 
-    it('Returns the correct link with nothing passed', () => {
-      expect(hookData.result.current.settingsYaml.path()).toBe(
-        '/gh/RulaKhaled/test/settings/yaml'
-      )
-    })
     it('can override the params', () => {
-      expect(
-        hookData.result.current.settingsYaml.path({ provider: 'bb' })
-      ).toBe('/bb/RulaKhaled/test/settings/yaml')
-      expect(hookData.result.current.settingsYaml.path({ repo: 'cat' })).toBe(
-        '/gh/RulaKhaled/cat/settings/yaml'
-      )
+      const { result } = renderHook(() => useNavLinks(), {
+        wrapper: wrapper('/gh/codecov/test/settings/yaml'),
+      })
+
+      const path = result.current.settingsYaml.path({
+        provider: 'bb',
+        owner: 'test-owner',
+        repo: 'test-repo',
+      })
+      expect(path).toBe('/bb/test-owner/test-repo/settings/yaml')
     })
   })
 
   describe('badge repo settings link', () => {
-    beforeAll(() => {
-      setup(['/gh/RulaKhaled/test/settings/badge'])
+    it('returns the correct link with nothing passed', () => {
+      const { result } = renderHook(() => useNavLinks(), {
+        wrapper: wrapper('/gh/codecov/test/settings/badge'),
+      })
+
+      const path = result.current.settingsBadge.path()
+      expect(path).toBe('/gh/codecov/test/settings/badge')
     })
 
-    it('Returns the correct link with nothing passed', () => {
-      expect(hookData.result.current.settingsBadge.path()).toBe(
-        '/gh/RulaKhaled/test/settings/badge'
-      )
-    })
     it('can override the params', () => {
-      expect(
-        hookData.result.current.settingsBadge.path({ provider: 'bb' })
-      ).toBe('/bb/RulaKhaled/test/settings/badge')
-      expect(hookData.result.current.settingsBadge.path({ repo: 'cat' })).toBe(
-        '/gh/RulaKhaled/cat/settings/badge'
-      )
+      const { result } = renderHook(() => useNavLinks(), {
+        wrapper: wrapper('/gh/codecov/test/settings/badge'),
+      })
+
+      const path = result.current.settingsBadge.path({
+        provider: 'bb',
+        owner: 'test-owner',
+        repo: 'test-repo',
+      })
+      expect(path).toBe('/bb/test-owner/test-repo/settings/badge')
     })
   })
 
@@ -893,9 +1007,6 @@ describe('useNavLinks', () => {
         'utmParams',
         'utm_source=a&utm_medium=b&utm_campaign=c&utm_term=d&utm_content=e'
       )
-      setup([
-        '/gh?utm_source=a&utm_medium=b&utm_campaign=c&utm_term=d&utm_content=e&not=f',
-      ])
     })
 
     afterEach(() => {
@@ -903,9 +1014,14 @@ describe('useNavLinks', () => {
     })
 
     it('returns the correct url', () => {
-      expect(
-        hookData.result.current.signUp.path({ pathname: 'random/path/name' })
-      ).toBe(
+      const { result } = renderHook(() => useNavLinks(), {
+        wrapper: wrapper(
+          '/gh?utm_source=a&utm_medium=b&utm_campaign=c&utm_term=d&utm_content=e&not=f'
+        ),
+      })
+
+      const path = result.current.signUp.path({ pathname: 'random/path/name' })
+      expect(path).toBe(
         config.MARKETING_BASE_URL +
           '/sign-up/?utm_source=a&utm_medium=b&utm_campaign=c&utm_term=d&utm_content=e'
       )
@@ -913,327 +1029,337 @@ describe('useNavLinks', () => {
   })
 
   describe('pull detail', () => {
-    beforeAll(() => {
-      setup(['/gl/doggo/squirrel-locator/pull/409'])
+    it('returns the correct link with nothing passed', () => {
+      const { result } = renderHook(() => useNavLinks(), {
+        wrapper: wrapper('/gl/doggo/squirrel-locator/pull/409'),
+      })
+
+      const path = result.current.pullDetail.path()
+      expect(path).toBe('/gl/doggo/squirrel-locator/pull/409')
     })
 
-    it('Returns the correct link with nothing passed', () => {
-      expect(hookData.result.current.pullDetail.path()).toBe(
-        `/gl/doggo/squirrel-locator/pull/409`
-      )
-    })
     it('can override the params', () => {
-      expect(hookData.result.current.pullDetail.path({ provider: 'bb' })).toBe(
-        `/bb/doggo/squirrel-locator/pull/409`
-      )
-      expect(hookData.result.current.pullDetail.path({ owner: 'cat' })).toBe(
-        `/gl/cat/squirrel-locator/pull/409`
-      )
-      expect(
-        hookData.result.current.pullDetail.path({ repo: 'tennis-ball' })
-      ).toBe(`/gl/doggo/tennis-ball/pull/409`)
-      expect(hookData.result.current.pullDetail.path({ pullId: 888 })).toBe(
-        `/gl/doggo/squirrel-locator/pull/888`
-      )
+      const { result } = renderHook(() => useNavLinks(), {
+        wrapper: wrapper('/gl/doggo/squirrel-locator/pull/409'),
+      })
+
+      const path = result.current.pullDetail.path({
+        provider: 'bb',
+        owner: 'test-owner',
+        repo: 'test-repo',
+        pullId: 123,
+      })
+      expect(path).toBe('/bb/test-owner/test-repo/pull/123')
     })
   })
 
   describe('pull commits', () => {
-    beforeAll(() => {
-      setup(['/gl/doggo/squirrel-locator/pull/409/commits'])
+    it('returns the correct link with nothing passed', () => {
+      const { result } = renderHook(() => useNavLinks(), {
+        wrapper: wrapper('/gl/doggo/squirrel-locator/pull/409/commits'),
+      })
+
+      const path = result.current.pullCommits.path()
+      expect(path).toBe('/gl/doggo/squirrel-locator/pull/409/commits')
     })
 
-    it('Returns the correct link with nothing passed', () => {
-      expect(hookData.result.current.pullCommits.path()).toBe(
-        `/gl/doggo/squirrel-locator/pull/409/commits`
-      )
-    })
     it('can override the params', () => {
-      expect(hookData.result.current.pullCommits.path({ provider: 'bb' })).toBe(
-        `/bb/doggo/squirrel-locator/pull/409/commits`
-      )
-      expect(hookData.result.current.pullCommits.path({ owner: 'cat' })).toBe(
-        `/gl/cat/squirrel-locator/pull/409/commits`
-      )
-      expect(
-        hookData.result.current.pullCommits.path({ repo: 'tennis-ball' })
-      ).toBe(`/gl/doggo/tennis-ball/pull/409/commits`)
-      expect(hookData.result.current.pullCommits.path({ pullId: 888 })).toBe(
-        `/gl/doggo/squirrel-locator/pull/888/commits`
-      )
+      const { result } = renderHook(() => useNavLinks(), {
+        wrapper: wrapper('/gl/doggo/squirrel-locator/pull/409/commits'),
+      })
+
+      const path = result.current.pullCommits.path({
+        provider: 'bb',
+        owner: 'test-owner',
+        repo: 'test-repo',
+        pullId: 123,
+      })
+      expect(path).toBe('/bb/test-owner/test-repo/pull/123/commits')
     })
   })
 
   describe('pull flags', () => {
-    beforeAll(() => {
-      setup(['/gl/doggo/squirrel-locator/pull/409/flags'])
+    it('returns the correct link with nothing passed', () => {
+      const { result } = renderHook(() => useNavLinks(), {
+        wrapper: wrapper('/gl/doggo/squirrel-locator/pull/409/flags'),
+      })
+
+      const path = result.current.pullFlags.path()
+      expect(path).toBe('/gl/doggo/squirrel-locator/pull/409/flags')
     })
 
-    it('Returns the correct link with nothing passed', () => {
-      expect(hookData.result.current.pullFlags.path()).toBe(
-        `/gl/doggo/squirrel-locator/pull/409/flags`
-      )
-    })
     it('can override the params', () => {
-      expect(hookData.result.current.pullFlags.path({ provider: 'bb' })).toBe(
-        `/bb/doggo/squirrel-locator/pull/409/flags`
-      )
-      expect(hookData.result.current.pullFlags.path({ owner: 'cat' })).toBe(
-        `/gl/cat/squirrel-locator/pull/409/flags`
-      )
-      expect(
-        hookData.result.current.pullFlags.path({ repo: 'tennis-ball' })
-      ).toBe(`/gl/doggo/tennis-ball/pull/409/flags`)
-      expect(hookData.result.current.pullFlags.path({ pullId: 888 })).toBe(
-        `/gl/doggo/squirrel-locator/pull/888/flags`
-      )
+      const { result } = renderHook(() => useNavLinks(), {
+        wrapper: wrapper('/gl/doggo/squirrel-locator/pull/409/flags'),
+      })
+
+      const path = result.current.pullFlags.path({
+        provider: 'bb',
+        owner: 'test-owner',
+        repo: 'test-repo',
+        pullId: 123,
+      })
+      expect(path).toBe('/bb/test-owner/test-repo/pull/123/flags')
     })
   })
 
   describe('pull components', () => {
-    beforeAll(() => {
-      setup(['/gl/doggo/squirrel-locator/pull/409/components'])
+    it('returns the correct link with nothing passed', () => {
+      const { result } = renderHook(() => useNavLinks(), {
+        wrapper: wrapper('/gl/doggo/squirrel-locator/pull/409/components'),
+      })
+
+      const path = result.current.pullComponents.path()
+      expect(path).toBe('/gl/doggo/squirrel-locator/pull/409/components')
     })
 
-    it('Returns the correct link with nothing passed', () => {
-      expect(hookData.result.current.pullComponents.path()).toBe(
-        `/gl/doggo/squirrel-locator/pull/409/components`
-      )
-    })
     it('can override the params', () => {
-      expect(
-        hookData.result.current.pullComponents.path({ provider: 'bb' })
-      ).toBe(`/bb/doggo/squirrel-locator/pull/409/components`)
-      expect(
-        hookData.result.current.pullComponents.path({ owner: 'cat' })
-      ).toBe(`/gl/cat/squirrel-locator/pull/409/components`)
-      expect(
-        hookData.result.current.pullComponents.path({ repo: 'tennis-ball' })
-      ).toBe(`/gl/doggo/tennis-ball/pull/409/components`)
-      expect(hookData.result.current.pullComponents.path({ pullId: 888 })).toBe(
-        `/gl/doggo/squirrel-locator/pull/888/components`
-      )
+      const { result } = renderHook(() => useNavLinks(), {
+        wrapper: wrapper('/gl/doggo/squirrel-locator/pull/409/components'),
+      })
+
+      const path = result.current.pullComponents.path({
+        provider: 'bb',
+        owner: 'test-owner',
+        repo: 'test-repo',
+        pullId: 888,
+      })
+      expect(path).toBe('/bb/test-owner/test-repo/pull/888/components')
     })
   })
 
   describe('pull indirect changes', () => {
-    beforeAll(() => {
-      setup(['/gl/doggo/squirrel-locator/pull/409/indirect-changes'])
+    it('returns the correct link with nothing passed', () => {
+      const { result } = renderHook(() => useNavLinks(), {
+        wrapper: wrapper(
+          '/gl/doggo/squirrel-locator/pull/409/indirect-changes'
+        ),
+      })
+
+      const path = result.current.pullIndirectChanges.path()
+      expect(path).toBe('/gl/doggo/squirrel-locator/pull/409/indirect-changes')
     })
 
-    it('Returns the correct link with nothing passed', () => {
-      expect(hookData.result.current.pullIndirectChanges.path()).toBe(
-        `/gl/doggo/squirrel-locator/pull/409/indirect-changes`
-      )
-    })
     it('can override the params', () => {
-      expect(
-        hookData.result.current.pullIndirectChanges.path({ provider: 'bb' })
-      ).toBe(`/bb/doggo/squirrel-locator/pull/409/indirect-changes`)
-      expect(
-        hookData.result.current.pullIndirectChanges.path({ owner: 'cat' })
-      ).toBe(`/gl/cat/squirrel-locator/pull/409/indirect-changes`)
-      expect(
-        hookData.result.current.pullIndirectChanges.path({
-          repo: 'tennis-ball',
-        })
-      ).toBe(`/gl/doggo/tennis-ball/pull/409/indirect-changes`)
-      expect(
-        hookData.result.current.pullIndirectChanges.path({ pullId: 888 })
-      ).toBe(`/gl/doggo/squirrel-locator/pull/888/indirect-changes`)
+      const { result } = renderHook(() => useNavLinks(), {
+        wrapper: wrapper(
+          '/gl/doggo/squirrel-locator/pull/409/indirect-changes'
+        ),
+      })
+
+      const path = result.current.pullIndirectChanges.path({
+        provider: 'bb',
+        owner: 'test-owner',
+        repo: 'test-repo',
+        pullId: 888,
+      })
+      expect(path).toBe('/bb/test-owner/test-repo/pull/888/indirect-changes')
     })
   })
 
   describe('commit indirect changes', () => {
-    beforeAll(() => {
-      setup(['/gl/doggo/squirrel-locator'])
+    it('returns the correct link with nothing passed', () => {
+      const { result } = renderHook(() => useNavLinks(), {
+        wrapper: wrapper('/gl/doggo/squirrel-locator'),
+      })
+
+      const path = result.current.commitIndirectChanges.path({ commit: 409 })
+      expect(path).toBe(
+        '/gl/doggo/squirrel-locator/commit/409/indirect-changes'
+      )
     })
 
-    it('Returns the correct link with nothing passed', () => {
-      expect(
-        hookData.result.current.commitIndirectChanges.path({ commit: 409 })
-      ).toBe(`/gl/doggo/squirrel-locator/commit/409/indirect-changes`)
-    })
     it('can override the params', () => {
-      expect(
-        hookData.result.current.commitIndirectChanges.path({
-          provider: 'bb',
-          commit: 409,
-        })
-      ).toBe(`/bb/doggo/squirrel-locator/commit/409/indirect-changes`)
-      expect(
-        hookData.result.current.commitIndirectChanges.path({
-          owner: 'cat',
-          commit: 409,
-        })
-      ).toBe(`/gl/cat/squirrel-locator/commit/409/indirect-changes`)
-      expect(
-        hookData.result.current.commitIndirectChanges.path({
-          repo: 'tennis-ball',
-          commit: 409,
-        })
-      ).toBe(`/gl/doggo/tennis-ball/commit/409/indirect-changes`)
-      expect(
-        hookData.result.current.commitIndirectChanges.path({ commit: 888 })
-      ).toBe(`/gl/doggo/squirrel-locator/commit/888/indirect-changes`)
+      const { result } = renderHook(() => useNavLinks(), {
+        wrapper: wrapper('/gl/doggo/squirrel-locator'),
+      })
+
+      const path = result.current.commitIndirectChanges.path({
+        provider: 'bb',
+        owner: 'test-owner',
+        repo: 'test-repo',
+        commit: 888,
+      })
+      expect(path).toBe('/bb/test-owner/test-repo/commit/888/indirect-changes')
     })
   })
+
   describe('prevLink', () => {
     describe('ref provided', () => {
-      beforeAll(() => {
-        setup([
-          `/gh/codecov?ref=${encodeURIComponent('/gh/codecov/codecov-demo')}`,
-        ])
-      })
-
       it('returns the correct url', () => {
-        expect(
-          hookData.result.current.prevLink.path({
-            ref: encodeURIComponent('/gh/codecov/codecov-demo'),
-          })
-        ).toBe('/gh/codecov/codecov-demo')
+        const url = `/gh/codecov?ref=${encodeURIComponent(
+          '/gh/codecov/codecov-demo'
+        )}`
+        const { result } = renderHook(() => useNavLinks(), {
+          wrapper: wrapper(url),
+        })
+
+        const path = result.current.prevLink.path({
+          ref: encodeURIComponent('/gh/codecov/codecov-demo'),
+        })
+        expect(path).toBe('/gh/codecov/codecov-demo')
       })
     })
-    describe('no ref provided', () => {
-      beforeAll(() => {
-        setup(['/gh/feedback'])
-      })
 
+    describe('no ref provided', () => {
       it('returns the correct url', () => {
-        expect(hookData.result.current.prevLink.path()).toBe('/gh')
+        const { result } = renderHook(() => useNavLinks(), {
+          wrapper: wrapper('/gh/feedback'),
+        })
+
+        const path = result.current.prevLink.path()
+        expect(path).toBe('/gh')
       })
     })
   })
 
   describe('access', () => {
     describe('testing all orgs and repos', () => {
-      beforeAll(() => {
-        setup(['/admin/gh/access'])
-      })
-
       it('returns the correct url', () => {
-        expect(hookData.result.current.access.path()).toBe('/admin/gh/access')
+        const { result } = renderHook(() => useNavLinks(), {
+          wrapper: wrapper('/admin/gh/access'),
+        })
+
+        const path = result.current.access.path()
+        expect(path).toBe('/admin/gh/access')
       })
 
-      it('returns the correct url provided provider', () => {
-        expect(hookData.result.current.access.path({ provider: 'gl' })).toBe(
-          '/admin/gl/access'
-        )
+      it('can override params', () => {
+        const { result } = renderHook(() => useNavLinks(), {
+          wrapper: wrapper('/admin/gh/access'),
+        })
+
+        const path = result.current.access.path({ provider: 'gl' })
+        expect(path).toBe('/admin/gl/access')
       })
     })
   })
 
   describe('users', () => {
     describe('testing all orgs and repos', () => {
-      beforeAll(() => {
-        setup(['/admin/gh/users'])
-      })
-
       it('returns the correct url', () => {
-        expect(hookData.result.current.users.path()).toBe('/admin/gh/users')
+        const { result } = renderHook(() => useNavLinks(), {
+          wrapper: wrapper('/admin/gh/users'),
+        })
+
+        const path = result.current.users.path()
+        expect(path).toBe('/admin/gh/users')
       })
 
-      it('returns the correct url provided provider', () => {
-        expect(hookData.result.current.users.path({ provider: 'gl' })).toBe(
-          '/admin/gl/users'
-        )
+      it('can override params', () => {
+        const { result } = renderHook(() => useNavLinks(), {
+          wrapper: wrapper('/admin/gh/users'),
+        })
+
+        const path = result.current.users.path({ provider: 'gl' })
+        expect(path).toBe('/admin/gl/users')
       })
     })
   })
 
   describe('general repo upload token link', () => {
-    beforeAll(() => {
-      setup(['/gh/codecov'])
+    it('returns the correct link with nothing passed', () => {
+      const { result } = renderHook(() => useNavLinks(), {
+        wrapper: wrapper('/gh/codecov'),
+      })
+
+      const path = result.current.orgUploadToken.path()
+      expect(path).toBe('/account/gh/codecov/org-upload-token')
     })
 
-    it('Returns the correct link with nothing passed', () => {
-      expect(hookData.result.current.orgUploadToken.path()).toBe(
-        '/account/gh/codecov/org-upload-token'
-      )
-    })
     it('can override the params', () => {
-      expect(
-        hookData.result.current.orgUploadToken.path({ provider: 'bb' })
-      ).toBe('/account/bb/codecov/org-upload-token')
-      expect(
-        hookData.result.current.orgUploadToken.path({ owner: 'cat' })
-      ).toBe('/account/gh/cat/org-upload-token')
+      const { result } = renderHook(() => useNavLinks(), {
+        wrapper: wrapper('/gh/codecov'),
+      })
+
+      const path = result.current.orgUploadToken.path({
+        provider: 'bb',
+        owner: 'test-owner',
+      })
+      expect(path).toBe('/account/bb/test-owner/org-upload-token')
     })
   })
 
   describe('github repo secrets', () => {
-    beforeAll(() => {
-      setup(['/gh/codecov/cool-repo'])
-    })
+    it('returns the correct link with nothing passed', () => {
+      const { result } = renderHook(() => useNavLinks(), {
+        wrapper: wrapper('/gh/codecov/cool-repo'),
+      })
 
-    it('Returns the correct link with nothing passed', () => {
-      expect(hookData.result.current.githubRepoSecrets.path()).toBe(
+      const path = result.current.githubRepoSecrets.path()
+      expect(path).toBe(
         'https://github.com/codecov/cool-repo/settings/secrets/actions'
       )
     })
+
     it('can override the params', () => {
-      expect(
-        hookData.result.current.githubRepoSecrets.path({ repo: 'test-repo' })
-      ).toBe('https://github.com/codecov/test-repo/settings/secrets/actions')
-      expect(
-        hookData.result.current.githubRepoSecrets.path({ owner: 'cat' })
-      ).toBe('https://github.com/cat/cool-repo/settings/secrets/actions')
+      const { result } = renderHook(() => useNavLinks(), {
+        wrapper: wrapper('/gh/codecov/cool-repo'),
+      })
+
+      const path = result.current.githubRepoSecrets.path({
+        owner: 'test-owner',
+        repo: 'test-repo',
+      })
+      expect(path).toBe(
+        'https://github.com/test-owner/test-repo/settings/secrets/actions'
+      )
     })
   })
 
   describe('github repo actions', () => {
-    beforeAll(() => {
-      setup(['/gh/codecov/cool-repo'])
+    it('returns the correct link with nothing passed', () => {
+      const { result } = renderHook(() => useNavLinks(), {
+        wrapper: wrapper('/gh/codecov/cool-repo'),
+      })
+
+      const path = result.current.githubRepoActions.path({ branch: 'main' })
+      expect(path).toBe(
+        'https://github.com/codecov/cool-repo/tree/main/.github/workflows'
+      )
     })
 
-    it('Returns the correct link with nothing passed', () => {
-      expect(
-        hookData.result.current.githubRepoActions.path({ branch: 'main' })
-      ).toBe('https://github.com/codecov/cool-repo/tree/main/.github/workflows')
-    })
     it('can override the params', () => {
-      expect(
-        hookData.result.current.githubRepoActions.path({
-          repo: 'test-repo',
-          branch: 'master',
-        })
-      ).toBe(
-        'https://github.com/codecov/test-repo/tree/master/.github/workflows'
+      const { result } = renderHook(() => useNavLinks(), {
+        wrapper: wrapper('/gh/codecov/cool-repo'),
+      })
+
+      const path = result.current.githubRepoActions.path({
+        owner: 'test-owner',
+        repo: 'test-repo',
+        branch: 'master',
+      })
+      expect(path).toBe(
+        'https://github.com/test-owner/test-repo/tree/master/.github/workflows'
       )
-      expect(
-        hookData.result.current.githubRepoActions.path({
-          owner: 'cat',
-          branch: 'master',
-        })
-      ).toBe('https://github.com/cat/cool-repo/tree/master/.github/workflows')
     })
   })
 
   describe('circleCI yaml', () => {
-    beforeAll(() => {
-      setup(['/gh/codecov/cool-repo'])
+    it('returns the correct link with nothing passed', () => {
+      const { result } = renderHook(() => useNavLinks(), {
+        wrapper: wrapper('/gh/codecov/cool-repo'),
+      })
+
+      const path = result.current.circleCIyaml.path({ branch: 'main' })
+      expect(path).toBe(
+        'https://github.com/codecov/cool-repo/tree/main/.circleci/config'
+      )
     })
 
-    it('Returns the correct link with nothing passed', () => {
-      expect(
-        hookData.result.current.circleCIyaml.path({ branch: 'main' })
-      ).toBe('https://github.com/codecov/cool-repo/tree/main/.circleci/config')
-    })
     it('can override the params', () => {
-      expect(
-        hookData.result.current.circleCIyaml.path({
-          repo: 'test-repo',
-          branch: 'master',
-        })
-      ).toBe(
-        'https://github.com/codecov/test-repo/tree/master/.circleci/config'
+      const { result } = renderHook(() => useNavLinks(), {
+        wrapper: wrapper('/gh/codecov/cool-repo'),
+      })
+
+      const path = result.current.circleCIyaml.path({
+        owner: 'test-owner',
+        repo: 'test-repo',
+        branch: 'master',
+      })
+      expect(path).toBe(
+        'https://github.com/test-owner/test-repo/tree/master/.circleci/config'
       )
-      expect(
-        hookData.result.current.circleCIyaml.path({
-          owner: 'cat',
-          branch: 'master',
-        })
-      ).toBe('https://github.com/cat/cool-repo/tree/master/.circleci/config')
     })
   })
 })


### PR DESCRIPTION
# Description

Currently we're using the `BASE_URL` value for sign in and sign out which isn't compatible with Login w/Sentry so this PR updates Gazebo to use the `API_URL` instead. As well these changes utilizes the changes made to the API to allow a `to` query parameter to be passed to `/logout` and have the user redirect to that value.

# Notable Changes

- Switch over to using `API_URL` over `BASE_URL` for sign in and sign out
- Add query params to sign out
- Add `to` query param to sign out in `Dropdown` so users are redirected to the marketing site (TBC)
- Refactor `useNavLink` tests