### PR TITLE
ref: Remove All Flag Multi Select ... Flags

### DIFF
--- a/src/pages/CommitDetailPage/CommitDetailPageContent/CommitDetailPageContent.spec.jsx
+++ b/src/pages/CommitDetailPage/CommitDetailPageContent/CommitDetailPageContent.spec.jsx
@@ -140,6 +140,39 @@ const mockRepoSettings = (isPrivate = false) => ({
   },
 })
 
+const mockFlagsResponse = {
+  owner: {
+    repository: {
+      flags: {
+        edges: [
+          {
+            node: {
+              name: 'flag-1',
+            },
+          },
+        ],
+        pageInfo: {
+          hasNextPage: true,
+          endCursor: '1-flag-1',
+        },
+      },
+    },
+  },
+}
+
+const mockBackfillResponse = {
+  config: {
+    isTimescaleEnabled: true,
+  },
+  owner: {
+    repository: {
+      flagsMeasurementsActive: true,
+      flagsMeasurementsBackfilled: true,
+      flagsCount: 4,
+    },
+  },
+}
+
 const queryClient = new QueryClient({
   defaultOptions: { queries: { retry: false, suspense: true } },
 })
@@ -212,6 +245,12 @@ describe('CommitDetailPageContent', () => {
       }),
       graphql.query('GetRepoSettingsTeam', (req, res, ctx) => {
         return res(ctx.status(200), ctx.data(mockRepoSettings(isPrivate)))
+      }),
+      graphql.query('FlagsSelect', (req, res, ctx) => {
+        return res(ctx.status(200), ctx.data(mockFlagsResponse))
+      }),
+      graphql.query('BackfillFlagMemberships', (req, res, ctx) => {
+        return res(ctx.status(200), ctx.data(mockBackfillResponse))
       })
     )
 

--- a/src/pages/CommitDetailPage/CommitDetailPageTabs/CommitDetailPageTabs.jsx
+++ b/src/pages/CommitDetailPage/CommitDetailPageTabs/CommitDetailPageTabs.jsx
@@ -9,7 +9,6 @@ import {
 } from 'pages/RepoPage/utils'
 import { useRepoSettingsTeam } from 'services/repo'
 import { TierNames, useTier } from 'services/tier'
-import { useFlags } from 'shared/featureFlags'
 import ToggleHeader from 'ui/FileViewer/ToggleHeader'
 import TabNavigation from 'ui/TabNavigation'
 
