### PR TITLE
[Client] Add logic to return measurements data based on specifying public and private repo

### DIFF
--- a/src/pages/AnalyticsPage/Chart/useCoverage.js
+++ b/src/pages/AnalyticsPage/Chart/useCoverage.js
@@ -3,6 +3,7 @@ import isFunction from 'lodash/isFunction'
 import { useParams } from 'react-router-dom'
 
 import { useReposCoverageMeasurements } from 'services/charts/useReposCoverageMeasurements'
+import { TierNames, useTier } from 'services/tier'
 import {
   analyticsQuery,
   TimeseriesInterval,
@@ -12,6 +13,8 @@ export const useCoverage = ({ params, options = {} }) => {
   const { provider, owner } = useParams()
 
   const { select, ...newOptions } = options
+  const { data: tierName } = useTier({ provider, owner })
+  const shouldDisplayPublicReposOnly = tierName === TierNames.TEAM ? true : null
 
   const queryVars = analyticsQuery(params)
 
@@ -22,6 +25,7 @@ export const useCoverage = ({ params, options = {} }) => {
     repos: queryVars?.repositories,
     before: queryVars?.endDate,
     after: queryVars?.startDate,
+    isPublic: shouldDisplayPublicReposOnly,
     opts: {
       select: (data) => {
         if (data?.measurements?.[0]?.max === null) {

--- a/src/pages/AnalyticsPage/Chart/useCoverage.spec.js
+++ b/src/pages/AnalyticsPage/Chart/useCoverage.spec.js
@@ -2,17 +2,13 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { renderHook, waitFor } from '@testing-library/react'
 import { graphql } from 'msw'
 import { setupServer } from 'msw/node'
-import { MemoryRouter, Route , useParams } from 'react-router-dom'
+import { MemoryRouter, Route } from 'react-router-dom'
 
 import { TierNames } from 'services/tier'
 
 import { useCoverage } from './useCoverage'
 
 jest.mock('services/charts')
-jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router-dom'), // import and retain the original functionalities
-  useParams: jest.fn(() => {}),
-}))
 
 const mockRepoMeasurements = {
   owner: {
@@ -95,7 +91,6 @@ describe('useCoverage', () => {
       tierValue: TierNames.PRO,
     }
   ) {
-    useParams.mockReturnValue({ owner: 'codecov', provider: 'gh' })
     server.use(
       graphql.query('GetReposCoverageMeasurements', (req, res, ctx) => {
         if (req.variables?.isPublic) {

--- a/src/services/charts/useReposCoverageMeasurements.ts
+++ b/src/services/charts/useReposCoverageMeasurements.ts
@@ -27,6 +27,7 @@ export interface UseReposCoverageMeasurementsArgs {
   after?: string
   repos?: string[]
   opts?: UseQueryOptions<ReposCoverageMeasurementsData>
+  isPublic?: boolean // by default, get both public and private repos
 }
 
 const query = `
@@ -36,6 +37,7 @@ const query = `
     $after: DateTime
     $interval: MeasurementInterval!
     $repos: [String!]
+    $isPublic: Boolean
   ) {
     owner(username: $owner) {
       measurements(
@@ -43,6 +45,7 @@ const query = `
         before: $before
         interval: $interval
         repos: $repos
+        isPublic: $isPublic
       ) {
         timestamp
         max
@@ -59,6 +62,7 @@ export const useReposCoverageMeasurements = ({
   after,
   repos,
   opts,
+  isPublic, // by default, get both public and private repos
 }: UseReposCoverageMeasurementsArgs) => {
   return useQuery({
     queryKey: [
@@ -70,6 +74,7 @@ export const useReposCoverageMeasurements = ({
       before,
       after,
       repos,
+      isPublic,
     ],
     queryFn: ({ signal }) =>
       Api.graphql({
@@ -82,6 +87,7 @@ export const useReposCoverageMeasurements = ({
           before,
           after,
           repos,
+          isPublic,
         },
       }).then(
         (res) => ReposCoverageMeasurementsConfig.parse(res?.data?.owner) ?? {}


### PR DESCRIPTION
# Description

Make the line chart on the Analytics page filter on only public repos if the user is on a team plan. This makes use of the new `isPublic` parameter on the measurements GQL field as added in https://github.com/codecov/engineering-team/issues/786. This PR closes https://github.com/codecov/engineering-team/issues/787.


<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.