### PR TITLE
fix: Update onboarding docs with global token

### DIFF
--- a/src/pages/RepoPage/NewRepoTab/GitHubActions/GitHubActions.spec.tsx
+++ b/src/pages/RepoPage/NewRepoTab/GitHubActions/GitHubActions.spec.tsx
@@ -18,6 +18,7 @@ const mockCurrentUser = {
 const mockGetRepo = {
   owner: {
     isCurrentUserPartOfOrg: true,
+    orgUploadToken: '9e6a6189-20f1-482d-ab62-ecfaa2629290',
     repository: {
       private: false,
       uploadToken: '9e6a6189-20f1-482d-ab62-ecfaa2629295',
@@ -39,7 +40,7 @@ const queryClient = new QueryClient({
 })
 const server = setupServer()
 
-const wrapper = ({ children }) => (
+const wrapper: React.FC<React.PropsWithChildren> = ({ children }) => (
   <QueryClientProvider client={queryClient}>
     <MemoryRouter initialEntries={['/gh/codecov/cool-repo/new']}>
       <Route
@@ -111,7 +112,7 @@ describe('GitHubActions', () => {
       expect(codecovToken).toBeInTheDocument()
 
       const tokenValue = await screen.findByText(
-        /9e6a6189-20f1-482d-ab62-ecfaa2629295/
+        /9e6a6189-20f1-482d-ab62-ecfaa2629290/
       )
       expect(tokenValue).toBeInTheDocument()
     })

--- a/src/pages/RepoPage/NewRepoTab/GitHubActions/GitHubActions.tsx
+++ b/src/pages/RepoPage/NewRepoTab/GitHubActions/GitHubActions.tsx
@@ -20,7 +20,7 @@ interface URLParams {
 function GitHubActions() {
   const { provider, owner, repo } = useParams<URLParams>()
   const { data } = useRepo({ provider, owner, repo })
-  const orgUploadToken = data?.orgUploadToken ?? 'Not found'
+  const orgUploadToken = data?.orgUploadToken
 
   return (
     <div className="flex flex-col gap-6">

--- a/src/pages/RepoPage/NewRepoTab/GitHubActions/GitHubActions.tsx
+++ b/src/pages/RepoPage/NewRepoTab/GitHubActions/GitHubActions.tsx
@@ -6,22 +6,33 @@ import A from 'ui/A'
 import CopyClipboard from 'ui/CopyClipboard'
 
 const codecovActionString = `- name: Upload coverage reports to Codecov
-  uses: codecov/codecov-action@v3
+  uses: codecov/codecov-action@v4
   env:
     CODECOV_TOKEN: \${{ secrets.CODECOV_TOKEN }}
 `
 
+interface URLParams {
+  provider: string
+  owner: string
+  repo: string
+}
+
 function GitHubActions() {
-  const { provider, owner, repo } = useParams()
+  const { provider, owner, repo } = useParams<URLParams>()
   const { data } = useRepo({ provider, owner, repo })
+  const orgUploadToken = data?.orgUploadToken ?? 'Not found'
 
   return (
     <div className="flex flex-col gap-6">
       <div className="flex flex-col gap-4">
         <div>
           <h2 className="text-base font-semibold">
-            Step 1: add repository token as{' '}
-            <A to={{ pageName: 'githubRepoSecrets' }} isExternal>
+            Step 1: add global token as{' '}
+            <A
+              to={{ pageName: 'githubRepoSecrets' }}
+              isExternal
+              hook="GitHub-repo-secrects-link"
+            >
               repository secret
             </A>
           </h2>
@@ -31,8 +42,8 @@ function GitHubActions() {
           </p>
         </div>
         <pre className="flex items-center gap-2 overflow-auto rounded-md border-2 border-ds-gray-secondary bg-ds-gray-primary px-4 py-2 font-mono">
-          CODECOV_TOKEN={data?.repository?.uploadToken}
-          <CopyClipboard string={data?.repository?.uploadToken} />
+          CODECOV_TOKEN={orgUploadToken}
+          <CopyClipboard string={orgUploadToken} />
         </pre>
       </div>
       <div className="flex flex-col gap-4">
@@ -45,7 +56,10 @@ function GitHubActions() {
               }}
               options={{ branch: data?.repository?.defaultBranch }}
               isExternal
-            />
+              hook="GitHub-repo-actions-link"
+            >
+              GitHub Actions workflow yaml file
+            </A>
           </h2>
           <p>
             After tests run, this will upload your coverage report to Codecov:
@@ -64,7 +78,7 @@ function GitHubActions() {
         </p>
         <img
           alt="codecov patch and project"
-          src={patchAndProject}
+          src={patchAndProject.toString()}
           className="my-3 md:px-5"
           loading="lazy"
         />
@@ -76,7 +90,11 @@ function GitHubActions() {
         <p className="mt-6 border-l-2 border-ds-gray-secondary pl-4">
           <span className="font-semibold">How was your setup experience?</span>{' '}
           Let us know in{' '}
-          <A to={{ pageName: 'repoConfigFeedback' }} isExternal>
+          <A
+            to={{ pageName: 'repoConfigFeedback' }}
+            isExternal
+            hook="repo-config-feedback"
+          >
             this issue
           </A>
         </p>

--- a/src/services/repo/useRepo.js
+++ b/src/services/repo/useRepo.js
@@ -9,6 +9,7 @@ function fetchRepoDetails({ provider, owner, repo, signal }) {
         isAdmin
         isCurrentUserPartOfOrg
         isCurrentUserActivated
+        orgUploadToken
         repository: repositoryDeprecated(name:$repo){
           private
           uploadToken
@@ -36,6 +37,7 @@ function fetchRepoDetails({ provider, owner, repo, signal }) {
       repository: res?.data?.owner?.repository,
       isCurrentUserPartOfOrg: res?.data?.owner?.isCurrentUserPartOfOrg,
       isCurrentUserActivated: res?.data?.owner?.isCurrentUserActivated,
+      orgUploadToken: res?.data?.owner?.orgUploadToken,
     }
   })
 }


### PR DESCRIPTION
# Description
Fix onboarding docs to reflect the use of the global token.

# Notable Changes
- Update GitHub actions with global token 
- Update tests 
- Refactor to typescript 

# Screenshots
<img width="1489" alt="Screenshot 2023-12-27 at 12 54 03 PM" src="https://github.com/codecov/gazebo/assets/91732700/6d2ba0e4-e626-4213-a2d4-abff05203d19">

closes: https://github.com/codecov/engineering-team/issues/940

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.