### PR TITLE
feat: adjust useRepos prop ingestion from active to activated

### DIFF
--- a/src/pages/AnalyticsPage/ChartSelectors/ChartSelectors.jsx
+++ b/src/pages/AnalyticsPage/ChartSelectors/ChartSelectors.jsx
@@ -56,7 +56,7 @@ function RepoSelector({
   const shouldDisplayPublicReposOnly = tierName === TierNames.TEAM ? true : null
 
   const { data, isLoading, fetchNextPage, hasNextPage } = useRepos({
-    active,
+    activated: active,
     sortItem,
     term: search,
     owner,

--- a/src/pages/AnalyticsPage/ChartSelectors/ChartSelectors.spec.jsx
+++ b/src/pages/AnalyticsPage/ChartSelectors/ChartSelectors.spec.jsx
@@ -37,7 +37,7 @@ const repositories = [
     name: 'Repo name 1',
     latestCommitAt: subDays(new Date(), 3),
     coverage: 43,
-    active: true,
+    activated: true,
   },
   {
     private: false,
@@ -47,7 +47,7 @@ const repositories = [
     name: 'Repo name 3',
     latestCommitAt: subDays(new Date(), 4),
     coverage: 35,
-    active: false,
+    activated: false,
   },
 ]
 
@@ -368,7 +368,7 @@ describe('ChartSelectors', () => {
 
         await waitFor(() => {
           expect(useRepos).toHaveBeenCalledWith({
-            active: true,
+            activated: true,
             first: Infinity,
             owner: 'codecov',
             sortItem: {
@@ -493,7 +493,7 @@ describe('ChartSelectors', () => {
       expect(upgradeLink).toHaveAttribute('href', '/plan/gh/codecov/upgrade')
       await waitFor(() => {
         expect(useRepos).toHaveBeenCalledWith({
-          active: true,
+          activated: true,
           first: Infinity,
           owner: 'codecov',
           sortItem: {

--- a/src/services/trial/useStartTrial.ts
+++ b/src/services/trial/useStartTrial.ts
@@ -74,6 +74,7 @@ export const useStartTrial = () => {
 
       queryClient.invalidateQueries(['accountDetails'])
       queryClient.invalidateQueries(['GetPlanData'])
+      queryClient.invalidateQueries(['GetAvailablePlans'])
 
       renderToast({
         type: 'generic',

--- a/src/shared/ListRepo/ReposTable/ReposTable.jsx
+++ b/src/shared/ListRepo/ReposTable/ReposTable.jsx
@@ -154,7 +154,6 @@ function ReposTable({ searchValue, owner, sortItem, filterValues = [] }) {
       isPublic: shouldDisplayPublicReposOnly,
     })
 
-  console.log(data)
   const dataTable = transformRepoToTable({
     repos: data.repos,
     owner,

--- a/src/shared/ListRepo/ReposTable/ReposTable.jsx
+++ b/src/shared/ListRepo/ReposTable/ReposTable.jsx
@@ -154,6 +154,7 @@ function ReposTable({ searchValue, owner, sortItem, filterValues = [] }) {
       isPublic: shouldDisplayPublicReposOnly,
     })
 
+  console.log(data)
   const dataTable = transformRepoToTable({
     repos: data.repos,
     owner,


### PR DESCRIPTION
# Description
The analytics chart selector was fetching all sorts of repos rather than using the activated ones. This is because we were supplying `active` rather than `activated` props to the useRepos hook, which wasn't caught cause that test still mocks the hook implementation rather than emulate it through MSW. 

# Notable Changes
- Fix prop provided to `useRepos` by the analytics chart selector

# Screenshots
<img width="765" alt="Screenshot 2023-11-16 at 10 55 36 AM" src="https://github.com/codecov/gazebo/assets/82913673/a8ef0893-d9c3-4c49-95e8-3ccd36c634a7">

Matching the lists to the repo list ^

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.