### PR TITLE
feat: Create function to format bundle size strings

### DIFF
--- a/src/shared/utils/bundleAnalysis.spec.ts
+++ b/src/shared/utils/bundleAnalysis.spec.ts
@@ -1,0 +1,38 @@
+import { formatSizeToString } from './bundleAnalysis'
+
+describe('formatSizeToString', () => {
+  describe('size is less then one kilobyte', () => {
+    it('returns size in bytes', () => {
+      const result = formatSizeToString(900)
+      expect(result).toBe('900B')
+    })
+  })
+
+  describe('size is greater then one kilobyte and smaller then one megabyte', () => {
+    it('returns size in kilobytes', () => {
+      const result = formatSizeToString(10000)
+      expect(result).toBe('10kB')
+    })
+  })
+
+  describe('size is greater then one megabyte and smaller then gigabyte', () => {
+    it('returns size in megabytes', () => {
+      const result = formatSizeToString(1000000)
+      expect(result).toBe('1MB')
+    })
+  })
+
+  describe('size is greater then gigabyte', () => {
+    it('returns size in gigabytes', () => {
+      const result = formatSizeToString(1000000000)
+      expect(result).toBe('1GB')
+    })
+  })
+
+  describe('handles decimal numbers', () => {
+    it('returns size with two decimal places', () => {
+      const result = formatSizeToString(12345678)
+      expect(result).toBe('12.35MB')
+    })
+  })
+})

--- a/src/shared/utils/bundleAnalysis.ts
+++ b/src/shared/utils/bundleAnalysis.ts
@@ -1,0 +1,41 @@
+const KILOBYTE = 1000
+const MEGABYTE = 1000000
+const GIGABYTE = 1000000000
+
+const formatSettings = {
+  style: 'unit',
+  unitDisplay: 'narrow',
+  maximumFractionDigits: 2,
+} as const
+
+export const formatSizeToString = (bytes: number) => {
+  if (bytes < KILOBYTE) {
+    return Intl.NumberFormat('en-US', {
+      ...formatSettings,
+      unit: 'byte',
+    }).format(bytes)
+  }
+
+  if (bytes >= KILOBYTE && bytes < MEGABYTE) {
+    let kilobytes = bytes / KILOBYTE
+
+    return Intl.NumberFormat('en-US', {
+      ...formatSettings,
+      unit: 'kilobyte',
+    }).format(kilobytes)
+  }
+
+  if (bytes >= MEGABYTE && bytes < GIGABYTE) {
+    let megabytes = bytes / MEGABYTE
+
+    return Intl.NumberFormat('en-US', {
+      ...formatSettings,
+      unit: 'megabyte',
+    }).format(megabytes)
+  }
+
+  return Intl.NumberFormat('en-US', {
+    ...formatSettings,
+    unit: 'gigabyte',
+  }).format(bytes / GIGABYTE)
+}


### PR DESCRIPTION
# Description

This PR adds in a new function that utilizes the `Intl.formatNumber()` class and method to correctly format sizes to strings ensuring the correct unit is placed as well as limiting to two decimal places. 

Closes codecov/engineering-team#1000

# Code Example

```tsx
import { formatSizeToString } from 'shared/bundleAnalysis'

const totalBundleSize = formatSizeToString(123456)
```

# Notable Changes

- Add in new function to format size numbers to formatted string
- Tests for new functions