### PR TITLE
fix: Fix z index of flags selector

### DIFF
--- a/src/ui/MultiSelect/MultiSelect.jsx
+++ b/src/ui/MultiSelect/MultiSelect.jsx
@@ -262,7 +262,7 @@ const MultiSelect = forwardRef(
     }
 
     return (
-      <div className="relative z-20">
+      <div className="relative">
         <div>
           <button
             data-marketing={dataMarketing}


### PR DESCRIPTION
# Description
before and after: 
<img width="1500" alt="Screenshot 2023-12-18 at 2 24 50 PM" src="https://github.com/codecov/gazebo/assets/91732700/b8a95552-5583-4008-9ba3-aae644bec9a4">
<img width="1500" alt="Screenshot 2023-12-18 at 2 35 25 PM" src="https://github.com/codecov/gazebo/assets/91732700/8cef621a-f394-4564-97d4-eee10488e2ab">

it's conflicting with flags multi selector, we're going to resolve this problem when we move the rest of the stuff down a to the gray box anyway. 

# Code Example

# Notable Changes

# Screenshots

# Link to Sample Entry

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.