### PR TITLE
[fix] Components filter section displays when not configured

### DIFF
--- a/src/pages/CommitDetailPage/subRoute/FilesChangedTab/FilesChangedTab.spec.tsx
+++ b/src/pages/CommitDetailPage/subRoute/FilesChangedTab/FilesChangedTab.spec.tsx
@@ -13,7 +13,10 @@ jest.mock('./FilesChangedTable', () => () => 'FilesChangedTable')
 jest.mock('./FilesChangedTableTeam', () => () => 'FilesChangedTableTeam')
 
 jest.mock('shared/featureFlags')
-const mockedUseFlags = useFlags as jest.Mock<{ multipleTiers: boolean }>
+const mockedUseFlags = useFlags as jest.Mock<{
+  multipleTiers: boolean
+  componentsSelect: boolean
+}>
 
 const mockTeamTier = {
   owner: {
@@ -80,6 +83,7 @@ describe('FilesChangedTab', () => {
   function setup({ planValue, flagValue, isPrivate = false }: SetupArgs) {
     mockedUseFlags.mockReturnValue({
       multipleTiers: flagValue,
+      componentsSelect: true,
     })
 
     server.use(

--- a/src/pages/PullRequestPage/subroute/ComponentsTab/ComponentsTab.jsx
+++ b/src/pages/PullRequestPage/subroute/ComponentsTab/ComponentsTab.jsx
@@ -3,6 +3,7 @@ import qs from 'qs'
 import { useLocation } from 'react-router-dom'
 
 import Table from 'old_ui/Table'
+import { useFlags } from 'shared/featureFlags'
 import Spinner from 'ui/Spinner'
 import TotalsNumber from 'ui/TotalsNumber'
 
@@ -114,6 +115,10 @@ function ComponentsTab() {
   const tableData = getTableData(componentComparisons)
   const isTableDataEmpty = tableData && tableData?.length <= 0
 
+  const { componentsSelect } = useFlags({
+    componentsSelect: false,
+  })
+
   if (isLoading) {
     return <Loader isLoading={isLoading} />
   }
@@ -124,9 +129,11 @@ function ComponentsTab() {
 
   return (
     <>
-      <div className="flex justify-end bg-ds-gray-primary p-2">
-        <ComponentsSelector />
-      </div>
+      {componentsSelect && (
+        <div className="flex justify-end bg-ds-gray-primary p-2">
+          <ComponentsSelector />
+        </div>
+      )}
       <Table data={tableData} columns={tableColumns} />
     </>
   )

--- a/src/pages/PullRequestPage/subroute/ComponentsTab/ComponentsTab.spec.jsx
+++ b/src/pages/PullRequestPage/subroute/ComponentsTab/ComponentsTab.spec.jsx
@@ -4,10 +4,13 @@ import { graphql } from 'msw'
 import { setupServer } from 'msw/node'
 import { MemoryRouter, Route } from 'react-router-dom'
 
+import { useFlags } from 'shared/featureFlags'
+
 import ComponentsTab from './ComponentsTab'
 
 jest.mock('./ComponentsNotConfigured', () => () => 'ComponentsNotConfigured')
 jest.mock('../ComponentsSelector', () => () => 'ComponentsSelector')
+jest.mock('shared/featureFlags')
 
 const queryClient = new QueryClient()
 const server = setupServer()
@@ -66,6 +69,9 @@ const mockPull = {
 describe('ComponentsTab', () => {
   function setup(overrideData) {
     const componentsMock = jest.fn()
+    useFlags.mockReturnValue({
+      componentsSelect: true,
+    })
 
     server.use(
       graphql.query('PullComponentComparison', (req, res, ctx) => {

--- a/src/pages/PullRequestPage/subroute/FilesChangedTab/FilesChangedTab.spec.tsx
+++ b/src/pages/PullRequestPage/subroute/FilesChangedTab/FilesChangedTab.spec.tsx
@@ -14,7 +14,10 @@ jest.mock('./FilesChanged/TableTeam', () => () => 'TeamFilesChanged')
 jest.mock('../ComponentsSelector', () => () => 'ComponentsSelector')
 
 jest.mock('shared/featureFlags')
-const mockedUseFlags = useFlags as jest.Mock<{ multipleTiers: boolean }>
+const mockedUseFlags = useFlags as jest.Mock<{
+  multipleTiers: boolean
+  componentsSelect: boolean
+}>
 
 const mockTeamTier = {
   owner: {
@@ -95,6 +98,7 @@ describe('FilesChangedTab', () => {
   function setup({ planValue, multipleTiers, privateRepo }: SetupArgs) {
     mockedUseFlags.mockReturnValue({
       multipleTiers: multipleTiers,
+      componentsSelect: true,
     })
 
     server.use(

--- a/src/pages/PullRequestPage/subroute/FilesChangedTab/FilesChangedTab.tsx
+++ b/src/pages/PullRequestPage/subroute/FilesChangedTab/FilesChangedTab.tsx
@@ -25,8 +25,9 @@ interface URLParams {
 function FilesChangedTab() {
   const { provider, owner } = useParams<URLParams>()
 
-  const { multipleTiers } = useFlags({
+  const { multipleTiers, componentsSelect } = useFlags({
     multipleTiers: false,
+    componentsSelect: false,
   })
   const { data: repoSettingsTeam } = useRepoSettingsTeam()
   const { data: tierData, isLoading } = useTier({ provider, owner })
@@ -49,9 +50,11 @@ function FilesChangedTab() {
 
   return (
     <Suspense fallback={<Loader />}>
-      <div className="flex justify-end bg-ds-gray-primary p-2">
-        <ComponentsSelector />
-      </div>
+      {componentsSelect && (
+        <div className="flex justify-end bg-ds-gray-primary p-2">
+          <ComponentsSelector />
+        </div>
+      )}
       <FilesChangedTable />
     </Suspense>
   )


### PR DESCRIPTION
# Description

This change removes the extra space taken up by the div when the components flag is disabled or there are no components. This PR closes https://github.com/codecov/engineering-team/issues/893.

# Screenshots
**Before**
![Screenshot 2023-12-13 at 3 51 44 PM](https://github.com/codecov/gazebo/assets/148245014/cb80738d-64fb-431d-bf9d-f972516a2449)

**After**
![Screenshot 2023-12-13 at 3 52 50 PM](https://github.com/codecov/gazebo/assets/148245014/70a8d4e0-83bb-44c6-8670-bb81d8dfbaba)


# Link to Sample Entry

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.