### PR TITLE
feat: Have upgrade to team plan links include URL search param

### DIFF
--- a/src/pages/PlanPage/subRoutes/CancelPlanPage/subRoutes/TeamPlanSpecialOffer/TeamPlanCard/TeamPlanCard.spec.tsx
+++ b/src/pages/PlanPage/subRoutes/CancelPlanPage/subRoutes/TeamPlanSpecialOffer/TeamPlanCard/TeamPlanCard.spec.tsx
@@ -177,7 +177,13 @@ describe('TeamPlanCard', () => {
       wrapper,
     })
 
-    const buttonText = await screen.findByText(/Change to Team plan/)
-    expect(buttonText).toBeInTheDocument()
+    const actionButton = await screen.findByRole('link', {
+      name: /Change to Team plan/,
+    })
+    expect(actionButton).toBeInTheDocument()
+    expect(actionButton).toHaveAttribute(
+      'href',
+      '/plan/bb/critical-role/upgrade?plan=team'
+    )
   })
 })

--- a/src/pages/PlanPage/subRoutes/CancelPlanPage/subRoutes/TeamPlanSpecialOffer/TeamPlanCard/TeamPlanCard.tsx
+++ b/src/pages/PlanPage/subRoutes/CancelPlanPage/subRoutes/TeamPlanSpecialOffer/TeamPlanCard/TeamPlanCard.tsx
@@ -1,6 +1,7 @@
 import { useParams } from 'react-router-dom'
 
 import { useAvailablePlans } from 'services/account'
+import { TierNames } from 'services/tier'
 import BenefitList from 'shared/plan/BenefitList'
 import { findTeamPlans } from 'shared/utils/billing'
 import Button from 'ui/Button'
@@ -43,7 +44,10 @@ const TeamPlanCard: React.FC = () => {
           </div>
           <div className="flex self-start">
             <Button
-              to={{ pageName: 'upgradeOrgPlan' }}
+              to={{
+                pageName: 'upgradeOrgPlan',
+                options: { params: { plan: TierNames.TEAM } },
+              }}
               variant="primary"
               disabled={undefined}
               hook="upgrade plan"

--- a/src/pages/PlanPage/subRoutes/CurrentOrgPlan/CurrentPlanCard/FreePlanCard/PlanUpgradeTeam/PlanUpgradeTeam.jsx
+++ b/src/pages/PlanPage/subRoutes/CurrentOrgPlan/CurrentPlanCard/FreePlanCard/PlanUpgradeTeam/PlanUpgradeTeam.jsx
@@ -1,6 +1,7 @@
 import { useParams } from 'react-router-dom'
 
 import { useAvailablePlans, usePlanData } from 'services/account'
+import { TierNames } from 'services/tier'
 import BenefitList from 'shared/plan/BenefitList'
 import { findTeamPlans, isFreePlan, isTrialPlan } from 'shared/utils/billing'
 import A from 'ui/A'
@@ -22,6 +23,11 @@ function PlanUpgradeTeam() {
   const monthlyMarketingName = teamPlanMonth?.marketingName
   const monthlyUnitPrice = teamPlanMonth?.baseUnitPrice
   const yearlyUnitPrice = teamPlanYear?.baseUnitPrice
+
+  let buttonText = 'Manage plan'
+  if (isFreePlan(currentPlan?.value) || isTrialPlan(currentPlan?.value)) {
+    buttonText = 'Upgrade to Team'
+  }
 
   return (
     <div className="flex flex-col gap-4">
@@ -52,11 +58,16 @@ function PlanUpgradeTeam() {
               </p>
             </div>
             <div className="flex self-start">
-              <Button to={{ pageName: 'upgradeOrgPlan' }} variant="primary">
-                {isFreePlan(currentPlan?.value) ||
-                isTrialPlan(currentPlan?.value)
-                  ? 'Upgrade to Team'
-                  : 'Manage plan'}
+              <Button
+                to={{
+                  pageName: 'upgradeOrgPlan',
+                  options: {
+                    params: { plan: TierNames.TEAM },
+                  },
+                }}
+                variant="primary"
+              >
+                {buttonText}
               </Button>
             </div>
           </div>

--- a/src/pages/PlanPage/subRoutes/CurrentOrgPlan/CurrentPlanCard/FreePlanCard/PlanUpgradeTeam/PlanUpgradeTeam.spec.jsx
+++ b/src/pages/PlanPage/subRoutes/CurrentOrgPlan/CurrentPlanCard/FreePlanCard/PlanUpgradeTeam/PlanUpgradeTeam.spec.jsx
@@ -261,8 +261,14 @@ describe('PlanUpgradeTeam', () => {
         wrapper,
       })
 
-      const buttonText = await screen.findByText(/Upgrade to Team/)
-      expect(buttonText).toBeInTheDocument()
+      const upgradeButton = await screen.findByRole('link', {
+        name: /Upgrade to Team/,
+      })
+      expect(upgradeButton).toBeInTheDocument()
+      expect(upgradeButton).toHaveAttribute(
+        'href',
+        '/plan/bb/critical-role/upgrade?plan=team'
+      )
     })
 
     it('shows upgrade to team when plan is trial', async () => {
@@ -271,8 +277,14 @@ describe('PlanUpgradeTeam', () => {
         wrapper,
       })
 
-      const buttonText = await screen.findByText(/Upgrade to Team/)
-      expect(buttonText).toBeInTheDocument()
+      const upgradeButton = await screen.findByRole('link', {
+        name: /Upgrade to Team/,
+      })
+      expect(upgradeButton).toBeInTheDocument()
+      expect(upgradeButton).toHaveAttribute(
+        'href',
+        '/plan/bb/critical-role/upgrade?plan=team'
+      )
     })
   })
 

