### PR TITLE
feat: Update Zod Schemas to Handle New FirstPullRequest GraphQL Type

### DIFF
--- a/src/pages/PullRequestPage/hooks/usePullPageData.tsx
+++ b/src/pages/PullRequestPage/hooks/usePullPageData.tsx
@@ -83,6 +83,9 @@ query PullPageData($owner: String!, $repo: String!, $pullId: Int!) {
               flagComparisonsCount
               componentComparisonsCount
             }
+            ... on FirstPullRequest {
+              message
+            }
             ... on MissingBaseCommit {
               message
             }
@@ -96,9 +99,6 @@ query PullPageData($owner: String!, $repo: String!, $pullId: Int!) {
               message
             }
             ... on MissingHeadReport {
-              message
-            }
-            ... on FirstPullRequest {
               message
             }
           }

--- a/src/pages/PullRequestPage/hooks/usePullPageData.tsx
+++ b/src/pages/PullRequestPage/hooks/usePullPageData.tsx
@@ -2,6 +2,7 @@ import { useQuery } from '@tanstack/react-query'
 import { z } from 'zod'
 
 import {
+  FirstPullRequestSchema,
   MissingBaseCommitSchema,
   MissingBaseReportSchema,
   MissingComparisonSchema,
@@ -35,6 +36,7 @@ const RepositorySchema = z.object({
             flagComparisonsCount: z.number(),
             componentComparisonsCount: z.number(),
           }),
+          FirstPullRequestSchema,
           MissingBaseCommitSchema,
           MissingBaseReportSchema,
           MissingComparisonSchema,
@@ -94,6 +96,9 @@ query PullPageData($owner: String!, $repo: String!, $pullId: Int!) {
               message
             }
             ... on MissingHeadReport {
+              message
+            }
+            ... on FirstPullRequest {
               message
             }
           }

--- a/src/pages/PullRequestPage/subroute/ComponentsTab/hooks/query.ts
+++ b/src/pages/PullRequestPage/subroute/ComponentsTab/hooks/query.ts
@@ -21,6 +21,9 @@ export const query = `
                   }
                 }
               }
+              ... on FirstPullRequest {
+                message
+              }
               ... on MissingBaseCommit {
                 message
               }
@@ -34,9 +37,6 @@ export const query = `
                 message
               }
               ... on MissingHeadReport {
-                message
-              }
-              ... on FirstPullRequest {
                 message
               }
             }

--- a/src/pages/PullRequestPage/subroute/ComponentsTab/hooks/query.ts
+++ b/src/pages/PullRequestPage/subroute/ComponentsTab/hooks/query.ts
@@ -36,6 +36,9 @@ export const query = `
               ... on MissingHeadReport {
                 message
               }
+              ... on FirstPullRequest {
+                message
+              }
             }
           }
         }

--- a/src/pages/PullRequestPage/subroute/ComponentsTab/hooks/useComponentComparison.tsx
+++ b/src/pages/PullRequestPage/subroute/ComponentsTab/hooks/useComponentComparison.tsx
@@ -3,6 +3,7 @@ import { useParams } from 'react-router-dom'
 import { z } from 'zod'
 
 import {
+  FirstPullRequestSchema,
   MissingBaseCommitSchema,
   MissingBaseReportSchema,
   MissingComparisonSchema,
@@ -44,6 +45,7 @@ const RepositorySchema = z.object({
             )
             .nullable(),
         }),
+        FirstPullRequestSchema,
         MissingBaseCommitSchema,
         MissingBaseReportSchema,
         MissingComparisonSchema,

--- a/src/services/comparison/schemas/FirstPullRequest.ts
+++ b/src/services/comparison/schemas/FirstPullRequest.ts
@@ -1,0 +1,8 @@
+import { z } from 'zod'
+
+export const FirstPullRequestSchema = z.object({
+  __typename: z.literal('FirstPullRequest'),
+  message: z.string(),
+})
+
+export type FirstPullRequest = z.infer<typeof FirstPullRequestSchema>

--- a/src/services/comparison/schemas/index.ts
+++ b/src/services/comparison/schemas/index.ts
@@ -1,3 +1,4 @@
+export * from './FirstPullRequest'
 export * from './MissingBaseCommit'
 export * from './MissingBaseReport'
 export * from './MissingComparison'

--- a/src/services/pulls/usePulls.tsx
+++ b/src/services/pulls/usePulls.tsx
@@ -6,6 +6,7 @@ import isArray from 'lodash/isArray'
 import { z } from 'zod'
 
 import {
+  FirstPullRequestSchema,
   MissingBaseCommitSchema,
   MissingBaseReportSchema,
   MissingComparisonSchema,
@@ -59,6 +60,7 @@ const PullSchema = z
             .nullable(),
           changeCoverage: z.number().nullable(),
         }),
+        FirstPullRequestSchema,
         MissingBaseCommitSchema,
         MissingBaseReportSchema,
         MissingComparisonSchema,
@@ -145,6 +147,9 @@ query GetPulls(
                     percentCovered
                   }
                   changeCoverage
+                }
+                ... on FirstPullRequest {
+                  message
                 }
                 ... on MissingBaseCommit {
                   message


### PR DESCRIPTION
# Description

Update current typescript translated hooks to support handling the new `FirstPullRequest` type added to the union `Comparison` type in the API.