### PR TITLE
feat: Update files changed tab with components selector

### DIFF
--- a/src/pages/PullRequestPage/subroute/ComponentsSelector/ComponentsSelector.tsx
+++ b/src/pages/PullRequestPage/subroute/ComponentsSelector/ComponentsSelector.tsx
@@ -55,34 +55,32 @@ function ComponentsSelector() {
   }
 
   return (
-    <div className="w-1/6">
-      <MultiSelect
-        // @ts-expect-error
-        disabled={false}
-        dataMarketing="coverage-tab-component-multi-select"
-        hook="coverage-tab-component-multi-select"
-        ariaName="Select components to show"
-        items={[...componentsNames]}
-        resourceName="component"
-        isLoading={isLoading}
-        selectedItemsOverride={selectedComponents}
-        onChange={(components: String[]) => {
-          setSelectedComponents(components)
-          updateParams({ components })
-        }}
-        onSearch={(term: string) => setComponentSearch(term)}
-        renderSelected={(selectedItems: String[]) => (
-          <span className="flex items-center gap-2">
-            <Icon variant="solid" name="database" />
-            {selectedItems.length === 0 ? (
-              'All components'
-            ) : (
-              <span>{selectedItems.length} selected components</span>
-            )}
-          </span>
-        )}
-      />
-    </div>
+    <MultiSelect
+      // @ts-expect-error
+      disabled={false}
+      dataMarketing="coverage-tab-component-multi-select"
+      hook="coverage-tab-component-multi-select"
+      ariaName="Select components to show"
+      items={[...componentsNames]}
+      resourceName="component"
+      isLoading={isLoading}
+      selectedItemsOverride={selectedComponents}
+      onChange={(components: String[]) => {
+        setSelectedComponents(components)
+        updateParams({ components })
+      }}
+      onSearch={(term: string) => setComponentSearch(term)}
+      renderSelected={(selectedItems: String[]) => (
+        <span className="flex items-center gap-2">
+          <Icon variant="solid" name="database" />
+          {selectedItems.length === 0 ? (
+            'All components'
+          ) : (
+            <span>{selectedItems.length} selected components</span>
+          )}
+        </span>
+      )}
+    />
   )
 }
 

--- a/src/pages/PullRequestPage/subroute/ComponentsSelector/index.js
+++ b/src/pages/PullRequestPage/subroute/ComponentsSelector/index.js
@@ -1,0 +1,1 @@
+export { default } from './ComponentsSelector'

--- a/src/pages/PullRequestPage/subroute/FilesChangedTab/FilesChanged/hooks/useImpactedFilesTable.js
+++ b/src/pages/PullRequestPage/subroute/FilesChangedTab/FilesChanged/hooks/useImpactedFilesTable.js
@@ -20,7 +20,7 @@ export const orderingParameter = Object.freeze({
   missesCount: 'MISSES_COUNT',
 })
 
-function getFilters({ sortBy, flags }) {
+function getFilters({ sortBy, flags, components }) {
   return {
     ordering: {
       direction: sortBy?.desc ? orderingDirection.desc : orderingDirection.asc,
@@ -28,6 +28,7 @@ function getFilters({ sortBy, flags }) {
     },
     hasUnintendedChanges: false,
     ...(flags ? { flags } : {}),
+    ...(components ? { components } : {}),
   }
 }
 
@@ -87,7 +88,8 @@ export function useImpactedFilesTable() {
     depth: 1,
   })
   const flags = queryParams?.flags
-  const filters = getFilters({ sortBy: sortBy[0], flags })
+  const components = queryParams?.components
+  const filters = getFilters({ sortBy: sortBy[0], flags, components })
 
   const { data: pullData, isLoading } = usePull({
     provider,

--- a/src/pages/PullRequestPage/subroute/FilesChangedTab/FilesChanged/hooks/useImpactedFilesTable.spec.js
+++ b/src/pages/PullRequestPage/subroute/FilesChangedTab/FilesChanged/hooks/useImpactedFilesTable.spec.js
@@ -317,4 +317,26 @@ describe('useImpactedFilesTable', () => {
       )
     })
   })
+
+  describe('sends components and filters to the API', () => {
+    it('correct variables are sent to the api', async () => {
+      const { componentsMock, flagsMock } = setup()
+      const { result } = renderHook(() => useImpactedFilesTable(), {
+        wrapper: wrapper([
+          '/gh/frumpkin/another-test/pull/14?components=component1,component2&flags=flag1,flag2',
+        ]),
+      })
+
+      await waitFor(() => result.current.isLoading)
+      await waitFor(() => !result.current.isLoading)
+
+      await waitFor(() => expect(componentsMock).toBeCalledTimes(1))
+      await waitFor(() =>
+        expect(componentsMock).toHaveBeenCalledWith('component1,component2')
+      )
+
+      await waitFor(() => expect(flagsMock).toBeCalledTimes(1))
+      await waitFor(() => expect(flagsMock).toHaveBeenCalledWith('flag1,flag2'))
+    })
+  })
 })

