### PR TITLE
feat: Remove Commit Summary from Commit Detail Page on Team Plan

### DIFF
--- a/src/pages/CommitDetailPage/CommitDetailPage.jsx
+++ b/src/pages/CommitDetailPage/CommitDetailPage.jsx
@@ -69,8 +69,9 @@ function CommitDetailPage() {
   ) {
     return <NotFound />
   }
-  const showCommitSummary =
-    !repoSettings?.repository?.private && tierName !== TierNames.TEAM
+
+  const hideCommitSummary =
+    repoSettings?.repository?.private && tierName === TierNames.TEAM
 
   return (
     <div className="flex flex-col gap-4 px-3 sm:px-0">
@@ -88,11 +89,11 @@ function CommitDetailPage() {
         ]}
       />
       <Header />
-      {showCommitSummary ? (
+      {hideCommitSummary ? null : (
         <Suspense fallback={<CommitDetailSummarySkeleton />}>
           <CommitDetailSummary />
         </Suspense>
-      ) : null}
+      )}
       {/**we are currently capturing a single error*/}
       <CommitErrorBanners />
       <div className="flex flex-col gap-8 md:flex-row-reverse">

--- a/src/pages/CommitDetailPage/CommitDetailPage.jsx
+++ b/src/pages/CommitDetailPage/CommitDetailPage.jsx
@@ -4,6 +4,8 @@ import { useParams } from 'react-router-dom'
 
 import NotFound from 'pages/NotFound'
 import { useCommitErrors } from 'services/commitErrors'
+import { useRepoSettingsTeam } from 'services/repo'
+import { TierNames, useTier } from 'services/tier'
 import { useOwner } from 'services/user'
 import Breadcrumb from 'ui/Breadcrumb'
 import Spinner from 'ui/Spinner'
