### PR TITLE
Update pull request page for better mobile styles, premtive work for flag select

### DIFF
--- a/src/pages/PullRequestPage/Header/Header.jsx
+++ b/src/pages/PullRequestPage/Header/Header.jsx
@@ -22,7 +22,7 @@ function Header() {
   const { data } = usePullHeadData({ provider, owner, repo, pullId })
 
   return (
-    <div className="flex justify-between border-b border-ds-gray-secondary pb-2 text-xs">
+    <div className="flex flex-col justify-between gap-2 border-b border-ds-gray-secondary pb-2 text-xs md:flex-row">
       <div>
         <h1 className="flex items-center gap-2 text-lg font-semibold">
           {data?.pull?.title}

--- a/src/ui/FileViewer/ToggleHeader/Title/Title.jsx
+++ b/src/ui/FileViewer/ToggleHeader/Title/Title.jsx
@@ -18,7 +18,7 @@ export default function Title({ title, children, sticky = false }) {
       data-testid="title-wrapper-div"
       className={cs(
         { 'z-10 sticky top-[4.5rem]': sticky },
-        'flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4 flex-wrap bg-white px-3 sm:px-0'
+        'flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4 flex-wrap bg-white px-0 w-full lg:w-auto flex-1 lg:flex-none md:mb-1'
       )}
     >
       {title && (
@@ -26,7 +26,7 @@ export default function Title({ title, children, sticky = false }) {
           {title}
         </span>
       )}
-      <div className="flex flex-col items-center justify-between gap-2 sm:flex-row">
+      <div className="flex w-full flex-wrap items-center justify-between gap-2 md:w-auto">
         {children}
       </div>
     </div>

--- a/src/ui/FileViewer/ToggleHeader/ToggleHeader.jsx
+++ b/src/ui/FileViewer/ToggleHeader/ToggleHeader.jsx
@@ -12,12 +12,10 @@ function ToggleHeader({
 }) {
   return (
     <Title title={title} sticky={sticky}>
-      <div className="flex flex-row gap-2">
-        <TitleCoverage coverage={LINE_STATE.UNCOVERED} />
-        <TitleCoverage coverage={LINE_STATE.PARTIAL} />
-        <TitleCoverage coverage={LINE_STATE.COVERED} />
-        <TitleHitCount showHitCount={showHitCount} />
-      </div>
+      <TitleCoverage coverage={LINE_STATE.UNCOVERED} />
+      <TitleCoverage coverage={LINE_STATE.PARTIAL} />
+      <TitleCoverage coverage={LINE_STATE.COVERED} />
+      <TitleHitCount showHitCount={showHitCount} />
       {showFlagsSelect && <TitleFlags />}
     </Title>
   )

--- a/src/ui/MultiSelect/MultiSelect.jsx
+++ b/src/ui/MultiSelect/MultiSelect.jsx
@@ -89,7 +89,7 @@ function DropdownList({
       className={cs(
         SelectClasses.listContainer,
         {
-          'border border-gray-ds-tertiary max-h-72 overflow-scroll': isOpen,
+          'border border-gray-ds-tertiary max-h-72 overflow-y-scroll': isOpen,
         },
         onSearch ? 'top-16' : 'top-8'
       )}

--- a/src/ui/TabNavigation/TabNavigation.jsx
+++ b/src/ui/TabNavigation/TabNavigation.jsx
@@ -3,15 +3,15 @@ import PropTypes from 'prop-types'
 import AppLink from 'shared/AppLink'
 
 const styles = {
-  link: 'mr-5 py-2 hover:border-b-4 hover:border-ds-gray-quinary text-ds-gray-quinary',
+  link: 'mr-5 py-2 hover:border-b-4 hover:border-ds-gray-quinary text-ds-gray-quinary whitespace-nowrap',
   activeLink:
     '!text-ds-gray-octonary border-b-4 !border-ds-gray-octonary font-semibold',
 }
 
 function TabNavigation({ tabs, component }) {
   return (
-    <div className="mx-4 flex flex-wrap justify-between overflow-auto border-b border-ds-gray-tertiary sm:mx-0">
-      <nav className="flex">
+    <div className="mx-0 flex flex-col-reverse justify-between gap-2 border-b border-ds-gray-tertiary md:flex-col xl:flex-row ">
+      <nav className="flex overflow-auto">
         {tabs.map((tab) => (
           <AppLink
             {...tab}


### PR DESCRIPTION
# Description
Preemptive css work to allow MultiSelect to be compatible with the pull request page / commit detail page tab navigation section

# Code Example

# Notable Changes
- I saw the order of stats + navigation on small screens because it looks nice.

# Screenshots

Note: flag multi select not included in these changes

![Screenshot 2023-09-21 at 2 53 55 PM](https://github.com/codecov/gazebo/assets/87824812/b53e0c97-c860-49e0-8ee9-d26eb5574474)
Desktop screens


![Screenshot 2023-09-21 at 2 54 31 PM](https://github.com/codecov/gazebo/assets/87824812/cb01c8b3-8ed0-49ea-b8b9-e4451a347761)
Medium screens

![Screenshot 2023-09-21 at 2 55 32 PM](https://github.com/codecov/gazebo/assets/87824812/c09d204d-128e-4211-a30c-60dd9a7ca05c)
Small screens

# Link to Sample Entry

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.