### PR TITLE
feat: Update files explorer tab with components selector

### DIFF
--- a/src/pages/PullRequestPage/subroute/FileExplorer/FileExplorer.jsx
+++ b/src/pages/PullRequestPage/subroute/FileExplorer/FileExplorer.jsx
@@ -13,6 +13,8 @@ import Spinner from 'ui/Spinner'
 
 import { useRepoPullContentsTable } from './hooks'
 
+import ComponentsSelector from '../ComponentsSelector'
+
 const Loader = () => (
   <div className="flex flex-1 justify-center">
     <Spinner size={60} />
@@ -43,12 +45,15 @@ function FileExplorer() {
           <DisplayTypeButton />
           <Breadcrumb paths={treePaths} />
         </div>
-        <SearchField
-          dataMarketing="pull-files-search"
-          placeholder="Search for files"
-          searchValue={params?.search}
-          setSearchValue={(search) => updateParams({ search })}
-        />
+        <div className="flex gap-2">
+          <ComponentsSelector />
+          <SearchField
+            dataMarketing="pull-files-search"
+            placeholder="Search for files"
+            searchValue={params?.search}
+            setSearchValue={(search) => updateParams({ search })}
+          />
+        </div>
       </ContentsTableHeader>
       <Table
         data={data}

--- a/src/pages/PullRequestPage/subroute/FileExplorer/FileExplorer.spec.jsx
+++ b/src/pages/PullRequestPage/subroute/FileExplorer/FileExplorer.spec.jsx
@@ -7,6 +7,8 @@ import { MemoryRouter, Route } from 'react-router-dom'
 
 import FileExplorer from './FileExplorer'
 
+jest.mock('../ComponentsSelector', () => () => 'ComponentsSelector')
+
 const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
@@ -191,6 +193,16 @@ describe('FileExplorer', () => {
 
         const coverage = await screen.findByText('Coverage %')
         expect(coverage).toBeInTheDocument()
+      })
+    })
+
+    describe('when rendered', () => {
+      it('renders ComponentsSelector', async () => {
+        setup()
+        render(<FileExplorer />, { wrapper: wrapper() })
+
+        const selector = await screen.findByText('ComponentsSelector')
+        expect(selector).toBeInTheDocument()
       })
     })
 

--- a/src/pages/PullRequestPage/subroute/FileExplorer/hooks/useRepoPullContentsTable.js
+++ b/src/pages/PullRequestPage/subroute/FileExplorer/hooks/useRepoPullContentsTable.js
@@ -153,7 +153,7 @@ const sortingParameter = Object.freeze({
   lines: 'LINES',
 })
 
-const getQueryFilters = ({ params, sortBy, flags }) => {
+const getQueryFilters = ({ params, sortBy, flags, components }) => {
   return {
     ...(params?.search && { searchValue: params.search }),
     ...(params?.displayType && {
@@ -166,6 +166,7 @@ const getQueryFilters = ({ params, sortBy, flags }) => {
       },
     }),
     ...(flags ? { flags } : {}),
+    ...(components ? { components } : {}),
   }
 }
 
@@ -177,6 +178,8 @@ export function useRepoPullContentsTable() {
     depth: 1,
   })
   const flags = queryParams?.flags
+  const components = queryParams?.components
+
   const { params } = useLocationParams(defaultQueryParams)
   const { treePaths } = usePullTreePaths()
   const [sortBy, setSortBy] = useTableDefaultSort()
@@ -187,7 +190,7 @@ export function useRepoPullContentsTable() {
     repo,
     pullId,
     path: urlPath || '',
-    filters: getQueryFilters({ params, sortBy: sortBy[0], flags }),
+    filters: getQueryFilters({ params, sortBy: sortBy[0], flags, components }),
     opts: {
       suspense: false,
     },

--- a/src/pages/PullRequestPage/subroute/FileExplorer/hooks/useRepoPullContentsTable.spec.js
+++ b/src/pages/PullRequestPage/subroute/FileExplorer/hooks/useRepoPullContentsTable.spec.js
@@ -258,6 +258,63 @@ describe('useRepoPullContentsTable', () => {
     })
   })
 
+  describe('when called with a selected components', () => {
+    it('makes a gql request with the list param', async () => {
+      const { variablesPassed } = setup()
+      const { result } = renderHook(() => useRepoPullContentsTable(), {
+        wrapper: wrapper([
+          '/gh/test-org/test-repo/pull/123/tree?components=a,b',
+        ]),
+      })
+
+      await waitFor(() => result.current.isLoading)
+      await waitFor(() => !result.current.isLoading)
+
+      expect(variablesPassed).toHaveBeenCalledWith({
+        pullId: 123,
+        filters: {
+          components: 'a,b',
+          ordering: {
+            direction: 'ASC',
+            parameter: 'NAME',
+          },
+        },
+        owner: 'test-org',
+        repo: 'test-repo',
+        path: '',
+      })
+    })
+  })
+
+  describe('when called with a selected flags and components', () => {
+    it('makes a gql request with the list param', async () => {
+      const { variablesPassed } = setup()
+      const { result } = renderHook(() => useRepoPullContentsTable(), {
+        wrapper: wrapper([
+          '/gh/test-org/test-repo/pull/123/tree?flags=a&components=b',
+        ]),
+      })
+
+      await waitFor(() => result.current.isLoading)
+      await waitFor(() => !result.current.isLoading)
+
+      expect(variablesPassed).toHaveBeenCalledWith({
+        pullId: 123,
+        filters: {
+          flags: 'a',
+          components: 'b',
+          ordering: {
+            direction: 'ASC',
+            parameter: 'NAME',
+          },
+        },
+        owner: 'test-org',
+        repo: 'test-repo',
+        path: '',
+      })
+    })
+  })
+
   describe('when handleSort is triggered', () => {
     it('makes a gql request with the updated params', async () => {
       const { variablesPassed } = setup()


### PR DESCRIPTION
# Description
Adding the selector to PR files explorer 

# Notable Changes
- Add the selector component 
- Support filters in the hook 

# Screenshots
https://github.com/codecov/gazebo/assets/91732700/467c1ed8-e28d-40c8-ba6c-9b8d8210cb05


# Link to Sample Entry

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.