### PR TITLE
feat: remove summary section of PR page for team tier customers

### DIFF
--- a/src/pages/PullRequestPage/PullRequestPage.jsx
+++ b/src/pages/PullRequestPage/PullRequestPage.jsx
@@ -2,6 +2,7 @@ import { lazy, Suspense } from 'react'
 import { useParams } from 'react-router-dom'
 
 import NotFound from 'pages/NotFound'
+import { TierNames, useTier } from 'services/tier'
 import Breadcrumb from 'ui/Breadcrumb'
 import Spinner from 'ui/Spinner'
 
@@ -23,6 +24,7 @@ const Loader = () => (
 function PullRequestPage() {
   const { owner, repo, pullId, provider } = useParams()
   const { data, isLoading } = usePullPageData({ provider, owner, repo, pullId })
+  const { data: tierName } = useTier({ owner, provider })
 
   if (!isLoading && !data?.pull) {
     return <NotFound />
@@ -45,7 +47,7 @@ function PullRequestPage() {
       />
       <Header />
       <Suspense fallback={<CompareSummarySkeleton />}>
-        <CompareSummary />
+        {tierName !== TierNames.TEAM && <CompareSummary />}
         <FirstPullBanner />
       </Suspense>
       <Suspense fallback={<Loader />}>


### PR DESCRIPTION
# Description
We're removing the summary section of the PR page for team tier customers\

# Notable Changes
- Add a conditional to render the compare summary if customer is part of team tier
- Adjust tests

# Screenshots
![Screenshot 2023-10-24 at 11 48 16 AM](https://github.com/codecov/gazebo/assets/82913673/18c31068-35f9-43c5-ada9-f5fa11f6746d)


# Link to Sample Entry

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.