### PR TITLE
fix: Fix BB bug

### DIFF
--- a/src/pages/TermsOfService/hooks/useTermsOfService.spec.tsx
+++ b/src/pages/TermsOfService/hooks/useTermsOfService.spec.tsx
@@ -125,6 +125,34 @@ describe('useSaveTermsAgreement', () => {
       })
     })
 
+    it('proceed with mutation on missing email', async () => {
+      setup()
+      const invalidateQueries = jest.spyOn(queryClient, 'invalidateQueries')
+      const successFn = jest.fn()
+      const { result } = renderHook(
+        () =>
+          useSaveTermsAgreement({
+            onSuccess: () => {
+              successFn('completed')
+            },
+          }),
+        {
+          wrapper: wrapper(),
+        }
+      )
+
+      result.current.mutate({
+        businessEmail: null,
+        termsAgreement: true,
+      })
+
+      await waitFor(() => expect(successFn).toBeCalledWith('completed'))
+
+      expect(invalidateQueries).toHaveBeenCalledWith({
+        queryKey: ['InternalUser'],
+      })
+    })
+
     describe('there is was an api error', () => {
       it('throws an error', async () => {
         setup({ apiError: true })

--- a/src/pages/TermsOfService/hooks/useTermsOfService.ts
+++ b/src/pages/TermsOfService/hooks/useTermsOfService.ts
@@ -4,7 +4,7 @@ import { z } from 'zod'
 import Api from 'shared/api'
 
 const SaveTermsAgreementInputConfig = z.object({
-  businessEmail: z.string().optional(),
+  businessEmail: z.string().nullable(),
   termsAgreement: z.boolean(),
   marketingConsent: z.boolean().optional(),
 })


### PR DESCRIPTION
# Description
we counted on the fact that users would have at least email when they login to Codecov, but we realised BB users can have both business email and email null, this is changing Zod schema to accommodate such use case .

# Screenshots
https://github.com/codecov/gazebo/assets/91732700/f7302a66-f472-4571-8c69-4ebb93220caf

https://github.com/codecov/gazebo/assets/91732700/d06d7709-9c51-4474-b96a-2701bc68606f


# Link to Sample Entry

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.