### PR TITLE
[feat] Add useRepoATS hook

### DIFF
--- a/src/services/ats/useRepoATS.spec.tsx
+++ b/src/services/ats/useRepoATS.spec.tsx
@@ -19,7 +19,7 @@ const mockNotFoundError = {
   owner: {
     repository: {
       __typename: 'NotFoundError',
-      message: 'commit not found',
+      message: 'repo not found',
     },
   },
 }

--- a/src/services/ats/useRepoATS.spec.tsx
+++ b/src/services/ats/useRepoATS.spec.tsx
@@ -1,0 +1,252 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { renderHook, waitFor } from '@testing-library/react'
+import { graphql } from 'msw'
+import { setupServer } from 'msw/node'
+
+import { useRepoATS } from './useRepoATS'
+
+const mockRepoATSData = {
+  owner: {
+    repository: {
+      __typename: 'Repository',
+      isATSConfigured: true,
+      primaryLanguage: 'python',
+    },
+  },
+}
+
+const mockNotFoundError = {
+  owner: {
+    repository: {
+      __typename: 'NotFoundError',
+      message: 'commit not found',
+    },
+  },
+}
+
+const mockOwnerNotActivatedError = {
+  owner: {
+    repository: {
+      __typename: 'OwnerNotActivatedError',
+      message: 'owner not activated',
+    },
+  },
+}
+
+const mockNullOwner = {
+  owner: null,
+}
+
+const mockUnsuccessfulParseError = {}
+
+const queryClient = new QueryClient({
+  defaultOptions: { queries: { retry: false } },
+})
+const server = setupServer()
+
+const wrapper: React.FC<React.PropsWithChildren> = ({ children }) => (
+  <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+)
+
+beforeAll(() => {
+  server.listen()
+})
+
+afterEach(() => {
+  queryClient.clear()
+  server.resetHandlers()
+})
+
+afterAll(() => {
+  server.close()
+})
+
+interface SetupArgs {
+  isNotFoundError?: boolean
+  isOwnerNotActivatedError?: boolean
+  isUnsuccessfulParseError?: boolean
+  isNullOwner?: boolean
+}
+
+describe('RepoATSInfo', () => {
+  function setup({
+    isNotFoundError = false,
+    isOwnerNotActivatedError = false,
+    isUnsuccessfulParseError = false,
+    isNullOwner = false,
+  }: SetupArgs) {
+    server.use(
+      graphql.query('RepoATSInfo', (req, res, ctx) => {
+        if (isNotFoundError) {
+          return res(ctx.status(200), ctx.data(mockNotFoundError))
+        } else if (isOwnerNotActivatedError) {
+          return res(ctx.status(200), ctx.data(mockOwnerNotActivatedError))
+        } else if (isUnsuccessfulParseError) {
+          return res(ctx.status(200), ctx.data(mockUnsuccessfulParseError))
+        } else if (isNullOwner) {
+          return res(ctx.status(200), ctx.data(mockNullOwner))
+        } else {
+          return res(ctx.status(200), ctx.data(mockRepoATSData))
+        }
+      })
+    )
+  }
+
+  describe('when executed', () => {
+    describe('returns Repository __typename', () => {
+      describe('there is data', () => {
+        it('fetches the correct data', async () => {
+          setup({})
+
+          const { result } = renderHook(
+            () =>
+              useRepoATS({
+                provider: 'gh',
+                owner: 'codecov',
+                repo: 'cool-repo',
+              }),
+            { wrapper }
+          )
+
+          await waitFor(() => result.current.isLoading)
+          await waitFor(() => !result.current.isLoading)
+
+          const expectedResult = {
+            __typename: 'Repository',
+            isATSConfigured: true,
+            primaryLanguage: 'python',
+          }
+
+          await waitFor(() =>
+            expect(result.current.data).toStrictEqual(expectedResult)
+          )
+        })
+      })
+      describe('there is a null owner', () => {
+        it('returns null value', async () => {
+          setup({ isNullOwner: true })
+
+          const { result } = renderHook(
+            () =>
+              useRepoATS({
+                provider: 'gh',
+                owner: 'codecov',
+                repo: 'cool-repo',
+              }),
+            { wrapper }
+          )
+
+          await waitFor(() => result.current.isLoading)
+          await waitFor(() => !result.current.isLoading)
+
+          await waitFor(() => expect(result.current.data).toStrictEqual(null))
+        })
+      })
+    })
+
+    describe('returns NotFoundError __typename', () => {
+      let oldConsoleError = console.error
+
+      beforeEach(() => {
+        console.error = () => null
+      })
+
+      afterEach(() => {
+        console.error = oldConsoleError
+      })
+
+      it('throws an error', async () => {
+        setup({ isNotFoundError: true })
+
+        const { result } = renderHook(
+          () =>
+            useRepoATS({
+              provider: 'gh',
+              owner: 'codecov',
+              repo: 'cool-repo',
+            }),
+          { wrapper }
+        )
+
+        await waitFor(() => expect(result.current.isError).toBeTruthy())
+        await waitFor(() =>
+          expect(result.current.error).toEqual(
+            expect.objectContaining({
+              status: 404,
+            })
+          )
+        )
+      })
+    })
+
+    describe('returns OwnerNotActivatedError __typename', () => {
+      let oldConsoleError = console.error
+
+      beforeEach(() => {
+        console.error = () => null
+      })
+
+      afterEach(() => {
+        console.error = oldConsoleError
+      })
+
+      it('throws an error', async () => {
+        setup({ isOwnerNotActivatedError: true })
+
+        const { result } = renderHook(
+          () =>
+            useRepoATS({
+              provider: 'gh',
+              owner: 'codecov',
+              repo: 'cool-repo',
+            }),
+          { wrapper }
+        )
+
+        await waitFor(() => expect(result.current.isError).toBeTruthy())
+        await waitFor(() =>
+          expect(result.current.error).toEqual(
+            expect.objectContaining({
+              status: 403,
+            })
+          )
+        )
+      })
+    })
+
+    describe('unsuccessful parse of zod schema', () => {
+      let oldConsoleError = console.error
+
+      beforeEach(() => {
+        console.error = () => null
+      })
+
+      afterEach(() => {
+        console.error = oldConsoleError
+      })
+
+      it('throws an error', async () => {
+        setup({ isUnsuccessfulParseError: true })
+
+        const { result } = renderHook(
+          () =>
+            useRepoATS({
+              provider: 'gh',
+              owner: 'codecov',
+              repo: 'cool-repo',
+            }),
+          { wrapper }
+        )
+
+        await waitFor(() => expect(result.current.isError).toBeTruthy())
+        await waitFor(() =>
+          expect(result.current.error).toEqual(
+            expect.objectContaining({
+              status: 404,
+            })
+          )
+        )
+      })
+    })
+  })
+})

