### PR TITLE
Remove F# files from the image blocklist

### DIFF
--- a/src/shared/utils/unsupportedExtensionsMapper.js
+++ b/src/shared/utils/unsupportedExtensionsMapper.js
@@ -268,7 +268,6 @@ const imageFileExtensions = new Set([
   'emf',
   'eps',
   'exif',
-  'fs',
   'gbr',
   'gif',
   'gpl',


### PR DESCRIPTION
Remove F# files from the image blocklist.

Fixes #2427 