### PR TITLE
fix: Update ongoing trial to handle last day of the trial

### DIFF
--- a/src/shared/GlobalTopBanners/TrialBanner/ExpiredBanner.spec.tsx
+++ b/src/shared/GlobalTopBanners/TrialBanner/ExpiredBanner.spec.tsx
@@ -24,7 +24,7 @@ describe('ExpiredBanner', () => {
       render(<ExpiredBanner />, { wrapper })
 
       const leftText = screen.getByText(
-        /The org's 14-day free Codecov Pro trial has ended./
+        /The organization's 14-day free Codecov Pro trial has ended./
       )
       expect(leftText).toBeInTheDocument()
     })

--- a/src/shared/GlobalTopBanners/TrialBanner/ExpiredBanner.tsx
+++ b/src/shared/GlobalTopBanners/TrialBanner/ExpiredBanner.tsx
@@ -9,7 +9,7 @@ const ExpiredBanner: React.FC = () => {
       <TopBanner.Start>
         <p className="font-semibold">
           <span className="pr-2 text-xl">&#127881;</span>
-          The org&apos;s 14-day free Codecov Pro trial has ended.{' '}
+          The organization&apos;s 14-day free Codecov Pro trial has ended.{' '}
           {/* @ts-expect-error */}
           <A to={{ pageName: 'upgradeOrgPlan' }}>
             Add payment method

--- a/src/shared/GlobalTopBanners/TrialBanner/OngoingBanner.spec.tsx
+++ b/src/shared/GlobalTopBanners/TrialBanner/OngoingBanner.spec.tsx
@@ -29,6 +29,15 @@ describe('OngoingBanner', () => {
       })
     })
 
+    describe('date diff eq to 0', () => {
+      it('renders left side text', () => {
+        render(<OngoingBanner dateDiff={0} />, { wrapper })
+
+        const leftText = screen.getByText('Your trial ends today.')
+        expect(leftText).toBeInTheDocument()
+      })
+    })
+
     describe('date diff lt or eq to 1', () => {
       it('renders left side text', () => {
         render(<OngoingBanner dateDiff={1} />, { wrapper })

--- a/src/shared/GlobalTopBanners/TrialBanner/OngoingBanner.tsx
+++ b/src/shared/GlobalTopBanners/TrialBanner/OngoingBanner.tsx
@@ -10,12 +10,12 @@ interface DayCountProps {
 }
 
 const DayCount: React.FC<DayCountProps> = ({ dateDiff }) => {
-  if (dateDiff === 0) {
+  if (dateDiff <= 0) {
     return <span>Your trial ends today.</span>
   }
 
-  if (dateDiff <= 1) {
-    return <span>Your trial ends in {dateDiff} day.</span>
+  if (dateDiff === 1) {
+    return <span>Your trial ends in 1 day.</span>
   }
 
   return <span>Your trial ends in {dateDiff} days.</span>

--- a/src/shared/GlobalTopBanners/TrialBanner/OngoingBanner.tsx
+++ b/src/shared/GlobalTopBanners/TrialBanner/OngoingBanner.tsx
@@ -10,6 +10,10 @@ interface DayCountProps {
 }
 
 const DayCount: React.FC<DayCountProps> = ({ dateDiff }) => {
+  if (dateDiff === 0) {
+    return <span>Your trial ends today.</span>
+  }
+
   if (dateDiff <= 1) {
     return <span>Your trial ends in {dateDiff} day.</span>
   }
@@ -30,7 +34,7 @@ const OngoingBanner: React.FC<OngoingBannerProps> = ({ dateDiff }) => {
           <span className="font-semibold">
             <DayCount dateDiff={dateDiff} />
             {/* @ts-expect-error */}
-            <A to={{ pageName: 'upgradeOrgPlan' }}>Upgrade now</A>.
+            <A to={{ pageName: 'upgradeOrgPlan' }}>&nbsp;Upgrade now</A>.
           </span>
         </p>
       </TopBanner.Start>

--- a/src/shared/GlobalTopBanners/TrialBanner/TrialBanner.spec.tsx
+++ b/src/shared/GlobalTopBanners/TrialBanner/TrialBanner.spec.tsx
@@ -402,7 +402,7 @@ describe('TrialBanner', () => {
         })
 
         const banner = await screen.findByText(
-          /The org's 14-day free Codecov Pro trial has ended./
+          /The organization's 14-day free Codecov Pro trial has ended./
         )
         expect(banner).toBeInTheDocument()
       })


### PR DESCRIPTION
# Description
We display 0 days if there are less than 24 hours left for the trial period, this is updating the trial banner to handle a different copy for the last day. 

# Notable Changes
- update ongoing banner
- update missing space in trial banner + expired trial banner with organization instead of org 
- update tests 

# Screenshots
<img width="1352" alt="Screenshot 2023-09-19 at 3 42 58 PM" src="https://github.com/codecov/gazebo/assets/91732700/76f8ef41-c378-442a-a653-89b35fc2a15b">

![Screenshot 2023-09-19 at 3 55 47 PM](https://github.com/codecov/gazebo/assets/91732700/00e1b1a6-8406-4ad9-9517-ea9d43516709)


Issue: https://github.com/codecov/engineering-team/issues/391

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.