### PR TITLE
fix: Update to depend on api for view permissions

### DIFF
--- a/src/pages/PullRequestPage/PullRequestPage.jsx
+++ b/src/pages/PullRequestPage/PullRequestPage.jsx
@@ -23,7 +23,7 @@ function PullRequestPage() {
   const { owner, repo, pullId, provider } = useParams()
   const { data, isLoading } = usePullPageData({ provider, owner, repo, pullId })
 
-  if (!isLoading && (!data?.hasAccess || !data?.pull)) {
+  if (!isLoading && !data?.pull) {
     return <NotFound />
   }
 

--- a/src/pages/PullRequestPage/PullRequestPage.spec.jsx
+++ b/src/pages/PullRequestPage/PullRequestPage.spec.jsx
@@ -77,7 +77,7 @@ afterAll(() => {
 })
 
 describe('PullRequestPage', () => {
-  function setup({ hasAccess = false, pullData = mockPullPageData }) {
+  function setup({ pullData = mockPullPageData }) {
     server.use(
       graphql.query('PullHeadData', (req, res, ctx) =>
         res(ctx.status(200), ctx.data(mockPullHeadData))
@@ -87,10 +87,8 @@ describe('PullRequestPage', () => {
           ctx.status(200),
           ctx.data({
             owner: {
-              isCurrentUserPartOfOrg: hasAccess,
               repository: {
                 __typename: 'Repository',
-                private: true,
                 pull: pullData,
               },
             },
@@ -100,8 +98,8 @@ describe('PullRequestPage', () => {
     )
   }
 
-  describe('when user has access and pull data', () => {
-    beforeEach(() => setup({ hasAccess: true }))
+  describe('when pull data is available', () => {
+    beforeEach(() => setup({}))
 
     it('renders breadcrumb', async () => {
       render(<PullRequestPage />, { wrapper: wrapper() })
@@ -155,19 +153,8 @@ describe('PullRequestPage', () => {
     })
   })
 
-  describe('when user does not have access', () => {
-    beforeEach(() => setup({ hasAccess: false }))
-
-    it('renders not found', async () => {
-      render(<PullRequestPage />, { wrapper: wrapper() })
-
-      const notFound = await screen.findByText(/Not found/)
-      expect(notFound).toBeInTheDocument()
-    })
-  })
-
   describe('when there is no pull data', () => {
-    beforeEach(() => setup({ hasAccess: true, pullData: null }))
+    beforeEach(() => setup({ pullData: null }))
 
     it('renders not found', async () => {
       render(<PullRequestPage />, { wrapper: wrapper() })

--- a/src/pages/PullRequestPage/hooks/usePullPageData.spec.tsx
+++ b/src/pages/PullRequestPage/hooks/usePullPageData.spec.tsx
@@ -7,10 +7,8 @@ import { usePullPageData } from './usePullPageData'
 
 const mockPullData = {
   owner: {
-    isCurrentUserPartOfOrg: true,
     repository: {
       __typename: 'Repository',
-      private: true,
       pull: {
         pullId: 1,
         head: {
@@ -31,7 +29,6 @@ const mockPullData = {
 
 const mockNotFoundError = {
   owner: {
-    isCurrentUserPartOfOrg: true,
     repository: {
       __typename: 'NotFoundError',
       message: 'commit not found',
@@ -41,7 +38,6 @@ const mockNotFoundError = {
 
 const mockOwnerNotActivatedError = {
   owner: {
-    isCurrentUserPartOfOrg: true,
     repository: {
       __typename: 'OwnerNotActivatedError',
       message: 'owner not activated',
@@ -132,7 +128,6 @@ describe('usePullPageData', () => {
 
           await waitFor(() =>
             expect(result.current.data).toStrictEqual({
-              hasAccess: true,
               pull: {
                 pullId: 1,
                 head: {
@@ -174,7 +169,6 @@ describe('usePullPageData', () => {
 
           await waitFor(() =>
             expect(result.current.data).toStrictEqual({
-              hasAccess: true,
               pull: null,
             })
           )

--- a/src/pages/PullRequestPage/hooks/usePullPageData.tsx
+++ b/src/pages/PullRequestPage/hooks/usePullPageData.tsx
@@ -13,12 +13,10 @@ import {
   RepoOwnerNotActivatedErrorSchema,
 } from 'services/repo'
 import Api from 'shared/api'
-import { userHasAccess } from 'shared/utils/user'
 import A from 'ui/A'
 
 const RepositorySchema = z.object({
   __typename: z.literal('Repository'),
-  private: z.boolean(),
   pull: z
     .object({
       pullId: z.number().nullable(),
@@ -51,7 +49,6 @@ const RepositorySchema = z.object({
 const PullPageDataSchema = z.object({
   owner: z
     .object({
-      isCurrentUserPartOfOrg: z.boolean(),
       repository: z
         .discriminatedUnion('__typename', [
           RepositorySchema,
@@ -66,7 +63,6 @@ const PullPageDataSchema = z.object({
 const query = `
 query PullPageData($owner: String!, $repo: String!, $pullId: Int!) {
   owner(username: $owner) {
-    isCurrentUserPartOfOrg
     repository(name: $repo) {
       __typename
       ... on Repository {
@@ -175,10 +171,6 @@ export const usePullPageData = ({
         }
 
         return {
-          hasAccess: userHasAccess({
-            privateRepo: data?.owner?.repository?.private,
-            isCurrentUserPartOfOrg: data?.owner?.isCurrentUserPartOfOrg,
-          }),
           pull: data?.owner?.repository?.pull ?? null,
         }
       }),


### PR DESCRIPTION
# Description
We don't need to check `isCurrentUserPartOfOrg` to view the repo, if user has access permissions (wether they are collaborators or part of the org), the base permission class in the api https://github.com/codecov/codecov-api/blob/7c60f91d2f0799285d43384bddd0736e875c2d3a/api/shared/permissions.py#L64 takes care of this. 

look here https://sentry.slack.com/archives/C04M5GE2R5M/p1695135465184899 for more context.

issue: https://github.com/codecov/gazebo/issues/2239

# Notable Changes
- Remove `isCurrentUserPartOfOrg` from pull request page
- Fix tests 

# Screenshots
nothing new to look at 

# Link to Sample Entry
try while logged in, then while logged out:
https://deploy-preview-2276--gazebo-staging.netlify.app/gh/codecov/codecov-assume-flag-test/pull/23

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.