### PR TITLE
ref: Update org not found copy

### DIFF
--- a/src/shared/ListRepo/OrgControlTable/RepoOrgNotFound/RepoOrgNotFound.jsx
+++ b/src/shared/ListRepo/OrgControlTable/RepoOrgNotFound/RepoOrgNotFound.jsx
@@ -1,8 +1,4 @@
-import { useParams } from 'react-router-dom'
-
 import { useResyncUser } from 'services/user'
-import { providerToName } from 'shared/utils/provider'
-import A from 'ui/A'
 import Spinner from 'ui/Spinner'
 
 function ResyncButton() {
@@ -27,29 +23,12 @@ function ResyncButton() {
 }
 
 function RepoOrgNotFound() {
-  const { provider } = useParams()
-  const isGh = providerToName(provider) === 'Github'
-
   return (
     <p className="flex-1 items-center text-sm">
       <span className="font-semibold text-ds-gray-quinary">
-        Can&apos;t find your repo{isGh ? ' organization?' : '?'}
+        Can&apos;t find your repo?
       </span>{' '}
       Try <ResyncButton />
-      {isGh && (
-        <>
-          {' '}
-          or{' '}
-          <A to={{ pageName: 'codecovAppInstallation' }}>
-            installing the Codecov app
-          </A>
-          . Check out{' '}
-          <A hook="oauth-troubleshoot" to={{ pageName: 'oauthTroubleshoot' }}>
-            our docs
-          </A>{' '}
-          for more information.
-        </>
-      )}
     </p>
   )
 }


### PR DESCRIPTION
# Description
- Update "Can't find your repo organization? Try re-syncing"-> "Can't find your repo? Try re-syncing"
- Remove "or installing the Codecov app" as users wont see this page if app isn't installed
- Remove "Checkout our docs for more information" as it's redundant and can be deleted

issue: https://github.com/codecov/engineering-team/issues/551

# Notable Changes
- Update copy
- Update tests

# Screenshots
![Screenshot 2023-10-02 at 1 36 00 PM](https://github.com/codecov/gazebo/assets/91732700/39154324-8cc3-40a2-b40c-3cc308674b01)

![Screenshot 2023-10-02 at 1 36 03 PM](https://github.com/codecov/gazebo/assets/91732700/111f9d7e-432b-4d4c-b5b3-e5f7af7761e1)


# Link to Sample Entry
repo page

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.