### PR TITLE
fix: Add percentage next to patch column title for team plan tables

### DIFF
--- a/src/pages/RepoPage/CommitsTab/CommitsTableTeam/CommitsTableTeam.spec.tsx
+++ b/src/pages/RepoPage/CommitsTab/CommitsTableTeam/CommitsTableTeam.spec.tsx
@@ -179,7 +179,7 @@ describe('CommitsTableTeam', () => {
         wrapper: wrapper(queryClient),
       })
 
-      const patchColumn = await screen.findByText('Patch')
+      const patchColumn = await screen.findByText('Patch %')
       expect(patchColumn).toBeInTheDocument()
     })
   })

--- a/src/pages/RepoPage/CommitsTab/CommitsTableTeam/CommitsTableTeam.tsx
+++ b/src/pages/RepoPage/CommitsTab/CommitsTableTeam/CommitsTableTeam.tsx
@@ -61,7 +61,7 @@ const columns = [
   }),
   columnHelper.accessor('patch', {
     id: 'patch',
-    header: 'Patch',
+    header: 'Patch %',
     cell: ({ renderValue }) => renderValue(),
   }),
 ]

--- a/src/pages/RepoPage/PullsTab/PullsTableTeam/PullsTableTeam.spec.tsx
+++ b/src/pages/RepoPage/PullsTab/PullsTableTeam/PullsTableTeam.spec.tsx
@@ -167,7 +167,7 @@ describe('PullsTableTeam', () => {
       const { queryClient } = setup({})
       render(<PullsTableTeam />, { wrapper: wrapper(queryClient) })
 
-      const patchColumn = await screen.findByText('Patch')
+      const patchColumn = await screen.findByText('Patch %')
       expect(patchColumn).toBeInTheDocument()
     })
   })

--- a/src/pages/RepoPage/PullsTab/PullsTableTeam/PullsTableTeam.tsx
+++ b/src/pages/RepoPage/PullsTab/PullsTableTeam/PullsTableTeam.tsx
@@ -49,7 +49,7 @@ const columns = [
   }),
   columnHelper.accessor('patch', {
     id: 'patch',
-    header: () => 'Patch',
+    header: () => 'Patch %',
     cell: ({ renderValue }) => renderValue(),
   }),
 ]


### PR DESCRIPTION
# Description

Closes https://github.com/codecov/engineering-team/issues/782. Pretty straightforward. 

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.