### PR TITLE
fix: Update installation nav link to use config value

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -7,6 +7,7 @@ const defaultConfig = {
   SENTRY_TRACING_SAMPLE_RATE: 0.2,
   SENTRY_SESSION_SAMPLE_RATE: 0.1,
   SENTRY_ERROR_SAMPLE_RATE: 0.9,
+  GH_APP: 'codecov',
 }
 
 export function removeReactAppPrefix(obj) {

--- a/src/services/navigation/useNavLinks/useStaticNavLinks.js
+++ b/src/services/navigation/useNavLinks/useStaticNavLinks.js
@@ -68,7 +68,7 @@ export function useStaticNavLinks() {
     },
     codecovAppInstallation: {
       text: 'Install Codecov app for an org',
-      path: () => 'https://github.com/apps/codecov/installations/new',
+      path: () => `https://github.com/apps/${config.GH_APP}/installations/new`,
       isExternalLink: true,
       openNewTab: true,
     },

--- a/src/services/navigation/useNavLinks/useStaticNavLinks.spec.js
+++ b/src/services/navigation/useNavLinks/useStaticNavLinks.spec.js
@@ -40,7 +40,7 @@ describe('useStaticNavLinks', () => {
       ${links.components}                    | ${'https://docs.codecov.com/docs/components'}
       ${links.unexpectedChanges}             | ${'https://docs.codecov.com/docs/unexpected-coverage-changes'}
       ${links.userAppManagePage}             | ${'https://github.com/settings/connections/applications/c68c81cbfd179a50784a'}
-      ${links.codecovAppInstallation}        | ${'https://github.com/apps/codecov/installations/new'}
+      ${links.codecovAppInstallation}        | ${`https://github.com/apps/${config.GH_APP}/installations/new`}
       ${links.deployingFlagsSupport}         | ${'https://docs.codecov.com/docs/implementing-flags-with-timescaledb'}
       ${links.blog}                          | ${`${config.MARKETING_BASE_URL}/blog`}
       ${links.sales}                         | ${`${config.MARKETING_BASE_URL}/sales`}


### PR DESCRIPTION
# Description
Change the [nav links](https://github.com/codecov/gazebo/blob/2751fa45ddd1ef7af7c71745cad21a61e1c70c37/src/services/navigation/useNavLinks/useStaticNavLinks.js#L69-L74) on the [context switcher](https://github.com/codecov/gazebo/blob/2751fa45ddd1ef7af7c71745cad21a61e1c70c37/src/ui/ContextSwitcher/ContextSwitcher.jsx#L154) https://github.com/apps/codecov/installations/new to use a config value for codecov (config.GH_APP). The value codecov is incorrect on self hosted + dedicated namespace.

We want to [default](https://github.com/codecov/gazebo/blob/main/src/config.js#L3-L10) GH_APP value to codecov to ensure no issues by default.

# Notable Changes
- Use config value in app installation static link 
- Fix test

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.