### PR TITLE
Table css styles fix

### DIFF
--- a/src/pages/CommitDetailPage/subRoute/FilesChangedTab/FilesChangedTableTeam/FilesChangedTableTeam.tsx
+++ b/src/pages/CommitDetailPage/subRoute/FilesChangedTab/FilesChangedTableTeam/FilesChangedTableTeam.tsx
@@ -212,8 +212,8 @@ export default function FilesChangedTableTeam() {
                     onClick: header.column.getToggleSortingHandler(),
                   }}
                   className={cs({
-                    'w-full @4xl/w-4/12': header.id === 'name',
-                    'w-2/12 hidden @4xl/filelist:block':
+                    'w-8/12': header.id === 'name',
+                    'w-2/12':
                       header.id === 'missedLines' ||
                       header.id === 'patchPercentage',
                   })}
@@ -223,6 +223,12 @@ export default function FilesChangedTableTeam() {
                       'flex-row-reverse justify-end': header.id === 'name',
                       'justify-end': header.id === 'patchPercentage',
                     })}
+                    {...(header.id === 'patchPercentage' ||
+                    header.id === 'missedLines'
+                      ? {
+                          'data-type': 'numeric',
+                        }
+                      : {})}
                   >
                     <span
                       className="text-ds-blue-darker"
@@ -256,8 +262,8 @@ export default function FilesChangedTableTeam() {
                           }
                         : {})}
                       className={cs({
-                        'w-full @4xl/w-4/12': cell.column.id === 'name',
-                        'w-2/12 hidden @4xl/filelist:block':
+                        'w-8/12': cell.column.id === 'name',
+                        'w-2/12':
                           cell.column.id === 'missedLines' ||
                           cell.column.id === 'patchPercentage',
                       })}

--- a/src/pages/PullRequestPage/subroute/FilesChangedTab/FilesChanged/TableTeam/TableTeam.tsx
+++ b/src/pages/PullRequestPage/subroute/FilesChangedTab/FilesChanged/TableTeam/TableTeam.tsx
@@ -223,11 +223,17 @@ export default function FilesChangedTableTeam() {
                     onClick: header.column.getToggleSortingHandler(),
                   }}
                   className={cs({
-                    'w-full @4xl/w-4/12': header.id === 'name',
-                    'w-2/12 hidden @xl/filelist:block':
-                      header.id === 'missedLines',
-                    'w-2/12': header.id === 'patchPercentage',
+                    'w-8/12': header.id === 'name',
+                    'w-2/12 flex':
+                      header.id === 'missedLines' ||
+                      header.id === 'patchPercentage',
                   })}
+                  {...(header.id === 'patchPercentage' ||
+                  header.id === 'missedLines'
+                    ? {
+                        'data-type': 'numeric',
+                      }
+                    : {})}
                 >
                   <div
                     className={cs('flex gap-1 items-center', {
@@ -267,10 +273,10 @@ export default function FilesChangedTableTeam() {
                           }
                         : {})}
                       className={cs({
-                        'w-full @4xl/w-4/12': cell.column.id === 'name',
-                        'w-2/12 hidden @xl/filelist:block':
-                          cell.column.id === 'missedLines',
-                        'w-2/12': cell.column.id === 'patchPercentage',
+                        'w-8/12': cell.column.id === 'name',
+                        'w-2/12':
+                          cell.column.id === 'missedLines' ||
+                          cell.column.id === 'patchPercentage',
                       })}
                     >
                       {flexRender(


### PR DESCRIPTION
# Description
Tweak team plan table styles

# Code Example

# Notable Changes
* mostly just applying numeric type to the headers to align titles. Can't make the table scroll on small screens till we refactor the code viewer unfortunately.

# Screenshots
<img width="1074" alt="Screenshot 2023-11-15 at 10 45 06 AM" src="https://github.com/codecov/gazebo/assets/87824812/90511405-741d-4595-8850-78f506fe8f3c">
<img width="847" alt="Screenshot 2023-11-15 at 10 46 03 AM" src="https://github.com/codecov/gazebo/assets/87824812/808fffd6-f3bb-45db-b8fb-247f60bec794">

# Link to Sample Entry

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.