### PR TITLE
fix: useTreePaths not spreading query params

### DIFF
--- a/src/shared/treePaths/useTreePaths.js
+++ b/src/shared/treePaths/useTreePaths.js
@@ -35,7 +35,7 @@ export function useTreePaths(passedPath) {
   const filePaths = getFilePathParts(passedPath || path)
   const defaultBranch = repoOverview?.defaultBranch
 
-  let queryParams = undefined
+  let queryParams = {}
   if (Object.keys(params).length > 0) {
     queryParams = params
   }

--- a/src/shared/treePaths/useTreePaths.js
+++ b/src/shared/treePaths/useTreePaths.js
@@ -46,7 +46,7 @@ export function useTreePaths(passedPath) {
     options: {
       tree: getTreeLocation(filePaths, location, index),
       ref: branch ?? ref ?? defaultBranch,
-      queryParams,
+      ...queryParams,
     },
   }))
 
@@ -55,7 +55,7 @@ export function useTreePaths(passedPath) {
     text: repo,
     options: {
       ref: branch ?? ref ?? defaultBranch,
-      queryParams,
+      ...queryParams,
     },
   }
 

--- a/src/shared/treePaths/useTreePaths.spec.js
+++ b/src/shared/treePaths/useTreePaths.spec.js
@@ -244,13 +244,13 @@ describe('useTreePaths', () => {
         {
           pageName: 'treeView',
           text: 'coolrepo',
-          options: { ref: 'main', queryParams: { flags: ['flag-1'] } },
+          options: { ref: 'main', flags: ['flag-1'] },
         },
         {
           options: {
             tree: 'src',
             ref: 'main',
-            queryParams: { flags: ['flag-1'] },
+            flags: ['flag-1'],
           },
           pageName: 'treeView',
           text: 'src',
@@ -259,7 +259,7 @@ describe('useTreePaths', () => {
           options: {
             tree: 'src/tests',
             ref: 'main',
-            queryParams: { flags: ['flag-1'] },
+            flags: ['flag-1'],
           },
           pageName: 'treeView',
           text: 'tests',


### PR DESCRIPTION
# Description

Quick small fix to the `useTreePaths` hook which instead of passing the query param object it actually spreads it so we can set the query params properly.

# Notable Changes

- Update `useTreePaths` to spread query params instead of passing a full object
- Update tests