### PR TITLE
fix: Update TabNav styles to fix hiding tabs

### DIFF
--- a/src/pages/CommitDetailPage/CommitDetailPageContent/CommitDetailPageContent.jsx
+++ b/src/pages/CommitDetailPage/CommitDetailPageContent/CommitDetailPageContent.jsx
@@ -58,7 +58,7 @@ function CommitDetailPageContent() {
     commitData?.commit?.compareWithParent?.directChangedFilesCount ?? 0
 
   return (
-    <>
+    <div className="@container/commit-detail-page">
       <CommitPageTabs
         commitSha={commitSha}
         indirectChangedFilesCount={indirectChangedFilesCount}
@@ -94,7 +94,7 @@ function CommitDetailPageContent() {
           />
         </Switch>
       </Suspense>
-    </>
+    </div>
   )
 }
 

--- a/src/ui/TabNavigation/TabNavigation.jsx
+++ b/src/ui/TabNavigation/TabNavigation.jsx
@@ -1,3 +1,4 @@
+import cs from 'classnames'
 import PropTypes from 'prop-types'
 
 import AppLink from 'shared/AppLink'
@@ -6,24 +7,29 @@ const styles = {
   link: 'mr-5 py-2 hover:border-b-4 hover:border-ds-gray-quinary text-ds-gray-quinary whitespace-nowrap',
   activeLink:
     '!text-ds-gray-octonary border-b-4 !border-ds-gray-octonary font-semibold',
+  commitDetailPageResponsive:
+    '@md/commit-detail-page:!flex-col-reverse @4xl/commit-detail-page:!flex-row',
 }
 
 function TabNavigation({ tabs, component }) {
   return (
-    <div className="@container/tabNav">
-      <div className="mx-0 flex flex-col-reverse justify-between gap-2 border-b border-ds-gray-tertiary  @md/tabNav:flex-col @4xl/tabNav:flex-row">
-        <nav className="flex overflow-auto">
-          {tabs.map((tab) => (
-            <AppLink
-              {...tab}
-              className={styles.link}
-              activeClassName={styles.activeLink}
-              key={tab.pageName}
-            />
-          ))}
-        </nav>
-        {component || null}
-      </div>
+    <div
+      className={cs(
+        'mx-0 flex flex-col-reverse justify-between gap-2 border-b border-ds-gray-tertiary md:flex-col xl:flex-row',
+        styles.commitDetailPageResponsive
+      )}
+    >
+      <nav className="flex overflow-auto">
+        {tabs.map((tab) => (
+          <AppLink
+            {...tab}
+            className={styles.link}
+            activeClassName={styles.activeLink}
+            key={tab.pageName}
+          />
+        ))}
+      </nav>
+      {component || null}
     </div>
   )
 }

--- a/src/ui/TabNavigation/TabNavigation.jsx
+++ b/src/ui/TabNavigation/TabNavigation.jsx
@@ -10,18 +10,20 @@ const styles = {
 
 function TabNavigation({ tabs, component }) {
   return (
-    <div className="mx-0 flex flex-col-reverse justify-between gap-2 border-b border-ds-gray-tertiary md:flex-col xl:flex-row ">
-      <nav className="flex overflow-auto">
-        {tabs.map((tab) => (
-          <AppLink
-            {...tab}
-            className={styles.link}
-            activeClassName={styles.activeLink}
-            key={tab.pageName}
-          />
-        ))}
-      </nav>
-      {component || null}
+    <div className="@container/tabNav">
+      <div className="mx-0 flex flex-col-reverse justify-between gap-2 border-b border-ds-gray-tertiary  @md/tabNav:flex-col @4xl/tabNav:flex-row">
+        <nav className="flex overflow-auto">
+          {tabs.map((tab) => (
+            <AppLink
+              {...tab}
+              className={styles.link}
+              activeClassName={styles.activeLink}
+              key={tab.pageName}
+            />
+          ))}
+        </nav>
+        {component || null}
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
# Description

This PR updates the `TabNavigation`, and the `CommitDetailPageContent` components to use container queries specifically for the tabs on the commit detail page so that the breakpoints are based off the size of the tab and not the screen itself.

Closes codecov/engineering-team#809

# Notable Changes

- Add in `div` to create a container selector for Tailwind in `CommitDetailPageContent`
- Add in container queries that override default media queries when `commit-detail-page` container is present.

# Screenshots

https://github.com/codecov/gazebo/assets/105234307/7d42d1bd-9f38-411b-8524-9c6e755dc093