### PR TITLE
feat add ProController component to the 2nd form component

### DIFF
--- a/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm2/Controllers/ProPlanController/BillingOptions/BillingOptions.spec.tsx
+++ b/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm2/Controllers/ProPlanController/BillingOptions/BillingOptions.spec.tsx
@@ -92,21 +92,21 @@ describe('BillingOptions', () => {
       )
     )
 
-    const mockSetValue = jest.fn()
+    const mockSetFormValue = jest.fn()
     const user = userEvent.setup()
 
-    return { user, mockSetValue }
+    return { user, mockSetFormValue }
   }
 
   describe('when rendered', () => {
     describe('planString is set to annual plan', () => {
       it('renders annual button as "selected"', async () => {
-        const { mockSetValue } = setup()
+        const { mockSetFormValue } = setup()
 
         render(
           <BillingOptions
-            planString={Plans.USERS_PR_INAPPY}
-            setValue={mockSetValue}
+            newPlan={Plans.USERS_PR_INAPPY}
+            setFormValue={mockSetFormValue}
           />,
           {
             wrapper,
@@ -125,12 +125,12 @@ describe('BillingOptions', () => {
       })
 
       it('renders annual pricing scheme', async () => {
-        const { mockSetValue } = setup()
+        const { mockSetFormValue } = setup()
 
         render(
           <BillingOptions
-            planString={Plans.USERS_PR_INAPPY}
-            setValue={mockSetValue}
+            newPlan={Plans.USERS_PR_INAPPY}
+            setFormValue={mockSetFormValue}
           />,
           {
             wrapper,
@@ -146,12 +146,12 @@ describe('BillingOptions', () => {
 
       describe('user clicks on monthly button', () => {
         it('calls setValue', async () => {
-          const { mockSetValue, user } = setup()
+          const { mockSetFormValue, user } = setup()
 
           render(
             <BillingOptions
-              planString={Plans.USERS_PR_INAPPY}
-              setValue={mockSetValue}
+              newPlan={Plans.USERS_PR_INAPPY}
+              setFormValue={mockSetFormValue}
             />,
             {
               wrapper,
@@ -165,7 +165,10 @@ describe('BillingOptions', () => {
           await user.click(monthlyBtn)
 
           await waitFor(() =>
-            expect(mockSetValue).toBeCalledWith('newPlan', 'users-pr-inappm')
+            expect(mockSetFormValue).toBeCalledWith(
+              'newPlan',
+              'users-pr-inappm'
+            )
           )
         })
       })
@@ -173,12 +176,12 @@ describe('BillingOptions', () => {
 
     describe('planString is set to a monthly plan', () => {
       it('renders monthly button as "selected"', async () => {
-        const { mockSetValue } = setup()
+        const { mockSetFormValue } = setup()
 
         render(
           <BillingOptions
-            planString={Plans.USERS_PR_INAPPM}
-            setValue={mockSetValue}
+            newPlan={Plans.USERS_PR_INAPPM}
+            setFormValue={mockSetFormValue}
           />,
           {
             wrapper,
@@ -197,12 +200,12 @@ describe('BillingOptions', () => {
       })
 
       it('renders correct pricing scheme', async () => {
-        const { mockSetValue } = setup()
+        const { mockSetFormValue } = setup()
 
         render(
           <BillingOptions
-            planString={Plans.USERS_PR_INAPPM}
-            setValue={mockSetValue}
+            newPlan={Plans.USERS_PR_INAPPM}
+            setFormValue={mockSetFormValue}
           />,
           {
             wrapper,
@@ -218,12 +221,12 @@ describe('BillingOptions', () => {
 
       describe('user clicks on annual button', () => {
         it('calls setValue', async () => {
-          const { mockSetValue, user } = setup()
+          const { mockSetFormValue, user } = setup()
 
           render(
             <BillingOptions
-              planString={Plans.USERS_PR_INAPPM}
-              setValue={mockSetValue}
+              newPlan={Plans.USERS_PR_INAPPM}
+              setFormValue={mockSetFormValue}
             />,
             {
               wrapper,
@@ -237,7 +240,10 @@ describe('BillingOptions', () => {
           await user.click(annualBtn)
 
           await waitFor(() =>
-            expect(mockSetValue).toBeCalledWith('newPlan', 'users-pr-inappy')
+            expect(mockSetFormValue).toBeCalledWith(
+              'newPlan',
+              'users-pr-inappy'
+            )
           )
         })
       })

--- a/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm2/Controllers/ProPlanController/BillingOptions/BillingOptions.tsx
+++ b/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm2/Controllers/ProPlanController/BillingOptions/BillingOptions.tsx
@@ -10,32 +10,34 @@ import {
 } from 'shared/utils/billing'
 import OptionButton from 'ui/OptionButton'
 
+import { NewPlanType } from '../../../PlanTypeOptions/PlanTypeOptions'
+
 interface BillingControlsProps {
-  planString: string
-  setValue: (x: string, y: string) => void
+  newPlan: NewPlanType
+  setFormValue: (x: string, y: string) => void
 }
 
 const BillingControls: React.FC<BillingControlsProps> = ({
-  planString,
-  setValue,
+  newPlan,
+  setFormValue,
 }) => {
   const { provider, owner } = useParams<{ provider: string; owner: string }>()
   const { data: plans } = useAvailablePlans({ provider, owner })
   const { proPlanMonth, proPlanYear } = useProPlans({ plans })
 
   const [option, setOption] = useState<'Annual' | 'Monthly'>(() =>
-    isMonthlyPlan(planString) ? 'Monthly' : 'Annual'
+    isMonthlyPlan(newPlan) ? 'Monthly' : 'Annual'
   )
 
   // used to update option selection if user selects
   // the switch to annual button in the total banner
   useEffect(() => {
-    if (isMonthlyPlan(planString) && option === 'Annual') {
+    if (isMonthlyPlan(newPlan) && option === 'Annual') {
       setOption('Monthly')
-    } else if (isAnnualPlan(planString) && option === 'Monthly') {
+    } else if (isAnnualPlan(newPlan) && option === 'Monthly') {
       setOption('Annual')
     }
-  }, [planString, option])
+  }, [newPlan, option])
 
   const baseUnitPrice =
     option === 'Monthly'
@@ -53,9 +55,9 @@ const BillingControls: React.FC<BillingControlsProps> = ({
           active={option}
           onChange={({ text }) => {
             if (text === 'Annual') {
-              setValue('newPlan', Plans.USERS_PR_INAPPY)
+              setFormValue('newPlan', Plans.USERS_PR_INAPPY)
             } else {
-              setValue('newPlan', Plans.USERS_PR_INAPPM)
+              setFormValue('newPlan', Plans.USERS_PR_INAPPM)
             }
 
             setOption(text)

--- a/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm2/Controllers/ProPlanController/PriceCallout/PriceCallout.spec.tsx
+++ b/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm2/Controllers/ProPlanController/PriceCallout/PriceCallout.spec.tsx
@@ -102,7 +102,7 @@ describe('PriceCallout', () => {
 
   function setup() {
     const user = userEvent.setup()
-    const mockSetValue = jest.fn()
+    const mockSetFormValue = jest.fn()
 
     server.use(
       graphql.query('GetAvailablePlans', (req, res, ctx) =>
@@ -115,7 +115,7 @@ describe('PriceCallout', () => {
       )
     )
 
-    return { mockSetValue, user }
+    return { mockSetFormValue, user }
   }
 
   describe('when rendered', () => {
@@ -126,9 +126,9 @@ describe('PriceCallout', () => {
       }
 
       it('displays per month price', async () => {
-        const { mockSetValue } = setup()
+        const { mockSetFormValue } = setup()
 
-        render(<PriceCallout {...props} setValue={mockSetValue} />, {
+        render(<PriceCallout {...props} setFormValue={mockSetFormValue} />, {
           wrapper,
         })
 
@@ -137,9 +137,9 @@ describe('PriceCallout', () => {
       })
 
       it('displays billed annually at price', async () => {
-        const { mockSetValue } = setup()
+        const { mockSetFormValue } = setup()
 
-        render(<PriceCallout {...props} setValue={mockSetValue} />, {
+        render(<PriceCallout {...props} setFormValue={mockSetFormValue} />, {
           wrapper,
         })
 
@@ -150,9 +150,9 @@ describe('PriceCallout', () => {
       })
 
       it('displays how much the user saves', async () => {
-        const { mockSetValue } = setup()
+        const { mockSetFormValue } = setup()
 
-        render(<PriceCallout {...props} setValue={mockSetValue} />, {
+        render(<PriceCallout {...props} setFormValue={mockSetFormValue} />, {
           wrapper,
         })
 
@@ -168,8 +168,8 @@ describe('PriceCallout', () => {
       }
 
       it('displays the monthly price', async () => {
-        const { mockSetValue } = setup()
-        render(<PriceCallout {...props} setValue={mockSetValue} />, {
+        const { mockSetFormValue } = setup()
+        render(<PriceCallout {...props} setFormValue={mockSetFormValue} />, {
           wrapper,
         })
 
@@ -178,8 +178,8 @@ describe('PriceCallout', () => {
       })
 
       it('displays what the user could save with annual plan', async () => {
-        const { mockSetValue } = setup()
-        render(<PriceCallout {...props} setValue={mockSetValue} />, {
+        const { mockSetFormValue } = setup()
+        render(<PriceCallout {...props} setFormValue={mockSetFormValue} />, {
           wrapper,
         })
 
@@ -189,8 +189,8 @@ describe('PriceCallout', () => {
 
       describe('user switches to annual plan', () => {
         it('calls mock set value with pro annual plan', async () => {
-          const { mockSetValue, user } = setup()
-          render(<PriceCallout {...props} setValue={mockSetValue} />, {
+          const { mockSetFormValue, user } = setup()
+          render(<PriceCallout {...props} setFormValue={mockSetFormValue} />, {
             wrapper,
           })
 
@@ -201,7 +201,10 @@ describe('PriceCallout', () => {
 
           await user.click(switchToAnnual)
 
-          expect(mockSetValue).toBeCalledWith('newPlan', Plans.USERS_PR_INAPPY)
+          expect(mockSetFormValue).toBeCalledWith(
+            'newPlan',
+            Plans.USERS_PR_INAPPY
+          )
         })
       })
     })

--- a/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm2/Controllers/ProPlanController/PriceCallout/PriceCallout.tsx
+++ b/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm2/Controllers/ProPlanController/PriceCallout/PriceCallout.tsx
@@ -10,16 +10,18 @@ import {
 import { calculatePriceProPlan } from 'shared/utils/upgradeForm'
 import Icon from 'ui/Icon'
 
-interface TotalPriceCalloutProps {
-  newPlan: string
+import { NewPlanType } from '../../../PlanTypeOptions/PlanTypeOptions'
+
+interface PriceCalloutProps {
+  newPlan: NewPlanType
   seats: number
-  setValue: (x: string, y: string) => void
+  setFormValue: (x: string, y: string) => void
 }
 
-const TotalPriceCallout: React.FC<TotalPriceCalloutProps> = ({
+const PriceCallout: React.FC<PriceCalloutProps> = ({
   newPlan,
   seats,
-  setValue,
+  setFormValue,
 }) => {
   const { provider, owner } = useParams<{ provider: string; owner: string }>()
   const { data: plans } = useAvailablePlans({ provider, owner })
@@ -72,7 +74,7 @@ const TotalPriceCallout: React.FC<TotalPriceCalloutProps> = ({
           a year with the annual plan,{' '}
           <button
             className="cursor-pointer font-semibold text-ds-blue-darker hover:underline"
-            onClick={() => setValue('newPlan', Plans.USERS_PR_INAPPY)}
+            onClick={() => setFormValue('newPlan', Plans.USERS_PR_INAPPY)}
           >
             switch to annual
           </button>
@@ -82,4 +84,4 @@ const TotalPriceCallout: React.FC<TotalPriceCalloutProps> = ({
   )
 }
 
-export default TotalPriceCallout
+export default PriceCallout

--- a/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm2/Controllers/ProPlanController/ProPlanController.spec.tsx
+++ b/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm2/Controllers/ProPlanController/ProPlanController.spec.tsx
@@ -254,14 +254,6 @@ describe('ProPlanController', () => {
         expect(optionBtn).toHaveClass('bg-ds-primary-base')
       })
 
-      it.skip('renders the seat input with 10 seats (existing subscription)', async () => {
-        setup({ planValue: Plans.USERS_PR_INAPPM })
-        render(<ProPlanController {...props} />, { wrapper: wrapper() })
-
-        const seatCount = await screen.findByRole('spinbutton')
-        expect(seatCount).toHaveValue(10)
-      })
-
       it('has the price for the year', async () => {
         setup({ planValue: Plans.USERS_PR_INAPPM })
         render(<ProPlanController {...props} />, { wrapper: wrapper() })
@@ -303,14 +295,6 @@ describe('ProPlanController', () => {
         const optionBtn = await screen.findByRole('button', { name: 'Annual' })
         expect(optionBtn).toBeInTheDocument()
         expect(optionBtn).toHaveClass('bg-ds-primary-base')
-      })
-
-      it.skip('renders the seat input with 13 seats (existing subscription)', async () => {
-        setup({ planValue: Plans.USERS_PR_INAPPY })
-        render(<ProPlanController {...props} />, { wrapper: wrapper() })
-
-        const seatCount = await screen.findByRole('spinbutton')
-        expect(seatCount).toHaveValue(13)
       })
 
       it('has the price for the year', async () => {

--- a/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm2/Controllers/ProPlanController/ProPlanController.spec.tsx
+++ b/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm2/Controllers/ProPlanController/ProPlanController.spec.tsx
@@ -1,0 +1,325 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { graphql, rest } from 'msw'
+import { setupServer } from 'msw/node'
+import { Suspense } from 'react'
+import { MemoryRouter, Route } from 'react-router-dom'
+
+import { TrialStatuses } from 'services/account'
+import { useAddNotification } from 'services/toastNotification'
+import { Plans } from 'shared/utils/billing'
+
+import ProPlanController from './ProPlanController'
+
+jest.mock('services/toastNotification')
+jest.mock('@stripe/react-stripe-js')
+
+const basicPlan = {
+  marketingName: 'Basic',
+  value: 'users-basic',
+  billingRate: null,
+  baseUnitPrice: 0,
+  benefits: [
+    'Up to 1 user',
+    'Unlimited public repositories',
+    'Unlimited private repositories',
+  ],
+  monthlyUploadLimit: 250,
+}
+
+const proPlanMonth = {
+  marketingName: 'Pro',
+  value: Plans.USERS_PR_INAPPM,
+  billingRate: 'monthly',
+  baseUnitPrice: 12,
+  benefits: [
+    'Configurable # of users',
+    'Unlimited public repositories',
+    'Unlimited private repositories',
+    'Priority Support',
+  ],
+  quantity: 10,
+  monthlyUploadLimit: null,
+}
+
+const proPlanYear = {
+  marketingName: 'Pro',
+  value: Plans.USERS_PR_INAPPY,
+  billingRate: 'annually',
+  baseUnitPrice: 10,
+  benefits: [
+    'Configurable # of users',
+    'Unlimited public repositories',
+    'Unlimited private repositories',
+    'Priority Support',
+  ],
+  monthlyUploadLimit: null,
+  quantity: 13,
+}
+
+const trialPlan = {
+  marketingName: 'Pro Trial Team',
+  value: 'users-trial',
+  billingRate: null,
+  baseUnitPrice: 12,
+  benefits: ['Configurable # of users', 'Unlimited repos'],
+  monthlyUploadLimit: null,
+}
+
+const mockAccountDetailsBasic = {
+  plan: basicPlan,
+  activatedUserCount: 1,
+  inactiveUserCount: 0,
+}
+
+const mockAccountDetailsProMonthly = {
+  plan: proPlanMonth,
+  activatedUserCount: 7,
+  inactiveUserCount: 0,
+  subscriptionDetail: {
+    latestInvoice: {
+      periodStart: 1595270468,
+      periodEnd: 1597948868,
+      dueDate: '1600544863',
+      amountPaid: 9600.0,
+      amountDue: 9600.0,
+      amountRemaining: 0.0,
+      total: 9600.0,
+      subtotal: 9600.0,
+      invoicePdf:
+        'https://pay.stripe.com/invoice/acct_14SJTOGlVGuVgOrk/invst_Hs2qfFwArnp6AMjWPlwtyqqszoBzO3q/pdf',
+    },
+  },
+}
+
+const mockAccountDetailsProYearly = {
+  plan: proPlanYear,
+  activatedUserCount: 11,
+  inactiveUserCount: 0,
+}
+
+const mockAccountDetailsTrial = {
+  plan: trialPlan,
+  activatedUserCount: 28,
+  inactiveUserCount: 0,
+}
+
+const mockPlanDataResponse = {
+  baseUnitPrice: 10,
+  benefits: [],
+  billingRate: 'monthly',
+  marketingName: 'Pro Team',
+  monthlyUploadLimit: 250,
+  value: 'test-plan',
+  trialStatus: TrialStatuses.NOT_STARTED,
+  trialStartDate: '',
+  trialEndDate: '',
+  trialTotalDays: 0,
+  pretrialUsersCount: 0,
+  planUserCount: 1,
+}
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      suspense: true,
+      retry: false,
+    },
+  },
+  logger: {
+    error: () => null,
+    warn: () => null,
+    log: () => null,
+  },
+})
+const server = setupServer()
+
+beforeAll(() => server.listen())
+afterEach(() => {
+  queryClient.clear()
+  server.resetHandlers()
+})
+afterAll(() => server.close())
+
+type WrapperClosure = (
+  initialEntries?: string[]
+) => React.FC<React.PropsWithChildren>
+const wrapper: WrapperClosure =
+  (initialEntries = ['/gh/codecov']) =>
+  ({ children }) =>
+    (
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter initialEntries={initialEntries}>
+          <Route path="/:provider/:owner">
+            <Suspense fallback={null}>{children}</Suspense>
+          </Route>
+        </MemoryRouter>
+      </QueryClientProvider>
+    )
+
+interface SetupArgs {
+  planValue: string
+  errorDetails?: string
+  trialStatus?: string
+}
+
+describe('ProPlanController', () => {
+  function setup(
+    { planValue = Plans.USERS_BASIC, trialStatus = undefined }: SetupArgs = {
+      planValue: Plans.USERS_BASIC,
+      trialStatus: undefined,
+    }
+  ) {
+    const addNotification = jest.fn()
+    const user = userEvent.setup()
+
+    //@ts-ignore
+    useAddNotification.mockReturnValue(addNotification)
+
+    server.use(
+      rest.get(`/internal/gh/codecov/account-details/`, (req, res, ctx) => {
+        if (planValue === Plans.USERS_BASIC) {
+          return res(ctx.status(200), ctx.json(mockAccountDetailsBasic))
+        } else if (planValue === Plans.USERS_PR_INAPPM) {
+          return res(ctx.status(200), ctx.json(mockAccountDetailsProMonthly))
+        } else if (planValue === Plans.USERS_PR_INAPPY) {
+          return res(ctx.status(200), ctx.json(mockAccountDetailsProYearly))
+        } else if (planValue === Plans.USERS_TRIAL) {
+          return res(ctx.status(200), ctx.json(mockAccountDetailsTrial))
+        }
+      }),
+      rest.patch(
+        '/internal/gh/codecov/account-details/',
+        async (req, res, ctx) => {
+          return res(ctx.status(200), ctx.json({ success: false }))
+        }
+      ),
+      graphql.query('GetAvailablePlans', (req, res, ctx) => {
+        return res(
+          ctx.status(200),
+          ctx.data({
+            owner: {
+              availablePlans: [basicPlan, proPlanMonth, proPlanYear, trialPlan],
+            },
+          })
+        )
+      }),
+      graphql.query('GetPlanData', (req, res, ctx) => {
+        return res(
+          ctx.status(200),
+          ctx.data({
+            owner: {
+              plan: { ...mockPlanDataResponse, trialStatus },
+            },
+          })
+        )
+      })
+    )
+
+    return { addNotification, user }
+  }
+
+  describe('when rendered', () => {
+    describe('when the user has a pro plan monthly', () => {
+      const props = {
+        setFormValue: jest.fn(),
+        register: jest.fn(),
+        newPlan: Plans.USERS_PR_INAPPM,
+        seats: 10,
+        errors: { seats: { message: '' } },
+      }
+      it('renders monthly option button', async () => {
+        setup({ planValue: Plans.USERS_PR_INAPPM })
+        render(<ProPlanController {...props} />, { wrapper: wrapper() })
+
+        const optionBtn = await screen.findByRole('button', { name: 'Monthly' })
+        expect(optionBtn).toBeInTheDocument()
+      })
+
+      it('renders annual option button', async () => {
+        setup({ planValue: Plans.USERS_PR_INAPPM })
+        render(<ProPlanController {...props} />, { wrapper: wrapper() })
+
+        const optionBtn = await screen.findByRole('button', { name: 'Annual' })
+        expect(optionBtn).toBeInTheDocument()
+      })
+
+      it('renders monthly option button as "selected"', async () => {
+        setup({ planValue: Plans.USERS_PR_INAPPM })
+        render(<ProPlanController {...props} />, { wrapper: wrapper() })
+
+        const optionBtn = await screen.findByRole('button', { name: 'Monthly' })
+        expect(optionBtn).toBeInTheDocument()
+        expect(optionBtn).toHaveClass('bg-ds-primary-base')
+      })
+
+      it.skip('renders the seat input with 10 seats (existing subscription)', async () => {
+        setup({ planValue: Plans.USERS_PR_INAPPM })
+        render(<ProPlanController {...props} />, { wrapper: wrapper() })
+
+        const seatCount = await screen.findByRole('spinbutton')
+        expect(seatCount).toHaveValue(10)
+      })
+
+      it('has the price for the year', async () => {
+        setup({ planValue: Plans.USERS_PR_INAPPM })
+        render(<ProPlanController {...props} />, { wrapper: wrapper() })
+
+        const price = await screen.findByText(/\$120/)
+        expect(price).toBeInTheDocument()
+      })
+    })
+
+    describe('when the user has a pro plan yearly', () => {
+      const props = {
+        setFormValue: jest.fn(),
+        register: jest.fn(),
+        newPlan: Plans.USERS_PR_INAPPY,
+        seats: 13,
+        errors: { seats: { message: '' } },
+      }
+
+      it('renders monthly option button', async () => {
+        setup({ planValue: Plans.USERS_PR_INAPPY })
+        render(<ProPlanController {...props} />, { wrapper: wrapper() })
+
+        const optionBtn = await screen.findByRole('button', { name: 'Monthly' })
+        expect(optionBtn).toBeInTheDocument()
+      })
+
+      it('renders annual option button', async () => {
+        setup({ planValue: Plans.USERS_PR_INAPPY })
+        render(<ProPlanController {...props} />, { wrapper: wrapper() })
+
+        const optionBtn = await screen.findByRole('button', { name: 'Annual' })
+        expect(optionBtn).toBeInTheDocument()
+      })
+
+      it('renders annual option button as "selected"', async () => {
+        setup({ planValue: Plans.USERS_PR_INAPPY })
+        render(<ProPlanController {...props} />, { wrapper: wrapper() })
+
+        const optionBtn = await screen.findByRole('button', { name: 'Annual' })
+        expect(optionBtn).toBeInTheDocument()
+        expect(optionBtn).toHaveClass('bg-ds-primary-base')
+      })
+
+      it.skip('renders the seat input with 13 seats (existing subscription)', async () => {
+        setup({ planValue: Plans.USERS_PR_INAPPY })
+        render(<ProPlanController {...props} />, { wrapper: wrapper() })
+
+        const seatCount = await screen.findByRole('spinbutton')
+        expect(seatCount).toHaveValue(13)
+      })
+
+      it('has the price for the year', async () => {
+        setup({ planValue: Plans.USERS_PR_INAPPY })
+        render(<ProPlanController {...props} />, { wrapper: wrapper() })
+
+        const price = await screen.findByText(/\$130/)
+        expect(price).toBeInTheDocument()
+      })
+    })
+  })
+})

--- a/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm2/Controllers/ProPlanController/ProPlanController.tsx
+++ b/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm2/Controllers/ProPlanController/ProPlanController.tsx
@@ -1,0 +1,81 @@
+import { FieldValues, UseFormRegister } from 'react-hook-form'
+import { useParams } from 'react-router-dom'
+
+import { useAccountDetails } from 'services/account'
+import { getNextBillingDate } from 'shared/utils/billing'
+import { MIN_NB_SEATS_PRO } from 'shared/utils/upgradeForm'
+import TextInput from 'ui/TextInput'
+
+import BillingOptions from './BillingOptions'
+import PriceCallout from './PriceCallout'
+import UserCount from './UserCount'
+
+import { NewPlanType } from '../../PlanTypeOptions/PlanTypeOptions'
+
+export type SelectedPlanType = 'users-pr-inappy' | 'users-sentryy'
+
+interface ProPlanControllerProps {
+  newPlan: NewPlanType
+  selectedPlan: SelectedPlanType
+  seats: number
+  setFormValue: (x: string, y: string) => void
+  register: UseFormRegister<FieldValues>
+  errors: {
+    seats: {
+      message: string
+    }
+  }
+}
+
+const ProPlanController: React.FC<ProPlanControllerProps> = ({
+  newPlan,
+  seats,
+  setFormValue,
+  register,
+  errors,
+}) => {
+  const { provider, owner } = useParams<{ owner: string; provider: string }>()
+  const { data: accountDetails } = useAccountDetails({ provider, owner })
+  const nextBillingDate = getNextBillingDate(accountDetails)
+
+  return (
+    <>
+      <div className="flex flex-col gap-2">
+        <BillingOptions newPlan={newPlan} setFormValue={setFormValue} />
+      </div>
+      <div className="flex flex-col gap-2 xl:w-5/12">
+        <div className="w-2/6">
+          <TextInput
+            data-cy="seats"
+            dataMarketing="plan-pricing-seats"
+            {...register('seats')}
+            id="nb-seats"
+            size={20}
+            type="number"
+            label="Seat count"
+            min={MIN_NB_SEATS_PRO}
+          />
+        </div>
+        <UserCount />
+      </div>
+      <PriceCallout
+        seats={seats}
+        newPlan={newPlan}
+        setFormValue={setFormValue}
+      />
+      {nextBillingDate && (
+        <p className="mt-1 flex">
+          Next Billing Date
+          <span className="ml-auto">{nextBillingDate}</span>
+        </p>
+      )}
+      {errors?.seats && (
+        <p className="rounded-md bg-ds-error-quinary p-3 text-ds-error-nonary">
+          {errors?.seats?.message}
+        </p>
+      )}
+    </>
+  )
+}
+
+export default ProPlanController

--- a/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm2/Controllers/ProPlanController/ProPlanController.tsx
+++ b/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm2/Controllers/ProPlanController/ProPlanController.tsx
@@ -12,17 +12,14 @@ import UserCount from './UserCount'
 
 import { NewPlanType } from '../../PlanTypeOptions/PlanTypeOptions'
 
-export type SelectedPlanType = 'users-pr-inappy' | 'users-sentryy'
-
 interface ProPlanControllerProps {
-  newPlan: NewPlanType
-  selectedPlan: SelectedPlanType
   seats: number
-  setFormValue: (x: string, y: string) => void
+  newPlan: NewPlanType
   register: UseFormRegister<FieldValues>
-  errors: {
-    seats: {
-      message: string
+  setFormValue: (x: string, y: string) => void
+  errors?: {
+    seats?: {
+      message?: string
     }
   }
 }

--- a/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm2/Controllers/ProPlanController/index.tsx
+++ b/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm2/Controllers/ProPlanController/index.tsx
@@ -1,0 +1,1 @@
+export { default } from './ProPlanController'

--- a/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm2/PlanTypeOptions/PlanTypeOptions.spec.tsx
+++ b/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm2/PlanTypeOptions/PlanTypeOptions.spec.tsx
@@ -206,24 +206,24 @@ describe('PlanTypeOptions', () => {
       })
     )
 
-    const mockSetValue = jest.fn()
+    const mockSetFormValue = jest.fn()
     const mockSetSelectedPlan = jest.fn()
     const user = userEvent.setup()
 
-    return { user, mockSetValue, mockSetSelectedPlan }
+    return { user, mockSetFormValue, mockSetSelectedPlan }
   }
 
   describe('user is doing a sentry upgrade', () => {
     describe('when plan is basic', () => {
       it('renders Pro button as "selected"', async () => {
-        const { mockSetValue, mockSetSelectedPlan } = setup({
+        const { mockSetFormValue, mockSetSelectedPlan } = setup({
           planValue: Plans.USERS_BASIC,
           hasSentryPlans: false,
         })
 
         render(
           <PlanTypeOptions
-            setValue={mockSetValue}
+            setFormValue={mockSetFormValue}
             setSelectedPlan={mockSetSelectedPlan}
           />,
           {
@@ -246,14 +246,14 @@ describe('PlanTypeOptions', () => {
 
       describe('user clicks Team button', () => {
         it('calls setValue and setSelectedPlan', async () => {
-          const { user, mockSetValue, mockSetSelectedPlan } = setup({
+          const { user, mockSetFormValue, mockSetSelectedPlan } = setup({
             planValue: Plans.USERS_BASIC,
             hasSentryPlans: true,
           })
 
           render(
             <PlanTypeOptions
-              setValue={mockSetValue}
+              setFormValue={mockSetFormValue}
               setSelectedPlan={mockSetSelectedPlan}
             />,
             {
@@ -268,7 +268,10 @@ describe('PlanTypeOptions', () => {
           await user.click(teamBtn)
 
           await waitFor(() =>
-            expect(mockSetValue).toBeCalledWith('newPlan', Plans.USERS_TEAMY)
+            expect(mockSetFormValue).toBeCalledWith(
+              'newPlan',
+              Plans.USERS_TEAMY
+            )
           )
           await waitFor(() =>
             expect(mockSetSelectedPlan).toBeCalledWith(teamPlanYear)
@@ -278,14 +281,14 @@ describe('PlanTypeOptions', () => {
 
       describe('user clicks Pro button', () => {
         it('calls setValue and setSelectedPlan', async () => {
-          const { user, mockSetValue, mockSetSelectedPlan } = setup({
+          const { user, mockSetFormValue, mockSetSelectedPlan } = setup({
             planValue: Plans.USERS_BASIC,
             hasSentryPlans: true,
           })
 
           render(
             <PlanTypeOptions
-              setValue={mockSetValue}
+              setFormValue={mockSetFormValue}
               setSelectedPlan={mockSetSelectedPlan}
             />,
             {
@@ -300,7 +303,10 @@ describe('PlanTypeOptions', () => {
           await user.click(proBtn)
 
           await waitFor(() =>
-            expect(mockSetValue).toBeCalledWith('newPlan', Plans.USERS_SENTRYY)
+            expect(mockSetFormValue).toBeCalledWith(
+              'newPlan',
+              Plans.USERS_SENTRYY
+            )
           )
           await waitFor(() =>
             expect(mockSetSelectedPlan).toBeCalledWith(sentryPlanYear)
@@ -311,14 +317,14 @@ describe('PlanTypeOptions', () => {
 
     describe('when plan is sentry yearly', () => {
       it('renders Pro button as "selected"', async () => {
-        const { mockSetValue, mockSetSelectedPlan } = setup({
+        const { mockSetFormValue, mockSetSelectedPlan } = setup({
           planValue: Plans.USERS_SENTRYY,
           hasSentryPlans: true,
         })
 
         render(
           <PlanTypeOptions
-            setValue={mockSetValue}
+            setFormValue={mockSetFormValue}
             setSelectedPlan={mockSetSelectedPlan}
           />,
           {
@@ -341,14 +347,14 @@ describe('PlanTypeOptions', () => {
 
       describe('user clicks Team button', () => {
         it('calls setValue and setSelectedPlan', async () => {
-          const { user, mockSetValue, mockSetSelectedPlan } = setup({
+          const { user, mockSetFormValue, mockSetSelectedPlan } = setup({
             planValue: Plans.USERS_SENTRYY,
             hasSentryPlans: true,
           })
 
           render(
             <PlanTypeOptions
-              setValue={mockSetValue}
+              setFormValue={mockSetFormValue}
               setSelectedPlan={mockSetSelectedPlan}
             />,
             {
@@ -363,7 +369,10 @@ describe('PlanTypeOptions', () => {
           await user.click(teamBtn)
 
           await waitFor(() =>
-            expect(mockSetValue).toBeCalledWith('newPlan', Plans.USERS_TEAMY)
+            expect(mockSetFormValue).toBeCalledWith(
+              'newPlan',
+              Plans.USERS_TEAMY
+            )
           )
           await waitFor(() =>
             expect(mockSetSelectedPlan).toBeCalledWith(teamPlanYear)
@@ -373,14 +382,14 @@ describe('PlanTypeOptions', () => {
 
       describe('user clicks Pro button', () => {
         it('calls setValue and setSelectedPlan', async () => {
-          const { user, mockSetValue, mockSetSelectedPlan } = setup({
+          const { user, mockSetFormValue, mockSetSelectedPlan } = setup({
             planValue: Plans.USERS_SENTRYY,
             hasSentryPlans: true,
           })
 
           render(
             <PlanTypeOptions
-              setValue={mockSetValue}
+              setFormValue={mockSetFormValue}
               setSelectedPlan={mockSetSelectedPlan}
             />,
             {
@@ -395,7 +404,10 @@ describe('PlanTypeOptions', () => {
           await user.click(proBtn)
 
           await waitFor(() =>
-            expect(mockSetValue).toBeCalledWith('newPlan', Plans.USERS_SENTRYY)
+            expect(mockSetFormValue).toBeCalledWith(
+              'newPlan',
+              Plans.USERS_SENTRYY
+            )
           )
           await waitFor(() =>
             expect(mockSetSelectedPlan).toBeCalledWith(sentryPlanYear)
@@ -406,14 +418,14 @@ describe('PlanTypeOptions', () => {
 
     describe('when plan is team yearly', () => {
       it('renders Pro button as "selected"', async () => {
-        const { mockSetValue, mockSetSelectedPlan } = setup({
+        const { mockSetFormValue, mockSetSelectedPlan } = setup({
           planValue: Plans.USERS_TEAMY,
           hasSentryPlans: true,
         })
 
         render(
           <PlanTypeOptions
-            setValue={mockSetValue}
+            setFormValue={mockSetFormValue}
             setSelectedPlan={mockSetSelectedPlan}
           />,
           {
@@ -436,14 +448,14 @@ describe('PlanTypeOptions', () => {
 
       describe('user clicks Team button', () => {
         it('calls setValue and setSelectedPlan', async () => {
-          const { user, mockSetValue, mockSetSelectedPlan } = setup({
+          const { user, mockSetFormValue, mockSetSelectedPlan } = setup({
             planValue: Plans.USERS_TEAMY,
             hasSentryPlans: true,
           })
 
           render(
             <PlanTypeOptions
-              setValue={mockSetValue}
+              setFormValue={mockSetFormValue}
               setSelectedPlan={mockSetSelectedPlan}
             />,
             {
@@ -458,7 +470,10 @@ describe('PlanTypeOptions', () => {
           await user.click(teamBtn)
 
           await waitFor(() =>
-            expect(mockSetValue).toBeCalledWith('newPlan', Plans.USERS_TEAMY)
+            expect(mockSetFormValue).toBeCalledWith(
+              'newPlan',
+              Plans.USERS_TEAMY
+            )
           )
           await waitFor(() =>
             expect(mockSetSelectedPlan).toBeCalledWith(teamPlanYear)
@@ -468,14 +483,14 @@ describe('PlanTypeOptions', () => {
 
       describe('user clicks Pro button', () => {
         it('calls setValue and setSelectedPlan', async () => {
-          const { user, mockSetValue, mockSetSelectedPlan } = setup({
+          const { user, mockSetFormValue, mockSetSelectedPlan } = setup({
             planValue: Plans.USERS_TEAMY,
             hasSentryPlans: true,
           })
 
           render(
             <PlanTypeOptions
-              setValue={mockSetValue}
+              setFormValue={mockSetFormValue}
               setSelectedPlan={mockSetSelectedPlan}
             />,
             {
@@ -490,7 +505,10 @@ describe('PlanTypeOptions', () => {
           await user.click(proBtn)
 
           await waitFor(() =>
-            expect(mockSetValue).toBeCalledWith('newPlan', Plans.USERS_SENTRYY)
+            expect(mockSetFormValue).toBeCalledWith(
+              'newPlan',
+              Plans.USERS_SENTRYY
+            )
           )
           await waitFor(() =>
             expect(mockSetSelectedPlan).toBeCalledWith(sentryPlanYear)
@@ -501,14 +519,14 @@ describe('PlanTypeOptions', () => {
 
     describe('when plan is trialing', () => {
       it('renders Pro button as "selected"', async () => {
-        const { mockSetValue, mockSetSelectedPlan } = setup({
+        const { mockSetFormValue, mockSetSelectedPlan } = setup({
           planValue: Plans.USERS_TRIAL,
           hasSentryPlans: true,
         })
 
         render(
           <PlanTypeOptions
-            setValue={mockSetValue}
+            setFormValue={mockSetFormValue}
             setSelectedPlan={mockSetSelectedPlan}
           />,
           {
@@ -531,14 +549,14 @@ describe('PlanTypeOptions', () => {
 
       describe('user clicks Team button', () => {
         it('calls setValue and setSelectedPlan', async () => {
-          const { user, mockSetValue, mockSetSelectedPlan } = setup({
+          const { user, mockSetFormValue, mockSetSelectedPlan } = setup({
             planValue: Plans.USERS_TRIAL,
             hasSentryPlans: true,
           })
 
           render(
             <PlanTypeOptions
-              setValue={mockSetValue}
+              setFormValue={mockSetFormValue}
               setSelectedPlan={mockSetSelectedPlan}
             />,
             {
@@ -553,7 +571,10 @@ describe('PlanTypeOptions', () => {
           await user.click(teamBtn)
 
           await waitFor(() =>
-            expect(mockSetValue).toBeCalledWith('newPlan', Plans.USERS_TEAMY)
+            expect(mockSetFormValue).toBeCalledWith(
+              'newPlan',
+              Plans.USERS_TEAMY
+            )
           )
           await waitFor(() =>
             expect(mockSetSelectedPlan).toBeCalledWith(teamPlanYear)
@@ -563,14 +584,14 @@ describe('PlanTypeOptions', () => {
 
       describe('user clicks Pro button', () => {
         it('calls setValue and setSelectedPlan', async () => {
-          const { user, mockSetValue, mockSetSelectedPlan } = setup({
+          const { user, mockSetFormValue, mockSetSelectedPlan } = setup({
             planValue: Plans.USERS_TRIAL,
             hasSentryPlans: true,
           })
 
           render(
             <PlanTypeOptions
-              setValue={mockSetValue}
+              setFormValue={mockSetFormValue}
               setSelectedPlan={mockSetSelectedPlan}
             />,
             {
@@ -585,7 +606,10 @@ describe('PlanTypeOptions', () => {
           await user.click(proBtn)
 
           await waitFor(() =>
-            expect(mockSetValue).toBeCalledWith('newPlan', Plans.USERS_SENTRYY)
+            expect(mockSetFormValue).toBeCalledWith(
+              'newPlan',
+              Plans.USERS_SENTRYY
+            )
           )
           await waitFor(() =>
             expect(mockSetSelectedPlan).toBeCalledWith(sentryPlanYear)
@@ -598,14 +622,14 @@ describe('PlanTypeOptions', () => {
   describe('user is not doing a sentry upgrade', () => {
     describe('when plan is basic', () => {
       it('renders Pro button as "selected"', async () => {
-        const { mockSetValue, mockSetSelectedPlan } = setup({
+        const { mockSetFormValue, mockSetSelectedPlan } = setup({
           planValue: Plans.USERS_BASIC,
           hasSentryPlans: false,
         })
 
         render(
           <PlanTypeOptions
-            setValue={mockSetValue}
+            setFormValue={mockSetFormValue}
             setSelectedPlan={mockSetSelectedPlan}
           />,
           {
@@ -628,14 +652,14 @@ describe('PlanTypeOptions', () => {
 
       describe('user clicks Team button', () => {
         it('calls setValue and setSelectedPlan', async () => {
-          const { user, mockSetValue, mockSetSelectedPlan } = setup({
+          const { user, mockSetFormValue, mockSetSelectedPlan } = setup({
             planValue: Plans.USERS_BASIC,
             hasSentryPlans: false,
           })
 
           render(
             <PlanTypeOptions
-              setValue={mockSetValue}
+              setFormValue={mockSetFormValue}
               setSelectedPlan={mockSetSelectedPlan}
             />,
             {
@@ -650,7 +674,10 @@ describe('PlanTypeOptions', () => {
           await user.click(teamBtn)
 
           await waitFor(() =>
-            expect(mockSetValue).toBeCalledWith('newPlan', Plans.USERS_TEAMY)
+            expect(mockSetFormValue).toBeCalledWith(
+              'newPlan',
+              Plans.USERS_TEAMY
+            )
           )
           await waitFor(() =>
             expect(mockSetSelectedPlan).toBeCalledWith(teamPlanYear)
@@ -660,14 +687,14 @@ describe('PlanTypeOptions', () => {
 
       describe('user clicks Pro button', () => {
         it('calls setValue and setSelectedPlan', async () => {
-          const { user, mockSetValue, mockSetSelectedPlan } = setup({
+          const { user, mockSetFormValue, mockSetSelectedPlan } = setup({
             planValue: Plans.USERS_BASIC,
             hasSentryPlans: false,
           })
 
           render(
             <PlanTypeOptions
-              setValue={mockSetValue}
+              setFormValue={mockSetFormValue}
               setSelectedPlan={mockSetSelectedPlan}
             />,
             {
@@ -682,7 +709,7 @@ describe('PlanTypeOptions', () => {
           await user.click(proBtn)
 
           await waitFor(() =>
-            expect(mockSetValue).toBeCalledWith(
+            expect(mockSetFormValue).toBeCalledWith(
               'newPlan',
               Plans.USERS_PR_INAPPY
             )
@@ -696,14 +723,14 @@ describe('PlanTypeOptions', () => {
 
     describe('when plan is pro yearly', () => {
       it('renders Pro button as "selected"', async () => {
-        const { mockSetValue, mockSetSelectedPlan } = setup({
+        const { mockSetFormValue, mockSetSelectedPlan } = setup({
           planValue: Plans.USERS_PR_INAPPY,
           hasSentryPlans: false,
         })
 
         render(
           <PlanTypeOptions
-            setValue={mockSetValue}
+            setFormValue={mockSetFormValue}
             setSelectedPlan={mockSetSelectedPlan}
           />,
           {
@@ -726,14 +753,14 @@ describe('PlanTypeOptions', () => {
 
       describe('user clicks Team button', () => {
         it('calls setValue and setSelectedPlan', async () => {
-          const { user, mockSetValue, mockSetSelectedPlan } = setup({
+          const { user, mockSetFormValue, mockSetSelectedPlan } = setup({
             planValue: Plans.USERS_SENTRYY,
             hasSentryPlans: false,
           })
 
           render(
             <PlanTypeOptions
-              setValue={mockSetValue}
+              setFormValue={mockSetFormValue}
               setSelectedPlan={mockSetSelectedPlan}
             />,
             {
@@ -748,7 +775,10 @@ describe('PlanTypeOptions', () => {
           await user.click(teamBtn)
 
           await waitFor(() =>
-            expect(mockSetValue).toBeCalledWith('newPlan', Plans.USERS_TEAMY)
+            expect(mockSetFormValue).toBeCalledWith(
+              'newPlan',
+              Plans.USERS_TEAMY
+            )
           )
           await waitFor(() =>
             expect(mockSetSelectedPlan).toBeCalledWith(teamPlanYear)
@@ -758,14 +788,14 @@ describe('PlanTypeOptions', () => {
 
       describe('user clicks Pro button', () => {
         it('calls setValue and setSelectedPlan', async () => {
-          const { user, mockSetValue, mockSetSelectedPlan } = setup({
+          const { user, mockSetFormValue, mockSetSelectedPlan } = setup({
             planValue: Plans.USERS_SENTRYY,
             hasSentryPlans: false,
           })
 
           render(
             <PlanTypeOptions
-              setValue={mockSetValue}
+              setFormValue={mockSetFormValue}
               setSelectedPlan={mockSetSelectedPlan}
             />,
             {
@@ -780,7 +810,7 @@ describe('PlanTypeOptions', () => {
           await user.click(proBtn)
 
           await waitFor(() =>
-            expect(mockSetValue).toBeCalledWith(
+            expect(mockSetFormValue).toBeCalledWith(
               'newPlan',
               Plans.USERS_PR_INAPPY
             )
@@ -794,14 +824,14 @@ describe('PlanTypeOptions', () => {
 
     describe('when plan is team yearly', () => {
       it('renders Pro button as "selected"', async () => {
-        const { mockSetValue, mockSetSelectedPlan } = setup({
+        const { mockSetFormValue, mockSetSelectedPlan } = setup({
           planValue: Plans.USERS_TEAMY,
           hasSentryPlans: false,
         })
 
         render(
           <PlanTypeOptions
-            setValue={mockSetValue}
+            setFormValue={mockSetFormValue}
             setSelectedPlan={mockSetSelectedPlan}
           />,
           {
@@ -824,14 +854,14 @@ describe('PlanTypeOptions', () => {
 
       describe('user clicks Team button', () => {
         it('calls setValue and setSelectedPlan', async () => {
-          const { user, mockSetValue, mockSetSelectedPlan } = setup({
+          const { user, mockSetFormValue, mockSetSelectedPlan } = setup({
             planValue: Plans.USERS_TEAMY,
             hasSentryPlans: false,
           })
 
           render(
             <PlanTypeOptions
-              setValue={mockSetValue}
+              setFormValue={mockSetFormValue}
               setSelectedPlan={mockSetSelectedPlan}
             />,
             {
@@ -846,7 +876,10 @@ describe('PlanTypeOptions', () => {
           await user.click(teamBtn)
 
           await waitFor(() =>
-            expect(mockSetValue).toBeCalledWith('newPlan', Plans.USERS_TEAMY)
+            expect(mockSetFormValue).toBeCalledWith(
+              'newPlan',
+              Plans.USERS_TEAMY
+            )
           )
           await waitFor(() =>
             expect(mockSetSelectedPlan).toBeCalledWith(teamPlanYear)
@@ -856,14 +889,14 @@ describe('PlanTypeOptions', () => {
 
       describe('user clicks Pro button', () => {
         it('calls setValue and setSelectedPlan', async () => {
-          const { user, mockSetValue, mockSetSelectedPlan } = setup({
+          const { user, mockSetFormValue, mockSetSelectedPlan } = setup({
             planValue: Plans.USERS_TEAMY,
             hasSentryPlans: false,
           })
 
           render(
             <PlanTypeOptions
-              setValue={mockSetValue}
+              setFormValue={mockSetFormValue}
               setSelectedPlan={mockSetSelectedPlan}
             />,
             {
@@ -878,7 +911,7 @@ describe('PlanTypeOptions', () => {
           await user.click(proBtn)
 
           await waitFor(() =>
-            expect(mockSetValue).toBeCalledWith(
+            expect(mockSetFormValue).toBeCalledWith(
               'newPlan',
               Plans.USERS_PR_INAPPY
             )
@@ -892,14 +925,14 @@ describe('PlanTypeOptions', () => {
 
     describe('when plan is trialing', () => {
       it('renders Pro button as "selected"', async () => {
-        const { mockSetValue, mockSetSelectedPlan } = setup({
+        const { mockSetFormValue, mockSetSelectedPlan } = setup({
           planValue: Plans.USERS_TRIAL,
           hasSentryPlans: false,
         })
 
         render(
           <PlanTypeOptions
-            setValue={mockSetValue}
+            setFormValue={mockSetFormValue}
             setSelectedPlan={mockSetSelectedPlan}
           />,
           {
@@ -922,14 +955,14 @@ describe('PlanTypeOptions', () => {
 
       describe('user clicks Team button', () => {
         it('calls setValue and setSelectedPlan', async () => {
-          const { user, mockSetValue, mockSetSelectedPlan } = setup({
+          const { user, mockSetFormValue, mockSetSelectedPlan } = setup({
             planValue: Plans.USERS_TRIAL,
             hasSentryPlans: false,
           })
 
           render(
             <PlanTypeOptions
-              setValue={mockSetValue}
+              setFormValue={mockSetFormValue}
               setSelectedPlan={mockSetSelectedPlan}
             />,
             {
@@ -944,7 +977,10 @@ describe('PlanTypeOptions', () => {
           await user.click(teamBtn)
 
           await waitFor(() =>
-            expect(mockSetValue).toBeCalledWith('newPlan', Plans.USERS_TEAMY)
+            expect(mockSetFormValue).toBeCalledWith(
+              'newPlan',
+              Plans.USERS_TEAMY
+            )
           )
           await waitFor(() =>
             expect(mockSetSelectedPlan).toBeCalledWith(teamPlanYear)
@@ -954,14 +990,14 @@ describe('PlanTypeOptions', () => {
 
       describe('user clicks Pro button', () => {
         it('calls setValue and setSelectedPlan', async () => {
-          const { user, mockSetValue, mockSetSelectedPlan } = setup({
+          const { user, mockSetFormValue, mockSetSelectedPlan } = setup({
             planValue: Plans.USERS_TRIAL,
             hasSentryPlans: false,
           })
 
           render(
             <PlanTypeOptions
-              setValue={mockSetValue}
+              setFormValue={mockSetFormValue}
               setSelectedPlan={mockSetSelectedPlan}
             />,
             {
@@ -976,7 +1012,7 @@ describe('PlanTypeOptions', () => {
           await user.click(proBtn)
 
           await waitFor(() =>
-            expect(mockSetValue).toBeCalledWith(
+            expect(mockSetFormValue).toBeCalledWith(
               'newPlan',
               Plans.USERS_PR_INAPPY
             )

--- a/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm2/PlanTypeOptions/PlanTypeOptions.tsx
+++ b/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm2/PlanTypeOptions/PlanTypeOptions.tsx
@@ -16,13 +16,21 @@ import {
 import { TEAM_PLAN_MAX_ACTIVE_USERS } from 'shared/utils/upgradeForm'
 import OptionButton from 'ui/OptionButton'
 
+export type NewPlanType =
+  | 'users-pr-inappm'
+  | 'users-pr-inappy'
+  | 'users-sentrym'
+  | 'users-sentryy'
+  | 'users-teamm'
+  | 'users-teamy'
+
 interface PlanTypeOptionsProps {
   setSelectedPlan: (x: z.infer<typeof IndividualPlanSchema>) => void
-  setValue: (x: string, y: string) => void
+  setFormValue: (x: string, y: string) => void
 }
 
 const PlanTypeOptions: React.FC<PlanTypeOptionsProps> = ({
-  setValue,
+  setFormValue,
   setSelectedPlan,
 }) => {
   const { provider, owner } = useParams<{ provider: string; owner: string }>()
@@ -49,10 +57,10 @@ const PlanTypeOptions: React.FC<PlanTypeOptionsProps> = ({
           onChange={({ text }) => {
             if (text === 'Pro') {
               setSelectedPlan(yearlyProPlan)
-              setValue('newPlan', yearlyProPlan?.value)
+              setFormValue('newPlan', yearlyProPlan?.value)
             } else {
               setSelectedPlan(teamPlanYear)
-              setValue('newPlan', teamPlanYear?.value)
+              setFormValue('newPlan', teamPlanYear?.value)
             }
             setOption(text)
           }}

--- a/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm2/UpdateButton/UpdateButton.spec.tsx
+++ b/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm2/UpdateButton/UpdateButton.spec.tsx
@@ -1,81 +1,160 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { rest } from 'msw'
+import { setupServer } from 'msw/node'
+import { Suspense } from 'react'
+import { MemoryRouter, Route } from 'react-router-dom'
 
 import { Plans } from 'shared/utils/billing'
 
 import UpdateButton from './UpdateButton'
 
+const server = setupServer()
+const queryClient = new QueryClient({
+  defaultOptions: { queries: { suspense: true } },
+})
+
+const wrapper: React.FC<React.PropsWithChildren> = ({ children }) => (
+  <QueryClientProvider client={queryClient}>
+    <MemoryRouter initialEntries={['/gh/codecov/upgrade']}>
+      <Route path="/:provider/:owner/upgrade">
+        <Suspense fallback={null}>{children}</Suspense>
+      </Route>
+    </MemoryRouter>
+  </QueryClientProvider>
+)
+
+beforeAll(() => {
+  server.listen()
+})
+afterEach(() => {
+  queryClient.clear()
+  server.resetHandlers()
+})
+afterAll(() => {
+  server.close()
+})
+
+const mockAccountDetailsBasic = {
+  plan: {
+    value: Plans.USERS_BASIC,
+    quantity: 1,
+  },
+}
+
+const mockAccountDetailsProMonthly = {
+  plan: {
+    value: Plans.USERS_PR_INAPPM,
+    quantity: 4,
+  },
+}
+
+interface SetupArgs {
+  planValue: string
+}
+
 describe('UpdateButton', () => {
-  describe('props align to not be disabled', () => {
-    it('renders non-disabled button', () => {
-      const props = {
-        isValid: true,
-        getValues: () => ({ newPlan: Plans.USERS_PR_INAPPY, seats: 10 }),
-        value: Plans.USERS_BASIC,
-        quantity: 2,
-        isSentryUpgrade: false,
-        trialStatus: 'NOT_STARTED',
-      }
+  function setup(
+    { planValue = Plans.USERS_BASIC }: SetupArgs = {
+      planValue: Plans.USERS_BASIC,
+    }
+  ) {
+    server.use(
+      rest.get(`/internal/gh/codecov/account-details/`, (req, res, ctx) => {
+        if (planValue === Plans.USERS_BASIC) {
+          return res(ctx.status(200), ctx.json(mockAccountDetailsBasic))
+        } else {
+          return res(ctx.status(200), ctx.json(mockAccountDetailsProMonthly))
+        }
+      })
+    )
 
-      render(<UpdateButton {...props} />)
+    const mockSetFormValue = jest.fn()
+    const user = userEvent.setup()
 
-      const button = screen.getByText('Proceed to Checkout')
-      expect(button).toBeInTheDocument()
-      expect(button).not.toBeDisabled()
+    return { user, mockSetFormValue }
+  }
+
+  describe('when rendered', () => {
+    describe('when there is a valid basic plan', () => {
+      it('renders a valid Proceed to Checkout button', async () => {
+        setup({ planValue: Plans.USERS_BASIC })
+
+        const props = {
+          isValid: true,
+          newPlan: Plans.USERS_PR_INAPPY,
+          seats: 3,
+        }
+
+        render(<UpdateButton {...props} />, {
+          wrapper,
+        })
+
+        const button = await screen.findByText('Proceed to Checkout')
+        expect(button).toBeInTheDocument()
+        expect(button).not.toBeDisabled()
+      })
     })
-  })
 
-  describe('there is no change in plan and seats', () => {
-    it('renders disabled button', () => {
-      const props = {
-        isValid: true,
-        getValues: () => ({ newPlan: Plans.USERS_PR_INAPPY, seats: 10 }),
-        value: Plans.USERS_PR_INAPPY,
-        quantity: 10,
-        isSentryUpgrade: false,
-        trialStatus: 'NOT_STARTED',
-      }
+    describe('when there is a valid pro plan', () => {
+      it('renders a valid Update button', async () => {
+        setup({ planValue: Plans.USERS_PR_INAPPY })
 
-      render(<UpdateButton {...props} />)
+        const props = {
+          isValid: true,
+          newPlan: Plans.USERS_PR_INAPPY,
+          seats: 27,
+        }
 
-      const button = screen.getByText('Update')
-      expect(button).toBeInTheDocument()
-      expect(button).toBeDisabled()
+        render(<UpdateButton {...props} />, {
+          wrapper,
+        })
+
+        const button = await screen.findByText('Update')
+        expect(button).toBeInTheDocument()
+        expect(button).not.toBeDisabled()
+      })
     })
-  })
 
-  describe('isValid is set to false', () => {
-    it('renders disabled button', () => {
-      const props = {
-        isValid: false,
-        getValues: () => ({ newPlan: Plans.USERS_PR_INAPPY, seats: 10 }),
-        value: Plans.USERS_BASIC,
-        quantity: 2,
-        isSentryUpgrade: false,
-        trialStatus: 'NOT_STARTED',
-      }
+    describe('when the button is invalid', () => {
+      it('renders a disabled valid Update button', async () => {
+        setup({ planValue: Plans.USERS_PR_INAPPY })
 
-      render(<UpdateButton {...props} />)
+        const props = {
+          isValid: false,
+          newPlan: Plans.USERS_PR_INAPPY,
+          seats: 6,
+        }
 
-      const button = screen.getByText('Proceed to Checkout')
-      expect(button).toBeInTheDocument()
-      expect(button).toBeDisabled()
+        render(<UpdateButton {...props} />, {
+          wrapper,
+        })
+
+        const button = await screen.findByText('Update')
+        expect(button).toBeInTheDocument()
+        expect(button).toBeDisabled()
+      })
     })
-  })
 
-  describe('user is able to start a new plan', () => {
-    it('displays button with "Proceed to Checkout" text', () => {
-      const props = {
-        isValid: true,
-        getValues: () => ({ newPlan: Plans.USERS_PR_INAPPY, seats: 10 }),
-        value: Plans.USERS_BASIC,
-        quantity: 2,
-      }
+    describe('when there are no changes in plan or seats', () => {
+      it('renders a disabled valid Update button', async () => {
+        setup({ planValue: Plans.USERS_PR_INAPPM })
 
-      render(<UpdateButton {...props} />)
+        const props = {
+          isValid: true,
+          newPlan: Plans.USERS_PR_INAPPM,
+          seats: 4,
+        }
 
-      const button = screen.getByText('Proceed to Checkout')
-      expect(button).toBeInTheDocument()
-      expect(button).not.toBeDisabled()
+        render(<UpdateButton {...props} />, {
+          wrapper,
+        })
+
+        const button = await screen.findByText('Update')
+        expect(button).toBeInTheDocument()
+        expect(button).toBeDisabled()
+      })
     })
   })
 })

--- a/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm2/UpdateButton/UpdateButton.tsx
+++ b/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm2/UpdateButton/UpdateButton.tsx
@@ -1,37 +1,47 @@
-import PropTypes, { type InferProps } from 'prop-types'
+import React from 'react'
+import { useParams } from 'react-router-dom'
 
+import { useAccountDetails } from 'services/account'
 import { isFreePlan } from 'shared/utils/billing'
 import Button from 'ui/Button'
 
-function UpdateButton({
+import { NewPlanType } from '../PlanTypeOptions/PlanTypeOptions'
+
+interface BillingControlsProps {
+  seats: number
+  isValid: boolean
+  newPlan: NewPlanType
+}
+
+const UpdateButton: React.FC<BillingControlsProps> = ({
   isValid,
-  getValues,
-  value,
-  quantity,
-}: InferProps<typeof UpdateButton.propTypes>) {
-  const isSamePlan = getValues()?.newPlan === value
-  const noChangeInSeats = getValues()?.seats === quantity
+  newPlan,
+  seats,
+}) => {
+  const { provider, owner } = useParams<{ provider: string; owner: string }>()
+  const { data: accountDetails } = useAccountDetails({ provider, owner })
+
+  const currentPlanValue = accountDetails?.plan?.value
+  const currentPlanQuantity = accountDetails?.plan?.quantity
+
+  const isSamePlan = newPlan === currentPlanValue
+  const noChangeInSeats = seats === currentPlanQuantity
   const disabled = !isValid || (isSamePlan && noChangeInSeats)
 
   return (
-    <Button
-      data-cy="plan-page-plan-update"
-      disabled={disabled}
-      type="submit"
-      variant="primary"
-      hook="submit-upgrade"
-      to={undefined}
-    >
-      {isFreePlan(value) ? 'Proceed to Checkout' : 'Update'}
-    </Button>
+    <div className="inline-flex">
+      <Button
+        data-cy="plan-page-plan-update"
+        disabled={disabled}
+        type="submit"
+        variant="primary"
+        hook="submit-upgrade"
+        to={undefined}
+      >
+        {isFreePlan(currentPlanValue) ? 'Proceed to Checkout' : 'Update'}
+      </Button>
+    </div>
   )
-}
-
-UpdateButton.propTypes = {
-  isValid: PropTypes.bool.isRequired,
-  getValues: PropTypes.func.isRequired,
-  value: PropTypes.string,
-  quantity: PropTypes.number,
 }
 
 export default UpdateButton

--- a/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm2/UpgradeForm2.jsx
+++ b/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm2/UpgradeForm2.jsx
@@ -11,7 +11,6 @@ import {
 import { useFlags } from 'shared/featureFlags'
 import {
   canApplySentryUpgrade,
-  getNextBillingDate,
   isTeamPlan,
   shouldDisplayTeamCard,
 } from 'shared/utils/billing'
@@ -21,11 +20,8 @@ import {
   MIN_NB_SEATS_PRO,
   MIN_SENTRY_SEATS,
 } from 'shared/utils/upgradeForm'
-import TextInput from 'ui/TextInput'
 
-import BillingOptions from './Controllers/ProPlanController/BillingOptions'
-import PriceCallout from './Controllers/ProPlanController/PriceCallout'
-import UserCount from './Controllers/ProPlanController/UserCount'
+import ProPlanController from './Controllers/ProPlanController'
 import { useUpgradeControls } from './hooks'
 import PlanTypeOptions from './PlanTypeOptions'
 import UpdateButton from './UpdateButton'
@@ -49,14 +45,12 @@ function UpgradeForm2({ selectedPlan, setSelectedPlan }) {
       : MIN_NB_SEATS_PRO
 
   const trialStatus = planData?.plan?.trialStatus
-  const nextBillingDate = getNextBillingDate(accountDetails)
   const {
     register,
     handleSubmit,
     watch,
     formState: { isValid, errors },
-    setValue,
-    getValues,
+    setValue: setFormValue,
   } = useForm({
     defaultValues: getDefaultValuesUpgradeForm({
       accountDetails,
@@ -89,48 +83,18 @@ function UpgradeForm2({ selectedPlan, setSelectedPlan }) {
       </div>
       {hasTeamPlans && multipleTiers && (
         <PlanTypeOptions
-          setValue={setValue}
+          setFormValue={setFormValue}
           setSelectedPlan={setSelectedPlan}
         />
       )}
-      <div className="flex flex-col gap-2">
-        <BillingOptions planString={newPlan} setValue={setValue} />
-      </div>
-      <div className="flex flex-col gap-2 xl:w-5/12">
-        <div className="w-2/6">
-          <TextInput
-            data-cy="seats"
-            dataMarketing="plan-pricing-seats"
-            {...register('seats')}
-            id="nb-seats"
-            size="20"
-            type="number"
-            label="Seat count"
-            min={MIN_NB_SEATS_PRO}
-          />
-        </div>
-        <UserCount />
-      </div>
-      <PriceCallout seats={seats} newPlan={newPlan} setValue={setValue} />
-      {nextBillingDate && (
-        <p className="mt-1 flex">
-          Next Billing Date
-          <span className="ml-auto">{nextBillingDate}</span>
-        </p>
-      )}
-      {errors?.seats && (
-        <p className="rounded-md bg-ds-error-quinary p-3 text-ds-error-nonary">
-          {errors?.seats?.message}
-        </p>
-      )}
-      <div className="w-fit">
-        <UpdateButton
-          isValid={isValid}
-          getValues={getValues}
-          value={accountDetails?.plan?.value}
-          quantity={accountDetails?.plan?.quantity}
-        />
-      </div>
+      <ProPlanController
+        newPlan={newPlan}
+        seats={seats}
+        setFormValue={setFormValue}
+        register={register}
+        errors={errors}
+      />
+      <UpdateButton isValid={isValid} newPlan={newPlan} seats={seats} />
     </form>
   )
 }

--- a/src/shared/utils/unsupportedExtensionsMapper.js
+++ b/src/shared/utils/unsupportedExtensionsMapper.js
@@ -268,7 +268,6 @@ const imageFileExtensions = new Set([
   'emf',
   'eps',
   'exif',
-  'fs',
   'gbr',
   'gif',
   'gpl',


### PR DESCRIPTION
# Description
We're adding the `ProController` isolated component that handles form data. This is to improve the general flow for the UpgradeForm component

# Notable Changes
- Added the `ProController`, a component that encapsulates the BillingOptions, UserCount and PriceCallout components
- Made use of `ProController` in the UpgradeForm2 component
- Some variable renaming: `setValue` to `setFormValue`, `planString` to `newPlan`
- Created some types to standardize the values
- Changed a bit the UpdateButton component to remove unnecessary prop drilling and adjusted test as well

* there are 2 tests that are skipped, I need a hand w/ those 🙃 

# Screenshots
![Screenshot 2023-11-28 at 3 40 14 PM](https://github.com/codecov/gazebo/assets/82913673/e29efa1b-6ed3-430e-8bbe-13533daaa6a5)

(Still only working for Pro. I'm abstaining from doing a full-blown check in every of these PRs as the code isn't running and I'll do one when all the 3 services are in)

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.