--- a/src/pages/PullRequestPage/subroute/FilesChangedTab/FilesChanged/hooks/useImpactedFilesTable.spec.js
+++ b/src/pages/PullRequestPage/subroute/FilesChangedTab/FilesChanged/hooks/useImpactedFilesTable.spec.js
@@ -115,15 +115,19 @@ describe('useImpactedFilesTable', () => {
   function setup(dataReturned = mockPull) {
     const callsHandleSort = jest.fn()
     const flagsMock = jest.fn()
+    const componentsMock = jest.fn()
+
     server.use(
       graphql.query('Pull', (req, res, ctx) => {
         const { direction, parameter } = req.variables.filters.ordering
         callsHandleSort({ direction, parameter })
         flagsMock(req.variables.filters.flags)
+        componentsMock(req.variables.filters.components)
+
         return res(ctx.status(200), ctx.data(dataReturned))
       })
     )
-    return { callsHandleSort, flagsMock }
+    return { callsHandleSort, flagsMock, componentsMock }
   }
 
   describe('when called', () => {
@@ -292,6 +296,25 @@ describe('useImpactedFilesTable', () => {
 
       await waitFor(() => expect(flagsMock).toBeCalledTimes(1))
       await waitFor(() => expect(flagsMock).toHaveBeenCalledWith('flag1,flag2'))
+    })
+  })
+
+  describe('sends components to the API', () => {
+    it('correct variables are sent to the api', async () => {
+      const { componentsMock } = setup()
+      const { result } = renderHook(() => useImpactedFilesTable(), {
+        wrapper: wrapper([
+          '/gh/frumpkin/another-test/pull/14?components=component1,component2',
+        ]),
+      })
+
+      await waitFor(() => result.current.isLoading)
+      await waitFor(() => !result.current.isLoading)
+
+      await waitFor(() => expect(componentsMock).toBeCalledTimes(1))
+      await waitFor(() =>
+        expect(componentsMock).toHaveBeenCalledWith('component1,component2')
+      )
     })
   })
 })

--- a/src/pages/PullRequestPage/subroute/FilesChangedTab/FilesChangedTab.spec.tsx
+++ b/src/pages/PullRequestPage/subroute/FilesChangedTab/FilesChangedTab.spec.tsx
@@ -11,6 +11,7 @@ import FilesChangedTab from './FilesChangedTab'
 
 jest.mock('./FilesChanged', () => () => 'FilesChanged')
 jest.mock('./FilesChanged/TableTeam', () => () => 'TeamFilesChanged')
+jest.mock('../ComponentsSelector', () => () => 'ComponentsSelector')
 
 jest.mock('shared/featureFlags')
 const mockedUseFlags = useFlags as jest.Mock<{ multipleTiers: boolean }>
@@ -155,4 +156,18 @@ describe('FilesChangedTab', () => {
       })
     }
   )
+
+  describe('when impacted files is rendered', () => {
+    it('renders ComponentsSelector', async () => {
+      setup({
+        multipleTiers: true,
+        planValue: TierNames.BASIC,
+        privateRepo: true,
+      })
+      render(<FilesChangedTab />, { wrapper })
+
+      const selector = await screen.findByText('ComponentsSelector')
+      expect(selector).toBeInTheDocument()
+    })
+  })
 })

--- a/src/pages/PullRequestPage/subroute/FilesChangedTab/FilesChangedTab.tsx
+++ b/src/pages/PullRequestPage/subroute/FilesChangedTab/FilesChangedTab.tsx
@@ -6,6 +6,8 @@ import { TierNames, useTier } from 'services/tier'
 import { useFlags } from 'shared/featureFlags'
 import Spinner from 'ui/Spinner'
 
+import ComponentsSelector from '../ComponentsSelector'
+
 const FilesChangedTable = lazy(() => import('./FilesChanged'))
 const TeamFilesChangedTable = lazy(() => import('./FilesChanged/TableTeam'))
 
@@ -47,6 +49,9 @@ function FilesChangedTab() {
 
   return (
     <Suspense fallback={<Loader />}>
+      <div className="flex justify-end bg-ds-gray-primary p-2">
+        <ComponentsSelector />
+      </div>
       <FilesChangedTable />
     </Suspense>
   )


### PR DESCRIPTION
# Description
Add components selector to impacted files tab.

# Notable Changes
- Add selector to files changed tab
- Adjust hook to accept filters 
- Tests 

# Screenshots
https://github.com/codecov/gazebo/assets/91732700/c4654f8c-e75e-4512-8f91-a3624fa98b42

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.