### PR TITLE
feat: Default to All branches when default branch has no commits

### DIFF
--- a/src/pages/RepoPage/CommitsTab/CommitsTab.jsx
+++ b/src/pages/RepoPage/CommitsTab/CommitsTab.jsx
@@ -23,6 +23,7 @@ import { useCommitsTabBranchSelector } from './hooks'
 
 import { useSetCrumbs } from '../context'
 
+const ALL_BRANCHES = 'All branches'
 const CommitsTable = lazy(() => import('./CommitsTable'))
 const CommitsTableTeam = lazy(() => import('./CommitsTableTeam'))
 
@@ -62,16 +63,16 @@ const useControlParams = ({ defaultBranch }) => {
   useEffect(() => {
     if (
       branchHasCommits === false &&
-      selectedBranch !== 'All branches' &&
+      selectedBranch !== ALL_BRANCHES &&
       !initialRenderDone.current
     ) {
       initialRenderDone.current = true
-      updateParams({ branch: 'All branches' })
+      updateParams({ branch: ALL_BRANCHES })
     }
   }, [branchHasCommits, selectedBranch, updateParams])
 
   let branch = selectedBranch
-  if (branch === 'All branches') {
+  if (branch === ALL_BRANCHES) {
     branch = ''
   }
 
@@ -124,7 +125,7 @@ function CommitsTab() {
   } = useCommitsTabBranchSelector({
     passedBranch: branch,
     defaultBranch: overview?.defaultBranch,
-    isAllCommits: selectedBranch === 'All branches',
+    isAllCommits: selectedBranch === ALL_BRANCHES,
   })
 
   useLayoutEffect(() => {
@@ -142,7 +143,7 @@ function CommitsTab() {
     ])
   }, [currentBranchSelected, setCrumbs])
 
-  const newBranches = [...(isSearching ? [] : ['All branches']), ...branchList]
+  const newBranches = [...(isSearching ? [] : [ALL_BRANCHES]), ...branchList]
 
   const handleStatusChange = (selectStates) => {
     const commitStates = selectStates?.map(

--- a/src/services/branches/index.js
+++ b/src/services/branches/index.js
@@ -1,3 +1,4 @@
 export * from './useBranch'
 export * from './useBranches'
 export * from './useBranchComponents'
+export * from './useBranchHasCommits'

--- a/src/services/branches/useBranchHasCommits.spec.tsx
+++ b/src/services/branches/useBranchHasCommits.spec.tsx
@@ -1,0 +1,327 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { renderHook, waitFor } from '@testing-library/react'
+import { graphql } from 'msw'
+import { setupServer } from 'msw/node'
+import { Suspense } from 'react'
+
+import { useBranchHasCommits } from './useBranchHasCommits'
+
+const mockBranchHasCommits = {
+  owner: {
+    repository: {
+      __typename: 'Repository',
+      commits: {
+        edges: [
+          {
+            node: {
+              commitId: 'commit-123',
+            },
+          },
+        ],
+      },
+    },
+  },
+}
+
+const mockBranchHasNoCommits = {
+  owner: {
+    repository: {
+      __typename: 'Repository',
+      commits: {
+        edges: [],
+      },
+    },
+  },
+}
+
+const mockCommitsIsNull = {
+  owner: {
+    repository: {
+      __typename: 'Repository',
+      commits: null,
+    },
+  },
+}
+
+const mockNotFoundError = {
+  owner: {
+    isCurrentUserPartOfOrg: true,
+    repository: {
+      __typename: 'NotFoundError',
+      message: 'commit not found',
+    },
+  },
+}
+
+const mockOwnerNotActivatedError = {
+  owner: {
+    isCurrentUserPartOfOrg: true,
+    repository: {
+      __typename: 'OwnerNotActivatedError',
+      message: 'owner not activated',
+    },
+  },
+}
+
+const mockNullOwner = {
+  owner: null,
+}
+
+const mockUnsuccessfulParseError = {}
+
+const queryClient = new QueryClient({
+  defaultOptions: { queries: { retry: false } },
+})
+const server = setupServer()
+
+const wrapper: React.FC<React.PropsWithChildren> = ({ children }) => (
+  <QueryClientProvider client={queryClient}>
+    <Suspense fallback={<p>loading</p>}>{children}</Suspense>
+  </QueryClientProvider>
+)
+
+beforeAll(() => {
+  server.listen()
+})
+
+afterEach(() => {
+  queryClient.clear()
+  server.resetHandlers()
+})
+
+afterAll(() => {
+  server.close()
+})
+
+interface SetupArgs {
+  isNotFoundError?: boolean
+  isOwnerNotActivatedError?: boolean
+  isUnsuccessfulParseError?: boolean
+  isNullOwner?: boolean
+  hasNoCommits?: boolean
+  commitsIsNull?: boolean
+}
+
+describe('useBranchHasCommits', () => {
+  function setup({
+    isNotFoundError = false,
+    isOwnerNotActivatedError = false,
+    isUnsuccessfulParseError = false,
+    isNullOwner = false,
+    hasNoCommits = false,
+    commitsIsNull = false,
+  }: SetupArgs) {
+    server.use(
+      graphql.query('GetBranchCommits', (req, res, ctx) => {
+        if (isNotFoundError) {
+          return res(ctx.status(200), ctx.data(mockNotFoundError))
+        } else if (isOwnerNotActivatedError) {
+          return res(ctx.status(200), ctx.data(mockOwnerNotActivatedError))
+        } else if (isUnsuccessfulParseError) {
+          return res(ctx.status(200), ctx.data(mockUnsuccessfulParseError))
+        } else if (isNullOwner) {
+          return res(ctx.status(200), ctx.data(mockNullOwner))
+        } else if (hasNoCommits) {
+          return res(ctx.status(200), ctx.data(mockBranchHasNoCommits))
+        } else if (commitsIsNull) {
+          return res(ctx.status(200), ctx.data(mockCommitsIsNull))
+        } else {
+          return res(ctx.status(200), ctx.data(mockBranchHasCommits))
+        }
+      })
+    )
+  }
+
+  describe('calling hook', () => {
+    describe('returns repository typename of Repository', () => {
+      describe('the branch has commits', () => {
+        it('returns true', async () => {
+          setup({})
+          const { result } = renderHook(
+            () =>
+              useBranchHasCommits({
+                provider: 'gh',
+                owner: 'codecov',
+                repo: 'cool-repo',
+                branch: 'main',
+                opts: {
+                  suspense: true,
+                },
+              }),
+            { wrapper }
+          )
+
+          await waitFor(() => expect(result.current.data).toBeTruthy())
+        })
+      })
+
+      describe('the branch has no commits', () => {
+        it('returns false', async () => {
+          setup({ hasNoCommits: true })
+          const { result } = renderHook(
+            () =>
+              useBranchHasCommits({
+                provider: 'gh',
+                owner: 'codecov',
+                repo: 'cool-repo',
+                branch: 'main',
+                opts: {
+                  suspense: true,
+                },
+              }),
+            { wrapper }
+          )
+
+          await waitFor(() => expect(result.current.data).toBe(false))
+        })
+      })
+
+      describe('the commits field is null', () => {
+        it('returns false', async () => {
+          setup({ commitsIsNull: true })
+          const { result } = renderHook(
+            () =>
+              useBranchHasCommits({
+                provider: 'gh',
+                owner: 'codecov',
+                repo: 'cool-repo',
+                branch: 'main',
+                opts: {
+                  suspense: true,
+                },
+              }),
+            { wrapper }
+          )
+
+          await waitFor(() => expect(result.current.data).toBe(false))
+        })
+      })
+
+      describe('there is a null owner', () => {
+        it('returns false', async () => {
+          setup({ isNullOwner: true })
+          const { result } = renderHook(
+            () =>
+              useBranchHasCommits({
+                provider: 'gh',
+                owner: 'codecov',
+                repo: 'cool-repo',
+                branch: 'main',
+                opts: {
+                  suspense: true,
+                },
+              }),
+            { wrapper }
+          )
+
+          await waitFor(() => expect(result.current.data).toBe(false))
+        })
+      })
+    })
+
+    describe('returns NotFoundError __typename', () => {
+      let oldConsoleError = console.error
+
+      beforeEach(() => {
+        console.error = () => null
+      })
+
+      afterEach(() => {
+        console.error = oldConsoleError
+      })
+
+      it('throws a 404', async () => {
+        setup({ isNotFoundError: true })
+        const { result } = renderHook(
+          () =>
+            useBranchHasCommits({
+              provider: 'gh',
+              owner: 'codecov',
+              repo: 'cool-repo',
+              branch: 'main',
+            }),
+          { wrapper }
+        )
+
+        await waitFor(() => expect(result.current.isError).toBeTruthy())
+        await waitFor(() =>
+          expect(result.current.error).toEqual(
+            expect.objectContaining({
+              status: 404,
+            })
+          )
+        )
+      })
+    })
+
+    describe('returns OwnerNotActivatedError __typename', () => {
+      let oldConsoleError = console.error
+
+      beforeEach(() => {
+        console.error = () => null
+      })
+
+      afterEach(() => {
+        console.error = oldConsoleError
+      })
+
+      it('throws a 403', async () => {
+        setup({ isOwnerNotActivatedError: true })
+        const { result } = renderHook(
+          () =>
+            useBranchHasCommits({
+              provider: 'gh',
+              owner: 'codecov',
+              repo: 'cool-repo',
+              branch: 'main',
+            }),
+          { wrapper }
+        )
+
+        await waitFor(() => expect(result.current.isError).toBeTruthy())
+        await waitFor(() =>
+          expect(result.current.error).toEqual(
+            expect.objectContaining({
+              status: 403,
+            })
+          )
+        )
+      })
+    })
+
+    describe('unsuccessful parse of zod schema', () => {
+      let oldConsoleError = console.error
+
+      beforeEach(() => {
+        console.error = () => null
+      })
+
+      afterEach(() => {
+        console.error = oldConsoleError
+      })
+
+      it('throws a 404', async () => {
+        setup({ isUnsuccessfulParseError: true })
+        const { result } = renderHook(
+          () =>
+            useBranchHasCommits({
+              provider: 'gh',
+              owner: 'codecov',
+              repo: 'cool-repo',
+              branch: 'main',
+            }),
+          { wrapper }
+        )
+
+        await waitFor(() => expect(result.current.isError).toBeTruthy())
+        await waitFor(() =>
+          expect(result.current.error).toEqual(
+            expect.objectContaining({
+              status: 404,
+            })
+          )
+        )
+      })
+    })
+  })
+})

--- a/src/services/branches/useBranchHasCommits.tsx
+++ b/src/services/branches/useBranchHasCommits.tsx
@@ -1,0 +1,141 @@
+import { useQuery } from '@tanstack/react-query'
+import isArray from 'lodash/isArray'
+import { z } from 'zod'
+
+import {
+  RepoNotFoundErrorSchema,
+  RepoOwnerNotActivatedErrorSchema,
+} from 'services/repo'
+import Api from 'shared/api'
+import A from 'ui/A'
+
+const CommitSchema = z.object({
+  commitId: z.string(),
+})
+
+const RepositorySchema = z.object({
+  __typename: z.literal('Repository'),
+  commits: z
+    .object({
+      edges: z.array(
+        z
+          .object({
+            node: CommitSchema,
+          })
+          .nullable()
+      ),
+    })
+    .nullable(),
+})
+
+const GetBranchCommitsSchema = z.object({
+  owner: z
+    .object({
+      repository: z.discriminatedUnion('__typename', [
+        RepositorySchema,
+        RepoNotFoundErrorSchema,
+        RepoOwnerNotActivatedErrorSchema,
+      ]),
+    })
+    .nullable(),
+})
+
+const query = `
+  query GetBranchCommits($owner: String!, $repo: String!, $branch: String!) {
+    owner(username: $owner) {
+      repository(name: $repo) {
+        __typename
+        ... on Repository {
+          commits(first: 1, filters: { branchName: $branch }) {
+            edges {
+              node {
+                commitid
+              }
+            }
+          }
+        }
+        ... on NotFoundError {
+          message
+        }
+        ... on OwnerNotActivatedError {
+          message
+        }
+      }
+    }
+  }`
+
+interface UseBranchCommitsArgs {
+  provider: string
+  owner: string
+  repo: string
+  branch: string
+  opts?: {
+    suspense?: boolean
+    enabled?: boolean
+  }
+}
+
+export const useBranchHasCommits = ({
+  provider,
+  owner,
+  repo,
+  branch,
+  opts,
+}: UseBranchCommitsArgs) => {
+  return useQuery({
+    queryKey: ['GetBranchCommits', provider, owner, repo, branch],
+    queryFn: ({ signal }) =>
+      Api.graphql({
+        provider,
+        query,
+        signal,
+        variables: {
+          owner,
+          repo,
+          branch,
+        },
+      }).then((res) => {
+        const parsedData = GetBranchCommitsSchema.safeParse(res.data)
+
+        if (!parsedData.success) {
+          return Promise.reject({
+            status: 404,
+            data: {},
+          })
+        }
+
+        const data = parsedData.data
+
+        if (data?.owner?.repository?.__typename === 'NotFoundError') {
+          return Promise.reject({
+            status: 404,
+            data: {},
+          })
+        }
+
+        if (data?.owner?.repository?.__typename === 'OwnerNotActivatedError') {
+          return Promise.reject({
+            status: 403,
+            data: {
+              detail: (
+                <p>
+                  Activation is required to view this repo, please{' '}
+                  {/* @ts-expect-error */}
+                  <A to={{ pageName: 'membersTab' }}>click here </A> to activate
+                  your account.
+                </p>
+              ),
+            },
+          })
+        }
+
+        const edges = data?.owner?.repository?.commits?.edges
+        if (isArray(edges)) {
+          return edges?.length > 0
+        }
+
+        return false
+      }),
+    ...(!!opts && opts),
+  })
+}


### PR DESCRIPTION
# Description

This PR makes it so that when you visit the commits tab of a repo whose default branch has no commits it will swap over to the `All branches` option by updating the query params on the initial render, so users can force their way back to the default branch if they wish to investigate further.

Closes codecov/engineering-team#870

# Notable Changes

- Add new `useBranchHasCommits` hook
- Update `CommitsTab` to swap to `All branches` when default branch has no commits only on initial render.

# Screenshots

https://github.com/codecov/gazebo/assets/105234307/f0e933d5-f82a-4c4d-8533-0363d9fe5247