### PR TITLE
feat: make flag entries links

### DIFF
--- a/src/pages/RepoPage/FlagsTab/subroute/FlagsTable/FlagsTable.jsx
+++ b/src/pages/RepoPage/FlagsTab/subroute/FlagsTable/FlagsTable.jsx
@@ -5,6 +5,7 @@ import { useParams } from 'react-router-dom'
 import Table from 'old_ui/Table'
 import { useRepoConfig } from 'services/repo/useRepoConfig'
 import { determineProgressColor } from 'shared/utils/determineProgressColor'
+import A from 'ui/A'
 import Button from 'ui/Button'
 import CoverageProgress from 'ui/CoverageProgress'
 import Icon from 'ui/Icon'
@@ -59,7 +60,17 @@ function createTableData({
   return tableData?.length > 0
     ? tableData.map(
         ({ name, percentCovered, percentChange, measurements }) => ({
-          name: <span>{name}</span>,
+          name: (
+            <A
+              to={{
+                pageName: 'coverage',
+                options: { queryParams: { flags: [name] } },
+              }}
+              variant="black"
+            >
+              {name}
+            </A>
+          ),
           coverage: (
             <>
               <CoverageProgress

--- a/src/pages/RepoPage/FlagsTab/subroute/FlagsTable/FlagsTable.spec.jsx
+++ b/src/pages/RepoPage/FlagsTab/subroute/FlagsTable/FlagsTable.spec.jsx
@@ -258,7 +258,7 @@ describe('RepoContentsTable', () => {
     })
   })
 
-  describe.only('flag name is clicked', () => {
+  describe('flag name is clicked', () => {
     it('goes to coverage page', async () => {
       const { user } = setup()
 

--- a/src/services/navigation/useNavLinks/useNavLinks.js
+++ b/src/services/navigation/useNavLinks/useNavLinks.js
@@ -341,6 +341,25 @@ export function useNavLinks() {
       ) => `/${provider}/${owner}/${repo}`,
       text: 'Overview',
     },
+    coverage: {
+      path: (
+        { provider = p, owner = o, repo = r, queryParams = {} } = {
+          provider: p,
+          owner: o,
+          repo: r,
+          queryParams: {},
+        }
+      ) => {
+        let query = ''
+        if (queryParams && Object.keys(queryParams).length > 0) {
+          query = qs.stringify(queryParams, { addQueryPrefix: true })
+        }
+
+        return `/${provider}/${owner}/${repo}${query}`
+      },
+      text: 'Overview',
+      isExternalLink: false,
+    },
     flagsTab: {
       path: (
         { provider = p, owner = o, repo = r } = {

--- a/src/services/navigation/useNavLinks/useNavLinks.spec.js
+++ b/src/services/navigation/useNavLinks/useNavLinks.spec.js
@@ -538,6 +538,44 @@ describe('useNavLinks', () => {
     })
   })
 
+  describe('coverage link', () => {
+    it('returns the correct link with nothing passed', () => {
+      const { result } = renderHook(() => useNavLinks(), {
+        wrapper: wrapper('/gl/doggo/squirrel-locator/'),
+      })
+
+      const path = result.current.coverage.path()
+      expect(path).toBe('/gl/doggo/squirrel-locator')
+    })
+
+    it('can override the params', () => {
+      const { result } = renderHook(() => useNavLinks(), {
+        wrapper: wrapper('/gl/doggo/squirrel-locator'),
+      })
+
+      const path = result.current.coverage.path({
+        provider: 'bb',
+        owner: 'test-owner',
+        repo: 'test-repo',
+      })
+      expect(path).toBe('/bb/test-owner/test-repo')
+    })
+
+    it('passes flags into the url', () => {
+      const { result } = renderHook(() => useNavLinks(), {
+        wrapper: wrapper('/gl/doggo/squirrel-locator'),
+      })
+
+      const path = result.current.coverage.path({
+        provider: 'bb',
+        owner: 'test-owner',
+        repo: 'test-repo',
+        queryParams: { flags: ['myFlag'] },
+      })
+      expect(path).toBe('/bb/test-owner/test-repo?flags%5B0%5D=myFlag')
+    })
+  })
+
   describe('commits link', () => {
     it('returns the correct link with nothing passed', () => {
       const { result } = renderHook(() => useNavLinks(), {


### PR DESCRIPTION
# Description
This PR makes entries in the flags page link to their selected flag in the coverage page.

Closes https://github.com/codecov/engineering-team/issues/847

# Notable Changes
- Added new link for the coverage page that accepts query params
- Made flag names link to the coverage page

# Screenshots
[screen-capture (13).webm](https://github.com/codecov/gazebo/assets/82913673/fa745eca-48a8-4ed4-969e-72df34a6ea74)

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.