### PR TITLE
Adjust useRepoBranchContentsTable to accept components filters

### DIFF
--- a/src/pages/RepoPage/CoverageTab/subroute/FileExplorer/hooks/useRepoBranchContentsTable.js
+++ b/src/pages/RepoPage/CoverageTab/subroute/FileExplorer/hooks/useRepoBranchContentsTable.js
@@ -143,6 +143,7 @@ const defaultQueryParams = {
   search: '',
   displayType: '',
   flags: [],
+  components: [],
 }
 
 const sortingParameter = Object.freeze({
@@ -159,6 +160,7 @@ const getQueryFilters = ({ params, sortBy }) => {
     ...(params?.search && { searchValue: params.search }),
     // doing a ternary here because it's an array and arrays + && do not go well
     ...(params?.flags ? { flags: params.flags } : {}),
+    ...(params?.components ? { components: params.components } : {}),
     ...(params?.displayType && {
       displayType: displayTypeParameter[params?.displayType],
     }),
@@ -239,6 +241,9 @@ export function useRepoBranchContentsTable() {
     headers,
     handleSort,
     hasFlagsSelected: params?.flags ? params?.flags?.length > 0 : false,
+    hasComponentsSelected: params?.components
+      ? params?.components?.length > 0
+      : false,
     isLoading: isLoadingRepo || isLoading,
     isSearching: !!params?.search,
     isMissingHeadReport:

--- a/src/pages/RepoPage/CoverageTab/subroute/FileExplorer/hooks/useRepoBranchContentsTable.spec.js
+++ b/src/pages/RepoPage/CoverageTab/subroute/FileExplorer/hooks/useRepoBranchContentsTable.spec.js
@@ -202,6 +202,7 @@ describe('useRepoBranchContentsTable', () => {
         filters: {
           searchValue: 'file.js',
           flags: [],
+          components: [],
           ordering: {
             direction: 'ASC',
             parameter: 'NAME',
@@ -235,6 +236,7 @@ describe('useRepoBranchContentsTable', () => {
         filters: {
           displayType: 'LIST',
           flags: [],
+          components: [],
           ordering: {
             direction: 'DESC',
             parameter: 'MISSES',
@@ -267,6 +269,40 @@ describe('useRepoBranchContentsTable', () => {
         branch: 'main',
         filters: {
           flags: ['flag-1'],
+          components: [],
+          ordering: {
+            direction: 'ASC',
+            parameter: 'NAME',
+          },
+        },
+        name: 'test-org',
+        repo: 'test-repo',
+        path: '',
+      })
+    })
+  })
+
+  describe('when there is a components param', () => {
+    it('makes a gql request with the components param', async () => {
+      const { calledCommitContents } = setup()
+      renderHook(() => useRepoBranchContentsTable(), {
+        wrapper: wrapper(
+          `/gh/test-org/test-repo/tree/main${qs.stringify(
+            { components: ['component-1'] },
+            { addQueryPrefix: true }
+          )}`
+        ),
+      })
+
+      await waitFor(() => expect(queryClient.isFetching()).toBeGreaterThan(0))
+      await waitFor(() => expect(queryClient.isFetching()).toBe(0))
+
+      expect(calledCommitContents).toHaveBeenCalled()
+      expect(calledCommitContents).toHaveBeenCalledWith({
+        branch: 'main',
+        filters: {
+          components: ['component-1'],
+          flags: [],
           ordering: {
             direction: 'ASC',
             parameter: 'NAME',
@@ -301,6 +337,7 @@ describe('useRepoBranchContentsTable', () => {
         branch: 'main',
         filters: {
           flags: [],
+          components: [],
           ordering: {
             direction: 'DESC',
             parameter: 'NAME',

--- a/src/shared/ContentsTable/TableEntries/BranchEntries/BranchDirEntry.jsx
+++ b/src/shared/ContentsTable/TableEntries/BranchEntries/BranchDirEntry.jsx
@@ -13,6 +13,7 @@ function BranchDirEntry({ branch, urlPath, name, filters }) {
 
   const queryParams = {
     flags: filters?.flags,
+    components: filters?.components,
   }
 
   return (
@@ -37,6 +38,7 @@ BranchDirEntry.propTypes = {
     }),
     searchValue: PropTypes.any,
     flags: PropTypes.arrayOf(PropTypes.string),
+    components: PropTypes.arrayOf(PropTypes.string),
   }),
 }
 

--- a/src/shared/ContentsTable/TableEntries/BranchEntries/BranchDirEntry.spec.jsx
+++ b/src/shared/ContentsTable/TableEntries/BranchEntries/BranchDirEntry.spec.jsx
@@ -110,6 +110,7 @@ describe('BranchDirEntry', () => {
           urlPath="path/to/directory"
           filters={{
             flags: ['flag-1'],
+            components: [],
           }}
         />,
         { wrapper }
@@ -119,6 +120,30 @@ describe('BranchDirEntry', () => {
       expect(a).toHaveAttribute(
         'href',
         '/gh/codecov/test-repo/tree/branch/path%2Fto%2Fdirectory%2Fdir?flags%5B0%5D=flag-1'
+      )
+    })
+  })
+
+  describe('components and flags filters is passed', () => {
+    it('sets the correct href', async () => {
+      setup()
+      render(
+        <BranchDirEntry
+          branch="branch"
+          name="dir"
+          urlPath="path/to/directory"
+          filters={{
+            flags: ['flag-1'],
+            components: ['component-1'],
+          }}
+        />,
+        { wrapper }
+      )
+
+      const a = await screen.findByRole('link')
+      expect(a).toHaveAttribute(
+        'href',
+        '/gh/codecov/test-repo/tree/branch/path%2Fto%2Fdirectory%2Fdir?flags%5B0%5D=flag-1&components%5B0%5D=component-1'
       )
     })
   })

--- a/src/shared/ContentsTable/TableEntries/BranchEntries/BranchFileEntry.jsx
+++ b/src/shared/ContentsTable/TableEntries/BranchEntries/BranchFileEntry.jsx
@@ -24,6 +24,7 @@ function BranchFileEntry({
 
   const queryParams = {
     flags: filters?.flags,
+    components: filters?.components,
   }
 
   return (
@@ -49,6 +50,7 @@ BranchFileEntry.propTypes = {
   urlPath: PropTypes.string.isRequired,
   filters: PropTypes.shape({
     flags: PropTypes.arrayOf(PropTypes.string),
+    components: PropTypes.arrayOf(PropTypes.string),
   }),
 }
 

--- a/src/shared/ContentsTable/TableEntries/BranchEntries/BranchFileEntry.spec.jsx
+++ b/src/shared/ContentsTable/TableEntries/BranchEntries/BranchFileEntry.spec.jsx
@@ -213,6 +213,7 @@ describe('BranchFileEntry', () => {
           displayType={displayTypeParameter.tree}
           filters={{
             flags: ['flag-1'],
+            components: [],
           }}
         />,
         { wrapper }
@@ -222,6 +223,33 @@ describe('BranchFileEntry', () => {
       expect(a).toHaveAttribute(
         'href',
         '/gh/codecov/test-repo/blob/main/dir%2Ffile.js?flags%5B0%5D=flag-1'
+      )
+    })
+  })
+
+  describe('flags and components filter is passed', () => {
+    it('sets the correct href', async () => {
+      setup()
+      render(
+        <BranchFileEntry
+          branch="main"
+          path="dir/file.js"
+          name="file.js"
+          urlPath="dir"
+          isCriticalFile={false}
+          displayType={displayTypeParameter.tree}
+          filters={{
+            flags: ['flag-1'],
+            components: ['component-3.1415924'],
+          }}
+        />,
+        { wrapper }
+      )
+
+      const a = await screen.findByRole('link')
+      expect(a).toHaveAttribute(
+        'href',
+        '/gh/codecov/test-repo/blob/main/dir%2Ffile.js?flags%5B0%5D=flag-1&components%5B0%5D=component-3.1415924'
       )
     })
   })


### PR DESCRIPTION
# Description

Updates `useRepoBranchContentsTable` to be used to filter components in file explorer and file viewer. Note that these changes do not affect anything that propagates `MissingFileData` as of yet. 

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.