### PR TITLE
fix: Update to Codecov App link in GitHub integration section #2306

### DIFF
--- a/src/pages/AccountSettings/tabs/Admin/GithubIntegrationSection/GithubIntegrationSection.jsx
+++ b/src/pages/AccountSettings/tabs/Admin/GithubIntegrationSection/GithubIntegrationSection.jsx
@@ -20,7 +20,10 @@ function GithubIntegrationCopy({ integrationId }) {
       integration with your team.
       <br />
       This will replace the team bot account and post pull request comments on
-      behalf of Codecov. <A to={{ pageName: 'githubMarketplace' }}></A>
+      behalf of Codecov.{' '}
+      <A to={{ pageName: 'codecovGithubApp' }}>
+        View the Codecov App on GitHub
+      </A>
     </p>
   )
 }

--- a/src/pages/AccountSettings/tabs/Admin/GithubIntegrationSection/GithubIntegrationSection.spec.jsx
+++ b/src/pages/AccountSettings/tabs/Admin/GithubIntegrationSection/GithubIntegrationSection.spec.jsx
@@ -113,13 +113,14 @@ describe('GithubIntegrationSection', () => {
       expect(p).toBeInTheDocument()
     })
 
-    it('has a link to the github marketplace', async () => {
+    it('has a link to the github codecov app', async () => {
       render(<GithubIntegrationSection />, { wrapper: wrapper() })
 
       const link = await screen.findByRole('link', {
-        name: /View in GitHub Marketplace/i,
+        name: /View the Codecov App on GitHub/i,
       })
       expect(link).toBeInTheDocument()
+      expect(link).toHaveAttribute('href', 'https://github.com/apps/codecov')
     })
   })
 


### PR DESCRIPTION
# Description
Update link and copy 

# Screenshots
<img width="1115" alt="Screenshot 2023-11-16 at 4 10 13 PM" src="https://github.com/codecov/gazebo/assets/91732700/ee43f5e9-3c88-4c4f-93ba-8f77c581b80a">

# Link to Sample Entry

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.