### PR TITLE
fix: change copy of team card when trialing

### DIFF
--- a/src/pages/PlanPage/subRoutes/CurrentOrgPlan/CurrentPlanCard/FreePlanCard/PlanUpgradeTeam/PlanUpgradeTeam.jsx
+++ b/src/pages/PlanPage/subRoutes/CurrentOrgPlan/CurrentPlanCard/FreePlanCard/PlanUpgradeTeam/PlanUpgradeTeam.jsx
@@ -2,7 +2,7 @@ import { useParams } from 'react-router-dom'
 
 import { useAvailablePlans, usePlanData } from 'services/account'
 import BenefitList from 'shared/plan/BenefitList'
-import { findTeamPlans, isFreePlan } from 'shared/utils/billing'
+import { findTeamPlans, isFreePlan, isTrialPlan } from 'shared/utils/billing'
 import Button from 'ui/Button'
 
 function PlanUpgradeTeam() {
@@ -51,7 +51,8 @@ function PlanUpgradeTeam() {
             </div>
             <div className="flex self-start">
               <Button to={{ pageName: 'upgradeOrgPlan' }} variant="primary">
-                {isFreePlan(currentPlan?.value)
+                {isFreePlan(currentPlan?.value) ||
+                isTrialPlan(currentPlan?.value)
                   ? 'Upgrade to Team'
                   : 'Manage plan'}
               </Button>

--- a/src/pages/PlanPage/subRoutes/CurrentOrgPlan/CurrentPlanCard/FreePlanCard/PlanUpgradeTeam/PlanUpgradeTeam.spec.jsx
+++ b/src/pages/PlanPage/subRoutes/CurrentOrgPlan/CurrentPlanCard/FreePlanCard/PlanUpgradeTeam/PlanUpgradeTeam.spec.jsx
@@ -41,6 +41,21 @@ const mockPlanPro = {
   planUserCount: 4,
 }
 
+const mockPlanTrialing = {
+  baseUnitPrice: 10,
+  benefits: ['Up to # user', 'Unlimited public repositories'],
+  billingRate: 'monthly',
+  marketingName: 'Trial',
+  monthlyUploadLimit: null,
+  value: 'users-trial',
+  trialStatus: TrialStatuses.ONGOING,
+  trialStartDate: '2023-01-01T08:55:25',
+  trialEndDate: '2023-01-10T08:55:25',
+  trialTotalDays: 0,
+  pretrialUsersCount: 0,
+  planUserCount: 4,
+}
+
 const mockAvailablePlans = [
   {
     marketingName: 'Basic',
@@ -186,10 +201,8 @@ describe('PlanUpgradeTeam', () => {
   }
 
   describe('when rendered with basic plan', () => {
-    beforeEach(() => {
-      setup({ plan: mockPlanBasic })
-    })
     it('shows the monthly marketing name', async () => {
+      setup({ plan: mockPlanBasic })
       render(<PlanUpgradeTeam />, {
         wrapper,
       })
@@ -199,6 +212,7 @@ describe('PlanUpgradeTeam', () => {
     })
 
     it('show the benefits list', async () => {
+      setup({ plan: mockPlanBasic })
       render(<PlanUpgradeTeam />, {
         wrapper,
       })
@@ -211,6 +225,7 @@ describe('PlanUpgradeTeam', () => {
     })
 
     it('shows pricing for monthly card', async () => {
+      setup({ plan: mockPlanBasic })
       render(<PlanUpgradeTeam />, {
         wrapper,
       })
@@ -226,6 +241,17 @@ describe('PlanUpgradeTeam', () => {
     })
 
     it('shows upgrade to team when plan is basic', async () => {
+      setup({ plan: mockPlanBasic })
+      render(<PlanUpgradeTeam />, {
+        wrapper,
+      })
+
+      const buttonText = await screen.findByText(/Upgrade to Team/)
+      expect(buttonText).toBeInTheDocument()
+    })
+
+    it('shows upgrade to team when plan is trial', async () => {
+      setup({ plan: mockPlanTrialing })
       render(<PlanUpgradeTeam />, {
         wrapper,
       })


### PR DESCRIPTION
# Description
Team card was displaying the incorrect name when trialing, this fixes it.

# Notable Changes
- Adjust copy for teamplancard when trialing + tests

# Screenshots
<img width="815" alt="Screenshot 2023-11-14 at 2 01 26 PM" src="https://github.com/codecov/gazebo/assets/82913673/de574551-bc69-46e1-b9fb-ed21b435d0f0">

# Link to Sample Entry

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.