### PR TITLE
Remove free trial expiry banner from plan page

### DIFF
--- a/src/shared/GlobalTopBanners/TrialBanner/TrialBanner.spec.tsx
+++ b/src/shared/GlobalTopBanners/TrialBanner/TrialBanner.spec.tsx
@@ -225,158 +225,108 @@ describe('TrialBanner', () => {
   })
 
   describe('trial is ongoing', () => {
-    describe('trial is ongoing', () => {
-      describe('date diff is less then 4', () => {
-        beforeAll(() => {
-          jest.useFakeTimers().setSystemTime(new Date('2021-01-01'))
+    beforeAll(() => {
+      jest.useFakeTimers().setSystemTime(new Date('2021-01-01'))
+    })
+
+    afterAll(() => {
+      jest.useRealTimers()
+    })
+
+    describe('date diff is greater than 4', () => {
+      it('renders nothing', async () => {
+        setup({
+          trialStatus: TrialStatuses.ONGOING,
+          isCurrentUserPartOfOrg: true,
+          isTrialPlan: true,
+          trialStartDate: '2021-01-01',
+          trialEndDate: '2021-01-14',
         })
 
-        describe('date diff is greater then 4', () => {
-          beforeAll(() => {
-            jest.useFakeTimers().setSystemTime(new Date('2021-01-01'))
-          })
-
-          afterAll(() => {
-            jest.useRealTimers()
-          })
-
-          it('renders nothing', async () => {
-            setup({
-              trialStatus: TrialStatuses.ONGOING,
-              isCurrentUserPartOfOrg: true,
-              isTrialPlan: true,
-              trialStartDate: '2021-01-01',
-              trialEndDate: '2021-01-14',
-            })
-
-            const { container } = render(<TrialBanner />, {
-              wrapper: wrapper(),
-            })
-
-            await waitFor(() => queryClient.isFetching())
-            await waitFor(() => !queryClient.isFetching())
-
-            expect(container).toBeEmptyDOMElement()
-          })
+        const { container } = render(<TrialBanner />, {
+          wrapper: wrapper(),
         })
 
-        describe('date diff is less then 0', () => {
-          beforeAll(() => {
-            jest.useFakeTimers().setSystemTime(new Date('2021-01-02'))
-          })
+        await waitFor(() => queryClient.isFetching())
+        await waitFor(() => !queryClient.isFetching())
 
-          afterAll(() => {
-            jest.useRealTimers()
-          })
-
-          it('renders nothing', async () => {
-            setup({
-              trialStatus: TrialStatuses.ONGOING,
-              isCurrentUserPartOfOrg: true,
-              isTrialPlan: true,
-              trialStartDate: '2021-01-02',
-              trialEndDate: '2021-01-01',
-            })
-
-            const { container } = render(<TrialBanner />, {
-              wrapper: wrapper(),
-            })
-
-            await waitFor(() => queryClient.isFetching())
-            await waitFor(() => !queryClient.isFetching())
-
-            expect(container).toBeEmptyDOMElement()
-          })
-        })
+        expect(container).toBeEmptyDOMElement()
       })
     })
 
-    describe('trial is expired', () => {
+    describe('date diff is less than 0', () => {
       beforeAll(() => {
-        jest.useFakeTimers().setSystemTime(new Date('2021-01-01'))
+        jest.useFakeTimers().setSystemTime(new Date('2021-01-02'))
       })
 
-      afterAll(() => {
-        jest.useRealTimers()
+      it('renders nothing', async () => {
+        setup({
+          trialStatus: TrialStatuses.ONGOING,
+          isCurrentUserPartOfOrg: true,
+          isTrialPlan: true,
+          trialStartDate: '2021-01-02',
+          trialEndDate: '2021-01-01',
+        })
+
+        const { container } = render(<TrialBanner />, {
+          wrapper: wrapper(),
+        })
+
+        await waitFor(() => queryClient.isFetching())
+        await waitFor(() => !queryClient.isFetching())
+
+        expect(container).toBeEmptyDOMElement()
+      })
+    })
+
+    describe('date diff is 2 and user is on a plan page', () => {
+      beforeAll(() => {
+        jest.useFakeTimers().setSystemTime(new Date('2021-01-02'))
       })
 
-      describe('user is on a free plan', () => {
-        it('renders expired banner', async () => {
-          setup({
-            trialStatus: TrialStatuses.ONGOING,
-            isCurrentUserPartOfOrg: true,
-            isTrialPlan: true,
-            trialStartDate: '2021-01-01',
-            trialEndDate: '2021-01-02',
-          })
-
-          render(<TrialBanner />, {
-            wrapper: wrapper(),
-          })
-
-          const text = await screen.findByText(/Your trial ends in 1 day/)
-          expect(text).toBeInTheDocument()
+      it('renders nothing', async () => {
+        setup({
+          trialStatus: TrialStatuses.ONGOING,
+          isCurrentUserPartOfOrg: true,
+          isTrialPlan: true,
+          trialStartDate: '2021-01-02',
+          trialEndDate: '2021-01-04',
         })
+
+        const { container } = render(<TrialBanner />, {
+          wrapper: wrapper('/plan/gh/codecov/'),
+        })
+
+        await waitFor(() => queryClient.isFetching())
+        await waitFor(() => !queryClient.isFetching())
+
+        expect(container).toBeEmptyDOMElement()
+      })
+    })
+
+    describe('date diff is 2 and user is not on a plan page', () => {
+      beforeAll(() => {
+        jest.useFakeTimers().setSystemTime(new Date('2021-01-02'))
       })
 
-      describe('date diff is greater then 4', () => {
-        beforeAll(() => {
-          jest.useFakeTimers().setSystemTime(new Date('2021-01-01'))
+      it('renders the trial banner', async () => {
+        setup({
+          trialStatus: TrialStatuses.ONGOING,
+          isCurrentUserPartOfOrg: true,
+          isTrialPlan: true,
+          trialStartDate: '2021-01-01',
+          trialEndDate: '2021-01-04',
         })
 
-        afterAll(() => {
-          jest.useRealTimers()
+        render(<TrialBanner />, {
+          wrapper: wrapper(),
         })
 
-        it('renders nothing', async () => {
-          setup({
-            trialStatus: TrialStatuses.ONGOING,
-            isCurrentUserPartOfOrg: true,
-            isTrialPlan: true,
-            trialStartDate: '2021-01-01',
-            trialEndDate: '2021-01-14',
-          })
+        await waitFor(() => queryClient.isFetching())
+        await waitFor(() => !queryClient.isFetching())
 
-          const { container } = render(<TrialBanner />, {
-            wrapper: wrapper(),
-          })
-
-          await waitFor(() =>
-            expect(queryClient.isFetching()).toBeGreaterThan(0)
-          )
-          await waitFor(() => expect(queryClient.isFetching()).toBe(0))
-
-          expect(container).toBeEmptyDOMElement()
-        })
-      })
-
-      describe('date diff is less then 0', () => {
-        beforeAll(() => {
-          jest.useFakeTimers().setSystemTime(new Date('2021-01-02'))
-        })
-
-        afterAll(() => {
-          jest.useRealTimers()
-        })
-
-        it('renders nothing', async () => {
-          setup({
-            trialStatus: TrialStatuses.ONGOING,
-            isCurrentUserPartOfOrg: true,
-            isTrialPlan: true,
-            trialStartDate: '2021-01-02',
-            trialEndDate: '2021-01-01',
-          })
-
-          const { container } = render(<TrialBanner />, {
-            wrapper: wrapper(),
-          })
-
-          await waitFor(() => queryClient.isFetching())
-          await waitFor(() => !queryClient.isFetching())
-
-          expect(container).toBeEmptyDOMElement()
-        })
+        const banner = await screen.findByText(/Your trial ends in 2 days./)
+        expect(banner).toBeInTheDocument()
       })
     })
   })
@@ -388,6 +338,83 @@ describe('TrialBanner', () => {
 
     afterAll(() => {
       jest.useRealTimers()
+    })
+
+    describe('user is on a free plan with one day expiry', () => {
+      it('renders expired banner', async () => {
+        setup({
+          trialStatus: TrialStatuses.ONGOING,
+          isCurrentUserPartOfOrg: true,
+          isTrialPlan: true,
+          trialStartDate: '2021-01-01',
+          trialEndDate: '2021-01-02',
+        })
+
+        render(<TrialBanner />, {
+          wrapper: wrapper(),
+        })
+
+        const text = await screen.findByText(/Your trial ends in 1 day/)
+        expect(text).toBeInTheDocument()
+      })
+    })
+
+    describe('date diff is greater than 4', () => {
+      beforeAll(() => {
+        jest.useFakeTimers().setSystemTime(new Date('2021-01-01'))
+      })
+
+      afterAll(() => {
+        jest.useRealTimers()
+      })
+
+      it('renders nothing', async () => {
+        setup({
+          trialStatus: TrialStatuses.ONGOING,
+          isCurrentUserPartOfOrg: true,
+          isTrialPlan: true,
+          trialStartDate: '2021-01-01',
+          trialEndDate: '2021-01-14',
+        })
+
+        const { container } = render(<TrialBanner />, {
+          wrapper: wrapper(),
+        })
+
+        await waitFor(() => expect(queryClient.isFetching()).toBeGreaterThan(0))
+        await waitFor(() => expect(queryClient.isFetching()).toBe(0))
+
+        expect(container).toBeEmptyDOMElement()
+      })
+    })
+
+    describe('date diff is less than 0', () => {
+      beforeAll(() => {
+        jest.useFakeTimers().setSystemTime(new Date('2021-01-02'))
+      })
+
+      afterAll(() => {
+        jest.useRealTimers()
+      })
+
+      it('renders nothing', async () => {
+        setup({
+          trialStatus: TrialStatuses.ONGOING,
+          isCurrentUserPartOfOrg: true,
+          isTrialPlan: true,
+          trialStartDate: '2021-01-02',
+          trialEndDate: '2021-01-01',
+        })
+
+        const { container } = render(<TrialBanner />, {
+          wrapper: wrapper(),
+        })
+
+        await waitFor(() => queryClient.isFetching())
+        await waitFor(() => !queryClient.isFetching())
+
+        expect(container).toBeEmptyDOMElement()
+      })
     })
 
     describe('user is on a free plan', () => {

--- a/src/shared/GlobalTopBanners/TrialBanner/TrialBanner.tsx
+++ b/src/shared/GlobalTopBanners/TrialBanner/TrialBanner.tsx
@@ -1,6 +1,6 @@
 import { differenceInCalendarDays } from 'date-fns'
 import isUndefined from 'lodash/isUndefined'
-import { useParams } from 'react-router-dom'
+import { useLocation, useParams } from 'react-router-dom'
 
 import config from 'config'
 
@@ -24,6 +24,10 @@ const determineDateDiff = ({
   return dateDiff
 }
 
+const startsWithPlan = (pathName: string): boolean => {
+  return pathName.startsWith('/plan')
+}
+
 interface UrlParams {
   provider?: string
   owner?: string
@@ -31,6 +35,7 @@ interface UrlParams {
 
 const TrialBanner: React.FC = () => {
   const { provider, owner } = useParams<UrlParams>()
+  const pathStartsWithPlan = startsWithPlan(useLocation().pathname)
 
   const enableQuery = !!owner
 
@@ -61,7 +66,8 @@ const TrialBanner: React.FC = () => {
     isUndefined(provider) ||
     isUndefined(owner) ||
     !ownerData?.isCurrentUserPartOfOrg ||
-    config.IS_SELF_HOSTED
+    config.IS_SELF_HOSTED ||
+    pathStartsWithPlan
   ) {
     return null
   }

--- a/src/shared/GlobalTopBanners/TrialBanner/TrialBanner.tsx
+++ b/src/shared/GlobalTopBanners/TrialBanner/TrialBanner.tsx
@@ -35,7 +35,8 @@ interface UrlParams {
 
 const TrialBanner: React.FC = () => {
   const { provider, owner } = useParams<UrlParams>()
-  const pathStartsWithPlan = startsWithPlan(useLocation().pathname)
+  const currentPathName = useLocation().pathname
+  const pathStartsWithPlan = startsWithPlan(currentPathName)
 
   const enableQuery = !!owner
 


### PR DESCRIPTION
# Description

Currently, the `Your trial ends in`  banner is visible across all tabs. This PR makes it such that it does on render on the `Plan` tab. Two approaches were considered. 

1.) Dismiss the banner no matter where the user is after they click **Upgrade** , even if they are on that page already
2.) Do not show the banner on the Plan page, even if they did not get there by clicking the button

This change implements approach 2, keeping in mind that the sales experience on that page is soon to be upgraded. 

# Notable Changes

I also cleaned up some redundancies in `TrialBanner.spec.tsx` in order to add tests for this behaviour. I'm leaning towards creating issues for any refactoring work in the future but prefer to keep these changes for now. 

# Screenshots


https://github.com/codecov/gazebo/assets/148245014/ed440317-cf79-4ab3-a850-01ef85740b30


# Link to Sample Entry

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.