--- a/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm2/PlanTypeOptions/PlanTypeOptions.spec.tsx
+++ b/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm2/PlanTypeOptions/PlanTypeOptions.spec.tsx
@@ -111,23 +111,28 @@ const queryClient = new QueryClient({
   defaultOptions: { queries: { suspense: true } },
 })
 
-const wrapper: React.FC<React.PropsWithChildren> = ({ children }) => (
-  <QueryClientProvider client={queryClient}>
-    <MemoryRouter initialEntries={['/gh/codecov']}>
-      <Route path="/:provider/:owner">
-        <Suspense fallback={null}>{children}</Suspense>
-      </Route>
-    </MemoryRouter>
-  </QueryClientProvider>
-)
+const wrapper =
+  (initialEntries = '/gh/codecov'): React.FC<React.PropsWithChildren> =>
+  ({ children }) =>
+    (
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter initialEntries={[initialEntries]}>
+          <Route path="/:provider/:owner">
+            <Suspense fallback={null}>{children}</Suspense>
+          </Route>
+        </MemoryRouter>
+      </QueryClientProvider>
+    )
 
 beforeAll(() => {
   server.listen()
 })
+
 afterEach(() => {
   queryClient.clear()
   server.resetHandlers()
 })
+
 afterAll(() => {
   server.close()
 })