@@ -23,17 +22,13 @@ function CommitDetailPageTabs({
   const { data: tierName } = useTier({ owner, provider })
   const { data: repoData } = useRepoSettingsTeam()
 
-  const { commitTabFlagMultiSelect } = useFlags({
-    commitTabFlagMultiSelect: false,
-  })
-
   const showIndirectChanges = !(
     repoData?.repository?.private && tierName === TierNames.TEAM
   )
 
-  const showFlagMultiSelect =
-    !(tierName === TierNames.TEAM && repoData?.repository?.private) &&
-    commitTabFlagMultiSelect
+  const showFlagMultiSelect = !(
+    tierName === TierNames.TEAM && repoData?.repository?.private
+  )
 
   const params = qs.parse(location.search, {
     ignoreQueryPrefix: true,

--- a/src/pages/CommitDetailPage/CommitDetailPageTabs/CommitDetailPageTabs.spec.jsx
+++ b/src/pages/CommitDetailPage/CommitDetailPageTabs/CommitDetailPageTabs.spec.jsx
@@ -115,7 +115,6 @@ describe('CommitDetailPageTabs', () => {
   ) {
     useFlags.mockReturnValue({
       commitTabFlagMultiSelect: flagValue,
-      coverageTabFlagMutliSelect: flagValue,
     })
 
     server.use(

--- a/src/pages/CommitDetailPage/CommitDetailPageTabs/CommitDetailPageTabs.spec.jsx
+++ b/src/pages/CommitDetailPage/CommitDetailPageTabs/CommitDetailPageTabs.spec.jsx
@@ -7,11 +7,8 @@ import { Suspense } from 'react'
 import { MemoryRouter, Route } from 'react-router-dom'
 
 import { TierNames } from 'services/tier'
-import { useFlags } from 'shared/featureFlags'
 
 import CommitDetailPageTabs from './CommitDetailPageTabs'
-
-jest.mock('shared/featureFlags')
 
 const mockRepoSettings = (isPrivate) => ({
   owner: {
@@ -113,10 +110,6 @@ describe('CommitDetailPageTabs', () => {
       isPrivate: false,
     }
   ) {
-    useFlags.mockReturnValue({
-      commitTabFlagMultiSelect: flagValue,
-    })
-
     server.use(
       graphql.query('FlagsSelect', (req, res, ctx) => {
         return res(ctx.status(200), ctx.data(mockFlagsResponse))
@@ -387,7 +380,7 @@ describe('CommitDetailPageTabs', () => {
   describe('flags multi-select', () => {
     describe('user is not on a team plan', () => {
       it('renders flag multi-select', async () => {
-        setup({ flagValue: true })
+        setup({})
         render(<CommitDetailPageTabs commitSha="sha256" />, {
           wrapper: wrapper(),
         })
@@ -401,7 +394,6 @@ describe('CommitDetailPageTabs', () => {
       describe('repo is public', () => {
         it('renders flag multi-select', async () => {
           setup({
-            flagValue: true,
             tierValue: TierNames.TEAM,
             isPrivate: false,
           })
@@ -416,7 +408,7 @@ describe('CommitDetailPageTabs', () => {
 
       describe('repo is private', () => {
         it('does not render the multi select', async () => {
-          setup({ flagValue: true, tierValue: TierNames.TEAM, isPrivate: true })
+          setup({ tierValue: TierNames.TEAM, isPrivate: true })
           render(<CommitDetailPageTabs commitSha="sha256" />, {
             wrapper: wrapper(),
           })

--- a/src/pages/CommitDetailPage/subRoute/CommitDetailFileExplorer/hooks/useRepoCommitContentsTable.js
+++ b/src/pages/CommitDetailPage/subRoute/CommitDetailFileExplorer/hooks/useRepoCommitContentsTable.js
@@ -10,7 +10,6 @@ import CommitDirEntry from 'shared/ContentsTable/TableEntries/CommitEntries/Comm
 import CommitFileEntry from 'shared/ContentsTable/TableEntries/CommitEntries/CommitFileEntry'
 import { useTableDefaultSort } from 'shared/ContentsTable/useTableDefaultSort'
 import { adjustListIfUpDir } from 'shared/ContentsTable/utils'
-import { useFlags } from 'shared/featureFlags'
 import { useCommitTreePaths } from 'shared/treePaths'
 import { determineProgressColor } from 'shared/utils/determineProgressColor'
 import CoverageProgress from 'ui/CoverageProgress'
@@ -152,9 +151,9 @@ const sortingParameter = Object.freeze({
   lines: 'LINES',
 })
 
-const getQueryFilters = ({ params, sortBy, enableFlags }) => {
+const getQueryFilters = ({ params, sortBy }) => {
   let flags = {}
-  if (params?.flags && enableFlags) {
+  if (params?.flags) {
     flags = { flags: params?.flags }
   }
 
@@ -179,10 +178,6 @@ export function useRepoCommitContentsTable() {
   const { treePaths } = useCommitTreePaths()
   const [sortBy, setSortBy] = useTableDefaultSort()
 
-  const { commitTabFlagMultiSelect } = useFlags({
-    commitTabFlagMultiSelect: false,
-  })
-
   const { data: commitData, isLoading: commitIsLoading } =
     useRepoCommitContents({
       provider,
@@ -193,7 +188,6 @@ export function useRepoCommitContentsTable() {
       filters: getQueryFilters({
         params,
         sortBy: sortBy[0],
-        enableFlags: commitTabFlagMultiSelect,
       }),
       opts: {
         suspense: false,

--- a/src/pages/CommitDetailPage/subRoute/FilesChangedTab/FilesChangedTable/FilesChangedTable.jsx
+++ b/src/pages/CommitDetailPage/subRoute/FilesChangedTab/FilesChangedTable/FilesChangedTable.jsx
@@ -9,7 +9,6 @@ import { useLocation, useParams } from 'react-router-dom'
 
 import Table from 'old_ui/Table'
 import { useCommit } from 'services/commit'
-import { useFlags } from 'shared/featureFlags'
 import A from 'ui/A'
 import Icon from 'ui/Icon'
 import Spinner from 'ui/Spinner'
@@ -152,19 +151,12 @@ function FilesChangedTable() {
   const { provider, owner, repo, commit: commitSha } = useParams()
   const location = useLocation()
 
-  const { commitTabFlagMultiSelect } = useFlags({
-    commitTabFlagMultiSelect: false,
-  })
-
   const queryParams = qs.parse(location.search, {
     ignoreQueryPrefix: true,
     depth: 1,
   })
 
-  const flags =
-    queryParams?.flags?.length > 0 && commitTabFlagMultiSelect
-      ? queryParams?.flags
-      : undefined
+  const flags = queryParams?.flags?.length > 0 ? queryParams?.flags : undefined
 
   const { data: commitData, isLoading } = useCommit({
     provider,

--- a/src/pages/CommitDetailPage/subRoute/FilesChangedTab/FilesChangedTable/FilesChangedTable.spec.jsx
+++ b/src/pages/CommitDetailPage/subRoute/FilesChangedTab/FilesChangedTable/FilesChangedTable.spec.jsx
@@ -7,11 +7,8 @@ import qs from 'qs'
 import { Suspense } from 'react'
 import { MemoryRouter, Route } from 'react-router-dom'
 
-import { useFlags } from 'shared/featureFlags'
-
 import FilesChangedTable from './FilesChangedTable'
 
-jest.mock('shared/featureFlags')
 jest.mock('../shared/CommitFileDiff', () => () => 'CommitFileDiff')
 
 const mockCommitData = ({ data, state }) => ({
@@ -88,10 +85,6 @@ describe('FilesChangedTable', () => {
           retry: false,
         },
       },
-    })
-
-    useFlags.mockReturnValue({
-      commitTabFlagMultiSelect: true,
     })
 
     server.use(

--- a/src/pages/CommitDetailPage/subRoute/IndirectChangesTab/IndirectChangesTable/IndirectChangesTable.jsx
+++ b/src/pages/CommitDetailPage/subRoute/IndirectChangesTab/IndirectChangesTable/IndirectChangesTable.jsx
@@ -9,7 +9,6 @@ import { useLocation, useParams } from 'react-router-dom'
 
 import Table from 'old_ui/Table'
 import { useCommit } from 'services/commit'
-import { useFlags } from 'shared/featureFlags'
 import A from 'ui/A'
 import Icon from 'ui/Icon'
 import Spinner from 'ui/Spinner'
@@ -141,19 +140,12 @@ function IndirectChangesTable() {
   const { provider, owner, repo, commit: commitSha } = useParams()
   const location = useLocation()
 
-  const { commitTabFlagMultiSelect } = useFlags({
-    commitTabFlagMultiSelect: false,
-  })
-
   const queryParams = qs.parse(location.search, {
     ignoreQueryPrefix: true,
     depth: 1,
   })
 
-  const flags =
-    queryParams?.flags?.length > 0 && commitTabFlagMultiSelect
-      ? queryParams?.flags
-      : undefined
+  const flags = queryParams?.flags?.length > 0 ? queryParams?.flags : undefined
 
   const { data: commitData, isLoading } = useCommit({
     provider,

--- a/src/pages/CommitDetailPage/subRoute/IndirectChangesTab/IndirectChangesTable/IndirectChangesTable.spec.jsx
+++ b/src/pages/CommitDetailPage/subRoute/IndirectChangesTab/IndirectChangesTable/IndirectChangesTable.spec.jsx
@@ -7,11 +7,8 @@ import qs from 'qs'
 import { Suspense } from 'react'
 import { MemoryRouter, Route } from 'react-router-dom'
 
-import { useFlags } from 'shared/featureFlags'
-
 import IndirectChangesTable from '../IndirectChangesTable'
 
-jest.mock('shared/featureFlags')
 jest.mock('./CommitFileDiff', () => () => 'CommitFileDiff')
 
 const server = setupServer()
@@ -60,10 +57,6 @@ describe('IndirectChangesTable', () => {
           retry: false,
         },
       },
-    })
-
-    useFlags.mockReturnValue({
-      commitTabFlagMultiSelect: true,
     })
 
     server.use(

--- a/src/pages/PullRequestPage/PullRequestPageTabs/PullRequestPageTabs.jsx
+++ b/src/pages/PullRequestPage/PullRequestPageTabs/PullRequestPageTabs.jsx
@@ -22,8 +22,7 @@ function PullRequestPageTabs() {
     commitsCount,
   } = useTabsCounts()
   const { data: settings, isLoading: settingsLoading } = useRepoSettings()
-  const { pullRequestPageFlagMultiSelect, multipleTiers } = useFlags({
-    pullRequestPageFlagMultiSelect: false,
+  const { multipleTiers } = useFlags({
     multipleTiers: false,
   })
 
@@ -165,8 +164,7 @@ function PullRequestPageTabs() {
           coverageIsLoading={false}
           showHitCount={true}
           showFlagsSelect={
-            pullRequestPageFlagMultiSelect &&
-            (tierData !== TierNames.TEAM || !settings?.repository?.private)
+            tierData !== TierNames.TEAM || !settings?.repository?.private
           }
         />
       }

--- a/src/pages/RepoPage/CoverageTab/subroute/FileExplorer/FlagMultiSelect.jsx
+++ b/src/pages/RepoPage/CoverageTab/subroute/FileExplorer/FlagMultiSelect.jsx
@@ -11,7 +11,6 @@ import {
   useRepoSettingsTeam,
 } from 'services/repo'
 import { TierNames, useTier } from 'services/tier'
-import { useFlags } from 'shared/featureFlags'
 import Icon from 'ui/Icon'
 import MultiSelect from 'ui/MultiSelect'
 
@@ -35,10 +34,6 @@ function FlagMultiSelect() {
   const flagsMeasurementsActive = !!repoBackfilledData?.flagsMeasurementsActive
   const noFlagsPresent = eq(repoBackfilledData?.flagsCount, 0)
 
-  const { coverageTabFlagMutliSelect } = useFlags({
-    coverageTabFlagMutliSelect: false,
-  })
-
   const hideFlagMultiSelect =
     tierName === TierNames.TEAM && repoData?.repository?.private
 
@@ -52,13 +47,12 @@ function FlagMultiSelect() {
     options: {
       suspense: false,
       enabled:
-        !!coverageTabFlagMutliSelect ||
         hideFlagMultiSelect ||
         (flagsMeasurementsActive && !noFlagsPresent && isTimescaleEnabled),
     },
   })
 
-  if (!coverageTabFlagMutliSelect || noFlagsPresent || hideFlagMultiSelect) {
+  if (noFlagsPresent || hideFlagMultiSelect) {
     return null
   }
 

--- a/src/pages/RepoPage/CoverageTab/subroute/Fileviewer/Fileviewer.jsx
+++ b/src/pages/RepoPage/CoverageTab/subroute/Fileviewer/Fileviewer.jsx
@@ -2,7 +2,6 @@ import { useParams } from 'react-router-dom'
 
 import { useRepoSettingsTeam } from 'services/repo'
 import { TierNames, useTier } from 'services/tier'
-import { useFlags } from 'shared/featureFlags'
 import RawFileviewer from 'shared/RawFileviewer'
 import { useTreePaths } from 'shared/treePaths'
 import Breadcrumb from 'ui/Breadcrumb'
@@ -12,15 +11,11 @@ function FileView() {
   const { provider, owner, ref: commit } = useParams()
   const { data: repoData } = useRepoSettingsTeam()
 
-  const { coverageTabFlagMutliSelect } = useFlags({
-    coverageTabFlagMutliSelect: false,
-  })
-
   const { data: tierName } = useTier({ provider, owner })
 
-  const showFlagSelector =
-    !(tierName === TierNames.TEAM && repoData?.repository?.private) &&
-    coverageTabFlagMutliSelect
+  const showFlagSelector = !(
+    tierName === TierNames.TEAM && repoData?.repository?.private
+  )
 
   return (
     <RawFileviewer

--- a/src/pages/RepoPage/CoverageTab/subroute/Fileviewer/Fileviewer.spec.jsx
+++ b/src/pages/RepoPage/CoverageTab/subroute/Fileviewer/Fileviewer.spec.jsx
@@ -5,12 +5,10 @@ import { setupServer } from 'msw/node'
 import { MemoryRouter, Route } from 'react-router-dom'
 
 import { TierNames } from 'services/tier'
-import { useFlags } from 'shared/featureFlags'
 import { useScrollToLine } from 'ui/CodeRenderer/hooks/useScrollToLine'
 
 import FileView from './Fileviewer'
 
-jest.mock('shared/featureFlags')
 jest.mock('ui/CodeRenderer/hooks/useScrollToLine')
 
 const mockRepoSettings = (isPrivate) => ({
@@ -156,10 +154,6 @@ describe('FileView', () => {
       handleClick: jest.fn(),
       targeted: false,
     }))
-
-    useFlags.mockReturnValue({
-      coverageTabFlagMutliSelect: true,
-    })
 
     server.use(
       graphql.query('DetailOwner', (req, res, ctx) =>

--- a/src/ui/FileViewer/ToggleHeader/ToggleHeader.spec.jsx
+++ b/src/ui/FileViewer/ToggleHeader/ToggleHeader.spec.jsx
@@ -4,11 +4,8 @@ import { graphql } from 'msw'
 import { setupServer } from 'msw/node'
 import { MemoryRouter, Route } from 'react-router-dom'
 
-import { useFlags } from 'shared/featureFlags'
-
 import ToggleHeader from './ToggleHeader'
 
-jest.mock('shared/featureFlags')
 jest.mock('react-use/lib/useIntersection')
 
 const mockFlagResponse = {
@@ -70,10 +67,6 @@ afterAll(() => {
 
 describe('ToggleHeader', () => {
   function setup() {
-    useFlags.mockReturnValue({
-      coverageTabFlagMutliSelect: true,
-    })
-
     server.use(
       graphql.query('BackfillFlagMemberships', (req, res, ctx) => {
         return res(ctx.status(200), ctx.data(mockBackfillResponse))


### PR DESCRIPTION
# Description

This PR removes the various feature flags used to conditionally render the flag multi select, as we've fully rolled it out, and as we also want to fully roll it out to enterprise customers as well.

# Notable Changes

- Removed `coverageTabFlagMutliSelect` flag
- Removed `commitTabFlagMultiSelect` flag
- Removed `pullRequestPageFlagMultSelect` flag