### PR TITLE
Fix analytics page chart selector behavior

### DIFF
--- a/src/pages/AnalyticsPage/ChartSelectors/ChartSelectors.jsx
+++ b/src/pages/AnalyticsPage/ChartSelectors/ChartSelectors.jsx
@@ -44,13 +44,16 @@ function RepoSelector({
   setSelectedRepos,
   resetRef,
 }) {
-  const { owner } = useParams()
+  const { owner, provider } = useParams()
   const [search, setSearch] = useState()
 
   const onSelectChangeHandler = (item) => {
     setSelectedRepos(item)
     updateParams({ repositories: item })
   }
+
+  const { data: tierName } = useTier({ provider, owner })
+  const shouldDisplayPublicReposOnly = tierName === TierNames.TEAM ? true : null
 
   const { data, isLoading, fetchNextPage, hasNextPage } = useRepos({
     active,
@@ -59,6 +62,7 @@ function RepoSelector({
     owner,
     first: Infinity,
     suspense: false,
+    isPublic: shouldDisplayPublicReposOnly,
   })
 
   return (

--- a/src/pages/AnalyticsPage/ChartSelectors/ChartSelectors.spec.jsx
+++ b/src/pages/AnalyticsPage/ChartSelectors/ChartSelectors.spec.jsx
@@ -367,7 +367,7 @@ describe('ChartSelectors', () => {
         expect(searchBoxUpdated).toHaveAttribute('value', 'codecov')
 
         await waitFor(() => {
-          expect(useRepos).toBeCalledWith({
+          expect(useRepos).toHaveBeenCalledWith({
             active: true,
             first: Infinity,
             owner: 'codecov',
@@ -377,6 +377,7 @@ describe('ChartSelectors', () => {
             },
             suspense: false,
             term: 'codecov',
+            isPublic: null,
           })
         })
       })
@@ -490,6 +491,20 @@ describe('ChartSelectors', () => {
       const upgradeLink = await screen.findByRole('link', { name: 'Upgrade' })
       expect(upgradeLink).toBeInTheDocument()
       expect(upgradeLink).toHaveAttribute('href', '/plan/gh/codecov/upgrade')
+      await waitFor(() => {
+        expect(useRepos).toHaveBeenCalledWith({
+          active: true,
+          first: Infinity,
+          owner: 'codecov',
+          sortItem: {
+            direction: 'ASC',
+            ordering: 'NAME',
+          },
+          suspense: false,
+          term: '',
+          isPublic: true,
+        })
+      })
     })
   })
 })


### PR DESCRIPTION
# Description

This PR closes https://github.com/codecov/engineering-team/issues/785. If the user is on a team plan, we only want to show them public repos on the analytics page. Adds similar logic as the one in the [table below](https://github.com/codecov/gazebo/blob/main/src/shared/ListRepo/ReposTable/ReposTable.jsx#L154) to filter public repositories. 

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.