### PR TITLE
 fix: Display Org Upload Token Tab in Self Hosted/Dedicated Cloud

### DIFF
--- a/src/pages/AccountSettings/AccountSettingsSideMenu.jsx
+++ b/src/pages/AccountSettings/AccountSettingsSideMenu.jsx
@@ -20,6 +20,7 @@ function selfHostedOverrideLinks({ isPersonalSettings }) {
     { pageName: isPersonalSettings ? 'profile' : '', exact: true },
     ...(internalAccessTab ? [{ pageName: internalAccessTab }] : []),
     { pageName: 'yamlTab' },
+    { pageName: 'orgUploadToken' },
   ]
 }
 

--- a/src/pages/AccountSettings/AccountSettingsSideMenu.jsx
+++ b/src/pages/AccountSettings/AccountSettingsSideMenu.jsx
@@ -12,15 +12,17 @@ function defaultLinks({ internalAccessTab }) {
   ]
 }
 
-function selfHostedOverrideLinks({ isPersonalSettings }) {
-  let internalAccessTab =
-    !config.HIDE_ACCESS_TAB && isPersonalSettings ? 'internalAccessTab' : null
+function selfHostedOverrideLinks({ isPersonalSettings, isAdmin }) {
+  let internalAccessTab = null
+  if (!config.HIDE_ACCESS_TAB && isPersonalSettings) {
+    internalAccessTab = 'internalAccessTab'
+  }
 
   return [
     { pageName: isPersonalSettings ? 'profile' : '', exact: true },
     ...(internalAccessTab ? [{ pageName: internalAccessTab }] : []),
     { pageName: 'yamlTab' },
-    { pageName: 'orgUploadToken' },
+    ...(isAdmin ? [{ pageName: 'orgUploadToken' }] : []),
   ]
 }
 
@@ -40,7 +42,7 @@ const generateLinks = ({ isAdmin, isPersonalSettings }) => {
   const internalAccessTab = isPersonalSettings ? 'internalAccessTab' : ''
 
   if (config.IS_SELF_HOSTED) {
-    return selfHostedOverrideLinks({ isPersonalSettings })
+    return selfHostedOverrideLinks({ isPersonalSettings, isAdmin })
   }
 
   if (isAdmin) {

--- a/src/pages/AccountSettings/AccountSettingsSideMenu.spec.jsx
+++ b/src/pages/AccountSettings/AccountSettingsSideMenu.spec.jsx
@@ -157,21 +157,38 @@ describe('AccountSettingsSideMenu', () => {
       expect(link).toHaveAttribute('href', '/account/gh/codecov/yaml')
     })
 
-    it('renders org upload token link', async () => {
-      setup({ isSelfHosted: true })
+    describe('user is not an admin', () => {
+      it('does not render org upload token link', async () => {
+        setup({ isSelfHosted: true })
 
-      render(<AccountSettingsSideMenu />, { wrapper: wrapper() })
+        render(<AccountSettingsSideMenu />, { wrapper: wrapper() })
 
-      const suspense = await screen.findByText('Loading')
-      expect(suspense).toBeInTheDocument()
-      await waitFor(() =>
-        expect(screen.queryByText('Loading')).not.toBeInTheDocument()
-      )
+        const suspense = await screen.findByText('Loading')
+        expect(suspense).toBeInTheDocument()
+        await waitFor(() =>
+          expect(screen.queryByText('Loading')).not.toBeInTheDocument()
+        )
 
-      const link = await screen.findByRole('link', {
-        name: 'Global Upload Token',
+        const link = screen.queryByRole('link', { name: 'Global Upload Token' })
+        expect(link).not.toBeInTheDocument()
       })
-      expect(link).toBeInTheDocument()
+    })
+
+    describe('user is an admin', () => {
+      it('renders org upload token link', async () => {
+        setup({ isSelfHosted: true, isAdmin: true })
+
+        render(<AccountSettingsSideMenu />, { wrapper: wrapper() })
+
+        const link = await screen.findByRole('link', {
+          name: 'Global Upload Token',
+        })
+        expect(link).toBeInTheDocument()
+        expect(link).toHaveAttribute(
+          'href',
+          '/account/gh/codecov/org-upload-token'
+        )
+      })
     })
   })
 

--- a/src/pages/AccountSettings/AccountSettingsSideMenu.spec.jsx
+++ b/src/pages/AccountSettings/AccountSettingsSideMenu.spec.jsx
@@ -157,7 +157,7 @@ describe('AccountSettingsSideMenu', () => {
       expect(link).toHaveAttribute('href', '/account/gh/codecov/yaml')
     })
 
-    it('does not render org upload token link', async () => {
+    it('renders org upload token link', async () => {
       setup({ isSelfHosted: true })
 
       render(<AccountSettingsSideMenu />, { wrapper: wrapper() })
@@ -168,8 +168,10 @@ describe('AccountSettingsSideMenu', () => {
         expect(screen.queryByText('Loading')).not.toBeInTheDocument()
       )
 
-      const link = screen.queryByRole('link', { name: 'Global Upload Token' })
-      expect(link).not.toBeInTheDocument()
+      const link = await screen.findByRole('link', {
+        name: 'Global Upload Token',
+      })
+      expect(link).toBeInTheDocument()
     })
   })
 


### PR DESCRIPTION
# Description

Currently we're not displaying the link to show the org upload token in self hosted, this PR fixes that by adding the link when the given user is an admin for the org.

Closes codecov/engineering-team#972

# Notable Changes

- Update `AccountSettingsSideMenu` to add in org upload token link for admins run running self-hosted
- Add/Update tests accordingly