### PR TITLE
feat: use 2nd upgrade form

### DIFF
--- a/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradePlanPage.jsx
+++ b/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradePlanPage.jsx
@@ -11,7 +11,7 @@ import {
 } from 'shared/utils/billing'
 
 import UpgradeDetails from './UpgradeDetails'
-import UpgradeForm from './UpgradeForm'
+import UpgradeForm2 from './UpgradeForm2'
 
 import { useSetCrumbs } from '../../context'
 
@@ -20,8 +20,8 @@ function UpgradePlanPage() {
   const setCrumbs = useSetCrumbs()
   const { data: accountDetails } = useAccountDetails({ provider, owner })
   const { data: plans } = useAvailablePlans({ provider, owner })
-  const { proPlanMonth, proPlanYear } = useProPlans({ plans })
-  const { sentryPlanMonth, sentryPlanYear } = findSentryPlans({ plans })
+  const { proPlanYear } = useProPlans({ plans })
+  const { sentryPlanYear } = findSentryPlans({ plans })
 
   const plan = accountDetails?.rootOrganization?.plan ?? accountDetails?.plan
 
@@ -46,12 +46,7 @@ function UpgradePlanPage() {
   return (
     <div className="flex flex-col gap-8 md:w-11/12 md:flex-row lg:w-10/12">
       <UpgradeDetails selectedPlan={selectedPlan} />
-      <UpgradeForm
-        accountDetails={accountDetails}
-        proPlanYear={proPlanYear}
-        proPlanMonth={proPlanMonth}
-        sentryPlanYear={sentryPlanYear}
-        sentryPlanMonth={sentryPlanMonth}
+      <UpgradeForm2
         selectedPlan={selectedPlan}
         setSelectedPlan={setSelectedPlan}
       />

--- a/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradePlanPage.spec.jsx
+++ b/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradePlanPage.spec.jsx
@@ -15,7 +15,7 @@ import { Plans } from 'shared/utils/billing'
 
 import UpgradePlanPage from './UpgradePlanPage'
 
-jest.mock('./UpgradeForm', () => () => 'UpgradeForm')
+jest.mock('./UpgradeForm2', () => () => 'UpgradeForm2')
 
 const plans = [
   {


### PR DESCRIPTION
# Description
This PR makes the use of the new upgrade form

closes https://github.com/codecov/engineering-team/issues/778

# Screenshots
[screen-capture (12).webm](https://github.com/codecov/gazebo/assets/82913673/168ce051-c0a0-43fa-8dc9-e04ffd2ad279)

# Link to Sample Entry

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.