### PR TITLE
ref: Allow SyncProviderPage in Self Hosted

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -55,13 +55,11 @@ const MainAppRoutes = () => (
         <AccountSettings />
       </BaseLayout>
     </SentryRoute>
-    {!config.IS_SELF_HOSTED && (
-      <SentryRoute path="/sync" exact>
-        <BaseLayout>
-          <SyncProviderPage />
-        </BaseLayout>
-      </SentryRoute>
-    )}
+    <SentryRoute path="/sync" exact>
+      <BaseLayout>
+        <SyncProviderPage />
+      </BaseLayout>
+    </SentryRoute>
     {config.IS_SELF_HOSTED && (
       <SentryRoute path="/admin/:provider">
         <BaseLayout>

--- a/src/App.spec.jsx
+++ b/src/App.spec.jsx
@@ -449,6 +449,16 @@ describe('App', () => {
         },
       },
     ],
+    [
+      {
+        testLabel: 'SyncProviderPage',
+        pathname: '/sync',
+        expected: {
+          page: /SyncProviderPage/i,
+          location: '/sync',
+        },
+      },
+    ],
   ]
 
   describe.each(selfHostedFullRouterCases)(

--- a/src/layouts/BaseLayout/BaseLayout.spec.jsx
+++ b/src/layouts/BaseLayout/BaseLayout.spec.jsx
@@ -130,12 +130,10 @@ describe('BaseLayout', () => {
       isImpersonating = false,
       termsOfServicePage = false,
       defaultOrgSelectorPage = false,
-      sentryLoginProvider = false,
     } = {
       termsOfServicePage: false,
       currentUser: loggedInUser,
       defaultOrgSelectorPage: false,
-      sentryLoginProvider: false,
     }
   ) {
     useImage.mockReturnValue({
@@ -146,7 +144,6 @@ describe('BaseLayout', () => {
     useFlags.mockReturnValue({
       termsOfServicePage,
       defaultOrgSelectorPage,
-      sentryLoginProvider,
     })
     useImpersonate.mockReturnValue({ isImpersonating })
 
@@ -311,36 +308,32 @@ describe('BaseLayout', () => {
     })
   })
 
-  describe('sentryLoginProvider flag is on', () => {
-    describe('user has not synced with providers', () => {
-      it('redirects the user', async () => {
-        setup({
-          internalUser: internalUserNoSyncedProviders,
-          sentryLoginProvider: true,
-        })
-
-        render(<BaseLayout>hello</BaseLayout>, {
-          wrapper: wrapper(),
-        })
-
-        await waitFor(() => expect(testLocation.pathname).toBe('/sync'))
+  describe('user has not synced with providers', () => {
+    it('redirects the user to /sync', async () => {
+      setup({
+        internalUser: internalUserNoSyncedProviders,
       })
+
+      render(<BaseLayout>hello</BaseLayout>, {
+        wrapper: wrapper(),
+      })
+
+      await waitFor(() => expect(testLocation.pathname).toBe('/sync'))
     })
+  })
 
-    describe('user has synced providers', () => {
-      it('renders the page', async () => {
-        setup({
-          internalUser: internalUserHasSyncedProviders,
-          sentryLoginProvider: true,
-        })
-
-        render(<BaseLayout>hello</BaseLayout>, {
-          wrapper: wrapper(),
-        })
-
-        const text = await screen.findByText('hello')
-        expect(text).toBeInTheDocument()
+  describe('user has synced providers', () => {
+    it('renders the page', async () => {
+      setup({
+        internalUser: internalUserHasSyncedProviders,
       })
+
+      render(<BaseLayout>hello</BaseLayout>, {
+        wrapper: wrapper(),
+      })
+
+      const text = await screen.findByText('hello')
+      expect(text).toBeInTheDocument()
     })
   })
 

--- a/src/layouts/BaseLayout/hooks/useUserAccessGate.js
+++ b/src/layouts/BaseLayout/hooks/useUserAccessGate.js
@@ -35,12 +35,10 @@ const useUserAccessGate = () => {
   const { provider } = useParams()
   const currentRoute = useRouteMatch()
 
-  const { termsOfServicePage, defaultOrgSelectorPage, sentryLoginProvider } =
-    useFlags({
-      termsOfServicePage: false,
-      defaultOrgSelectorPage: false,
-      sentryLoginProvider: false,
-    })
+  const { termsOfServicePage, defaultOrgSelectorPage } = useFlags({
+    termsOfServicePage: false,
+    defaultOrgSelectorPage: false,
+  })
 
   const {
     data: userData,
@@ -58,7 +56,6 @@ const useUserAccessGate = () => {
     isFetching: internalUserIsFetching,
     isSuccess: internalUserIsSuccess,
   } = useInternalUser({
-    enabled: !config.IS_SELF_HOSTED,
     retry: false,
     retryOnMount: false,
     suspense: false,
@@ -86,13 +83,18 @@ const useUserAccessGate = () => {
   }
 
   const onSyncPage = currentRoute.path === '/sync'
-  if (sentryLoginProvider && !isGuest && !onSyncPage) {
+  if (!isGuest && !onSyncPage) {
     // owners array contains a list of the synced providers
     // if it is zero then they haven't synced any other providers
     redirectToSyncPage = isEqual(internalUser?.owners?.length, 0)
   }
 
-  if (defaultOrgSelectorPage && !isUndefined(provider) && !isGuest) {
+  if (
+    defaultOrgSelectorPage &&
+    !isUndefined(provider) &&
+    !isGuest &&
+    !config.IS_SELF_HOSTED
+  ) {
     showDefaultOrgSelector = !userData?.owner?.defaultOrgUsername
   }
 
@@ -106,11 +108,9 @@ const useUserAccessGate = () => {
   }
 
   // Not fully tested logic yet, waiting on API to be available.
-  // Assuming self hosted users do not need to sign
   return {
     isFullExperience:
-      !!config.IS_SELF_HOSTED ||
-      (!showAgreeToTerms && !redirectToSyncPage && !showDefaultOrgSelector),
+      !showAgreeToTerms && !redirectToSyncPage && !showDefaultOrgSelector,
     isLoading,
     showAgreeToTerms,
     showDefaultOrgSelector,

--- a/src/layouts/BaseLayout/hooks/useUserAccessGate.spec.tsx
+++ b/src/layouts/BaseLayout/hooks/useUserAccessGate.spec.tsx
@@ -35,9 +35,11 @@ let testLocation: { pathname: string; search: string } = {
   pathname: '',
   search: '',
 }
+
 type WrapperClosure = (
   initialEntries?: string[]
 ) => React.FC<React.PropsWithChildren>
+
 const wrapper: WrapperClosure =
   (initialEntries = ['/gh']) =>
   ({ children }) =>
@@ -185,7 +187,6 @@ type SetupArgs = {
   internalUser: InternalUser
   termsOfServicePage: boolean
   defaultOrgSelectorPage: boolean
-  sentryLoginProvider: boolean
 }
 
 describe('useUserAccessGate', () => {
@@ -195,13 +196,11 @@ describe('useUserAccessGate', () => {
       internalUser = internalUserHasSyncedProviders,
       termsOfServicePage = false,
       defaultOrgSelectorPage = false,
-      sentryLoginProvider = false,
     }: SetupArgs = {
       user: loggedInUser,
       internalUser: internalUserHasSyncedProviders,
       termsOfServicePage: false,
       defaultOrgSelectorPage: false,
-      sentryLoginProvider: false,
     }
   ) {
     const mockedUseFlags = jest.mocked(useFlags)
@@ -210,7 +209,6 @@ describe('useUserAccessGate', () => {
     mockedUseFlags.mockReturnValue({
       termsOfServicePage,
       defaultOrgSelectorPage,
-      sentryLoginProvider,
     })
 
     server.use(
@@ -255,8 +253,6 @@ describe('useUserAccessGate', () => {
         termsOfServicePage: true,
         isSelfHosted: false,
         defaultOrgSelectorPage: false,
-        sentryLoginProvider: false,
-
         expected: {
           beforeSettled: {
             isFullExperience: true,
@@ -285,8 +281,6 @@ describe('useUserAccessGate', () => {
         termsOfServicePage: true,
         isSelfHosted: false,
         defaultOrgSelectorPage: false,
-        sentryLoginProvider: false,
-
         expected: {
           beforeSettled: {
             isFullExperience: true,
@@ -315,8 +309,6 @@ describe('useUserAccessGate', () => {
         termsOfServicePage: false,
         isSelfHosted: false,
         defaultOrgSelectorPage: false,
-        sentryLoginProvider: false,
-
         expected: {
           beforeSettled: {
             isFullExperience: true,
@@ -345,8 +337,6 @@ describe('useUserAccessGate', () => {
         termsOfServicePage: false,
         isSelfHosted: false,
         defaultOrgSelectorPage: false,
-        sentryLoginProvider: false,
-
         expected: {
           beforeSettled: {
             isFullExperience: true,
@@ -375,8 +365,6 @@ describe('useUserAccessGate', () => {
         termsOfServicePage: true,
         isSelfHosted: false,
         defaultOrgSelectorPage: false,
-        sentryLoginProvider: false,
-
         expected: {
           beforeSettled: {
             isFullExperience: true,
@@ -405,8 +393,6 @@ describe('useUserAccessGate', () => {
         termsOfServicePage: false,
         isSelfHosted: false,
         defaultOrgSelectorPage: false,
-        sentryLoginProvider: false,
-
         expected: {
           beforeSettled: {
             isFullExperience: true,
@@ -435,8 +421,6 @@ describe('useUserAccessGate', () => {
         termsOfServicePage: false,
         isSelfHosted: false,
         defaultOrgSelectorPage: false,
-        sentryLoginProvider: false,
-
         expected: {
           beforeSettled: {
             isFullExperience: true,
@@ -465,8 +449,6 @@ describe('useUserAccessGate', () => {
         termsOfServicePage: false,
         isSelfHosted: false,
         defaultOrgSelectorPage: true,
-        sentryLoginProvider: false,
-
         expected: {
           beforeSettled: {
             isFullExperience: false,
@@ -495,8 +477,6 @@ describe('useUserAccessGate', () => {
         termsOfServicePage: false,
         isSelfHosted: false,
         defaultOrgSelectorPage: true,
-        sentryLoginProvider: false,
-
         expected: {
           beforeSettled: {
             isFullExperience: false,
@@ -525,12 +505,10 @@ describe('useUserAccessGate', () => {
         termsOfServicePage: true,
         isSelfHosted: true,
         defaultOrgSelectorPage: false,
-        sentryLoginProvider: false,
-
         expected: {
           beforeSettled: {
             isFullExperience: true,
-            isLoading: false,
+            isLoading: true,
             showAgreeToTerms: false,
             showDefaultOrgSelector: false,
             redirectToSyncPage: false,
@@ -555,12 +533,10 @@ describe('useUserAccessGate', () => {
         termsOfServicePage: true,
         isSelfHosted: true,
         defaultOrgSelectorPage: false,
-        sentryLoginProvider: false,
-
         expected: {
           beforeSettled: {
             isFullExperience: true,
-            isLoading: false,
+            isLoading: true,
             showAgreeToTerms: false,
             showDefaultOrgSelector: false,
             redirectToSyncPage: false,
@@ -585,12 +561,10 @@ describe('useUserAccessGate', () => {
         termsOfServicePage: true,
         isSelfHosted: true,
         defaultOrgSelectorPage: false,
-        sentryLoginProvider: false,
-
         expected: {
           beforeSettled: {
             isFullExperience: true,
-            isLoading: false,
+            isLoading: true,
             showAgreeToTerms: false,
             showDefaultOrgSelector: false,
             redirectToSyncPage: false,
@@ -615,12 +589,10 @@ describe('useUserAccessGate', () => {
         termsOfServicePage: true,
         isSelfHosted: true,
         defaultOrgSelectorPage: false,
-        sentryLoginProvider: false,
-
         expected: {
           beforeSettled: {
             isFullExperience: true,
-            isLoading: false,
+            isLoading: true,
             showAgreeToTerms: false,
             showDefaultOrgSelector: false,
             redirectToSyncPage: false,
@@ -645,12 +617,10 @@ describe('useUserAccessGate', () => {
         termsOfServicePage: false,
         isSelfHosted: true,
         defaultOrgSelectorPage: false,
-        sentryLoginProvider: false,
-
         expected: {
           beforeSettled: {
             isFullExperience: true,
-            isLoading: false,
+            isLoading: true,
             showAgreeToTerms: false,
             showDefaultOrgSelector: false,
             redirectToSyncPage: false,
@@ -675,12 +645,10 @@ describe('useUserAccessGate', () => {
         termsOfServicePage: false,
         isSelfHosted: true,
         defaultOrgSelectorPage: false,
-        sentryLoginProvider: false,
-
         expected: {
           beforeSettled: {
             isFullExperience: true,
-            isLoading: false,
+            isLoading: true,
             showAgreeToTerms: false,
             showDefaultOrgSelector: false,
             redirectToSyncPage: false,
@@ -705,12 +673,10 @@ describe('useUserAccessGate', () => {
         termsOfServicePage: false,
         isSelfHosted: true,
         defaultOrgSelectorPage: false,
-        sentryLoginProvider: false,
-
         expected: {
           beforeSettled: {
             isFullExperience: true,
-            isLoading: false,
+            isLoading: true,
             showAgreeToTerms: false,
             showDefaultOrgSelector: false,
             redirectToSyncPage: false,
@@ -735,12 +701,10 @@ describe('useUserAccessGate', () => {
         termsOfServicePage: false,
         isSelfHosted: true,
         defaultOrgSelectorPage: false,
-        sentryLoginProvider: false,
-
         expected: {
           beforeSettled: {
             isFullExperience: true,
-            isLoading: false,
+            isLoading: true,
             showAgreeToTerms: false,
             showDefaultOrgSelector: false,
             redirectToSyncPage: false,
@@ -757,7 +721,7 @@ describe('useUserAccessGate', () => {
     ],
     [
       'cloud',
-      'Sentry login provider flag: ON',
+      'Sentry login provider',
       'has synced a provider',
       {
         user: loggedInUser,
@@ -765,8 +729,6 @@ describe('useUserAccessGate', () => {
         termsOfServicePage: false,
         isSelfHosted: false,
         defaultOrgSelectorPage: false,
-        sentryLoginProvider: true,
-
         expected: {
           beforeSettled: {
             isFullExperience: true,
@@ -787,7 +749,7 @@ describe('useUserAccessGate', () => {
     ],
     [
       'cloud',
-      'Sentry login provider flag: ON',
+      'Sentry login provider',
       'has not synced a provider',
       {
         user: loggedInUser,
@@ -795,8 +757,62 @@ describe('useUserAccessGate', () => {
         termsOfServicePage: false,
         isSelfHosted: false,
         defaultOrgSelectorPage: false,
-        sentryLoginProvider: true,
-
+        expected: {
+          beforeSettled: {
+            isFullExperience: true,
+            isLoading: true,
+            showAgreeToTerms: false,
+            showDefaultOrgSelector: false,
+            redirectToSyncPage: false,
+          },
+          afterSettled: {
+            isFullExperience: false,
+            isLoading: false,
+            showAgreeToTerms: false,
+            showDefaultOrgSelector: false,
+            redirectToSyncPage: true,
+          },
+        },
+      },
+    ],
+    [
+      'self hosted',
+      'Sentry login provider',
+      'has synced a provider',
+      {
+        user: loggedInUser,
+        internalUser: internalUserHasSyncedProviders,
+        termsOfServicePage: false,
+        isSelfHosted: true,
+        defaultOrgSelectorPage: false,
+        expected: {
+          beforeSettled: {
+            isFullExperience: true,
+            isLoading: true,
+            showAgreeToTerms: false,
+            showDefaultOrgSelector: false,
+            redirectToSyncPage: false,
+          },
+          afterSettled: {
+            isFullExperience: true,
+            isLoading: false,
+            showAgreeToTerms: false,
+            showDefaultOrgSelector: false,
+            redirectToSyncPage: false,
+          },
+        },
+      },
+    ],
+    [
+      'self hosted',
+      'Sentry login provider',
+      'has not synced a provider',
+      {
+        user: loggedInUser,
+        internalUser: internalUserNoSyncedProviders,
+        termsOfServicePage: false,
+        isSelfHosted: true,
+        defaultOrgSelectorPage: false,
         expected: {
           beforeSettled: {
             isFullExperience: true,
@@ -828,7 +844,6 @@ describe('useUserAccessGate', () => {
         isSelfHosted,
         expected,
         defaultOrgSelectorPage,
-        sentryLoginProvider,
       }
     ) => {
       describe(`${termsFlagStatus}`, () => {
@@ -840,9 +855,9 @@ describe('useUserAccessGate', () => {
               internalUser,
               termsOfServicePage,
               defaultOrgSelectorPage,
-              sentryLoginProvider,
             })
           })
+
           it(`return values are expect while useUser resolves`, async () => {
             const { result } = renderHook(() => useUserAccessGate(), {
               wrapper: wrapper(['/gh?']),
@@ -865,13 +880,16 @@ describe('useUserAccessGate', () => {
   )
 
   describe('feature flag is on and set up action param is request', () => {
+    beforeEach(() => {
+      config.IS_SELF_HOSTED = false
+    })
+
     it('renders children', async () => {
       setup({
         user: loggedInUser,
         internalUser: internalUserHasSyncedProviders,
         termsOfServicePage: true,
         defaultOrgSelectorPage: true,
-        sentryLoginProvider: true,
       })
 
       const { result } = renderHook(() => useUserAccessGate(), {
@@ -894,7 +912,6 @@ describe('useUserAccessGate', () => {
         internalUser: internalUserHasSyncedProviders,
         termsOfServicePage: true,
         defaultOrgSelectorPage: true,
-        sentryLoginProvider: true,
       })
 
       const { result } = renderHook(() => useUserAccessGate(), {

--- a/src/pages/LoginPage/LoginButton.jsx
+++ b/src/pages/LoginPage/LoginButton.jsx
@@ -1,34 +1,17 @@
 import PropTypes from 'prop-types'
-import { Redirect, useLocation } from 'react-router-dom'
 
 import { useNavLinks } from 'services/navigation'
-import { useFlags } from 'shared/featureFlags'
 import {
-  LOGIN_PROVIDER_NAMES,
   loginProviderImage,
   loginProviderToName,
 } from 'shared/utils/loginProviders'
 
-// temp disabling because of flag
-
 function LoginButton({ provider }) {
-  const { sentryLoginProvider } = useFlags({
-    sentryLoginProvider: false,
-  })
-  const location = useLocation()
   const { signIn } = useNavLinks()
 
   const to = `${window.location.protocol}//${window.location.host}/${provider}`
   const providerName = loginProviderToName(provider)
   const providerImage = loginProviderImage(provider)
-
-  if (!sentryLoginProvider && providerName === LOGIN_PROVIDER_NAMES.sentry) {
-    if (location.pathname === '/login') {
-      return null
-    }
-
-    return <Redirect to="/login" />
-  }
 
   return (
     <a

--- a/src/pages/LoginPage/LoginButton.spec.jsx
+++ b/src/pages/LoginPage/LoginButton.spec.jsx
@@ -1,13 +1,10 @@
-import { render, screen, waitFor } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 import { MemoryRouter, Route } from 'react-router-dom'
-
-import { useFlags } from 'shared/featureFlags'
 
 import LoginButton from './LoginButton'
 
 jest.mock('shared/featureFlags')
 
-let testLocation
 const wrapper =
   ({ initialEntries, path }) =>
   ({ children }) =>
@@ -16,27 +13,12 @@ const wrapper =
         <Route path={path} exact>
           {children}
         </Route>
-        <Route
-          path="*"
-          render={({ location }) => {
-            testLocation = location
-            return null
-          }}
-        />
       </MemoryRouter>
     )
 
 describe('LoginButton', () => {
-  function setup(flagValue = false) {
-    useFlags.mockReturnValue({
-      sentryLoginProvider: flagValue,
-    })
-  }
-
   describe('bitbucket', () => {
     it('renders bitbucket login button', () => {
-      setup()
-
       render(<LoginButton provider="bb" />, {
         wrapper: wrapper({
           initialEntries: '/login/bb',
@@ -51,8 +33,6 @@ describe('LoginButton', () => {
 
   describe('github', () => {
     it('renders github login button', () => {
-      setup()
-
       render(<LoginButton provider="gh" />, {
         wrapper: wrapper({
           initialEntries: '/login/gh',
@@ -67,8 +47,6 @@ describe('LoginButton', () => {
 
   describe('gitlab', () => {
     it('renders gitlab login button', () => {
-      setup()
-
       render(<LoginButton provider="gl" />, {
         wrapper: wrapper({
           initialEntries: '/login/gl',
@@ -82,50 +60,16 @@ describe('LoginButton', () => {
   })
 
   describe('sentry', () => {
-    describe('flag is enabled', () => {
-      it('renders sentry login button', () => {
-        setup(true)
-        render(<LoginButton provider="sentry" />, {
-          wrapper: wrapper({
-            initialEntries: '/login/sentry',
-            path: '/login/:provider',
-          }),
-        })
-
-        const sentry = screen.getByText(/Login with Sentry/i)
-        expect(sentry).toBeInTheDocument()
-      })
-    })
-
-    describe('flag is disabled', () => {
-      describe('provider is set to sentry', () => {
-        it('redirects the user to base login page', async () => {
-          setup(false)
-          render(<LoginButton provider="sentry" />, {
-            wrapper: wrapper({
-              initialEntries: '/login/sentry',
-              path: '/login/:provider',
-            }),
-          })
-
-          await waitFor(() => expect(testLocation.pathname).toBe('/login'))
-        })
+    it('renders sentry login button', () => {
+      render(<LoginButton provider="sentry" />, {
+        wrapper: wrapper({
+          initialEntries: '/login/sentry',
+          path: '/login/:provider',
+        }),
       })
 
-      describe('on root login route', () => {
-        it('renders nothing', () => {
-          setup(false)
-
-          const { container } = render(<LoginButton provider="sentry" />, {
-            wrapper: wrapper({
-              initialEntries: '/login',
-              path: '/login',
-            }),
-          })
-
-          expect(container).toBeEmptyDOMElement()
-        })
-      })
+      const sentry = screen.getByText(/Login with Sentry/i)
+      expect(sentry).toBeInTheDocument()
     })
   })
 })

--- a/src/pages/LoginPage/LoginPage.jsx
+++ b/src/pages/LoginPage/LoginPage.jsx
@@ -1,17 +1,12 @@
 import { useParams } from 'react-router-dom'
 
 import { useLocationParams } from 'services/navigation'
-import { useFlags } from 'shared/featureFlags'
 import { loginProviderToShortName } from 'shared/utils/loginProviders'
 import A from 'ui/A'
 
 import LoginButton from './LoginButton'
 
 function LoginPage() {
-  const { sentryLoginProvider } = useFlags({
-    sentryLoginProvider: false,
-  })
-
   const { provider } = useParams()
   const { params } = useLocationParams()
   const providerName = loginProviderToShortName(provider)
@@ -33,7 +28,7 @@ function LoginPage() {
         ) : (
           <div className="space-y-4">
             <LoginButton provider="gh" />
-            {sentryLoginProvider && <LoginButton provider="sentry" />}
+            <LoginButton provider="sentry" />
             <LoginButton provider="bb" />
             <LoginButton provider="gl" />
           </div>

--- a/src/pages/LoginPage/LoginPage.spec.jsx
+++ b/src/pages/LoginPage/LoginPage.spec.jsx
@@ -1,11 +1,7 @@
 import { render, screen } from '@testing-library/react'
 import { MemoryRouter, Route, Switch } from 'react-router-dom'
 
-import { useFlags } from 'shared/featureFlags'
-
 import LoginPage from './LoginPage'
-
-jest.mock('shared/featureFlags')
 
 const wrapper =
   (initialEntries) =>
@@ -20,11 +16,9 @@ const wrapper =
     )
 
 describe('LoginPage', () => {
-  function setup(flagValue = false) {
+  function setup() {
     const mockSetItem = jest.spyOn(window.localStorage.__proto__, 'setItem')
     const mockGetItem = jest.spyOn(window.localStorage.__proto__, 'getItem')
-
-    useFlags.mockReturnValue({ sentryLoginProvider: flagValue })
 
     return { mockSetItem, mockGetItem }
   }
@@ -32,75 +26,40 @@ describe('LoginPage', () => {
   afterEach(() => jest.resetAllMocks())
 
   describe('when the url is /login', () => {
-    describe('flag is not enabled', () => {
-      beforeEach(() => setup())
+    it('renders github login button', () => {
+      render(<LoginPage />, { wrapper: wrapper('/login') })
 
-      it('renders github login button', () => {
-        render(<LoginPage />, { wrapper: wrapper('/login') })
-
-        const githubLink = screen.getByRole('link', {
-          name: /login with github/i,
-        })
-        expect(githubLink).toBeInTheDocument()
+      const githubLink = screen.getByRole('link', {
+        name: /login with github/i,
       })
-
-      it('renders gitlab login button', () => {
-        render(<LoginPage />, { wrapper: wrapper('/login') })
-
-        const gitlabLink = screen.getByRole('link', {
-          name: /login with gitlab/i,
-        })
-        expect(gitlabLink).toBeInTheDocument()
-      })
-
-      it('renders bitbucket login button', () => {
-        render(<LoginPage />, { wrapper: wrapper('/login') })
-
-        const bitBucketLink = screen.getByRole('link', {
-          name: /login with bitbucket/i,
-        })
-        expect(bitBucketLink).toBeInTheDocument()
-      })
+      expect(githubLink).toBeInTheDocument()
     })
 
-    describe('flag is enabled', () => {
-      beforeEach(() => setup(true))
+    it('renders sentry login button', () => {
+      render(<LoginPage />, { wrapper: wrapper('/login') })
 
-      it('renders github login button', () => {
-        render(<LoginPage />, { wrapper: wrapper('/login') })
-
-        const githubLink = screen.getByRole('link', {
-          name: /login with github/i,
-        })
-        expect(githubLink).toBeInTheDocument()
+      const sentryLink = screen.getByRole('link', {
+        name: /login with sentry/i,
       })
+      expect(sentryLink).toBeInTheDocument()
+    })
 
-      it('renders sentry login button', () => {
-        render(<LoginPage />, { wrapper: wrapper('/login') })
+    it('renders gitlab login button', () => {
+      render(<LoginPage />, { wrapper: wrapper('/login') })
 
-        const sentryLink = screen.getByRole('link', {
-          name: /login with sentry/i,
-        })
-        expect(sentryLink).toBeInTheDocument()
+      const gitlabLink = screen.getByRole('link', {
+        name: /login with gitlab/i,
       })
+      expect(gitlabLink).toBeInTheDocument()
+    })
 
-      it('renders gitlab login button', () => {
-        render(<LoginPage />, { wrapper: wrapper('/login') })
+    it('renders bitbucket login button', () => {
+      render(<LoginPage />, { wrapper: wrapper('/login') })
 
-        const gitlabLink = screen.getByRole('link', {
-          name: /login with gitlab/i,
-        })
-        expect(gitlabLink).toBeInTheDocument()
+      const bitBucketLink = screen.getByRole('link', {
+        name: /login with bitbucket/i,
       })
-
-      it('renders bitbucket login button', () => {
-        render(<LoginPage />, { wrapper: wrapper('/login') })
-
-        const bitBucketLink = screen.getByRole('link', {
-          name: /login with bitbucket/i,
-        })
-        expect(bitBucketLink).toBeInTheDocument()
-      })
+      expect(bitBucketLink).toBeInTheDocument()
     })
   })
 

--- a/src/pages/SyncProviderPage/SyncProviderPage.spec.tsx
+++ b/src/pages/SyncProviderPage/SyncProviderPage.spec.tsx
@@ -8,13 +8,8 @@ import {
   InternalUserData,
   InternalUserOwnerData,
 } from 'services/user/useInternalUser'
-import { useFlags } from 'shared/featureFlags'
 
 import SyncProviderPage from './SyncProviderPage'
-
-jest.mock('shared/featureFlags')
-
-const mockedUseFlags = useFlags as jest.Mock<{ sentryLoginProvider: boolean }>
 
 const createMockedInternalUser = (
   owner?: InternalUserOwnerData
@@ -61,19 +56,11 @@ afterAll(() => {
 })
 
 interface SetupArgs {
-  flagValue?: boolean
   user?: InternalUserData
 }
 
 describe('SyncProviderPage', () => {
-  function setup({
-    flagValue = false,
-    user = createMockedInternalUser(),
-  }: SetupArgs) {
-    mockedUseFlags.mockReturnValue({
-      sentryLoginProvider: flagValue,
-    })
-
+  function setup({ user = createMockedInternalUser() }: SetupArgs) {
     server.use(
       rest.get('/internal/user', (req, res, ctx) =>
         res(ctx.status(200), ctx.json(user))
@@ -81,113 +68,92 @@ describe('SyncProviderPage', () => {
     )
   }
 
-  describe('flag is enabled', () => {
-    describe('user has not synced a provider', () => {
-      it('renders page header', async () => {
-        setup({
-          flagValue: true,
-          user: createMockedInternalUser({ name: 'test-provider' }),
-        })
-
-        render(<SyncProviderPage />, { wrapper })
-
-        const header = screen.getByRole('heading', {
-          name: /What repo provider would you like to sync?/,
-        })
-        expect(header).toBeInTheDocument()
+  describe('user has not synced a provider', () => {
+    it('renders page header', async () => {
+      setup({
+        user: createMockedInternalUser({ name: 'test-provider' }),
       })
-
-      it('renders paragraph text', async () => {
-        setup({
-          flagValue: true,
-          user: createMockedInternalUser({ name: 'test-provider' }),
-        })
-
-        render(<SyncProviderPage />, { wrapper })
-
-        const paragraph = await screen.findByText(
-          /You'll be taken to your repo provider to authenticate/
-        )
-        expect(paragraph).toBeInTheDocument()
-      })
-
-      it('renders github sync button', async () => {
-        setup({
-          flagValue: true,
-          user: createMockedInternalUser({ name: 'test-provider' }),
-        })
-
-        render(<SyncProviderPage />, { wrapper })
-
-        const githubSyncButton = await screen.findByText(/Sync with Github/)
-        expect(githubSyncButton).toBeInTheDocument()
-      })
-
-      it('renders gitlab sync button', async () => {
-        setup({
-          flagValue: true,
-          user: createMockedInternalUser({ name: 'test-provider' }),
-        })
-
-        render(<SyncProviderPage />, { wrapper })
-
-        const gitlabSyncButton = await screen.findByText(/Sync with Gitlab/)
-        expect(gitlabSyncButton).toBeInTheDocument()
-      })
-
-      it('renders bitbucket sync button', async () => {
-        setup({
-          flagValue: true,
-          user: createMockedInternalUser({ name: 'test-provider' }),
-        })
-
-        render(<SyncProviderPage />, { wrapper })
-
-        const bitbucketSyncButton = await screen.findByText(
-          /Sync with BitBucket/
-        )
-        expect(bitbucketSyncButton).toBeInTheDocument()
-      })
-    })
-
-    describe('user has synced a provider', () => {
-      describe('service is valid', () => {
-        it('redirects to the service provider', async () => {
-          setup({
-            flagValue: true,
-            user: createMockedInternalUser({
-              name: 'github',
-              service: 'github',
-            }),
-          })
-
-          render(<SyncProviderPage />, { wrapper })
-
-          await waitFor(() => expect(testLocation.pathname).toBe('/gh'))
-        })
-      })
-      describe('user does not have a service', () => {
-        it('redirects user to /', async () => {
-          setup({
-            flagValue: true,
-            user: createMockedInternalUser({ name: 'github' }),
-          })
-
-          render(<SyncProviderPage />, { wrapper })
-
-          await waitFor(() => expect(testLocation.pathname).toBe('/'))
-        })
-      })
-    })
-  })
-
-  describe('flag is disabled', () => {
-    it('redirects user to /', async () => {
-      setup({ flagValue: false })
 
       render(<SyncProviderPage />, { wrapper })
 
-      await waitFor(() => expect(testLocation.pathname).toBe('/'))
+      const header = screen.getByRole('heading', {
+        name: /What repo provider would you like to sync?/,
+      })
+      expect(header).toBeInTheDocument()
+    })
+
+    it('renders paragraph text', async () => {
+      setup({
+        user: createMockedInternalUser({ name: 'test-provider' }),
+      })
+
+      render(<SyncProviderPage />, { wrapper })
+
+      const paragraph = await screen.findByText(
+        /You'll be taken to your repo provider to authenticate/
+      )
+      expect(paragraph).toBeInTheDocument()
+    })
+
+    it('renders github sync button', async () => {
+      setup({
+        user: createMockedInternalUser({ name: 'test-provider' }),
+      })
+
+      render(<SyncProviderPage />, { wrapper })
+
+      const githubSyncButton = await screen.findByText(/Sync with Github/)
+      expect(githubSyncButton).toBeInTheDocument()
+    })
+
+    it('renders gitlab sync button', async () => {
+      setup({
+        user: createMockedInternalUser({ name: 'test-provider' }),
+      })
+
+      render(<SyncProviderPage />, { wrapper })
+
+      const gitlabSyncButton = await screen.findByText(/Sync with Gitlab/)
+      expect(gitlabSyncButton).toBeInTheDocument()
+    })
+
+    it('renders bitbucket sync button', async () => {
+      setup({
+        user: createMockedInternalUser({ name: 'test-provider' }),
+      })
+
+      render(<SyncProviderPage />, { wrapper })
+
+      const bitbucketSyncButton = await screen.findByText(/Sync with BitBucket/)
+      expect(bitbucketSyncButton).toBeInTheDocument()
+    })
+  })
+
+  describe('user has synced a provider', () => {
+    describe('service is valid', () => {
+      it('redirects to the service provider', async () => {
+        setup({
+          user: createMockedInternalUser({
+            name: 'github',
+            service: 'github',
+          }),
+        })
+
+        render(<SyncProviderPage />, { wrapper })
+
+        await waitFor(() => expect(testLocation.pathname).toBe('/gh'))
+      })
+    })
+    describe('user does not have a service', () => {
+      it('redirects user to /', async () => {
+        setup({
+          user: createMockedInternalUser({ name: 'github' }),
+        })
+
+        render(<SyncProviderPage />, { wrapper })
+
+        await waitFor(() => expect(testLocation.pathname).toBe('/'))
+      })
     })
   })
 })

--- a/src/pages/SyncProviderPage/SyncProviderPage.tsx
+++ b/src/pages/SyncProviderPage/SyncProviderPage.tsx
@@ -2,16 +2,11 @@ import gt from 'lodash/gt'
 import { Redirect } from 'react-router-dom'
 
 import { useInternalUser } from 'services/user/useInternalUser'
-import { useFlags } from 'shared/featureFlags'
 import { loginProviderToShortName } from 'shared/utils/loginProviders'
 
 import SyncButton from './SyncButton'
 
 function SyncProviderPage() {
-  const { sentryLoginProvider } = useFlags({
-    sentryLoginProvider: false,
-  })
-
   const { data: internalUser } = useInternalUser({})
 
   // will be false if 0 | undefined | null
@@ -26,7 +21,7 @@ function SyncProviderPage() {
   // --
   // once we allow users to sync multiple providers need change this logic
   // to allow them to view this page
-  if (!sentryLoginProvider || hasSynced) {
+  if (hasSynced) {
     const service = internalUser?.owners?.[0]?.service
     if (service) {
       const provider = loginProviderToShortName(service)


### PR DESCRIPTION
# Description

This PR removes the feature flag for login w/Sentry, as well as removing the checks hiding the `SyncProviderPage` when running in self hosted mode.

Closes codecov/engineering-team#476

# Notable Changes

- Enable `SyncProviderPage` in `App`
- Remove `sentryLoginProvider` flag from components and tests
- Update `useUserAccessGate` to function properly in self hosted mode.