@@ -234,7 +239,7 @@ describe('PlanTypeOptions', () => {
             setSelectedPlan={mockSetSelectedPlan}
           />,
           {
-            wrapper,
+            wrapper: wrapper(),
           }
         )
 
@@ -249,6 +254,39 @@ describe('PlanTypeOptions', () => {
         })
         expect(teamBtn).toBeInTheDocument()
         expect(teamBtn).not.toHaveClass('bg-ds-primary-base')
+      })
+
+      describe('plan param is set to team', () => {
+        it('renders Team button as "selected"', async () => {
+          const { mockSetFormValue, mockSetSelectedPlan } = setup({
+            planValue: Plans.USERS_BASIC,
+            hasSentryPlans: false,
+            hasTeamPlans: true,
+          })
+
+          render(
+            <PlanTypeOptions
+              multipleTiers={true}
+              setFormValue={mockSetFormValue}
+              setSelectedPlan={mockSetSelectedPlan}
+            />,
+            {
+              wrapper: wrapper('/gh/codecov?plan=team'),
+            }
+          )
+
+          const proBtn = await screen.findByRole('button', {
+            name: 'Pro',
+          })
+          expect(proBtn).toBeInTheDocument()
+          expect(proBtn).not.toHaveClass('bg-ds-primary-base')
+
+          const teamBtn = await screen.findByRole('button', {
+            name: 'Team',
+          })
+          expect(teamBtn).toBeInTheDocument()
+          expect(teamBtn).toHaveClass('bg-ds-primary-base')
+        })
       })
 
       describe('user clicks Team button', () => {
@@ -266,7 +304,7 @@ describe('PlanTypeOptions', () => {
               setSelectedPlan={mockSetSelectedPlan}
             />,
             {
-              wrapper,
+              wrapper: wrapper(),
             }
           )
 
@@ -303,7 +341,7 @@ describe('PlanTypeOptions', () => {
               setSelectedPlan={mockSetSelectedPlan}
             />,
             {
-              wrapper,
+              wrapper: wrapper(),
             }
           )
 
@@ -341,7 +379,7 @@ describe('PlanTypeOptions', () => {
             setSelectedPlan={mockSetSelectedPlan}
           />,
           {
-            wrapper,
+            wrapper: wrapper(),
           }
         )
 
@@ -356,6 +394,39 @@ describe('PlanTypeOptions', () => {
         })
         expect(teamBtn).toBeInTheDocument()
         expect(teamBtn).not.toHaveClass('bg-ds-primary-base')
+      })
+
+      describe('plan param is set to team', () => {
+        it('renders Team button as "selected"', async () => {
+          const { mockSetFormValue, mockSetSelectedPlan } = setup({
+            planValue: Plans.USERS_SENTRYY,
+            hasSentryPlans: true,
+            hasTeamPlans: true,
+          })
+
+          render(
+            <PlanTypeOptions
+              multipleTiers={true}
+              setFormValue={mockSetFormValue}
+              setSelectedPlan={mockSetSelectedPlan}
+            />,
+            {
+              wrapper: wrapper('/gh/codecov?plan=team'),
+            }
+          )
+
+          const proBtn = await screen.findByRole('button', {
+            name: 'Pro',
+          })
+          expect(proBtn).toBeInTheDocument()
+          expect(proBtn).not.toHaveClass('bg-ds-primary-base')
+
+          const teamBtn = await screen.findByRole('button', {
+            name: 'Team',
+          })
+          expect(teamBtn).toBeInTheDocument()
+          expect(teamBtn).toHaveClass('bg-ds-primary-base')
+        })
       })
 
       describe('user clicks Team button', () => {
@@ -373,7 +444,7 @@ describe('PlanTypeOptions', () => {
               setSelectedPlan={mockSetSelectedPlan}
             />,
             {
-              wrapper,
+              wrapper: wrapper(),
             }
           )
 
@@ -410,7 +481,7 @@ describe('PlanTypeOptions', () => {
               setSelectedPlan={mockSetSelectedPlan}
             />,
             {
-              wrapper,
+              wrapper: wrapper(),
             }
           )
 
@@ -448,7 +519,7 @@ describe('PlanTypeOptions', () => {
             setSelectedPlan={mockSetSelectedPlan}
           />,
           {
-            wrapper,
+            wrapper: wrapper(),
           }
         )
 
@@ -463,6 +534,39 @@ describe('PlanTypeOptions', () => {
         })
         expect(teamBtn).toBeInTheDocument()
         expect(teamBtn).not.toHaveClass('bg-ds-primary-base')
+      })
+
+      describe('plan param is set to team', () => {
+        it('renders Team button as "selected"', async () => {
+          const { mockSetFormValue, mockSetSelectedPlan } = setup({
+            planValue: Plans.USERS_TEAMY,
+            hasSentryPlans: true,
+            hasTeamPlans: true,
+          })
+
+          render(
+            <PlanTypeOptions
+              multipleTiers={true}
+              setFormValue={mockSetFormValue}
+              setSelectedPlan={mockSetSelectedPlan}
+            />,
+            {
+              wrapper: wrapper('/gh/codecov?plan=team'),
+            }
+          )
+
+          const proBtn = await screen.findByRole('button', {
+            name: 'Pro',
+          })
+          expect(proBtn).toBeInTheDocument()
+          expect(proBtn).not.toHaveClass('bg-ds-primary-base')
+
+          const teamBtn = await screen.findByRole('button', {
+            name: 'Team',
+          })
+          expect(teamBtn).toBeInTheDocument()
+          expect(teamBtn).toHaveClass('bg-ds-primary-base')
+        })
       })
 
       describe('user clicks Team button', () => {
@@ -480,7 +584,7 @@ describe('PlanTypeOptions', () => {
               setSelectedPlan={mockSetSelectedPlan}
             />,
             {
-              wrapper,
+              wrapper: wrapper(),
             }
           )
 
@@ -517,7 +621,7 @@ describe('PlanTypeOptions', () => {
               setSelectedPlan={mockSetSelectedPlan}
             />,
             {
-              wrapper,
+              wrapper: wrapper(),
             }
           )
 
@@ -555,7 +659,7 @@ describe('PlanTypeOptions', () => {
             setSelectedPlan={mockSetSelectedPlan}
           />,
           {
-            wrapper,
+            wrapper: wrapper(),
           }
         )
 
@@ -589,7 +693,7 @@ describe('PlanTypeOptions', () => {
             setSelectedPlan={mockSetSelectedPlan}
           />,
           {
-            wrapper,
+            wrapper: wrapper(),
           }
         )
 
@@ -604,6 +708,39 @@ describe('PlanTypeOptions', () => {
         })
         expect(teamBtn).toBeInTheDocument()
         expect(teamBtn).not.toHaveClass('bg-ds-primary-base')
+      })
+
+      describe('plan param is set to team', () => {
+        it('renders Team button as "selected"', async () => {
+          const { mockSetFormValue, mockSetSelectedPlan } = setup({
+            planValue: Plans.USERS_TRIAL,
+            hasSentryPlans: true,
+            hasTeamPlans: true,
+          })
+
+          render(
+            <PlanTypeOptions
+              multipleTiers={true}
+              setFormValue={mockSetFormValue}
+              setSelectedPlan={mockSetSelectedPlan}
+            />,
+            {
+              wrapper: wrapper('/gh/codecov?plan=team'),
+            }
+          )
+
+          const proBtn = await screen.findByRole('button', {
+            name: 'Pro',
+          })
+          expect(proBtn).toBeInTheDocument()
+          expect(proBtn).not.toHaveClass('bg-ds-primary-base')
+
+          const teamBtn = await screen.findByRole('button', {
+            name: 'Team',
+          })
+          expect(teamBtn).toBeInTheDocument()
+          expect(teamBtn).toHaveClass('bg-ds-primary-base')
+        })
       })
 
       describe('user clicks Team button', () => {
@@ -621,7 +758,7 @@ describe('PlanTypeOptions', () => {
               setSelectedPlan={mockSetSelectedPlan}
             />,
             {
-              wrapper,
+              wrapper: wrapper(),
             }
           )
 
@@ -658,7 +795,7 @@ describe('PlanTypeOptions', () => {
               setSelectedPlan={mockSetSelectedPlan}
             />,
             {
-              wrapper,
+              wrapper: wrapper(),
             }
           )
 
@@ -698,7 +835,7 @@ describe('PlanTypeOptions', () => {
             setSelectedPlan={mockSetSelectedPlan}
           />,
           {
-            wrapper,
+            wrapper: wrapper(),
           }
         )
 
@@ -713,6 +850,39 @@ describe('PlanTypeOptions', () => {
         })
         expect(teamBtn).toBeInTheDocument()
         expect(teamBtn).not.toHaveClass('bg-ds-primary-base')
+      })
+
+      describe('plan param is set to team', () => {
+        it('renders Team button as "selected"', async () => {
+          const { mockSetFormValue, mockSetSelectedPlan } = setup({
+            planValue: Plans.USERS_BASIC,
+            hasSentryPlans: false,
+            hasTeamPlans: true,
+          })
+
+          render(
+            <PlanTypeOptions
+              multipleTiers={true}
+              setFormValue={mockSetFormValue}
+              setSelectedPlan={mockSetSelectedPlan}
+            />,
+            {
+              wrapper: wrapper('/gh/codecov?plan=team'),
+            }
+          )
+
+          const proBtn = await screen.findByRole('button', {
+            name: 'Pro',
+          })
+          expect(proBtn).toBeInTheDocument()
+          expect(proBtn).not.toHaveClass('bg-ds-primary-base')
+
+          const teamBtn = await screen.findByRole('button', {
+            name: 'Team',
+          })
+          expect(teamBtn).toBeInTheDocument()
+          expect(teamBtn).toHaveClass('bg-ds-primary-base')
+        })
       })
 
       describe('user clicks Team button', () => {
@@ -730,7 +900,7 @@ describe('PlanTypeOptions', () => {
               setSelectedPlan={mockSetSelectedPlan}
             />,
             {
-              wrapper,
+              wrapper: wrapper(),
             }
           )
 
@@ -767,7 +937,7 @@ describe('PlanTypeOptions', () => {
               setSelectedPlan={mockSetSelectedPlan}
             />,
             {
-              wrapper,
+              wrapper: wrapper(),
             }
           )
 
@@ -805,7 +975,7 @@ describe('PlanTypeOptions', () => {
             setSelectedPlan={mockSetSelectedPlan}
           />,
           {
-            wrapper,
+            wrapper: wrapper(),
           }
         )
 
@@ -820,6 +990,39 @@ describe('PlanTypeOptions', () => {
         })
         expect(teamBtn).toBeInTheDocument()
         expect(teamBtn).not.toHaveClass('bg-ds-primary-base')
+      })
+
+      describe('plan param is set to team', () => {
+        it('renders Team button as "selected"', async () => {
+          const { mockSetFormValue, mockSetSelectedPlan } = setup({
+            planValue: Plans.USERS_PR_INAPPY,
+            hasSentryPlans: false,
+            hasTeamPlans: true,
+          })
+
+          render(
+            <PlanTypeOptions
+              multipleTiers={true}
+              setFormValue={mockSetFormValue}
+              setSelectedPlan={mockSetSelectedPlan}
+            />,
+            {
+              wrapper: wrapper('/gh/codecov?plan=team'),
+            }
+          )
+
+          const proBtn = await screen.findByRole('button', {
+            name: 'Pro',
+          })
+          expect(proBtn).toBeInTheDocument()
+          expect(proBtn).not.toHaveClass('bg-ds-primary-base')
+
+          const teamBtn = await screen.findByRole('button', {
+            name: 'Team',
+          })
+          expect(teamBtn).toBeInTheDocument()
+          expect(teamBtn).toHaveClass('bg-ds-primary-base')
+        })
       })
 
       describe('user clicks Team button', () => {
@@ -837,7 +1040,7 @@ describe('PlanTypeOptions', () => {
               setSelectedPlan={mockSetSelectedPlan}
             />,
             {
-              wrapper,
+              wrapper: wrapper(),
             }
           )
 
@@ -874,7 +1077,7 @@ describe('PlanTypeOptions', () => {
               setSelectedPlan={mockSetSelectedPlan}
             />,
             {
-              wrapper,
+              wrapper: wrapper(),
             }
           )
 
@@ -912,7 +1115,7 @@ describe('PlanTypeOptions', () => {
             setSelectedPlan={mockSetSelectedPlan}
           />,
           {
-            wrapper,
+            wrapper: wrapper(),
           }
         )
 
@@ -927,6 +1130,39 @@ describe('PlanTypeOptions', () => {
         })
         expect(teamBtn).toBeInTheDocument()
         expect(teamBtn).not.toHaveClass('bg-ds-primary-base')
+      })
+
+      describe('plan param is set to team', () => {
+        it('renders Team button as "selected"', async () => {
+          const { mockSetFormValue, mockSetSelectedPlan } = setup({
+            planValue: Plans.USERS_TEAMY,
+            hasSentryPlans: false,
+            hasTeamPlans: true,
+          })
+
+          render(
+            <PlanTypeOptions
+              multipleTiers={true}
+              setFormValue={mockSetFormValue}
+              setSelectedPlan={mockSetSelectedPlan}
+            />,
+            {
+              wrapper: wrapper('/gh/codecov?plan=team'),
+            }
+          )
+
+          const proBtn = await screen.findByRole('button', {
+            name: 'Pro',
+          })
+          expect(proBtn).toBeInTheDocument()
+          expect(proBtn).not.toHaveClass('bg-ds-primary-base')
+
+          const teamBtn = await screen.findByRole('button', {
+            name: 'Team',
+          })
+          expect(teamBtn).toBeInTheDocument()
+          expect(teamBtn).toHaveClass('bg-ds-primary-base')
+        })
       })
 
       describe('user clicks Team button', () => {
@@ -944,7 +1180,7 @@ describe('PlanTypeOptions', () => {
               setSelectedPlan={mockSetSelectedPlan}
             />,
             {
-              wrapper,
+              wrapper: wrapper(),
             }
           )
 
@@ -981,7 +1217,7 @@ describe('PlanTypeOptions', () => {
               setSelectedPlan={mockSetSelectedPlan}
             />,
             {
-              wrapper,
+              wrapper: wrapper(),
             }
           )
 
@@ -1019,7 +1255,7 @@ describe('PlanTypeOptions', () => {
             setSelectedPlan={mockSetSelectedPlan}
           />,
           {
-            wrapper,
+            wrapper: wrapper(),
           }
         )
 
@@ -1034,6 +1270,39 @@ describe('PlanTypeOptions', () => {
         })
         expect(teamBtn).toBeInTheDocument()
         expect(teamBtn).not.toHaveClass('bg-ds-primary-base')
+      })
+
+      describe('plan param is set to team', () => {
+        it('renders Team button as "selected"', async () => {
+          const { mockSetFormValue, mockSetSelectedPlan } = setup({
+            planValue: Plans.USERS_TRIAL,
+            hasSentryPlans: false,
+            hasTeamPlans: true,
+          })
+
+          render(
+            <PlanTypeOptions
+              multipleTiers={true}
+              setFormValue={mockSetFormValue}
+              setSelectedPlan={mockSetSelectedPlan}
+            />,
+            {
+              wrapper: wrapper('/gh/codecov?plan=team'),
+            }
+          )
+
+          const proBtn = await screen.findByRole('button', {
+            name: 'Pro',
+          })
+          expect(proBtn).toBeInTheDocument()
+          expect(proBtn).not.toHaveClass('bg-ds-primary-base')
+
+          const teamBtn = await screen.findByRole('button', {
+            name: 'Team',
+          })
+          expect(teamBtn).toBeInTheDocument()
+          expect(teamBtn).toHaveClass('bg-ds-primary-base')
+        })
       })
 
       describe('user clicks Team button', () => {
@@ -1051,7 +1320,7 @@ describe('PlanTypeOptions', () => {
               setSelectedPlan={mockSetSelectedPlan}
             />,
             {
-              wrapper,
+              wrapper: wrapper(),
             }
           )
 
@@ -1088,7 +1357,7 @@ describe('PlanTypeOptions', () => {
               setSelectedPlan={mockSetSelectedPlan}
             />,
             {
-              wrapper,
+              wrapper: wrapper(),
             }
           )
 

--- a/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm2/PlanTypeOptions/PlanTypeOptions.tsx
+++ b/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm2/PlanTypeOptions/PlanTypeOptions.tsx
@@ -7,6 +7,7 @@ import {
   useAccountDetails,
   useAvailablePlans,
 } from 'services/account'
+import { TierNames } from 'services/tier'
 import {
   canApplySentryUpgrade,
   findSentryPlans,
@@ -18,6 +19,7 @@ import { TEAM_PLAN_MAX_ACTIVE_USERS } from 'shared/utils/upgradeForm'
 import OptionButton from 'ui/OptionButton'
 
 import { PlanTiers, TierName } from '../constants'
+import { usePlanParams } from '../hooks/usePlanParams'
 
 interface PlanTypeOptionsProps {
   multipleTiers: boolean
@@ -34,17 +36,26 @@ const PlanTypeOptions: React.FC<PlanTypeOptionsProps> = ({
   const { data: plans } = useAvailablePlans({ provider, owner })
   const { data: accountDetails } = useAccountDetails({ provider, owner })
   const { proPlanYear } = useProPlans({ plans })
+  const planParam = usePlanParams()
 
   const { sentryPlanYear } = findSentryPlans({ plans })
   const { teamPlanYear } = findTeamPlans({
     plans,
   })
+
   const hasTeamPlans = shouldDisplayTeamCard({ plans })
   const plan = accountDetails?.rootOrganization?.plan ?? accountDetails?.plan
   const isSentryUpgrade = canApplySentryUpgrade({ plan, plans })
   const yearlyProPlan = isSentryUpgrade ? sentryPlanYear : proPlanYear
 
-  const [option, setOption] = useState<PlanTiers>(TierName.PRO)
+  let planOption = null
+  if (hasTeamPlans && planParam === TierNames.TEAM) {
+    planOption = TierName.TEAM
+  } else {
+    planOption = TierName.PRO
+  }
+
+  const [option, setOption] = useState<PlanTiers>(planOption)
 
   if (hasTeamPlans && multipleTiers) {
     return (

--- a/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm2/hooks/usePlanParams.spec.tsx
+++ b/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm2/hooks/usePlanParams.spec.tsx
@@ -1,0 +1,48 @@
+import { renderHook } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+
+import { usePlanParams } from './usePlanParams'
+
+describe('usePlanParams', () => {
+  describe('there is a plan search param', () => {
+    it('returns the plan value', () => {
+      const { result } = renderHook(() => usePlanParams(), {
+        wrapper: ({ children }) => (
+          <MemoryRouter initialEntries={['/test?plan=team']}>
+            {children}
+          </MemoryRouter>
+        ),
+      })
+
+      expect(result.current).toEqual('team')
+    })
+  })
+
+  describe('there is no plan search param', () => {
+    describe('there are other search params', () => {
+      it('returns null', () => {
+        const { result } = renderHook(() => usePlanParams(), {
+          wrapper: ({ children }) => (
+            <MemoryRouter initialEntries={['/test?test=params']}>
+              {children}
+            </MemoryRouter>
+          ),
+        })
+
+        expect(result.current).toBeNull()
+      })
+    })
+
+    describe('there are no search params', () => {
+      it('returns null', () => {
+        const { result } = renderHook(() => usePlanParams(), {
+          wrapper: ({ children }) => (
+            <MemoryRouter initialEntries={['/test']}>{children}</MemoryRouter>
+          ),
+        })
+
+        expect(result.current).toBeNull()
+      })
+    })
+  })
+})

--- a/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm2/hooks/usePlanParams.ts
+++ b/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm2/hooks/usePlanParams.ts
@@ -1,0 +1,14 @@
+import qs from 'qs'
+import { useLocation } from 'react-router-dom'
+
+export const usePlanParams = () => {
+  const location = useLocation()
+
+  const params = qs.parse(location.search, { ignoreQueryPrefix: true })
+
+  if ('plan' in params && typeof params.plan === 'string') {
+    return params.plan
+  }
+
+  return null
+}

--- a/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradePlanPage.jsx
+++ b/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradePlanPage.jsx
@@ -2,16 +2,20 @@ import { useLayoutEffect, useState } from 'react'
 import { Redirect, useParams } from 'react-router-dom'
 
 import { useAccountDetails, useAvailablePlans } from 'services/account'
+import { TierNames } from 'services/tier'
 import {
   canApplySentryUpgrade,
   findSentryPlans,
+  findTeamPlans,
   isEnterprisePlan,
   isFreePlan,
+  shouldDisplayTeamCard,
   useProPlans,
 } from 'shared/utils/billing'
 
 import UpgradeDetails from './UpgradeDetails'
 import UpgradeForm2 from './UpgradeForm2'
+import { usePlanParams } from './UpgradeForm2/hooks/usePlanParams'
 
 import { useSetCrumbs } from '../../context'
 
@@ -20,13 +24,26 @@ function UpgradePlanPage() {
   const setCrumbs = useSetCrumbs()
   const { data: accountDetails } = useAccountDetails({ provider, owner })
   const { data: plans } = useAvailablePlans({ provider, owner })
+  const planParam = usePlanParams()
+
   const { proPlanYear } = useProPlans({ plans })
   const { sentryPlanYear } = findSentryPlans({ plans })
+  const { teamPlanYear } = findTeamPlans({ plans })
+  const hasTeamPlans = shouldDisplayTeamCard({ plans })
 
   const plan = accountDetails?.rootOrganization?.plan ?? accountDetails?.plan
 
   const isSentryUpgrade = canApplySentryUpgrade({ plan, plans })
-  const defaultPaidYearlyPlan = isSentryUpgrade ? sentryPlanYear : proPlanYear
+
+  let defaultPaidYearlyPlan = null
+  if (hasTeamPlans && planParam === TierNames.TEAM) {
+    defaultPaidYearlyPlan = teamPlanYear
+  } else if (isSentryUpgrade) {
+    defaultPaidYearlyPlan = sentryPlanYear
+  } else {
+    defaultPaidYearlyPlan = proPlanYear
+  }
+
   const [selectedPlan, setSelectedPlan] = useState(defaultPaidYearlyPlan)
 
   useLayoutEffect(() => {

--- a/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradePlanPage.spec.jsx
+++ b/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradePlanPage.spec.jsx
@@ -114,6 +114,24 @@ const sentryPlanYear = {
   trialDays: 14,
 }
 
+const teamPlanMonth = {
+  baseUnitPrice: 6,
+  benefits: ['Up to 10 users'],
+  billingRate: 'monthly',
+  marketingName: 'Users Team',
+  monthlyUploadLimit: 2500,
+  value: 'users-teamm',
+}
+
+const teamPlanYear = {
+  baseUnitPrice: 5,
+  benefits: ['Up to 10 users'],
+  billingRate: 'annually',
+  marketingName: 'Users Team',
+  monthlyUploadLimit: 2500,
+  value: 'users-teamy',
+}
+
 const mockPlanData = {
   baseUnitPrice: 10,
   benefits: [],
@@ -175,10 +193,12 @@ describe('UpgradePlanPage', () => {
       planValue = Plans.USERS_INAPPY,
       periodEnd = undefined,
       includeSentryPlans = false,
+      includeTeamPlans = false,
     } = {
       planValue: Plans.USERS_INAPPY,
       periodEnd: undefined,
       includeSentryPlans: false,
+      includeTeamPlans: false,
     }
   ) {
     server.use(
@@ -200,6 +220,13 @@ describe('UpgradePlanPage', () => {
             ctx.status(200),
             ctx.data({
               owner: { availablePlans: [sentryPlanMonth, sentryPlanYear] },
+            })
+          )
+        } else if (includeTeamPlans) {
+          return res(
+            ctx.status(200),
+            ctx.data({
+              owner: { availablePlans: [teamPlanMonth, teamPlanYear] },
             })
           )
         } else {
@@ -306,6 +333,43 @@ describe('UpgradePlanPage', () => {
 
       const banner = screen.queryByText(/You are choosing to upgrade/)
       expect(banner).not.toBeInTheDocument()
+    })
+
+    describe('when rendered with a team plan search param', () => {
+      it('renders the team plan title', async () => {
+        setup({ planValue: Plans.USERS_BASIC, includeTeamPlans: true })
+        render(<UpgradePlanPage />, {
+          wrapper: wrapper('/plan/gh/codecov/upgrade?plan=team'),
+        })
+
+        const teamTitle = await screen.findByText(/Team plan/)
+        expect(teamTitle).toBeInTheDocument()
+      })
+
+      it('renders the team plan price', async () => {
+        setup({ planValue: Plans.USERS_BASIC, includeTeamPlans: true })
+        render(<UpgradePlanPage />, {
+          wrapper: wrapper('/plan/gh/codecov/upgrade?plan=team'),
+        })
+
+        const teamPlanPrice = await screen.findByText(/\$5/)
+        expect(teamPlanPrice).toBeInTheDocument()
+
+        const teamPlanPricingScheme = await screen.findByText(
+          /\/per user, per month/
+        )
+        expect(teamPlanPricingScheme).toBeInTheDocument()
+      })
+
+      it('renders the team plan benefits', async () => {
+        setup({ planValue: Plans.USERS_BASIC, includeTeamPlans: true })
+        render(<UpgradePlanPage />, {
+          wrapper: wrapper('/plan/gh/codecov/upgrade?plan=team'),
+        })
+
+        const userCount = await screen.findByText(/Up to 10 users/)
+        expect(userCount).toBeInTheDocument()
+      })
     })
   })
 

--- a/src/services/navigation/useNavLinks/useNavLinks.js
+++ b/src/services/navigation/useNavLinks/useNavLinks.js
@@ -98,7 +98,7 @@ export function useNavLinks() {
       path: (
         { provider = p, owner = o, params = null } = { provider: p, owner: o }
       ) => {
-        if (qs !== null) {
+        if (params !== null) {
           const queryString = qs.stringify(params, {
             addQueryPrefix: true,
           })

--- a/src/services/navigation/useNavLinks/useNavLinks.js
+++ b/src/services/navigation/useNavLinks/useNavLinks.js
@@ -95,8 +95,19 @@ export function useNavLinks() {
     },
     upgradeOrgPlan: {
       text: 'Upgrade Plan',
-      path: ({ provider = p, owner = o } = { provider: p, owner: o }) =>
-        `/plan/${provider}/${owner}/upgrade`,
+      path: (
+        { provider = p, owner = o, params = null } = { provider: p, owner: o }
+      ) => {
+        if (qs !== null) {
+          const queryString = qs.stringify(params, {
+            addQueryPrefix: true,
+          })
+
+          return `/plan/${provider}/${owner}/upgrade${queryString}`
+        }
+
+        return `/plan/${provider}/${owner}/upgrade`
+      },
       isExternalLink: false,
     },
     cancelOrgPlan: {

--- a/src/services/navigation/useNavLinks/useNavLinks.spec.js
+++ b/src/services/navigation/useNavLinks/useNavLinks.spec.js
@@ -262,6 +262,19 @@ describe('useNavLinks', () => {
       })
       expect(path).toBe('/plan/bb/test-owner/upgrade')
     })
+
+    describe('user passes params object', () => {
+      it('gets appended to the url as search params', () => {
+        const { result } = renderHook(() => useNavLinks(), {
+          wrapper: wrapper('/gl/doggo/squirrel-locator'),
+        })
+
+        const path = result.current.upgradeOrgPlan.path({
+          params: { search: 'params' },
+        })
+        expect(path).toBe('/plan/gl/doggo/upgrade?search=params')
+      })
+    })
   })
 
   describe('Cancel Plan', () => {


### PR DESCRIPTION
# Description

This PR updates a couple different pieces regarding the team plan, by adding in a URL search param when linking to the upgrade page so that the page will default to showing the team plan.

Closes: codecov/engineering-team#706

# Notable Changes

- Update `useNavLinks -> upgradeOrgPlan` to support query params being appended to URL
- Create new `usePlanParams` hook to grab `plan` search param from the URL
-  Update relevant cards to append `?plan=team` to upgrade link
- Update `PlanTypeOptions` and `UpgradePlanPage` to grab plan param and set value to team plan if they have access to the team plan.