### PR TITLE
fix: Switch integrationId to a Number from String Type

### DIFF
--- a/src/services/user/useInternalUser.ts
+++ b/src/services/user/useInternalUser.ts
@@ -6,7 +6,7 @@ import Api from 'shared/api'
 const OwnerSchema = z
   .object({
     avatarUrl: z.string().nullish(),
-    integrationId: z.string().nullish(),
+    integrationId: z.number().nullish(),
     name: z.string().nullish(),
     ownerid: z.number().nullish(),
     service: z.string().nullish(),


### PR DESCRIPTION
# Description

Super small PR changing the schema type from `string` to `number`.