### PR TITLE
fix: Plan user count can be a nullable value

### DIFF
--- a/src/services/account/usePlanData.ts
+++ b/src/services/account/usePlanData.ts
@@ -28,7 +28,7 @@ export const PlanDataSchema = z
             trialStatus: z.nativeEnum(TrialStatuses),
             trialStartDate: z.string().nullable(),
             trialTotalDays: z.number().nullable(),
-            planUserCount: z.number(),
+            planUserCount: z.number().nullable(),
           })
           .nullish(),
         pretrialPlan: z


### PR DESCRIPTION
# Description

`planUserCount` can be a `null` value so we need to set it to be `nullable` in our zod schema.