@@ -46,6 +48,8 @@ function CommitErrorBanners() {
 function CommitDetailPage() {
   const { provider, owner, repo, commit: commitSha } = useParams()
   const shortSHA = commitSha?.slice(0, 7)
+  const { data: tierName } = useTier({ provider, owner })
+  const { data: repoSettings } = useRepoSettingsTeam()
 
   // reset cache when user navigates to the commit detail page
   const queryClient = useQueryClient()
@@ -65,6 +69,8 @@ function CommitDetailPage() {
   ) {
     return <NotFound />
   }
+  const showCommitSummary =
+    !repoSettings?.repository?.private && tierName !== TierNames.TEAM
 
   return (
     <div className="flex flex-col gap-4 px-3 sm:px-0">
@@ -82,9 +88,11 @@ function CommitDetailPage() {
         ]}
       />
       <Header />
-      <Suspense fallback={<CommitDetailSummarySkeleton />}>
-        <CommitDetailSummary />
-      </Suspense>
+      {showCommitSummary ? (
+        <Suspense fallback={<CommitDetailSummarySkeleton />}>
+          <CommitDetailSummary />
+        </Suspense>
+      ) : null}
       {/**we are currently capturing a single error*/}
       <CommitErrorBanners />
       <div className="flex flex-col gap-8 md:flex-row-reverse">

--- a/src/pages/CommitDetailPage/CommitDetailPage.spec.jsx
+++ b/src/pages/CommitDetailPage/CommitDetailPage.spec.jsx
@@ -14,15 +14,7 @@ jest.mock('./CommitDetailPageContent', () => () => 'CommitDetailPageContent')
 jest.mock('./UploadsCard', () => () => 'UploadsCard')
 jest.mock('ui/TruncatedMessage/hooks')
 
-const mockProTier = {
-  owner: {
-    plan: {
-      tierName: TierNames.PRO,
-    },
-  },
-}
-
-const mockRepoSettings = (isPrivate) => ({
+const mockRepoSettings = (isPrivate = false) => ({
   owner: {
     repository: {
       defaultBranch: 'master',
@@ -147,10 +139,18 @@ afterAll(() => {
 
 describe('CommitPage', () => {
   function setup(
-    { hasYamlErrors, noCommit, suspense = false } = {
+    {
+      hasYamlErrors,
+      noCommit,
+      suspense = false,
+      tierValue = TierNames.PRO,
+      isPrivate = false,
+    } = {
       hasYamlErrors: false,
       noCommit: false,
       suspense: false,
+      tierValue: TierNames.PRO,
+      isPrivate: false,
     }
   ) {
     const queryClient = new QueryClient({
@@ -207,11 +207,14 @@ describe('CommitPage', () => {
       rest.get('/internal/gh/codecov/account-details/', (req, res, ctx) => {
         return res(ctx.status(200), ctx.json({}))
       }),
-      graphql.query('GetRepoSettingsTeam', (req, res, ctx) => {
-        return res(ctx.status(200), ctx.data(mockRepoSettings(false)))
-      }),
       graphql.query('OwnerTier', (req, res, ctx) => {
-        return res(ctx.status(200), ctx.data(mockProTier))
+        return res(
+          ctx.status(200),
+          ctx.data({ owner: { plan: { tierName: tierValue } } })
+        )
+      }),
+      graphql.query('GetRepoSettingsTeam', (req, res, ctx) => {
+        return res(ctx.status(200), ctx.data(mockRepoSettings(isPrivate)))
       })
     )
 
@@ -313,6 +316,63 @@ describe('CommitPage', () => {
             []
           )
         )
+      })
+    })
+
+    describe('testing hiding of summary component', () => {
+      describe('user is on team tier', () => {
+        describe('repo is public', () => {
+          it('renders the commit summary', async () => {
+            const { queryClient } = setup({
+              tierValue: TierNames.TEAM,
+              isPrivate: false,
+              suspense: true,
+            })
+            render(<CommitPage />, {
+              wrapper: wrapper(queryClient),
+            })
+
+            const head = await screen.findByText(/HEAD/)
+            expect(head).toBeInTheDocument()
+
+            const patch = await screen.findByText(/Patch/)
+            expect(patch).toBeInTheDocument()
+
+            const change = await screen.findByText(/Change/)
+            expect(change).toBeInTheDocument()
+
+            const source = await screen.findByText(/Source/)
+            expect(source).toBeInTheDocument()
+          })
+        })
+
+        describe('repo is private', () => {
+          it('does not render the commit summary', async () => {
+            const { queryClient } = setup({
+              tierValue: TierNames.TEAM,
+              isPrivate: true,
+              suspense: true,
+            })
+            render(<CommitPage />, {
+              wrapper: wrapper(queryClient),
+            })
+
+            const commitMessage = await screen.findByText('Cool Commit Message')
+            expect(commitMessage).toBeInTheDocument()
+
+            const head = screen.queryByText(/HEAD/)
+            expect(head).not.toBeInTheDocument()
+
+            const patch = screen.queryByText(/Patch/)
+            expect(patch).not.toBeInTheDocument()
+
+            const change = screen.queryByText(/Change/)
+            expect(change).not.toBeInTheDocument()
+
+            const source = screen.queryByText(/Source/)
+            expect(source).not.toBeInTheDocument()
+          })
+        })
       })
     })
   })


### PR DESCRIPTION
# Description

This PR hides the commit summary on the commit detail page when the owner is on a team plan as well as the repo being private, if the repo is public then it will still show the commit summary.

Closes codecov/engineering-team#618

# Notable Changes

- Update the `CommitDetailPage` to conditionally render the `CommitDetailSummary` based off of repo visibility and tier value.
- Update tests to check new cases.

# Screenshots

Public Repo:

![Screenshot 2023-10-27 at 7 45 32 AM](https://github.com/codecov/gazebo/assets/105234307/01e00727-0306-410b-846a-91c91ab371ed)

Private Repo:

![Screenshot 2023-10-27 at 7 47 44 AM](https://github.com/codecov/gazebo/assets/105234307/5f5a5b32-2132-4b54-987c-22ede10b6ac8)