### PR TITLE
feat: Hide Commits Page Team Files Changed Table for Public Repos 

### DIFF
--- a/src/pages/CommitDetailPage/CommitDetailPage.spec.jsx
+++ b/src/pages/CommitDetailPage/CommitDetailPage.spec.jsx
@@ -5,6 +5,7 @@ import { setupServer } from 'msw/node'
 import { Suspense } from 'react'
 import { MemoryRouter, Route } from 'react-router-dom'
 
+import { TierNames } from 'services/tier'
 import { useTruncation } from 'ui/TruncatedMessage/hooks'
 
 import CommitPage from './CommitDetailPage'
@@ -12,6 +13,29 @@ import CommitPage from './CommitDetailPage'
 jest.mock('./CommitDetailPageContent', () => () => 'CommitDetailPageContent')
 jest.mock('./UploadsCard', () => () => 'UploadsCard')
 jest.mock('ui/TruncatedMessage/hooks')
+
+const mockProTier = {
+  owner: {
+    plan: {
+      tierName: TierNames.PRO,
+    },
+  },
+}
+
+const mockRepoSettings = (isPrivate) => ({
+  owner: {
+    repository: {
+      defaultBranch: 'master',
+      private: isPrivate,
+      uploadToken: 'token',
+      graphToken: 'token',
+      yaml: 'yaml',
+      bot: {
+        username: 'test',
+      },
+    },
+  },
+})
 
 const mockCommit = {
   owner: {
@@ -182,6 +206,12 @@ describe('CommitPage', () => {
       }),
       rest.get('/internal/gh/codecov/account-details/', (req, res, ctx) => {
         return res(ctx.status(200), ctx.json({}))
+      }),
+      graphql.query('GetRepoSettingsTeam', (req, res, ctx) => {
+        return res(ctx.status(200), ctx.data(mockRepoSettings(false)))
+      }),
+      graphql.query('OwnerTier', (req, res, ctx) => {
+        return res(ctx.status(200), ctx.data(mockProTier))
       })
     )
 

--- a/src/pages/CommitDetailPage/subRoute/FilesChangedTab/FilesChangedTab.tsx
+++ b/src/pages/CommitDetailPage/subRoute/FilesChangedTab/FilesChangedTab.tsx
@@ -1,7 +1,8 @@
 import { lazy, Suspense } from 'react'
 import { useParams } from 'react-router-dom'
 
-import { useTier } from 'services/tier'
+import { useRepoSettingsTeam } from 'services/repo'
+import { TierNames, useTier } from 'services/tier'
 import { useFlags } from 'shared/featureFlags'
 import Spinner from 'ui/Spinner'
 
@@ -21,6 +22,7 @@ interface URLParams {
 
 function FilesChanged() {
   const { provider, owner } = useParams<URLParams>()
+  const { data: repoSettings } = useRepoSettingsTeam()
 
   const { multipleTiers } = useFlags({
     multipleTiers: false,
@@ -28,7 +30,11 @@ function FilesChanged() {
 
   const { data: tierData } = useTier({ provider, owner })
 
-  if (tierData === 'team' && multipleTiers) {
+  if (
+    tierData === TierNames.TEAM &&
+    !!repoSettings?.repository.private &&
+    multipleTiers
+  ) {
     return (
       <Suspense fallback={<Loader />}>
         <FilesChangedTableTeam />


### PR DESCRIPTION
# Description

Quickly updating the `FilesChangedTableTeam` for the commit detail page to only render the team table when the repo is private and the tier is team.

# Notable Changes

- Update `FilesChangedTableTeam` to check repo visibility
- Update tests 