### PR TITLE
fix: Show Branch Icon in Branch Dropdown for Team Plan

### DIFF
--- a/src/pages/RepoPage/CoverageTab/SummaryTeamPlan/SummaryTeamPlan.spec.tsx
+++ b/src/pages/RepoPage/CoverageTab/SummaryTeamPlan/SummaryTeamPlan.spec.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { render, screen, waitFor } from '@testing-library/react'
+import { render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { graphql } from 'msw'
 import { setupServer } from 'msw/node'
@@ -229,6 +229,14 @@ describe('Summary', () => {
 
       const dropDownBtn = await screen.findByText('main')
       expect(dropDownBtn).toBeInTheDocument()
+    })
+
+    it('renders branch icon inside select button', async () => {
+      render(<SummaryTeamPlan />, { wrapper: wrapper() })
+
+      const dropDownBtn = await screen.findByRole('button')
+      const icon = await within(dropDownBtn).findByText('branch.svg')
+      expect(icon).toBeInTheDocument()
     })
 
     it('renders the source commit short sha', async () => {

--- a/src/pages/RepoPage/CoverageTab/SummaryTeamPlan/SummaryTeamPlan.tsx
+++ b/src/pages/RepoPage/CoverageTab/SummaryTeamPlan/SummaryTeamPlan.tsx
@@ -74,6 +74,11 @@ const SummaryTeamPlan = () => {
                 }}
                 onSearch={(term: any) => setBranchSearchTerm(term)}
                 items={branchList}
+                buttonIcon={
+                  <span className="text-ds-gray-quinary">
+                    <Icon name="branch" size="sm" variant="developer" />
+                  </span>
+                }
               />
             </span>
             {currentBranchSelected?.head?.commitid && (

--- a/src/ui/Select/Select.jsx
+++ b/src/ui/Select/Select.jsx
@@ -83,6 +83,7 @@ const Select = forwardRef(
       onLoadMore,
       isLoading,
       searchValue = '',
+      buttonIcon,
     },
     ref
   ) => {
@@ -163,7 +164,10 @@ const Select = forwardRef(
             className={cs(SelectClasses.button, ButtonVariantClass[variant])}
             {...getToggleButtonProps()}
           >
-            {renderButton()}
+            <span className="inline-flex items-center gap-1">
+              {buttonIcon}
+              {renderButton()}
+            </span>
             <Icon
               variant="solid"
               name={isOpen ? 'chevron-up' : 'chevron-down'}
@@ -239,6 +243,7 @@ Select.propTypes = {
   onLoadMore: PropTypes.func,
   isLoading: PropTypes.bool,
   searchValue: PropTypes.string,
+  buttonIcon: PropTypes.element,
 }
 
 export default Select

--- a/src/ui/Select/Select.spec.jsx
+++ b/src/ui/Select/Select.spec.jsx
@@ -108,6 +108,25 @@ describe('Select', () => {
     })
   })
 
+  describe('rendering with a button icon', () => {
+    it('renders the correct icon', async () => {
+      const onChange = jest.fn()
+      render(
+        <Select
+          ariaName="select test"
+          dataMarketing="select test"
+          items={['item1', 'item2', 'item3']}
+          onChange={onChange}
+          resourceName="item"
+          buttonIcon={<p>Super cool icon</p>}
+        />
+      )
+
+      const icon = screen.getByText(/Super cool icon/)
+      expect(icon).toBeInTheDocument()
+    })
+  })
+
   describe('when rendering with a value', () => {
     it('renders the default selected item', () => {
       const onChange = jest.fn()


### PR DESCRIPTION
# Description

This PR enables devs to pass along an icon that lives next to the select text, as well as updating the team plan version of the coverage tab summary to pass along a branch icon. This change in plan was confirmed with design.

Closes codecov/engineering-team#780

# Notable Changes

- Update `Select` to support passing along a button icon prop
- Update `SummaryTeamPlan` to pass along the branch icon
- Update tests

# Screenshots

![Screenshot 2023-11-09 at 9 12 01 AM](https://github.com/codecov/gazebo/assets/105234307/b41fb578-03cd-450b-a529-9b072113ba0d)