### PR TITLE
feat: Handle first PR experience 

### DIFF
--- a/src/pages/PullRequestPage/FirstPullBanner/FirstPullBanner.spec.tsx
+++ b/src/pages/PullRequestPage/FirstPullBanner/FirstPullBanner.spec.tsx
@@ -1,0 +1,31 @@
+import { render, screen } from '@testing-library/react'
+
+import FirstPullBanner from './FirstPullBanner'
+
+describe('FirstPullBanner', () => {
+  it('should render', () => {
+    render(<FirstPullBanner firstPull={true} state={'OPEN'} />)
+
+    const header = screen.getByRole('heading', { name: /Welcome to Codecov/ })
+    expect(header).toBeInTheDocument()
+
+    const content = screen.getByText(/Once merged to your default branch/)
+    expect(content).toBeInTheDocument()
+  })
+
+  it('should not render if not first pull', () => {
+    const { container } = render(
+      <FirstPullBanner firstPull={false} state={'OPEN'} />
+    )
+
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('should not render if state not open', () => {
+    const { container } = render(
+      <FirstPullBanner firstPull={true} state={'CLOSED'} />
+    )
+
+    expect(container).toBeEmptyDOMElement()
+  })
+})

--- a/src/pages/PullRequestPage/FirstPullBanner/FirstPullBanner.tsx
+++ b/src/pages/PullRequestPage/FirstPullBanner/FirstPullBanner.tsx
@@ -1,0 +1,40 @@
+import PropTypes from 'prop-types'
+
+import Banner from 'ui/Banner'
+import BannerContent from 'ui/Banner/BannerContent'
+import BannerHeading from 'ui/Banner/BannerHeading'
+
+interface FirstPullBannerProps {
+  firstPull: boolean
+  state: 'OPEN' | 'CLOSED' | 'MERGED' | null
+}
+
+const FirstPullBanner: React.FC<FirstPullBannerProps> = ({
+  firstPull,
+  state,
+}) => {
+  if (!firstPull || state !== 'OPEN') {
+    return null
+  }
+
+  return (
+    <Banner>
+      <BannerHeading>
+        <h2 className="flex justify-center gap-2 font-semibold">
+          Welcome to Codecov &#127881;
+        </h2>
+      </BannerHeading>
+      <BannerContent>
+        Once merged to your default branch, Codecov will compare your coverage
+        reports and display the results here.
+      </BannerContent>
+    </Banner>
+  )
+}
+
+FirstPullBanner.propTypes = {
+  firstPull: PropTypes.bool.isRequired,
+  state: PropTypes.oneOf(['OPEN', 'CLOSED', 'MERGED']),
+}
+
+export default FirstPullBanner

--- a/src/pages/PullRequestPage/FirstPullBanner/index.js
+++ b/src/pages/PullRequestPage/FirstPullBanner/index.js
@@ -1,0 +1,1 @@
+export { default } from './FirstPullBanner'

--- a/src/pages/PullRequestPage/PullRequestPage.jsx
+++ b/src/pages/PullRequestPage/PullRequestPage.jsx
@@ -12,6 +12,7 @@ import CompareSummarySkeleton from './Summary/CompareSummarySkeleton'
 const CompareSummary = lazy(() => import('./Summary'))
 const PullRequestPageTabs = lazy(() => import('./PullRequestPageTabs'))
 const PullRequestPageContent = lazy(() => import('./PullRequestPageContent'))
+const FirstPullBanner = lazy(() => import('./FirstPullBanner'))
 
 const Loader = () => (
   <div className="flex items-center justify-center py-16">
@@ -45,6 +46,10 @@ function PullRequestPage() {
       <Header />
       <Suspense fallback={<CompareSummarySkeleton />}>
         <CompareSummary />
+        <FirstPullBanner
+          firstPull={data?.pull?.firstPull}
+          state={data?.pull?.state}
+        />
       </Suspense>
       <Suspense fallback={<Loader />}>
         <div className="grid grid-cols-1 gap-4 space-y-2 lg:grid-cols-2">

--- a/src/pages/PullRequestPage/PullRequestPage.spec.jsx
+++ b/src/pages/PullRequestPage/PullRequestPage.spec.jsx
@@ -12,6 +12,7 @@ jest.mock('shared/featureFlags')
 jest.mock('./Summary', () => () => 'CompareSummary')
 jest.mock('./PullRequestPageContent', () => () => 'PullRequestPageContent')
 jest.mock('./PullRequestPageTabs', () => () => 'PullRequestPageTabs')
+jest.mock('./FirstPullBanner', () => () => 'FirstPullBanner')
 
 const mockPullHeadData = {
   owner: {
@@ -19,6 +20,7 @@ const mockPullHeadData = {
       __typename: 'Repository',
       pull: {
         pullId: 12,
+        firstPull: false,
         title: 'Cool New Pull Request',
         state: 'OPEN',
         author: {
@@ -36,6 +38,8 @@ const mockPullHeadData = {
 
 const mockPullPageData = {
   pullId: 1,
+  firstPull: false,
+  state: 'OPEN',
   head: {
     commitid: '123',
   },
@@ -132,7 +136,7 @@ describe('PullRequestPage', () => {
     it('renders compare summary', async () => {
       render(<PullRequestPage />, { wrapper: wrapper() })
 
-      const compareSummary = await screen.findByText('CompareSummary')
+      const compareSummary = await screen.findByText(/CompareSummary/)
       expect(compareSummary).toBeInTheDocument()
     })
 
@@ -150,6 +154,13 @@ describe('PullRequestPage', () => {
         /PullRequestPageContent/
       )
       expect(pullRequestPageContent).toBeInTheDocument()
+    })
+
+    it('renders first pull banner', async () => {
+      render(<PullRequestPage />, { wrapper: wrapper() })
+
+      const firstPullBanner = await screen.findByText(/FirstPullBanner/)
+      expect(firstPullBanner).toBeInTheDocument()
     })
   })
 

--- a/src/pages/PullRequestPage/PullRequestPageContent/PullRequestPageContent.jsx
+++ b/src/pages/PullRequestPage/PullRequestPageContent/PullRequestPageContent.jsx
@@ -31,7 +31,10 @@ function PullRequestPageContent() {
 
   const resultType = data?.pull?.compareWithBase?.__typename
 
-  if (resultType !== ComparisonReturnType.SUCCESSFUL_COMPARISON) {
+  if (
+    resultType !== ComparisonReturnType.SUCCESSFUL_COMPARISON &&
+    !data?.pull?.firstPull
+  ) {
     return <ErrorBanner errorType={resultType} />
   }
 

--- a/src/pages/PullRequestPage/PullRequestPageTabs/PullRequestPageTabs.spec.jsx
+++ b/src/pages/PullRequestPage/PullRequestPageTabs/PullRequestPageTabs.spec.jsx
@@ -24,6 +24,8 @@ const mockPullData = {
       private: true,
       pull: {
         pullId: 1,
+        firstPull: false,
+        state: 'OPEN',
         head: {
           commitid: '123',
         },

--- a/src/pages/PullRequestPage/PullRequestPageTabs/hooks/useTabsCounts.spec.js
+++ b/src/pages/PullRequestPage/PullRequestPageTabs/hooks/useTabsCounts.spec.js
@@ -39,6 +39,8 @@ const mockPullData = {
       private: true,
       pull: {
         pullId: 1,
+        firstPull: false,
+        state: 'OPEN',
         head: {
           commitid: '123',
         },

--- a/src/pages/PullRequestPage/hooks/usePullPageData.spec.tsx
+++ b/src/pages/PullRequestPage/hooks/usePullPageData.spec.tsx
@@ -11,6 +11,8 @@ const mockPullData = {
       __typename: 'Repository',
       pull: {
         pullId: 1,
+        firstPull: false,
+        state: 'OPEN',
         head: {
           commitid: '123',
         },
@@ -130,6 +132,8 @@ describe('usePullPageData', () => {
             expect(result.current.data).toStrictEqual({
               pull: {
                 pullId: 1,
+                firstPull: false,
+                state: 'OPEN',
                 head: {
                   commitid: '123',
                 },

--- a/src/pages/PullRequestPage/hooks/usePullPageData.tsx
+++ b/src/pages/PullRequestPage/hooks/usePullPageData.tsx
@@ -16,11 +16,16 @@ import {
 import Api from 'shared/api'
 import A from 'ui/A'
 
+// state could be state  OPEN | CLOSED | MERGED
 const RepositorySchema = z.object({
   __typename: z.literal('Repository'),
   pull: z
     .object({
       pullId: z.number().nullable(),
+      firstPull: z.boolean(),
+      state: z
+        .union([z.literal('OPEN'), z.literal('CLOSED'), z.literal('MERGED')])
+        .nullable(),
       head: z
         .object({
           commitid: z.string().nullable(),
@@ -71,6 +76,8 @@ query PullPageData($owner: String!, $repo: String!, $pullId: Int!) {
         private
         pull(id: $pullId) {
           pullId
+          firstPull
+          state
           head {
             commitid
           }


### PR DESCRIPTION
# Description
Mostly meant to identify the first PR in the pull request page, display the welcome banner, handle the new type in files changed and indirect changed tab.

# Notable Changes
- New welcome banner (TS!!)
- Handle different types in pull request content 
- Refactor of tests + new tests

# Screenshots
##

# Link to Sample Entry

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.