### PR TITLE
feat: Default to file explorer for the first time UX

### DIFF
--- a/src/pages/PullRequestPage/PullRequestPageContent/ErrorBanner/ErrorBanner.jsx
+++ b/src/pages/PullRequestPage/PullRequestPageContent/ErrorBanner/ErrorBanner.jsx
@@ -1,9 +1,8 @@
 import PropTypes from 'prop-types'
 
+import { ComparisonReturnType } from 'shared/utils/comparison'
 import A from 'ui/A'
 import Banner from 'ui/Banner'
-
-import { ComparisonReturnType } from './constants'
 
 function BannerContent({ errorType }) {
   if (errorType === ComparisonReturnType.MISSING_BASE_COMMIT) {

--- a/src/pages/PullRequestPage/PullRequestPageContent/ErrorBanner/ErrorBanner.spec.jsx
+++ b/src/pages/PullRequestPage/PullRequestPageContent/ErrorBanner/ErrorBanner.spec.jsx
@@ -2,7 +2,8 @@ import { render, screen } from 'custom-testing-library'
 
 import { MemoryRouter, Route } from 'react-router-dom'
 
-import { ComparisonReturnType } from './constants'
+import { ComparisonReturnType } from 'shared/utils/comparison'
+
 import ErrorBanner from './ErrorBanner'
 
 describe('ErrorBanner Card', () => {

--- a/src/pages/PullRequestPage/PullRequestPageContent/PullRequestPageContent.jsx
+++ b/src/pages/PullRequestPage/PullRequestPageContent/PullRequestPageContent.jsx
@@ -4,10 +4,10 @@ import { Redirect, Switch, useParams } from 'react-router-dom'
 import { SentryRoute } from 'sentry'
 
 import SilentNetworkErrorWrapper from 'layouts/shared/SilentNetworkErrorWrapper'
+import { ComparisonReturnType } from 'shared/utils/comparison'
 import Spinner from 'ui/Spinner'
 
 import ErrorBanner from './ErrorBanner'
-import { ComparisonReturnType } from './ErrorBanner/constants'
 
 import { usePullPageData } from '../hooks'
 

--- a/src/pages/PullRequestPage/PullRequestPageContent/PullRequestPageContent.spec.jsx
+++ b/src/pages/PullRequestPage/PullRequestPageContent/PullRequestPageContent.spec.jsx
@@ -4,7 +4,8 @@ import { graphql } from 'msw'
 import { setupServer } from 'msw/node'
 import { MemoryRouter, Route } from 'react-router-dom'
 
-import { ComparisonReturnType } from './ErrorBanner/constants'
+import { ComparisonReturnType } from 'shared/utils/comparison'
+
 import PullRequestPageContent from './PullRequestPageContent'
 
 jest.mock('../subroute/FilesChangedTab', () => () => 'FilesChangedTab')

--- a/src/pages/RepoPage/PullsTab/PullsTable/PullsTable.jsx
+++ b/src/pages/RepoPage/PullsTab/PullsTable/PullsTable.jsx
@@ -84,6 +84,7 @@ function transformPullToTable(pulls, isLoading) {
           pullId={pullId}
           title={title}
           updatestamp={updatestamp}
+          compareWithBaseType={compareWithBase?.__typename}
         />
       ),
       coverage: <Coverage head={head} state={state} pullId={pullId} />,

--- a/src/pages/RepoPage/PullsTab/PullsTable/Title/Title.jsx
+++ b/src/pages/RepoPage/PullsTab/PullsTable/Title/Title.jsx
@@ -4,11 +4,13 @@ import { formatTimeToNow } from 'shared/utils/dates'
 import A from 'ui/A'
 import Avatar, { DefaultAuthor } from 'ui/Avatar'
 
-const Title = ({ author, pullId, title, updatestamp }) => {
+const Title = ({ author, pullId, title, updatestamp, compareWithBaseType }) => {
   const user = {
     avatarUrl: author?.avatarUrl || DefaultAuthor.AVATAR_URL,
     username: author?.username || DefaultAuthor.USERNAME,
   }
+  const pageName =
+    compareWithBaseType === 'FirstPullRequest' ? 'pullTreeView' : 'pullDetail'
 
   return (
     <div className="flex w-96 flex-row lg:w-auto">
@@ -16,7 +18,12 @@ const Title = ({ author, pullId, title, updatestamp }) => {
         <Avatar user={user} bordered />
       </span>
       <div className="flex w-5/6 flex-col lg:w-auto">
-        <A to={{ pageName: 'pullDetail', options: { pullId } }}>
+        <A
+          to={{
+            pageName,
+            options: { pullId },
+          }}
+        >
           <h2 className="text-sm font-semibold text-black">{title}</h2>
         </A>
         <p className="text-xs">
@@ -43,6 +50,7 @@ Title.propTypes = {
   pullId: PropTypes.number,
   title: PropTypes.string,
   updatestamp: PropTypes.string,
+  compareWithBaseType: PropTypes.string,
 }
 
 export default Title

--- a/src/pages/RepoPage/PullsTab/PullsTable/Title/Title.jsx
+++ b/src/pages/RepoPage/PullsTab/PullsTable/Title/Title.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types'
 
+import { ComparisonReturnType } from 'shared/utils/comparison'
 import { formatTimeToNow } from 'shared/utils/dates'
 import A from 'ui/A'
 import Avatar, { DefaultAuthor } from 'ui/Avatar'
@@ -10,7 +11,9 @@ const Title = ({ author, pullId, title, updatestamp, compareWithBaseType }) => {
     username: author?.username || DefaultAuthor.USERNAME,
   }
   const pageName =
-    compareWithBaseType === 'FirstPullRequest' ? 'pullTreeView' : 'pullDetail'
+    compareWithBaseType === ComparisonReturnType.FIRST_PULL_REQUEST
+      ? 'pullTreeView'
+      : 'pullDetail'
 
   return (
     <div className="flex w-96 flex-row lg:w-auto">

--- a/src/pages/RepoPage/PullsTab/PullsTable/Title/Title.spec.jsx
+++ b/src/pages/RepoPage/PullsTab/PullsTable/Title/Title.spec.jsx
@@ -24,8 +24,9 @@ describe('Title', () => {
         { wrapper }
       )
 
-      const text = screen.getByText(/Test1/)
+      const text = screen.getByRole('link', { name: 'Test1' })
       expect(text).toBeInTheDocument()
+      expect(text).toHaveAttribute('href', '/gh/owner/repo/pull/746')
     })
 
     it('renders pull author', () => {
@@ -57,6 +58,25 @@ describe('Title', () => {
       const dt = formatTimeToNow('2021-08-30T19:33:49.819672')
       const dt1 = screen.getByText('last updated ' + dt)
       expect(dt1).toBeInTheDocument()
+    })
+  })
+
+  describe('when rendered for first pull request', () => {
+    it('renders pull title', () => {
+      render(
+        <Title
+          author={{ username: 'RulaKhaled', avatarUrl: 'random' }}
+          pullId={746}
+          title="Test1"
+          updatestamp="2021-08-30T19:33:49.819672"
+          compareWithBaseType="FirstPullRequest"
+        />,
+        { wrapper }
+      )
+
+      const text = screen.getByRole('link', { name: 'Test1' })
+      expect(text).toBeInTheDocument()
+      expect(text).toHaveAttribute('href', '/gh/owner/repo/pull/746/tree')
     })
   })
 })

--- a/src/shared/utils/comparison.js
+++ b/src/shared/utils/comparison.js
@@ -3,5 +3,6 @@ import { CommitErrorTypes } from 'shared/utils/commit'
 export const ComparisonReturnType = Object.freeze({
   SUCCESSFUL_COMPARISON: 'Comparison',
   MISSING_COMPARISON: 'MissingComparison',
+  FIRST_PULL_REQUEST: 'FirstPullRequest',
   ...CommitErrorTypes,
 })


### PR DESCRIPTION
# Description
if first pull request, default to file explorer. 

# Changes
- Update pulls page to default to file explorer for the first pull request  
- Tests 

issue: https://github.com/codecov/engineering-team/issues/404

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.