--- a/src/services/ats/useRepoATS.tsx
+++ b/src/services/ats/useRepoATS.tsx
@@ -10,8 +10,8 @@ import A from 'ui/A'
 
 const RepositorySchema = z.object({
   __typename: z.literal('Repository'),
-  isATSConfigured: z.boolean().nullish(),
-  primaryLanguage: z.string().nullish(),
+  isATSConfigured: z.boolean().nullable(),
+  primaryLanguage: z.string().nullable(),
 })
 
 const GetRepoATSDataSchema = z.object({

--- a/src/services/ats/useRepoATS.tsx
+++ b/src/services/ats/useRepoATS.tsx
@@ -14,7 +14,7 @@ const RepositorySchema = z.object({
   primaryLanguage: z.string().nullish(),
 })
 
-const GetRepoDataSchema = z.object({
+const GetRepoATSDataSchema = z.object({
   owner: z
     .object({
       repository: z
@@ -28,7 +28,7 @@ const GetRepoDataSchema = z.object({
     .nullable(),
 })
 
-export type RepoATSInfo = z.infer<typeof GetRepoDataSchema>
+export type RepoATSInfo = z.infer<typeof GetRepoATSDataSchema>
 
 const query = `
   query RepoATSInfo($owner: String!, $repo: String!) {
@@ -70,7 +70,7 @@ export const useRepoATS = ({ provider, owner, repo }: RepoATSInfoArgs) =>
           repo,
         },
       }).then((res) => {
-        const parsedData = GetRepoDataSchema.safeParse(res?.data)
+        const parsedData = GetRepoATSDataSchema.safeParse(res?.data)
 
         if (!parsedData.success) {
           return Promise.reject({

--- a/src/services/ats/useRepoATS.tsx
+++ b/src/services/ats/useRepoATS.tsx
@@ -1,0 +1,114 @@
+import { useQuery } from '@tanstack/react-query'
+import { z } from 'zod'
+
+import {
+  RepoNotFoundErrorSchema,
+  RepoOwnerNotActivatedErrorSchema,
+} from 'services/repo'
+import Api from 'shared/api'
+import A from 'ui/A'
+
+const RepositorySchema = z.object({
+  __typename: z.literal('Repository'),
+  isATSConfigured: z.boolean().nullish(),
+  primaryLanguage: z.string().nullish(),
+})
+
+const GetRepoDataSchema = z.object({
+  owner: z
+    .object({
+      repository: z
+        .discriminatedUnion('__typename', [
+          RepositorySchema,
+          RepoNotFoundErrorSchema,
+          RepoOwnerNotActivatedErrorSchema,
+        ])
+        .nullable(),
+    })
+    .nullable(),
+})
+
+export type RepoATSInfo = z.infer<typeof GetRepoDataSchema>
+
+const query = `
+  query RepoATSInfo($owner: String!, $repo: String!) {
+    owner(username: $owner) {
+      repository(name: $repo) {
+        __typename
+        ... on Repository {
+          isATSConfigured
+          primaryLanguage
+        }
+        ... on NotFoundError {
+          message
+        }
+        ... on OwnerNotActivatedError {
+          message
+        }
+      }
+    }
+  }
+`
+
+interface RepoATSInfoArgs {
+  provider: string
+  owner: string
+  repo: string
+}
+
+export const useRepoATS = ({ provider, owner, repo }: RepoATSInfoArgs) =>
+  useQuery({
+    queryKey: ['RepoATSInfo', provider, owner, repo, query],
+    queryFn: ({ signal }) =>
+      Api.graphql({
+        provider,
+        query,
+        signal,
+        variables: {
+          provider,
+          owner,
+          repo,
+        },
+      }).then((res) => {
+        const parsedData = GetRepoDataSchema.safeParse(res?.data)
+
+        if (!parsedData.success) {
+          return Promise.reject({
+            status: 404,
+            data: {},
+          })
+        }
+
+        const { data } = parsedData
+
+        if (data?.owner?.repository?.__typename === 'NotFoundError') {
+          return Promise.reject({
+            status: 404,
+            data: {},
+          })
+        }
+
+        if (data?.owner?.repository?.__typename === 'OwnerNotActivatedError') {
+          return Promise.reject({
+            status: 403,
+            data: {
+              detail: (
+                <p>
+                  Activation is required to view this repo, please{' '}
+                  <A
+                    to={{ pageName: 'membersTab' }}
+                    hook="activate-user"
+                    isExternal={false}
+                  >
+                    click here{' '}
+                  </A>{' '}
+                  to activate your account.
+                </p>
+              ),
+            },
+          })
+        }
+
+        return data?.owner?.repository ?? null
+      }),
+  })


### PR DESCRIPTION
# Description

Now that we have `primaryLanguage` and `isATSConfigured` supported on the [backend](https://github.com/codecov/codecov-api/pull/323), this change adds a [useRepoATS](url) hook to be consumed on the main repo view(to be added in a follow-up PR). 

The idea is to call this hook and use the response to conditionally render the ATS tab and its contents as per the [design](https://github.com/codecov/engineering-team/issues/811). 


This PR closes https://github.com/codecov/engineering-team/issues/931.

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.