### PR TITLE
feat: Add learn more link to the team plan card when upgrading

### DIFF
--- a/src/pages/PlanPage/subRoutes/CurrentOrgPlan/CurrentPlanCard/FreePlanCard/PlanUpgradeTeam/PlanUpgradeTeam.jsx
+++ b/src/pages/PlanPage/subRoutes/CurrentOrgPlan/CurrentPlanCard/FreePlanCard/PlanUpgradeTeam/PlanUpgradeTeam.jsx
@@ -3,6 +3,7 @@ import { useParams } from 'react-router-dom'
 import { useAvailablePlans, usePlanData } from 'services/account'
 import BenefitList from 'shared/plan/BenefitList'
 import { findTeamPlans, isFreePlan, isTrialPlan } from 'shared/utils/billing'
+import A from 'ui/A'
 import Button from 'ui/Button'
 
 function PlanUpgradeTeam() {
@@ -27,6 +28,7 @@ function PlanUpgradeTeam() {
       <div className="flex flex-col border">
         <div className="flex flex-row gap-2 p-4">
           <h2 className="font-semibold">{monthlyMarketingName} plan</h2>
+          <A to={{ pageName: 'teamPlanAbout' }}>Learn more</A>
         </div>
         <hr />
         <div className="grid gap-4 p-4 sm:grid-cols-2 sm:gap-0">

--- a/src/pages/PlanPage/subRoutes/CurrentOrgPlan/CurrentPlanCard/FreePlanCard/PlanUpgradeTeam/PlanUpgradeTeam.spec.jsx
+++ b/src/pages/PlanPage/subRoutes/CurrentOrgPlan/CurrentPlanCard/FreePlanCard/PlanUpgradeTeam/PlanUpgradeTeam.spec.jsx
@@ -211,6 +211,21 @@ describe('PlanUpgradeTeam', () => {
       expect(marketingName).toBeInTheDocument()
     })
 
+    it('shows link to learn more plan page', async () => {
+      setup({ plan: mockPlanBasic })
+      render(<PlanUpgradeTeam />, {
+        wrapper,
+      })
+
+      const learnMoreLink = await screen.findByRole('link', {
+        name: /learn more/i,
+      })
+      expect(learnMoreLink).toBeInTheDocument()
+      expect(learnMoreLink.href).toBe(
+        'https://about.codecov.io/team-plan-compare'
+      )
+    })
+
     it('show the benefits list', async () => {
       setup({ plan: mockPlanBasic })
       render(<PlanUpgradeTeam />, {

--- a/src/services/navigation/useNavLinks/useStaticNavLinks.js
+++ b/src/services/navigation/useNavLinks/useStaticNavLinks.js
@@ -214,6 +214,12 @@ export function useStaticNavLinks() {
       isExternalLink: true,
       openNewTab: true,
     },
+    teamPlanAbout: {
+      text: 'Team plan',
+      path: () => 'https://about.codecov.io/team-plan-compare',
+      isExternalLink: true,
+      openNewTab: true,
+    },
     prCommentLayout: {
       text: 'Pull request comment layout',
       path: () => 'https://docs.codecov.com/docs/pull-request-comments#layout',

--- a/src/services/navigation/useNavLinks/useStaticNavLinks.spec.js
+++ b/src/services/navigation/useNavLinks/useStaticNavLinks.spec.js
@@ -35,6 +35,7 @@ describe('useStaticNavLinks', () => {
       ${links.freeTrial}               | ${`${config.MARKETING_BASE_URL}/trial`}
       ${links.demo}                    | ${`${config.MARKETING_BASE_URL}/demo`}
       ${links.oauthTroubleshoot}       | ${'https://docs.codecov.com/docs/github-oauth-application-authorization#troubleshooting'}
+      ${links.teamPlanAbout}           | ${'https://about.codecov.io/team-plan-compare'}
       ${links.flags}                   | ${'https://docs.codecov.com/docs/flags'}
       ${links.components}              | ${'https://docs.codecov.com/docs/components'}
       ${links.unexpectedChanges}       | ${'https://docs.codecov.com/docs/unexpected-coverage-changes'}


### PR DESCRIPTION
# Description
We're adding a `learn more` link to the team card plan. We didn't add it before cause we didn't know the link.

# Notable Changes
- Add link + tests for the team plan card + links hook

# Screenshots
<img width="768" alt="Screenshot 2023-11-15 at 1 21 04 PM" src="https://github.com/codecov/gazebo/assets/82913673/2a6eedf9-9ce3-4b87-8b75-2b0059463ad6">


<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.