### PR TITLE
Make previous team plan changes only apply if repo is private

### DIFF
--- a/src/pages/CommitDetailPage/Header/Header.tsx
+++ b/src/pages/CommitDetailPage/Header/Header.tsx
@@ -1,5 +1,6 @@
 import { useParams } from 'react-router-dom'
 
+import { useRepoSettingsTeam } from 'services/repo'
 import { TierNames, useTier } from 'services/tier'
 import { useFlags } from 'shared/featureFlags'
 
@@ -17,8 +18,14 @@ function Header() {
   const { multipleTiers } = useFlags({
     multipleTiers: false,
   })
+  const { data: repoSettingsTeam } = useRepoSettingsTeam()
 
-  if (multipleTiers && tierData === TierNames.TEAM) {
+  const showHeaderTeam =
+    repoSettingsTeam?.repository?.private &&
+    multipleTiers &&
+    tierData === TierNames.TEAM
+
+  if (showHeaderTeam) {
     return <HeaderTeam />
   }
 

--- a/src/pages/CommitDetailPage/Header/Header.tsx
+++ b/src/pages/CommitDetailPage/Header/Header.tsx
@@ -20,12 +20,11 @@ function Header() {
   })
   const { data: repoSettingsTeam } = useRepoSettingsTeam()
 
-  const showHeaderTeam =
+  if (
     repoSettingsTeam?.repository?.private &&
     multipleTiers &&
     tierData === TierNames.TEAM
-
-  if (showHeaderTeam) {
+  ) {
     return <HeaderTeam />
   }
 

--- a/src/pages/PullRequestPage/Header/Header.tsx
+++ b/src/pages/PullRequestPage/Header/Header.tsx
@@ -1,5 +1,6 @@
 import { useParams } from 'react-router-dom'
 
+import { useRepoSettingsTeam } from 'services/repo'
 import { TierNames, useTier } from 'services/tier'
 import { useFlags } from 'shared/featureFlags'
 
@@ -17,8 +18,14 @@ function Header() {
   const { multipleTiers } = useFlags({
     multipleTiers: false,
   })
+  const { data: repoSettingsTeam } = useRepoSettingsTeam()
 
-  if (multipleTiers && tierData === TierNames.TEAM) {
+  const showHeaderTeam =
+    repoSettingsTeam?.repository?.private &&
+    multipleTiers &&
+    tierData === TierNames.TEAM
+
+  if (showHeaderTeam) {
     return <HeaderTeam />
   }
 

--- a/src/pages/PullRequestPage/Header/Header.tsx
+++ b/src/pages/PullRequestPage/Header/Header.tsx
@@ -20,12 +20,11 @@ function Header() {
   })
   const { data: repoSettingsTeam } = useRepoSettingsTeam()
 
-  const showHeaderTeam =
+  if (
     repoSettingsTeam?.repository?.private &&
     multipleTiers &&
     tierData === TierNames.TEAM
-
-  if (showHeaderTeam) {
+  ) {
     return <HeaderTeam />
   }
 

--- a/src/pages/RepoPage/RepoPage.jsx
+++ b/src/pages/RepoPage/RepoPage.jsx
@@ -33,6 +33,7 @@ const getRepoTabs = ({
   owner,
   repo,
   tierData,
+  isRepoPrivate,
 }) => {
   let location = undefined
   if (matchTree) {
@@ -40,6 +41,7 @@ const getRepoTabs = ({
   } else if (matchBlobs) {
     location = { pathname: `/${provider}/${owner}/${repo}/blob` }
   }
+  const hideFlagsTab = isRepoPrivate && tierData === TierNames.TEAM
 
   return [
     {
@@ -48,7 +50,7 @@ const getRepoTabs = ({
       exact: !matchTree && !matchBlobs,
       location,
     },
-    ...(tierData === TierNames.TEAM ? [] : [{ pageName: 'flagsTab' }]),
+    ...(hideFlagsTab ? [] : [{ pageName: 'flagsTab' }]),
     { pageName: 'commits' },
     { pageName: 'pulls' },
     ...(isCurrentUserPartOfOrg ? [{ pageName: 'settings' }] : []),
@@ -101,6 +103,8 @@ function RepoPage() {
       ),
     })
 
+  console.log(isRepoActive)
+
   return (
     <RepoBreadcrumbProvider>
       <div>
@@ -116,6 +120,7 @@ function RepoPage() {
                 owner,
                 repo,
                 tierData,
+                isRepoPrivate,
               })}
             />
           </div>

--- a/src/pages/RepoPage/RepoPage.jsx
+++ b/src/pages/RepoPage/RepoPage.jsx
@@ -103,8 +103,6 @@ function RepoPage() {
       ),
     })
 
-  console.log(isRepoActive)
-
   return (
     <RepoBreadcrumbProvider>
       <div>

--- a/src/pages/RepoPage/SettingsTab/tabs/GeneralTab/GeneralTab.jsx
+++ b/src/pages/RepoPage/SettingsTab/tabs/GeneralTab/GeneralTab.jsx
@@ -4,22 +4,25 @@ import { TierNames, useTier } from 'services/tier'
 
 import DangerZone from './DangerZone'
 import DefaultBranch from './DefaultBranch'
-import { useRepoDefaultBranch } from './hooks'
+import { useRepoForTokensTeam } from './hooks'
 import { Tokens, TokensTeam } from './Tokens'
 
 function GeneralTab() {
   const { provider, owner, repo } = useParams()
-  const { data: defaultBranch } = useRepoDefaultBranch({
+  const { data: repoData } = useRepoForTokensTeam({
     provider,
     owner,
     repo,
   })
   const { data: tierData } = useTier({ provider, owner })
+  const defaultBranch = repoData?.defaultBranch
+  const isPrivate = repoData?.private
+  const showTokensTeam = isPrivate && tierData === TierNames.TEAM
 
   return (
     <div className="flex flex-col gap-6">
       {defaultBranch && <DefaultBranch defaultBranch={defaultBranch} />}
-      {tierData === TierNames.TEAM ? <TokensTeam /> : <Tokens />}
+      {showTokensTeam ? <TokensTeam /> : <Tokens />}
       <DangerZone />
     </div>
   )

--- a/src/pages/RepoPage/SettingsTab/tabs/GeneralTab/hooks/index.ts
+++ b/src/pages/RepoPage/SettingsTab/tabs/GeneralTab/hooks/index.ts
@@ -1,1 +1,1 @@
-export * from './useRepoDefaultBranch'
+export * from './useRepoForTokensTeam'

--- a/src/pages/RepoPage/SettingsTab/tabs/GeneralTab/hooks/useRepoForTokensTeam.spec.tsx
+++ b/src/pages/RepoPage/SettingsTab/tabs/GeneralTab/hooks/useRepoForTokensTeam.spec.tsx
@@ -3,13 +3,14 @@ import { renderHook, waitFor } from '@testing-library/react'
 import { graphql } from 'msw'
 import { setupServer } from 'msw/node'
 
-import { useRepoDefaultBranch } from './useRepoDefaultBranch'
+import { useRepoForTokensTeam } from './useRepoForTokensTeam'
 
 const mockRepoData = {
   owner: {
     repository: {
       __typename: 'Repository',
       defaultBranch: 'main',
+      private: false,
     },
   },
 }
@@ -67,7 +68,7 @@ interface SetupArgs {
   isNullOwner?: boolean
 }
 
-describe('useRepoDefaultBranch', () => {
+describe('useRepoForTokensTeam', () => {
   function setup({
     isNotFoundError = false,
     isOwnerNotActivatedError = false,
@@ -75,7 +76,7 @@ describe('useRepoDefaultBranch', () => {
     isNullOwner = false,
   }: SetupArgs) {
     server.use(
-      graphql.query('RepoDefaultBranch', (req, res, ctx) => {
+      graphql.query('RepoDataTokensTeam', (req, res, ctx) => {
         if (isNotFoundError) {
           return res(ctx.status(200), ctx.data(mockNotFoundError))
         } else if (isOwnerNotActivatedError) {
@@ -99,7 +100,7 @@ describe('useRepoDefaultBranch', () => {
 
           const { result } = renderHook(
             () =>
-              useRepoDefaultBranch({
+              useRepoForTokensTeam({
                 provider: 'gh',
                 owner: 'codecov',
                 repo: 'cool-repo',
@@ -110,7 +111,11 @@ describe('useRepoDefaultBranch', () => {
           await waitFor(() => result.current.isLoading)
           await waitFor(() => !result.current.isLoading)
 
-          const expectedResult = 'main'
+          const expectedResult = {
+            __typename: 'Repository',
+            defaultBranch: 'main',
+            private: false,
+          }
 
           await waitFor(() =>
             expect(result.current.data).toStrictEqual(expectedResult)
@@ -123,7 +128,7 @@ describe('useRepoDefaultBranch', () => {
 
           const { result } = renderHook(
             () =>
-              useRepoDefaultBranch({
+              useRepoForTokensTeam({
                 provider: 'gh',
                 owner: 'codecov',
                 repo: 'cool-repo',
@@ -155,7 +160,7 @@ describe('useRepoDefaultBranch', () => {
 
         const { result } = renderHook(
           () =>
-            useRepoDefaultBranch({
+            useRepoForTokensTeam({
               provider: 'gh',
               owner: 'codecov',
               repo: 'cool-repo',
@@ -190,7 +195,7 @@ describe('useRepoDefaultBranch', () => {
 
         const { result } = renderHook(
           () =>
-            useRepoDefaultBranch({
+            useRepoForTokensTeam({
               provider: 'gh',
               owner: 'codecov',
               repo: 'cool-repo',
@@ -225,7 +230,7 @@ describe('useRepoDefaultBranch', () => {
 
         const { result } = renderHook(
           () =>
-            useRepoDefaultBranch({
+            useRepoForTokensTeam({
               provider: 'gh',
               owner: 'codecov',
               repo: 'cool-repo',

--- a/src/pages/RepoPage/SettingsTab/tabs/GeneralTab/hooks/useRepoForTokensTeam.tsx
+++ b/src/pages/RepoPage/SettingsTab/tabs/GeneralTab/hooks/useRepoForTokensTeam.tsx
@@ -11,9 +11,10 @@ import A from 'ui/A'
 const RepositorySchema = z.object({
   __typename: z.literal('Repository'),
   defaultBranch: z.string().nullable(),
+  private: z.boolean().nullable(),
 })
 
-const GetRepoDefaultBranchSchema = z.object({
+const GetRepoDataSchema = z.object({
   owner: z
     .object({
       repository: z
@@ -27,15 +28,16 @@ const GetRepoDefaultBranchSchema = z.object({
     .nullable(),
 })
 
-export type GetRepoDefaultBranch = z.infer<typeof GetRepoDefaultBranchSchema>
+export type RepoDataTokensTeam = z.infer<typeof GetRepoDataSchema>
 
 const query = `
-  query RepoDefaultBranch($owner: String!, $repo: String!) {
+  query RepoDataTokensTeam($owner: String!, $repo: String!) {
     owner(username: $owner) {
       repository(name: $repo) {
         __typename
         ... on Repository {
           defaultBranch
+          private
         }
         ... on NotFoundError {
           message
@@ -48,19 +50,19 @@ const query = `
   }
 `
 
-interface RepoDefaultBranchArgs {
+interface RepoDataTokensArgs {
   provider: string
   owner: string
   repo: string
 }
 
-export const useRepoDefaultBranch = ({
+export const useRepoForTokensTeam = ({
   provider,
   owner,
   repo,
-}: RepoDefaultBranchArgs) =>
+}: RepoDataTokensArgs) =>
   useQuery({
-    queryKey: ['RepoDefaultBranch', provider, owner, repo, query],
+    queryKey: ['RepoDataTokensTeam', provider, owner, repo, query],
     queryFn: ({ signal }) =>
       Api.graphql({
         provider,
@@ -72,7 +74,7 @@ export const useRepoDefaultBranch = ({
           repo,
         },
       }).then((res) => {
-        const parsedData = GetRepoDefaultBranchSchema.safeParse(res?.data)
+        const parsedData = GetRepoDataSchema.safeParse(res?.data)
 
         if (!parsedData.success) {
           return Promise.reject({
@@ -106,6 +108,6 @@ export const useRepoDefaultBranch = ({
           })
         }
 
-        return data?.owner?.repository?.defaultBranch ?? null
+        return data?.owner?.repository ?? null
       }),
   })


### PR DESCRIPTION
# Description
We recently added the requirement to only show the team plan for private repos. This change goes back to work that was pushed prior to this decision and adding that check there to ensure only public repos follow.

# Notable Changes
- Add checks in a bunch of different files + adjusted the tests
- Rename useRepoDefaultBranch.spec.tsx to useRepoForTokensTeam.spec.tsx

# Link to Sample Entry

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.