### PR TITLE
feat: Hide expired banner when clicking on upgrade link

### DIFF
--- a/src/shared/GlobalTopBanners/TrialBanner/ExpiredBanner.spec.tsx
+++ b/src/shared/GlobalTopBanners/TrialBanner/ExpiredBanner.spec.tsx
@@ -42,12 +42,34 @@ describe('ExpiredBanner', () => {
       )
     })
 
-    it('renders button to upgrade', () => {
-      render(<ExpiredBanner />, { wrapper })
+    describe('rendering upgrade button', () => {
+      it('renders button', () => {
+        render(<ExpiredBanner />, { wrapper })
 
-      const btn = screen.getByRole('link', { name: /Upgrade/ })
-      expect(btn).toBeInTheDocument()
-      expect(btn).toHaveAttribute('href', '/plan/gh/codecov/upgrade')
+        const btn = screen.getByRole('link', { name: /Upgrade/ })
+        expect(btn).toBeInTheDocument()
+        expect(btn).toHaveAttribute('href', '/plan/gh/codecov/upgrade')
+      })
+
+      describe('user clicks the button', () => {
+        it('calls local storage', async () => {
+          const { user, mockGetItem, mockSetItem } = setup()
+          render(<ExpiredBanner />, { wrapper })
+
+          mockGetItem.mockReturnValue(null)
+
+          const btn = screen.getByRole('link', { name: /Upgrade/ })
+          expect(btn).toBeInTheDocument()
+          await user.click(btn)
+
+          await waitFor(() =>
+            expect(mockSetItem).toHaveBeenCalledWith(
+              'dismissed-top-banners',
+              JSON.stringify({ 'global-top-expired-trial-banner': 'true' })
+            )
+          )
+        })
+      })
     })
 
     it('renders dismiss button', () => {
@@ -70,7 +92,7 @@ describe('ExpiredBanner', () => {
       await user.click(dismissBtn)
 
       await waitFor(() =>
-        expect(mockSetItem).toBeCalledWith(
+        expect(mockSetItem).toHaveBeenCalledWith(
           'dismissed-top-banners',
           JSON.stringify({ 'global-top-expired-trial-banner': 'true' })
         )

--- a/src/shared/GlobalTopBanners/TrialBanner/ExpiredBanner.tsx
+++ b/src/shared/GlobalTopBanners/TrialBanner/ExpiredBanner.tsx
@@ -1,11 +1,13 @@
 import A from 'ui/A/A'
 import Button from 'ui/Button/Button'
 import Icon from 'ui/Icon/Icon'
-import TopBanner from 'ui/TopBanner'
+import TopBanner, { saveToLocalStorage } from 'ui/TopBanner'
+
+const localStorageKey = 'global-top-expired-trial-banner'
 
 const ExpiredBanner: React.FC = () => {
   return (
-    <TopBanner localStorageKey="global-top-expired-trial-banner">
+    <TopBanner localStorageKey={localStorageKey}>
       <TopBanner.Start>
         <p className="font-semibold">
           <span className="pr-2 text-xl">&#127881;</span>
@@ -23,6 +25,10 @@ const ExpiredBanner: React.FC = () => {
           hook="expired-trial-banner-to-upgrade-page"
           disabled={false}
           variant="primary"
+          onClick={() => {
+            // this has the side effect of hiding the banner
+            saveToLocalStorage(localStorageKey)
+          }}
         >
           Upgrade
         </Button>

--- a/src/ui/TopBanner/TopBanner.tsx
+++ b/src/ui/TopBanner/TopBanner.tsx
@@ -34,6 +34,25 @@ type TopBannerContextValue = z.infer<typeof topBannerContext>
 
 const TopBannerContext = createContext<TopBannerContextValue | null>(null)
 
+export const saveToLocalStorage = (localStorageKey: string) => {
+  const currentStore = localStorage.getItem(LOCAL_STORE_ROOT_KEY)
+
+  if (isNull(currentStore)) {
+    localStorage.setItem(
+      LOCAL_STORE_ROOT_KEY,
+      JSON.stringify({ [localStorageKey]: 'true' })
+    )
+  } else {
+    localStorage.setItem(
+      LOCAL_STORE_ROOT_KEY,
+      JSON.stringify({
+        ...JSON.parse(currentStore),
+        [localStorageKey]: 'true',
+      })
+    )
+  }
+}
+
 /*
  * WARNING: not for use outside of this hook, only exported for testing purposes
  */
@@ -61,23 +80,7 @@ const DismissButton: React.FC<React.PropsWithChildren> = ({ children }) => {
         variant="plain"
         hook={`dismiss-${localStorageKey}`}
         onClick={() => {
-          const currentStore = localStorage.getItem(LOCAL_STORE_ROOT_KEY)
-
-          if (isNull(currentStore)) {
-            localStorage.setItem(
-              LOCAL_STORE_ROOT_KEY,
-              JSON.stringify({ [localStorageKey]: 'true' })
-            )
-          } else {
-            localStorage.setItem(
-              LOCAL_STORE_ROOT_KEY,
-              JSON.stringify({
-                ...JSON.parse(currentStore),
-                [localStorageKey]: 'true',
-              })
-            )
-          }
-
+          saveToLocalStorage(localStorageKey)
           setHideBanner(true)
         }}
       >

--- a/src/ui/TopBanner/index.ts
+++ b/src/ui/TopBanner/index.ts
@@ -1,3 +1,5 @@
-import { TopBanner } from './TopBanner'
+import { saveToLocalStorage, TopBanner } from './TopBanner'
 
 export default TopBanner
+
+export { saveToLocalStorage }


### PR DESCRIPTION
# Description

This PR adds an `onClick` event to the upgrade button in the `ExpiredBanner` that saves the value to the local storage. This is a little hacky because it's reliant on the navigation to update the state when returning to the previous page to actually hide the banner because there's no real way to update the state from the `ExpiredBanner` component itself.

Closes codecov/engineering-team#746

# Notable Changes

- Update `ExpiredBanner`
- Update `TopBanner`
- Update tests