### PR TITLE
feat: Seats validation for team plan

### DIFF
--- a/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/UpgradeForm.jsx
+++ b/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/UpgradeForm.jsx
@@ -48,6 +48,7 @@ const useUpgradeForm = ({
   isSentryUpgrade,
   teamPlanMonth,
   teamPlanYear,
+  selectedPlan,
 }) => {
   const { provider, owner } = useParams()
   const history = useHistory()
@@ -100,6 +101,7 @@ const useUpgradeForm = ({
         accountDetails,
         minSeats,
         trialStatus: planData?.plan?.trialStatus,
+        selectedPlan,
       })
     ),
     mode: 'onChange',
@@ -238,6 +240,7 @@ function UpgradeForm({
     isSentryUpgrade,
     teamPlanMonth,
     teamPlanYear,
+    selectedPlan,
   })
 
   const planString = getValues('newPlan')

--- a/src/shared/utils/upgradeForm.js
+++ b/src/shared/utils/upgradeForm.js
@@ -93,7 +93,7 @@ export const getSchema = ({
       })
       .transform((val, ctx) => {
         if (
-          selectedPlan?.value === Plans.USERS_TEAMY &&
+          isTeamPlan(selectedPlan?.value) &&
           val > TEAM_PLAN_MAX_ACTIVE_USERS
         ) {
           ctx.addIssue({

--- a/src/shared/utils/upgradeForm.js
+++ b/src/shared/utils/upgradeForm.js
@@ -75,7 +75,12 @@ export const getInitialDataForm = ({
   }
 }
 
-export const getSchema = ({ accountDetails, minSeats, trialStatus }) =>
+export const getSchema = ({
+  accountDetails,
+  minSeats,
+  trialStatus,
+  selectedPlan,
+}) =>
   z.object({
     seats: z.coerce
       .number({
@@ -87,6 +92,16 @@ export const getSchema = ({ accountDetails, minSeats, trialStatus }) =>
         message: `You cannot purchase a per user plan for less than ${minSeats} users`,
       })
       .transform((val, ctx) => {
+        if (
+          selectedPlan?.value === Plans.USERS_TEAMY &&
+          val > TEAM_PLAN_MAX_ACTIVE_USERS
+        ) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: `Team plan is only available for ${TEAM_PLAN_MAX_ACTIVE_USERS} or less users`,
+          })
+        }
+
         if (
           trialStatus === TrialStatuses.ONGOING &&
           accountDetails?.plan?.value === Plans.USERS_TRIAL

--- a/src/shared/utils/upgradeForm.spec.js
+++ b/src/shared/utils/upgradeForm.spec.js
@@ -313,6 +313,57 @@ describe('getSchema', () => {
     expect(response.success).toEqual(true)
     expect(response.error).toBeUndefined()
   })
+
+  describe('when the user upgrades to team plan', () => {
+    it('fails to parse when seats are above max seats', () => {
+      const accountDetails = {
+        plan: {
+          value: Plans.USERS_INAPPY,
+        },
+      }
+      const schema = getSchema({
+        accountDetails,
+        selectedPlan: {
+          value: Plans.USERS_TEAMY,
+        },
+      })
+
+      const response = schema.safeParse({
+        seats: 12,
+        newPlan: Plans.USERS_TEAMY,
+      })
+      expect(response.success).toBe(false)
+
+      const [issue] = response.error.issues
+      expect(issue).toEqual(
+        expect.objectContaining({
+          message: 'Team plan is only available for 10 or less users',
+        })
+      )
+    })
+
+    it('passes when seats are below max seats', () => {
+      const accountDetails = {
+        plan: {
+          value: Plans.USERS_INAPPY,
+        },
+      }
+      const schema = getSchema({
+        accountDetails,
+        selectedPlan: {
+          value: Plans.USERS_TEAMY,
+        },
+      })
+
+      const response = schema.safeParse({
+        seats: 9,
+        newPlan: Plans.USERS_TEAMY,
+      })
+
+      expect(response.success).toEqual(true)
+      expect(response.error).toBeUndefined()
+    })
+  })
 })
 
 describe('calculateNonBundledCost', () => {

--- a/src/shared/utils/upgradeForm.spec.js
+++ b/src/shared/utils/upgradeForm.spec.js
@@ -342,7 +342,7 @@ describe('getSchema', () => {
       )
     })
 
-    it('passes when seats are below max seats', () => {
+    it('passes when seats are below max seats for team yearly plan', () => {
       const accountDetails = {
         plan: {
           value: Plans.USERS_INAPPY,
@@ -363,6 +363,28 @@ describe('getSchema', () => {
       expect(response.success).toEqual(true)
       expect(response.error).toBeUndefined()
     })
+  })
+
+  it('passes when seats are below max seats for team monthly plan', () => {
+    const accountDetails = {
+      plan: {
+        value: Plans.USERS_INAPPY,
+      },
+    }
+    const schema = getSchema({
+      accountDetails,
+      selectedPlan: {
+        value: Plans.USERS_TEAMM,
+      },
+    })
+
+    const response = schema.safeParse({
+      seats: 9,
+      newPlan: Plans.USERS_TEAMM,
+    })
+
+    expect(response.success).toEqual(true)
+    expect(response.error).toBeUndefined()
   })
 })
 


### PR DESCRIPTION
# Description
Add validation logic when person is trying add seats when going for team plan where it can't exceed 10 seats

# Notable Changes
Alter schema to handle the seats validation for the team plan 

# Screenshots
<img width="1331" alt="Screenshot 2023-11-09 at 6 46 52 PM" src="https://github.com/codecov/gazebo/assets/91732700/0dc7980e-5e1e-42f7-b8cf-2f31595d2836">


<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.