### PR TITLE
[feat] Place the new multi selector for components in file explorer

### DIFF
--- a/src/pages/RepoPage/CoverageTab/subroute/FileExplorer/FileExplorer.jsx
+++ b/src/pages/RepoPage/CoverageTab/subroute/FileExplorer/FileExplorer.jsx
@@ -1,6 +1,7 @@
 import { useLocationParams } from 'services/navigation'
 import DisplayTypeButton from 'shared/ContentsTable/DisplayTypeButton'
 import FileBreadcrumb from 'shared/ContentsTable/FileBreadcrumb'
+import ComponentsSelectCommit from 'ui/ComponentsSelect'
 import SearchField from 'ui/SearchField'
 
 import CodeTreeTable from './CodeTreeTable'
@@ -30,6 +31,7 @@ function FileExplorer() {
           <FileBreadcrumb />
         </div>
         <FlagMultiSelect />
+        <ComponentsSelectCommit />
         <SearchField
           dataMarketing="files-search"
           placeholder="Search for files"

--- a/src/pages/RepoPage/CoverageTab/subroute/FileExplorer/FileExplorer.spec.jsx
+++ b/src/pages/RepoPage/CoverageTab/subroute/FileExplorer/FileExplorer.spec.jsx
@@ -5,6 +5,8 @@ import { graphql } from 'msw'
 import { setupServer } from 'msw/node'
 import { MemoryRouter, Route } from 'react-router-dom'
 
+import { useFlags } from 'shared/featureFlags'
+
 import FileExplorer from './FileExplorer'
 
 jest.mock('./FileListTable', () => () => 'File list table')
@@ -15,6 +17,11 @@ jest.mock(
 )
 jest.mock('shared/ContentsTable/FileBreadcrumb', () => () => 'File breadcrumb')
 jest.mock('./FlagMultiSelect', () => () => 'FlagMultiSelect')
+jest.mock(
+  'ui/ComponentsSelect/ComponentsSelectCommit',
+  () => () => 'Components Selector'
+)
+jest.mock('shared/featureFlags')
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -126,6 +133,10 @@ describe('FileExplorer', () => {
   function setup() {
     const user = userEvent.setup()
 
+    useFlags.mockReturnValue({
+      componentsSelect: true,
+    })
+
     server.use(
       graphql.query('BranchContents', (req, res, ctx) => {
         if (
@@ -184,6 +195,14 @@ describe('FileExplorer', () => {
 
       const table = await screen.findByText('Code tree table')
       expect(table).toBeInTheDocument()
+    })
+
+    it('renders components selector', async () => {
+      setup()
+      render(<FileExplorer />, { wrapper: wrapper() })
+
+      const searchField = await screen.findByText(/Components Selector/)
+      expect(searchField).toBeInTheDocument()
     })
 
     describe('user searches for a file', () => {

--- a/src/pages/RepoPage/CoverageTab/subroute/Fileviewer/Fileviewer.jsx
+++ b/src/pages/RepoPage/CoverageTab/subroute/Fileviewer/Fileviewer.jsx
@@ -5,8 +5,7 @@ import { TierNames, useTier } from 'services/tier'
 import RawFileviewer from 'shared/RawFileviewer'
 import { useTreePaths } from 'shared/treePaths'
 import Breadcrumb from 'ui/Breadcrumb'
-
-import { ComponentsSelectCommit } from './ComponentsSelectCommit'
+import ComponentsSelectCommit from 'ui/ComponentsSelect'
 
 function FileView() {
   const { treePaths } = useTreePaths()

--- a/src/ui/ComponentsSelect/ComponentsSelectCommit.spec.tsx
+++ b/src/ui/ComponentsSelect/ComponentsSelectCommit.spec.tsx
@@ -9,7 +9,7 @@ import { MemoryRouter, Route } from 'react-router-dom'
 
 import { useFlags } from 'shared/featureFlags'
 
-import { ComponentsSelectCommit } from './ComponentsSelectCommit'
+import ComponentsSelectCommit from './ComponentsSelectCommit'
 
 jest.mock('shared/featureFlags')
 

--- a/src/ui/ComponentsSelect/ComponentsSelectCommit.tsx
+++ b/src/ui/ComponentsSelect/ComponentsSelectCommit.tsx
@@ -32,7 +32,7 @@ export default function ComponentsSelectCommit() {
     params?.components
   )
   const { componentsSelect: componentsSelectFlag } = useFlags({
-    componentsSelect: true,
+    componentsSelect: false,
   })
 
   const { data, isLoading } = useBranchComponents({

--- a/src/ui/ComponentsSelect/ComponentsSelectCommit.tsx
+++ b/src/ui/ComponentsSelect/ComponentsSelectCommit.tsx
@@ -8,7 +8,7 @@ import { useFlags } from 'shared/featureFlags'
 import Icon from 'ui/Icon'
 import MultiSelect from 'ui/MultiSelect'
 
-import { useSummary } from '../../summaryHooks'
+import { useSummary } from '../../pages/RepoPage/CoverageTab/summaryHooks'
 
 const defaultQueryParams = {
   search: '',
@@ -21,7 +21,7 @@ interface URLParams {
   repo: string
 }
 
-export function ComponentsSelectCommit() {
+export default function ComponentsSelectCommit() {
   const { currentBranchSelected } = useSummary()
 
   const { provider, owner, repo } = useParams<URLParams>()
@@ -32,7 +32,7 @@ export function ComponentsSelectCommit() {
     params?.components
   )
   const { componentsSelect: componentsSelectFlag } = useFlags({
-    componentsSelect: false,
+    componentsSelect: true,
   })
 
   const { data, isLoading } = useBranchComponents({

--- a/src/ui/ComponentsSelect/index.ts
+++ b/src/ui/ComponentsSelect/index.ts
@@ -1,0 +1,1 @@
+export { default } from './ComponentsSelectCommit'


### PR DESCRIPTION
# Description

Adds the components multi select to the file explorer in the Coverage tab. This closes https://github.com/codecov/engineering-team/issues/829. 

This PR also moves `ComponentsSelectCommit` to its own ui folder for shared access across multiple components. 

# Link to Sample Entry

https://github.com/codecov/gazebo/assets/148245014/089cd4b8-a753-4000-b405-4505a2eb15e1


<!--



  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.