### PR TITLE
feat: change planName to value for planData hook

### DIFF
--- a/src/pages/DefaultOrgSelector/DefaultOrgSelector.jsx
+++ b/src/pages/DefaultOrgSelector/DefaultOrgSelector.jsx
@@ -102,7 +102,7 @@ function DefaultOrgSelector() {
     updateDefaultOrg({ username: selectedOrg })
 
     if (
-      isBasicPlan(planData?.plan?.planName) &&
+      isBasicPlan(planData?.plan?.value) &&
       selectedOrg !== currentUser?.user?.username &&
       isNewTrial
     ) {

--- a/src/pages/DefaultOrgSelector/DefaultOrgSelector.spec.jsx
+++ b/src/pages/DefaultOrgSelector/DefaultOrgSelector.spec.jsx
@@ -23,7 +23,7 @@ const mockTrialData = {
   billingRate: 'monthly',
   marketingName: 'Users Basic',
   monthlyUploadLimit: 250,
-  planName: 'users-basic',
+  value: 'users-basic',
   trialStatus: 'ONGOING',
   trialStartDate: '2023-01-01T08:55:25',
   trialEndDate: '2023-01-10T08:55:25',
@@ -73,7 +73,7 @@ describe('DefaultOrgSelector', () => {
     useUserData,
     isValidUser = true,
     trialStatus = 'NOT_STARTED',
-    planName = 'users-basic',
+    value = 'users-basic',
   } = {}) {
     const mockMutationVariables = jest.fn()
     const mockTrialMutationVariables = jest.fn()
@@ -103,7 +103,7 @@ describe('DefaultOrgSelector', () => {
               plan: {
                 ...mockTrialData,
                 trialStatus,
-                planName,
+                value,
               },
               pretrialPlan: {
                 baseUnitPrice: 10,
@@ -111,7 +111,7 @@ describe('DefaultOrgSelector', () => {
                 billingRate: 'monthly',
                 marketingName: 'Users Basic',
                 monthlyUploadLimit: 250,
-                planName: 'users-basic',
+                value: 'users-basic',
               },
             },
           })
@@ -677,7 +677,7 @@ describe('DefaultOrgSelector', () => {
             },
           },
         },
-        planName: 'users-free',
+        value: 'users-free',
         myOrganizationsData: {
           me: {
             myOrganizations: {
@@ -956,7 +956,7 @@ describe('DefaultOrgSelector', () => {
             },
           },
         },
-        planName: 'users-basic',
+        value: 'users-basic',
       })
 
       render(<DefaultOrgSelector />, { wrapper: wrapper() })

--- a/src/pages/MembersPage/MembersActivation/Activation/Activation.jsx
+++ b/src/pages/MembersPage/MembersActivation/Activation/Activation.jsx
@@ -19,7 +19,7 @@ function Activation() {
   const planQuantity = accountDetails?.plan?.quantity || 0
 
   if (
-    isTrialPlan(planData?.plan?.planName) &&
+    isTrialPlan(planData?.plan?.value) &&
     planData?.plan?.trialStatus === TrialStatuses.ONGOING
   ) {
     return (
@@ -42,7 +42,7 @@ function Activation() {
   }
 
   if (
-    isFreePlan(planData?.plan?.planName) &&
+    isFreePlan(planData?.plan?.value) &&
     planData?.plan?.trialStatus === TrialStatuses.EXPIRED
   ) {
     return (

--- a/src/pages/MembersPage/MembersActivation/Activation/Activation.spec.jsx
+++ b/src/pages/MembersPage/MembersActivation/Activation/Activation.spec.jsx
@@ -29,7 +29,7 @@ const mockPlanData = {
   billingRate: 'monthly',
   marketingName: 'Users Basic',
   monthlyUploadLimit: 250,
-  planName: 'users-basic',
+  value: 'users-basic',
   trialStatus: TrialStatuses.NOT_STARTED,
   trialStartDate: '',
   trialEndDate: '',
@@ -85,7 +85,7 @@ describe('Activation', () => {
               plan: {
                 ...mockPlanData,
                 trialStatus,
-                planName: planValue,
+                value: planValue,
               },
             },
           })

--- a/src/pages/MembersPage/MembersActivation/MembersActivation.jsx
+++ b/src/pages/MembersPage/MembersActivation/MembersActivation.jsx
@@ -21,7 +21,7 @@ function MemberActivation() {
 
   const showAutoActivate =
     !isUndefined(planAutoActivate) &&
-    !isTrialPlan(planData?.plan?.planName) &&
+    !isTrialPlan(planData?.plan?.value) &&
     planData?.plan?.trialStatus !== TrialStatuses.ONGOING
 
   return (

--- a/src/pages/MembersPage/MembersActivation/MembersActivation.spec.jsx
+++ b/src/pages/MembersPage/MembersActivation/MembersActivation.spec.jsx
@@ -30,7 +30,7 @@ const mockPlanData = {
   billingRate: 'monthly',
   marketingName: 'Users Basic',
   monthlyUploadLimit: 250,
-  planName: 'users-basic',
+  value: 'users-basic',
   trialStatus: TrialStatuses.NOT_STARTED,
   trialStartDate: '',
   trialEndDate: '',
@@ -82,7 +82,7 @@ describe('Members Activation', () => {
               plan: {
                 ...mockPlanData,
                 trialStatus,
-                planName: planValue,
+                value: planValue,
               },
             },
           })

--- a/src/pages/OwnerPage/Tabs/TrialReminder/TrialReminder.spec.tsx
+++ b/src/pages/OwnerPage/Tabs/TrialReminder/TrialReminder.spec.tsx
@@ -32,7 +32,7 @@ const mockResponse = {
   billingRate: 'monthly',
   marketingName: 'Users Basic',
   monthlyUploadLimit: 250,
-  planName: 'users-basic',
+  value: 'users-basic',
   trialStatus: TrialStatuses.NOT_STARTED,
   trialStartDate: '',
   trialEndDate: '',
@@ -97,7 +97,7 @@ describe('TrialReminder', () => {
                 trialStatus,
                 trialStartDate,
                 trialEndDate,
-                planName: planValue,
+                value: planValue,
               },
             },
           })

--- a/src/pages/OwnerPage/Tabs/TrialReminder/TrialReminder.tsx
+++ b/src/pages/OwnerPage/Tabs/TrialReminder/TrialReminder.tsx
@@ -50,7 +50,7 @@ const TrialReminder: React.FC = () => {
     },
   })
 
-  const planValue = planData?.plan?.planName
+  const planValue = planData?.plan?.value
 
   const { trialNotStarted, trialOngoing, trialExpired, cannotTrial } =
     determineTrialStates({

--- a/src/pages/PlanPage/subRoutes/CancelPlanPage/CancelPlanPage.jsx
+++ b/src/pages/PlanPage/subRoutes/CancelPlanPage/CancelPlanPage.jsx
@@ -27,7 +27,7 @@ function CancelPlanPage() {
   const { data: planData } = usePlanData({ provider, owner })
 
   const isOnTrial =
-    isTrialPlan(planData?.plan?.planName) &&
+    isTrialPlan(planData?.plan?.value) &&
     planData?.plan?.trialStatus === TrialStatuses.ONGOING
 
   // redirect right away if the user is on an enterprise plan

--- a/src/pages/PlanPage/subRoutes/CancelPlanPage/CancelPlanPage.spec.jsx
+++ b/src/pages/PlanPage/subRoutes/CancelPlanPage/CancelPlanPage.spec.jsx
@@ -19,7 +19,7 @@ const mockPlanData = {
   billingRate: 'monthly',
   marketingName: 'Users Basic',
   monthlyUploadLimit: 250,
-  planName: 'users-basic',
+  value: 'users-basic',
   trialStatus: TrialStatuses.NOT_STARTED,
   trialStartDate: '',
   trialEndDate: '',
@@ -105,7 +105,7 @@ describe('CancelPlanPage', () => {
               plan: {
                 ...mockPlanData,
                 trialStatus,
-                planName: planValue,
+                value: planValue,
               },
             },
           })

--- a/src/pages/PlanPage/subRoutes/CurrentOrgPlan/CurrentPlanCard/FreePlanCard/FreePlanCard.jsx
+++ b/src/pages/PlanPage/subRoutes/CurrentOrgPlan/CurrentPlanCard/FreePlanCard/FreePlanCard.jsx
@@ -124,16 +124,16 @@ function FreePlanCard({ plan, scheduledPhase }) {
 
   const uploadsNumber = ownerData?.numberOfUploads
   const trialOngoing =
-    isTrialPlan(planData?.plan?.planName) &&
+    isTrialPlan(planData?.plan?.value) &&
     planData?.plan.trialStatus === TrialStatuses.ONGOING
 
   let benefits = plan?.benefits
-  let planName = plan?.value
+  let planValue = plan?.value
   let baseUnitPrice = plan?.baseUnitPrice
   let marketingName = plan?.marketingName
   if (trialOngoing) {
     benefits = planData?.pretrialPlan?.benefits
-    planName = planData?.pretrialPlan?.planName
+    planValue = planData?.pretrialPlan?.value
     baseUnitPrice = planData?.pretrialPlan?.baseUnitPrice
     marketingName = planData?.pretrialPlan?.marketingName
   }
@@ -161,7 +161,7 @@ function FreePlanCard({ plan, scheduledPhase }) {
           </div>
           <div className="flex flex-col gap-3 border-t pt-2 sm:border-0 sm:p-0">
             <p className="text-xs font-semibold">Pricing</p>
-            <PlanPricing value={planName} baseUnitPrice={baseUnitPrice} />
+            <PlanPricing value={planValue} baseUnitPrice={baseUnitPrice} />
             <div>
               {isNumber(uploadsNumber) && (
                 <p className="mt-4 text-xs text-ds-gray-senary">

--- a/src/pages/PlanPage/subRoutes/CurrentOrgPlan/CurrentPlanCard/FreePlanCard/FreePlanCard.spec.jsx
+++ b/src/pages/PlanPage/subRoutes/CurrentOrgPlan/CurrentPlanCard/FreePlanCard/FreePlanCard.spec.jsx
@@ -116,7 +116,7 @@ const mockPlanData = {
   billingRate: 'monthly',
   marketingName: 'Users Basic',
   monthlyUploadLimit: 250,
-  planName: 'users-basic',
+  value: 'users-basic',
   trialStatus: TrialStatuses.NOT_STARTED,
   trialStartDate: '',
   trialEndDate: '',
@@ -130,7 +130,7 @@ const mockPreTrialPlanInfo = {
   billingRate: 'monthly',
   marketingName: 'Users Basic',
   monthlyUploadLimit: 250,
-  planName: 'users-basic',
+  value: 'users-basic',
 }
 
 const server = setupServer()
@@ -192,7 +192,7 @@ describe('FreePlanCard', () => {
               plan: {
                 ...mockPlanData,
                 trialStatus,
-                planName: planValue,
+                value: planValue,
               },
               pretrialPlan: mockPreTrialPlanInfo,
             },

--- a/src/pages/PlanPage/subRoutes/CurrentOrgPlan/CurrentPlanCard/FreePlanCard/ProPlanSubheading/ProPlanSubheading.spec.tsx
+++ b/src/pages/PlanPage/subRoutes/CurrentOrgPlan/CurrentPlanCard/FreePlanCard/ProPlanSubheading/ProPlanSubheading.spec.tsx
@@ -14,7 +14,7 @@ const mockResponse = {
   billingRate: 'monthly',
   marketingName: 'Users Basic',
   monthlyUploadLimit: 250,
-  planName: 'users-basic',
+  value: 'users-basic',
   trialStatus: TrialStatuses.NOT_STARTED,
   trialStartDate: '',
   trialEndDate: '',
@@ -67,7 +67,7 @@ describe('ProPlanSubheading', () => {
               plan: {
                 ...mockResponse,
                 trialStatus,
-                planName: planValue,
+                value: planValue,
               },
             },
           })

--- a/src/pages/PlanPage/subRoutes/CurrentOrgPlan/CurrentPlanCard/FreePlanCard/ProPlanSubheading/ProPlanSubheading.tsx
+++ b/src/pages/PlanPage/subRoutes/CurrentOrgPlan/CurrentPlanCard/FreePlanCard/ProPlanSubheading/ProPlanSubheading.tsx
@@ -21,7 +21,7 @@ function ProPlanSubheading() {
   // - user on a free plan
   // - trial status is not started
   if (
-    isFreePlan(planData?.plan?.planName) &&
+    isFreePlan(planData?.plan?.value) &&
     planData?.plan?.trialStatus === TrialStatuses.NOT_STARTED
   ) {
     return (
@@ -36,7 +36,7 @@ function ProPlanSubheading() {
   // - user is on a trial plan
   // - trial status is currently ongoing
   if (
-    isTrialPlan(planData?.plan?.planName) &&
+    isTrialPlan(planData?.plan?.value) &&
     planData?.plan?.trialStatus === TrialStatuses.ONGOING
   ) {
     return (
@@ -51,7 +51,7 @@ function ProPlanSubheading() {
   // - user is currently on a free plan
   // - trial status is expired
   if (
-    isFreePlan(planData?.plan?.planName) &&
+    isFreePlan(planData?.plan?.value) &&
     planData?.plan?.trialStatus === TrialStatuses.EXPIRED
   ) {
     return <p className="text-ds-gray-quinary">Your org trialed this plan</p>

--- a/src/pages/PlanPage/subRoutes/CurrentOrgPlan/CurrentPlanCard/ProPlanCard/ProPlanCard.spec.jsx
+++ b/src/pages/PlanPage/subRoutes/CurrentOrgPlan/CurrentPlanCard/ProPlanCard/ProPlanCard.spec.jsx
@@ -38,8 +38,8 @@ describe('ProPlanCard', () => {
         wrapper,
       })
 
-      const planName = screen.getByText(/Pro Team plan/)
-      expect(planName).toBeInTheDocument()
+      const planValue = screen.getByText(/Pro Team plan/)
+      expect(planValue).toBeInTheDocument()
     })
 
     it('renders the benefits', () => {

--- a/src/pages/PlanPage/subRoutes/CurrentOrgPlan/CurrentPlanCard/shared/ActionsBilling/ActionsBilling.jsx
+++ b/src/pages/PlanPage/subRoutes/CurrentOrgPlan/CurrentPlanCard/shared/ActionsBilling/ActionsBilling.jsx
@@ -31,7 +31,7 @@ function PlansActionsBilling({ plan }) {
 
   const canStartTrial =
     planData?.plan?.trialStatus === TrialStatuses.NOT_STARTED &&
-    isFreePlan(planData?.plan?.planName)
+    isFreePlan(planData?.plan?.value)
 
   if (canStartTrial) {
     return (

--- a/src/pages/PlanPage/subRoutes/CurrentOrgPlan/CurrentPlanCard/shared/ActionsBilling/ActionsBilling.spec.jsx
+++ b/src/pages/PlanPage/subRoutes/CurrentOrgPlan/CurrentPlanCard/shared/ActionsBilling/ActionsBilling.spec.jsx
@@ -142,7 +142,7 @@ const mockTrialData = {
     billingRate: 'monthly',
     marketingName: 'Users Basic',
     monthlyUploadLimit: 250,
-    planName: 'users-basic',
+    value: 'users-basic',
     trialStatus: 'ONGOING',
     trialStartDate: '2023-01-01T08:55:25',
     trialEndDate: '2023-01-10T08:55:25',

--- a/src/pages/PlanPage/subRoutes/InvoiceDetailsPage/InvoiceDetail.spec.jsx
+++ b/src/pages/PlanPage/subRoutes/InvoiceDetailsPage/InvoiceDetail.spec.jsx
@@ -30,7 +30,7 @@ const invoice = {
       amount: -9449,
       currency: 'usd',
       period: { end: 1610473200, start: 1609298708 },
-      planName: 'users-pr-inappm',
+      value: 'users-pr-inappm',
       quantity: 19,
     },
     {
@@ -38,7 +38,7 @@ const invoice = {
       amount: 72000,
       currency: 'usd',
       period: { end: 1640834708, start: 1609298708 },
-      planName: 'users-pr-inappy',
+      value: 'users-pr-inappy',
       quantity: 6,
     },
     {
@@ -46,7 +46,7 @@ const invoice = {
       amount: 72000,
       currency: 'usd',
       period: { end: null, start: null },
-      planName: 'same period doesnt render date',
+      value: 'same period doesnt render date',
       quantity: 1,
     },
   ],

--- a/src/pages/PlanPage/subRoutes/InvoiceDetailsPage/sections/InvoiceFooter.spec.jsx
+++ b/src/pages/PlanPage/subRoutes/InvoiceDetailsPage/sections/InvoiceFooter.spec.jsx
@@ -26,7 +26,7 @@ const invoice = {
       amount: -9449,
       currency: 'usd',
       period: { end: 1610473200, start: 1609298708 },
-      planName: 'users-pr-inappm',
+      value: 'users-pr-inappm',
       quantity: 19,
     },
     {
@@ -34,7 +34,7 @@ const invoice = {
       amount: 72000,
       currency: 'usd',
       period: { end: 1640834708, start: 1609298708 },
-      planName: 'users-pr-inappy',
+      value: 'users-pr-inappy',
       quantity: 6,
     },
     {
@@ -42,7 +42,7 @@ const invoice = {
       amount: 72000,
       currency: 'usd',
       period: { end: null, start: null },
-      planName: 'same period doesnt render date',
+      value: 'same period doesnt render date',
       quantity: 1,
     },
   ],

--- a/src/pages/PlanPage/subRoutes/InvoiceDetailsPage/sections/InvoiceHeader.spec.jsx
+++ b/src/pages/PlanPage/subRoutes/InvoiceDetailsPage/sections/InvoiceHeader.spec.jsx
@@ -27,7 +27,7 @@ const mockInvoice = ({ status = 'paid' } = {}) => {
         amount: -9449,
         currency: 'usd',
         period: { end: 1610473200, start: 1609298708 },
-        planName: 'users-pr-inappm',
+        value: 'users-pr-inappm',
         quantity: 19,
       },
       {
@@ -35,7 +35,7 @@ const mockInvoice = ({ status = 'paid' } = {}) => {
         amount: 72000,
         currency: 'usd',
         period: { end: 1640834708, start: 1609298708 },
-        planName: 'users-pr-inappy',
+        value: 'users-pr-inappy',
         quantity: 6,
       },
       {
@@ -43,7 +43,7 @@ const mockInvoice = ({ status = 'paid' } = {}) => {
         amount: 72000,
         currency: 'usd',
         period: { end: null, start: null },
-        planName: 'same period doesnt render date',
+        value: 'same period doesnt render date',
         quantity: 1,
       },
     ],

--- a/src/pages/PlanPage/subRoutes/InvoiceDetailsPage/sections/InvoiceItems.jsx
+++ b/src/pages/PlanPage/subRoutes/InvoiceDetailsPage/sections/InvoiceItems.jsx
@@ -28,7 +28,7 @@ InvoiceItems.propTypes = {
         quantity: PropTypes.number.isRequired,
         amount: PropTypes.number.isRequired,
         description: PropTypes.string,
-        planName: PropTypes.string,
+        value: PropTypes.string,
         period: PropTypes.shape({
           start: PropTypes.number,
           end: PropTypes.number,

--- a/src/pages/PlanPage/subRoutes/InvoiceDetailsPage/sections/InvoiceItems.spec.jsx
+++ b/src/pages/PlanPage/subRoutes/InvoiceDetailsPage/sections/InvoiceItems.spec.jsx
@@ -26,7 +26,7 @@ const invoice = {
       amount: -9449,
       currency: 'usd',
       period: { end: 1610473200, start: 1609298708 },
-      planName: 'users-pr-inappm',
+      value: 'users-pr-inappm',
       quantity: 19,
     },
     {
@@ -34,7 +34,7 @@ const invoice = {
       amount: 72000,
       currency: 'usd',
       period: { end: 1640834708, start: 1609298708 },
-      planName: 'users-pr-inappy',
+      value: 'users-pr-inappy',
       quantity: 6,
     },
     {
@@ -42,7 +42,7 @@ const invoice = {
       amount: 72000,
       currency: 'usd',
       period: { end: null, start: null },
-      planName: 'same period doesnt render date',
+      value: 'same period doesnt render date',
       quantity: 1,
     },
   ],

--- a/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeDetails/UpgradeDetails.spec.jsx
+++ b/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeDetails/UpgradeDetails.spec.jsx
@@ -88,7 +88,7 @@ const mockPlanData = {
   billingRate: 'monthly',
   marketingName: 'Users Basic',
   monthlyUploadLimit: 250,
-  planName: 'users-basic',
+  value: 'users-basic',
   trialStatus: TrialStatuses.NOT_STARTED,
   trialStartDate: '',
   trialEndDate: '',
@@ -154,9 +154,7 @@ describe('UpgradeDetails', () => {
                 trialStatus: isOngoingTrial
                   ? TrialStatuses.ONGOING
                   : TrialStatuses.CANNOT_TRIAL,
-                planName: isOngoingTrial
-                  ? Plans.USERS_TRIAL
-                  : Plans.USERS_BASIC,
+                value: isOngoingTrial ? Plans.USERS_TRIAL : Plans.USERS_BASIC,
               },
             },
           })

--- a/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/UpgradeForm.spec.jsx
+++ b/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/UpgradeForm.spec.jsx
@@ -97,7 +97,7 @@ const mockPlanData = {
   billingRate: 'monthly',
   marketingName: 'Users Basic',
   monthlyUploadLimit: 250,
-  planName: 'users-basic',
+  value: 'users-basic',
   trialStatus: TrialStatuses.NOT_STARTED,
   trialStartDate: '',
   trialEndDate: '',

--- a/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradePlanPage.spec.jsx
+++ b/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradePlanPage.spec.jsx
@@ -120,7 +120,7 @@ const mockPlanData = {
   billingRate: 'monthly',
   marketingName: 'Users Basic',
   monthlyUploadLimit: 250,
-  planName: 'users-basic',
+  value: 'users-basic',
   trialStatus: TrialStatuses.NOT_STARTED,
   trialStartDate: '',
   trialEndDate: '',

--- a/src/services/account/usePlanData.spec.tsx
+++ b/src/services/account/usePlanData.spec.tsx
@@ -12,7 +12,7 @@ const mockTrialData = {
     billingRate: 'monthly',
     marketingName: 'Users Basic',
     monthlyUploadLimit: 250,
-    planName: 'users-basic',
+    value: 'users-basic',
     trialStatus: 'ONGOING',
     trialStartDate: '2023-01-01T08:55:25',
     trialEndDate: '2023-01-10T08:55:25',
@@ -25,7 +25,7 @@ const mockTrialData = {
     billingRate: 'monthly',
     marketingName: 'Users Basic',
     monthlyUploadLimit: 250,
-    planName: 'users-basic',
+    value: 'users-basic',
   },
 }
 
@@ -82,7 +82,7 @@ describe('usePlanData', () => {
               billingRate: 'monthly',
               marketingName: 'Users Basic',
               monthlyUploadLimit: 250,
-              planName: 'users-basic',
+              value: 'users-basic',
               trialStatus: 'ONGOING',
               trialStartDate: '2023-01-01T08:55:25',
               trialEndDate: '2023-01-10T08:55:25',
@@ -95,7 +95,7 @@ describe('usePlanData', () => {
               billingRate: 'monthly',
               marketingName: 'Users Basic',
               monthlyUploadLimit: 250,
-              planName: 'users-basic',
+              value: 'users-basic',
             },
           })
         )

--- a/src/services/account/usePlanData.ts
+++ b/src/services/account/usePlanData.ts
@@ -19,7 +19,7 @@ const PlanDataSchema = z
         billingRate: z.string().nullable(),
         marketingName: z.string(),
         monthlyUploadLimit: z.number().nullable(),
-        planName: z.string(),
+        value: z.string(),
         pretrialUsersCount: z.number().nullable(),
         trialEndDate: z.string().nullable(),
         trialStatus: z.nativeEnum(TrialStatuses),
@@ -34,7 +34,7 @@ const PlanDataSchema = z
         billingRate: z.string().nullable(),
         marketingName: z.string(),
         monthlyUploadLimit: z.number().nullable(),
-        planName: z.string(),
+        value: z.string(),
       })
       .nullish(),
   })
@@ -51,7 +51,7 @@ export const query = `
         billingRate
         marketingName
         monthlyUploadLimit
-        planName
+        value
         pretrialUsersCount
         trialEndDate
         trialStatus
@@ -64,7 +64,7 @@ export const query = `
         billingRate
         marketingName
         monthlyUploadLimit
-        planName
+        value
       }
     }
   }

--- a/src/shared/GlobalTopBanners/TrialBanner/TrialBanner.spec.tsx
+++ b/src/shared/GlobalTopBanners/TrialBanner/TrialBanner.spec.tsx
@@ -138,7 +138,7 @@ describe('TrialBanner', () => {
                 billingRate: null,
                 marketingName: plan.marketingName,
                 monthlyUploadLimit: null,
-                planName: plan.value,
+                value: plan.value,
                 trialStatus,
                 trialStartDate,
                 trialEndDate,

--- a/src/shared/GlobalTopBanners/TrialBanner/TrialBanner.tsx
+++ b/src/shared/GlobalTopBanners/TrialBanner/TrialBanner.tsx
@@ -56,7 +56,7 @@ const TrialBanner: React.FC = () => {
     opts: { enabled: enableQuery },
   })
 
-  const planName = planData?.plan?.planName
+  const planValue = planData?.plan?.value
   const trialStatus = planData?.plan?.trialStatus
   const dateDiff = determineDateDiff({
     trialEndDate: planData?.plan?.trialEndDate,
@@ -76,7 +76,7 @@ const TrialBanner: React.FC = () => {
   // user is not on a free plan, trial is currently on going
   // there are 3 or less days left, so display ongoing banner
   if (
-    isTrialPlan(planName) &&
+    isTrialPlan(planValue) &&
     trialStatus === TrialStatuses.ONGOING &&
     dateDiff < 4 &&
     dateDiff >= 0
@@ -85,7 +85,7 @@ const TrialBanner: React.FC = () => {
   }
 
   // user has a free plan again, and the trial status is expired
-  if (isFreePlan(planName) && trialStatus === TrialStatuses.EXPIRED) {
+  if (isFreePlan(planValue) && trialStatus === TrialStatuses.EXPIRED) {
     return <ExpiredBanner />
   }
 


### PR DESCRIPTION
# Description
We're changing the `planName` resolver value for plan data to `value`. Historically, we've used `value`, and although we ultimately want to use `planName`, maintaining both keys/utils/proptypes/revolving logic with different key names can be hard to follow, specially with those files not using TS atm.

# Notable Changes
- Change `usePlanData` hook to use `value` over `planName`
- Change every use of planName to use value throughout the codebase + tests


# Link to Sample Entry

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.