### PR TITLE
fix: Update Remaining Comparisons with FirstPullRequest Spread

### DIFF
--- a/src/services/commit/useCommit.tsx
+++ b/src/services/commit/useCommit.tsx
@@ -2,6 +2,7 @@ import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { z } from 'zod'
 
 import {
+  FirstPullRequestSchema,
   MissingBaseCommitSchema,
   MissingBaseReportSchema,
   MissingComparisonSchema,
@@ -93,6 +94,7 @@ const ComparisonSchema = z.object({
 
 const CompareWithParentSchema = z.discriminatedUnion('__typename', [
   ComparisonSchema,
+  FirstPullRequestSchema,
   MissingBaseCommitSchema,
   MissingBaseReportSchema,
   MissingComparisonSchema,
@@ -219,6 +221,9 @@ query Commit(
                 }
               }
             }
+            ... on FirstPullRequest {
+              message
+            }
             ... on MissingBaseCommit {
               message
             }
@@ -292,7 +297,6 @@ export function useCommit({
         const parsedRes = RequestSchema.safeParse(res?.data)
 
         if (!parsedRes.success) {
-          console.debug(parsedRes.error)
           return Promise.reject({
             status: 404,
             data: null,

--- a/src/services/commit/useCompareTotals.tsx
+++ b/src/services/commit/useCompareTotals.tsx
@@ -2,6 +2,7 @@ import { useQuery, type UseQueryOptions } from '@tanstack/react-query'
 import { z } from 'zod'
 
 import {
+  FirstPullRequestSchema,
   MissingBaseCommitSchema,
   MissingBaseReportSchema,
   MissingComparisonSchema,
@@ -36,6 +37,7 @@ const ComparisonSchema = z.object({
 const CompareWithParentSchema = z
   .discriminatedUnion('__typename', [
     ComparisonSchema,
+    FirstPullRequestSchema,
     MissingBaseCommitSchema,
     MissingBaseReportSchema,
     MissingComparisonSchema,
@@ -96,6 +98,9 @@ query CompareTotals(
                   coverage: percentCovered
                 }
               }
+            }
+            ... on FirstPullRequest {
+              message
             }
             ... on MissingBaseCommit {
               message

--- a/src/services/commits/useCommits.js
+++ b/src/services/commits/useCommits.js
@@ -30,6 +30,24 @@ function fetchRepoCommits({ provider, owner, repo, variables, after, signal }) {
                 coverage
             }
           }
+          ... on FirstPullRequest {
+            message
+          }
+          ... on MissingBaseCommit {
+            message
+          }
+          ... on MissingHeadCommit {
+            message
+          }
+          ... on MissingComparison {
+            message
+          }
+          ... on MissingBaseReport {
+            message
+          }
+          ... on MissingHeadReport {
+            message
+          }
         }
     }
   `

--- a/src/services/comparison/constants.js
+++ b/src/services/comparison/constants.js
@@ -41,5 +41,23 @@ fragment ComparisonFragment on Comparison {
       }
     }
   }
+  ... on FirstPullRequest {
+    message
+  }
+  ... on MissingBaseCommit {
+    message
+  }
+  ... on MissingHeadCommit {
+    message
+  }
+  ... on MissingComparison {
+    message
+  }
+  ... on MissingBaseReport {
+    message
+  }
+  ... on MissingHeadReport {
+    message
+  }
 }
 `

--- a/src/services/pull/fragments.js
+++ b/src/services/pull/fragments.js
@@ -41,6 +41,24 @@ fragment SummaryOnPullFragment on Pull {
       changeCoverage
       hasDifferentNumberOfHeadAndBaseReports
     }
+    ... on FirstPullRequest {
+      message
+    }
+    ... on MissingBaseCommit {
+      message
+    }
+    ... on MissingHeadCommit {
+      message
+    }
+    ... on MissingComparison {
+      message
+    }
+    ... on MissingBaseReport {
+      message
+    }
+    ... on MissingHeadReport {
+      message
+    }
   }
   commits {
     edges {
@@ -88,6 +106,24 @@ fragment FlagComparisonsOnPull on Pull {
       }
     }
   }
+  ... on FirstPullRequest {
+    message
+  }
+  ... on MissingBaseCommit {
+    message
+  }
+  ... on MissingHeadCommit {
+    message
+  }
+  ... on MissingComparison {
+    message
+  }
+  ... on MissingBaseReport {
+    message
+  }
+  ... on MissingHeadReport {
+    message
+  }
 }
 `
 
@@ -125,6 +161,24 @@ fragment ImpactedFilesOnPull on Pull {
         }
         changeCoverage
       }
+    }
+    ... on FirstPullRequest {
+      message
+    }
+    ... on MissingBaseCommit {
+      message
+    }
+    ... on MissingHeadCommit {
+      message
+    }
+    ... on MissingComparison {
+      message
+    }
+    ... on MissingBaseReport {
+      message
+    }
+    ... on MissingHeadReport {
+      message
     }
   }
 }
@@ -172,6 +226,24 @@ fragment FileComparisonWithBase on Pull {
           }
         }
       }
+    }
+    ... on FirstPullRequest {
+      message
+    }
+    ... on MissingBaseCommit {
+      message
+    }
+    ... on MissingHeadCommit {
+      message
+    }
+    ... on MissingComparison {
+      message
+    }
+    ... on MissingBaseReport {
+      message
+    }
+    ... on MissingHeadReport {
+      message
     }
   }
 }

--- a/src/services/pulls/usePulls.tsx
+++ b/src/services/pulls/usePulls.tsx
@@ -2,7 +2,6 @@ import {
   useInfiniteQuery,
   type UseInfiniteQueryOptions,
 } from '@tanstack/react-query'
-import isArray from 'lodash/isArray'
 import { z } from 'zod'
 
 import {
@@ -18,6 +17,7 @@ import {
   RepoOwnerNotActivatedErrorSchema,
 } from 'services/repo'
 import Api from 'shared/api'
+import { mapEdges } from 'shared/utils/graphql'
 import A from 'ui/A'
 
 const PullStatesSchema = z.union([
@@ -255,22 +255,10 @@ export function usePulls({
           })
         }
 
-        const edges = data?.owner?.repository?.pulls?.edges
-        let branches: Array<Pull | null> = []
-        if (isArray(edges)) {
-          for (const edge of edges) {
-            if (edge?.node) {
-              branches.push(edge.node)
-            }
-
-            if (edge === null) {
-              branches.push(edge)
-            }
-          }
-        }
+        const pulls = mapEdges(data?.owner?.repository?.pulls)
 
         return {
-          pulls: branches,
+          pulls,
           pageInfo: data?.owner?.repository?.pulls?.pageInfo ?? null,
         }
       })


### PR DESCRIPTION
# Description

With the addition of this new type on the union we need to check for it in a few more locations.

# Notable Changes

- Update `usePulls` to use new `mapEdges` funciton
- Update `useCommit` hook to handle `FirstPullRequest` type
- Update `useCompareTotals` hook to handle `FirstPullRequest` type
- Update other queries to spread on comparison type