### PR TITLE
feat: Update GitHub Actions tab with GUT 

### DIFF
--- a/src/pages/RepoPage/CoverageOnboarding/GitHubActions/GitHubActions.spec.tsx
+++ b/src/pages/RepoPage/CoverageOnboarding/GitHubActions/GitHubActions.spec.tsx
@@ -5,20 +5,22 @@ import { setupServer } from 'msw/node'
 import { Suspense } from 'react'
 import { MemoryRouter, Route } from 'react-router-dom'
 
+import { useFlags } from 'shared/featureFlags'
+
 import GitHubActions from './GitHubActions'
 
-const mockCurrentUser = {
-  me: {
-    trackingMetadata: {
-      ownerid: 'user-owner-id',
-    },
-  },
-}
+jest.mock('./GitHubActionsRepoToken', () => () => 'GitHubActionsRepoToken')
+jest.mock('./GitHubActionsOrgToken', () => () => 'GitHubActionsOrgToken')
+jest.mock('shared/featureFlags')
 
-const mockGetRepo = {
+const mockedNewRepoFlag = useFlags as jest.Mock<{ newRepoFlag: boolean }>
+
+const mockGetRepo = (hasOrgUploadToken: boolean | null) => ({
   owner: {
     isCurrentUserPartOfOrg: true,
-    orgUploadToken: '9e6a6189-20f1-482d-ab62-ecfaa2629290',
+    orgUploadToken: hasOrgUploadToken
+      ? '9e6a6189-20f1-482d-ab62-ecfaa2629290'
+      : null,
     repository: {
       private: false,
       uploadToken: '9e6a6189-20f1-482d-ab62-ecfaa2629295',
@@ -28,7 +30,7 @@ const mockGetRepo = {
       oldestCommitAt: '',
     },
   },
-}
+})
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -66,126 +68,43 @@ afterEach(() => {
 afterAll(() => server.close())
 
 describe('GitHubActions', () => {
-  function setup() {
+  function setup(hasOrgUploadToken: boolean | null) {
+    mockedNewRepoFlag.mockReturnValue({ newRepoFlag: true })
+
     server.use(
       graphql.query('GetRepo', (req, res, ctx) =>
-        res(ctx.status(200), ctx.data(mockGetRepo))
-      ),
-      graphql.query('CurrentUser', (req, res, ctx) =>
-        res(ctx.status(200), ctx.data(mockCurrentUser))
+        res(ctx.status(200), ctx.data(mockGetRepo(hasOrgUploadToken)))
       )
     )
   }
 
-  describe('step one', () => {
-    beforeEach(() => setup())
-
-    it('renders header', async () => {
-      render(<GitHubActions />, { wrapper })
-
-      const header = await screen.findByRole('heading', { name: /Step 1/ })
-      expect(header).toBeInTheDocument()
-
-      const repositorySecretLink = await screen.findByRole('link', {
-        name: /repository secret/,
-      })
-      expect(repositorySecretLink).toBeInTheDocument()
-      expect(repositorySecretLink).toHaveAttribute(
-        'href',
-        'https://github.com/codecov/cool-repo/settings/secrets/actions'
-      )
+  describe('when org upload token is available', () => {
+    beforeEach(() => {
+      setup(true)
     })
 
-    it('renders body', async () => {
+    it('renders GitHubActionsOrgToken', async () => {
       render(<GitHubActions />, { wrapper })
 
-      const body = await screen.findByText(
-        /Admin required to access repo settings > secrets and variable > actions/
+      const githubActionsOrgToken = await screen.findByText(
+        'GitHubActionsOrgToken'
       )
-      expect(body).toBeInTheDocument()
-    })
-
-    it('renders token box', async () => {
-      render(<GitHubActions />, { wrapper })
-
-      const codecovToken = await screen.findByText(/CODECOV_TOKEN=/)
-      expect(codecovToken).toBeInTheDocument()
-
-      const tokenValue = await screen.findByText(
-        /9e6a6189-20f1-482d-ab62-ecfaa2629295/
-      )
-      expect(tokenValue).toBeInTheDocument()
+      expect(githubActionsOrgToken).toBeInTheDocument()
     })
   })
 
-  describe('step two', () => {
-    beforeEach(() => setup())
+  describe('when org upload token is not available', () => {
+    beforeEach(() => {
+      setup(false)
+    })
 
-    it('renders header', async () => {
+    it('renders GitHubActionsRepoToken', async () => {
       render(<GitHubActions />, { wrapper })
 
-      const header = await screen.findByRole('heading', { name: /Step 2/ })
-      expect(header).toBeInTheDocument()
-
-      const gitHubActionsWorkflowLink = await screen.findByRole('link', {
-        name: /GitHub Actions workflow/,
-      })
-      expect(gitHubActionsWorkflowLink).toBeInTheDocument()
-      expect(gitHubActionsWorkflowLink).toHaveAttribute(
-        'href',
-        'https://github.com/codecov/cool-repo/tree/main/.github/workflows'
+      const githubActionsRepoToken = await screen.findByText(
+        'GitHubActionsRepoToken'
       )
-    })
-
-    it('renders yaml section', async () => {
-      render(<GitHubActions />, { wrapper })
-
-      const yamlBox = await screen.findByText(
-        /Upload coverage reports to Codecov/
-      )
-      expect(yamlBox).toBeInTheDocument()
-    })
-  })
-
-  describe('step three', () => {
-    beforeEach(() => setup())
-    it('renders first body', async () => {
-      render(<GitHubActions />, { wrapper })
-
-      const body = await screen.findByText(/After you committed your changes/)
-      expect(body).toBeInTheDocument()
-    })
-
-    it('renders second body', async () => {
-      render(<GitHubActions />, { wrapper })
-
-      const body = await screen.findByText(/Once merged to the/)
-      expect(body).toBeInTheDocument()
-    })
-
-    it('renders status check image', async () => {
-      render(<GitHubActions />, { wrapper })
-
-      const img = await screen.findByRole('img', {
-        name: 'codecov patch and project',
-      })
-      expect(img).toBeInTheDocument()
-    })
-  })
-
-  describe('ending', () => {
-    beforeEach(() => setup())
-    it('renders body', async () => {
-      render(<GitHubActions />, { wrapper })
-
-      const body = await screen.findByText(/How was your setup experience/)
-      expect(body).toBeInTheDocument()
-
-      const bodyLink = await screen.findByRole('link', { name: /this issue/ })
-      expect(bodyLink).toHaveAttribute(
-        'href',
-        'https://github.com/codecov/Codecov-user-feedback/issues/18'
-      )
+      expect(githubActionsRepoToken).toBeInTheDocument()
     })
   })
 })

--- a/src/pages/RepoPage/CoverageOnboarding/GitHubActions/GitHubActions.tsx
+++ b/src/pages/RepoPage/CoverageOnboarding/GitHubActions/GitHubActions.tsx
@@ -1,15 +1,10 @@
 import { useParams } from 'react-router-dom'
 
-import patchAndProject from 'assets/repoConfig/patch-and-project.svg'
 import { useRepo } from 'services/repo'
-import A from 'ui/A'
-import CopyClipboard from 'ui/CopyClipboard'
+import { useFlags } from 'shared/featureFlags'
 
-const codecovActionString = `- name: Upload coverage reports to Codecov
-  uses: codecov/codecov-action@v3
-  env:
-    CODECOV_TOKEN: \${{ secrets.CODECOV_TOKEN }}
-`
+import GitHubActionsOrgToken from './GitHubActionsOrgToken'
+import GitHubActionsRepoToken from './GitHubActionsRepoToken'
 
 interface URLParams {
   provider: string
@@ -18,89 +13,15 @@ interface URLParams {
 }
 
 function GitHubActions() {
+  const { newRepoFlag } = useFlags({
+    newRepoFlag: false,
+  })
+
   const { provider, owner, repo } = useParams<URLParams>()
   const { data } = useRepo({ provider, owner, repo })
-  const repoUploadToken = data?.repository?.uploadToken
+  const showOrgToken = newRepoFlag && data?.orgUploadToken
 
-  return (
-    <div className="flex flex-col gap-6">
-      <div className="flex flex-col gap-4">
-        <div>
-          <h2 className="text-base font-semibold">
-            Step 1: add repository token as{' '}
-            <A
-              to={{ pageName: 'githubRepoSecrets' }}
-              isExternal
-              hook="GitHub-repo-secrects-link"
-            >
-              repository secret
-            </A>
-          </h2>
-          <p className="text-base">
-            Admin required to access repo settings {'>'} secrets and variable
-            {' >'} actions
-          </p>
-        </div>
-        <pre className="flex items-center gap-2 overflow-auto rounded-md border-2 border-ds-gray-secondary bg-ds-gray-primary px-4 py-2 font-mono">
-          CODECOV_TOKEN={repoUploadToken}
-          <CopyClipboard string={repoUploadToken} />
-        </pre>
-      </div>
-      <div className="flex flex-col gap-4">
-        <div className="text-base">
-          <h2 className="font-semibold">
-            Step 2: add Codecov to your{' '}
-            <A
-              to={{
-                pageName: 'githubRepoActions',
-              }}
-              options={{ branch: data?.repository?.defaultBranch }}
-              isExternal
-              hook="GitHub-repo-actions-link"
-            >
-              GitHub Actions workflow yaml file
-            </A>
-          </h2>
-          <p>
-            After tests run, this will upload your coverage report to Codecov:
-          </p>
-        </div>
-        <div className="flex items-start justify-between overflow-auto rounded-md border-2 border-ds-gray-secondary bg-ds-gray-primary px-4 py-2 font-mono">
-          <pre className="whitespace-pre">{codecovActionString}</pre>
-          <CopyClipboard string={codecovActionString} />
-        </div>
-      </div>
-      <div>
-        <p>
-          After you committed your changes and ran the repo&apos;s CI/CD
-          pipeline. In your pull request, you should see two status checks and
-          PR comment.
-        </p>
-        <img
-          alt="codecov patch and project"
-          src={patchAndProject.toString()}
-          className="my-3 md:px-5"
-          loading="lazy"
-        />
-        <p>
-          Once merged to the default branch, subsequent pull requests will have
-          checks and report comment. Additionally, you&apos;ll find your repo
-          coverage dashboard here.
-        </p>
-        <p className="mt-6 border-l-2 border-ds-gray-secondary pl-4">
-          <span className="font-semibold">How was your setup experience?</span>{' '}
-          Let us know in{' '}
-          <A
-            to={{ pageName: 'repoConfigFeedback' }}
-            isExternal
-            hook="repo-config-feedback"
-          >
-            this issue
-          </A>
-        </p>
-      </div>
-    </div>
-  )
+  return showOrgToken ? <GitHubActionsOrgToken /> : <GitHubActionsRepoToken />
 }
 
 export default GitHubActions

--- a/src/pages/RepoPage/CoverageOnboarding/GitHubActions/GitHubActionsOrgToken.spec.tsx
+++ b/src/pages/RepoPage/CoverageOnboarding/GitHubActions/GitHubActionsOrgToken.spec.tsx
@@ -1,0 +1,183 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { render, screen } from '@testing-library/react'
+import { graphql } from 'msw'
+import { setupServer } from 'msw/node'
+import { Suspense } from 'react'
+import { MemoryRouter, Route } from 'react-router-dom'
+
+import GitHubActionsOrgToken from './GitHubActionsOrgToken'
+
+const mockGetRepo = {
+  owner: {
+    isCurrentUserPartOfOrg: true,
+    orgUploadToken: '9e6a6189-20f1-482d-ab62-ecfaa2629290',
+    repository: {
+      private: false,
+      uploadToken: '9e6a6189-20f1-482d-ab62-ecfaa2629295',
+      defaultBranch: 'main',
+      yaml: '',
+      activated: false,
+      oldestCommitAt: '',
+    },
+  },
+}
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      suspense: true,
+      retry: false,
+    },
+  },
+})
+const server = setupServer()
+
+const wrapper: React.FC<React.PropsWithChildren> = ({ children }) => (
+  <QueryClientProvider client={queryClient}>
+    <MemoryRouter initialEntries={['/gh/codecov/cool-repo/new']}>
+      <Route
+        path={[
+          '/:provider/:owner/:repo/new',
+          '/:provider/:owner/:repo/new/other-ci',
+        ]}
+      >
+        <Suspense fallback={null}>{children}</Suspense>
+      </Route>
+    </MemoryRouter>
+  </QueryClientProvider>
+)
+
+beforeAll(() => {
+  console.error = () => {}
+  server.listen()
+})
+afterEach(() => {
+  queryClient.clear()
+  server.resetHandlers()
+})
+afterAll(() => server.close())
+
+describe('GitHubActionsOrgToken', () => {
+  function setup() {
+    server.use(
+      graphql.query('GetRepo', (req, res, ctx) =>
+        res(ctx.status(200), ctx.data(mockGetRepo))
+      )
+    )
+  }
+
+  describe('step one', () => {
+    beforeEach(() => setup())
+
+    it('renders header', async () => {
+      render(<GitHubActionsOrgToken />, { wrapper })
+
+      const header = await screen.findByRole('heading', { name: /Step 1/ })
+      expect(header).toBeInTheDocument()
+
+      const repositorySecretLink = await screen.findByRole('link', {
+        name: /repository secret/,
+      })
+      expect(repositorySecretLink).toBeInTheDocument()
+      expect(repositorySecretLink).toHaveAttribute(
+        'href',
+        'https://github.com/codecov/cool-repo/settings/secrets/actions'
+      )
+    })
+
+    it('renders body', async () => {
+      render(<GitHubActionsOrgToken />, { wrapper })
+
+      const body = await screen.findByText(
+        /Admin required to access repo settings > secrets and variable > actions/
+      )
+      expect(body).toBeInTheDocument()
+    })
+
+    it('renders token box', async () => {
+      render(<GitHubActionsOrgToken />, { wrapper })
+
+      const codecovToken = await screen.findByText(/CODECOV_TOKEN=/)
+      expect(codecovToken).toBeInTheDocument()
+
+      const tokenValue = await screen.findByText(
+        /9e6a6189-20f1-482d-ab62-ecfaa2629290/
+      )
+      expect(tokenValue).toBeInTheDocument()
+    })
+  })
+
+  describe('step two', () => {
+    beforeEach(() => setup())
+
+    it('renders header', async () => {
+      render(<GitHubActionsOrgToken />, { wrapper })
+
+      const header = await screen.findByRole('heading', { name: /Step 2/ })
+      expect(header).toBeInTheDocument()
+
+      const GitHubActionsOrgTokenWorkflowLink = await screen.findByRole(
+        'link',
+        {
+          name: /GitHub Actions workflow/,
+        }
+      )
+      expect(GitHubActionsOrgTokenWorkflowLink).toBeInTheDocument()
+      expect(GitHubActionsOrgTokenWorkflowLink).toHaveAttribute(
+        'href',
+        'https://github.com/codecov/cool-repo/tree/main/.github/workflows'
+      )
+    })
+
+    it('renders yaml section', async () => {
+      render(<GitHubActionsOrgToken />, { wrapper })
+
+      const yamlBox = await screen.findByText(
+        /Upload coverage reports to Codecov/
+      )
+      expect(yamlBox).toBeInTheDocument()
+    })
+  })
+
+  describe('step three', () => {
+    beforeEach(() => setup())
+    it('renders first body', async () => {
+      render(<GitHubActionsOrgToken />, { wrapper })
+
+      const body = await screen.findByText(/After you committed your changes/)
+      expect(body).toBeInTheDocument()
+    })
+
+    it('renders second body', async () => {
+      render(<GitHubActionsOrgToken />, { wrapper })
+
+      const body = await screen.findByText(/Once merged to the/)
+      expect(body).toBeInTheDocument()
+    })
+
+    it('renders status check image', async () => {
+      render(<GitHubActionsOrgToken />, { wrapper })
+
+      const img = await screen.findByRole('img', {
+        name: 'codecov patch and project',
+      })
+      expect(img).toBeInTheDocument()
+    })
+  })
+
+  describe('ending', () => {
+    beforeEach(() => setup())
+    it('renders body', async () => {
+      render(<GitHubActionsOrgToken />, { wrapper })
+
+      const body = await screen.findByText(/How was your setup experience/)
+      expect(body).toBeInTheDocument()
+
+      const bodyLink = await screen.findByRole('link', { name: /this issue/ })
+      expect(bodyLink).toHaveAttribute(
+        'href',
+        'https://github.com/codecov/Codecov-user-feedback/issues/18'
+      )
+    })
+  })
+})

--- a/src/pages/RepoPage/CoverageOnboarding/GitHubActions/GitHubActionsOrgToken.tsx
+++ b/src/pages/RepoPage/CoverageOnboarding/GitHubActions/GitHubActionsOrgToken.tsx
@@ -39,8 +39,8 @@ function GitHubActionsOrgToken() {
             </A>
           </h2>
           <p className="text-base">
-            Admin required to access repo settings {'>'} secrets and variable
-            {' >'} actions
+            Admin required to access repo settings &gt; secrets and variable
+            &gt; actions
           </p>
         </div>
         <pre className="flex items-center gap-2 overflow-auto rounded-md border-2 border-ds-gray-secondary bg-ds-gray-primary px-4 py-2 font-mono">

--- a/src/pages/RepoPage/CoverageOnboarding/GitHubActions/GitHubActionsOrgToken.tsx
+++ b/src/pages/RepoPage/CoverageOnboarding/GitHubActions/GitHubActionsOrgToken.tsx
@@ -1,0 +1,108 @@
+import { useParams } from 'react-router-dom'
+
+import patchAndProject from 'assets/repoConfig/patch-and-project.svg'
+import { useRepo } from 'services/repo'
+import A from 'ui/A'
+import CopyClipboard from 'ui/CopyClipboard'
+
+interface URLParams {
+  provider: string
+  owner: string
+  repo: string
+}
+
+function GitHubActionsOrgToken() {
+  const { provider, owner, repo } = useParams<URLParams>()
+  const { data } = useRepo({ provider, owner, repo })
+
+  const orgUploadToken = data?.orgUploadToken
+
+  const orgTokenActionString = `- name: Upload coverage reports to Codecov
+  uses: codecov/codecov-action@v4
+  env:
+    token: \${{ secrets.CODECOV_TOKEN }}
+    slug: ${owner}/${repo}
+`
+
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="flex flex-col gap-4">
+        <div>
+          <h2 className="text-base font-semibold">
+            Step 1: add global token as{' '}
+            <A
+              to={{ pageName: 'githubRepoSecrets' }}
+              isExternal
+              hook="GitHub-repo-secrects-link"
+            >
+              repository secret
+            </A>
+          </h2>
+          <p className="text-base">
+            Admin required to access repo settings {'>'} secrets and variable
+            {' >'} actions
+          </p>
+        </div>
+        <pre className="flex items-center gap-2 overflow-auto rounded-md border-2 border-ds-gray-secondary bg-ds-gray-primary px-4 py-2 font-mono">
+          CODECOV_TOKEN={orgUploadToken}
+          <CopyClipboard string={orgUploadToken} />
+        </pre>
+      </div>
+      <div className="flex flex-col gap-4">
+        <div className="text-base">
+          <h2 className="font-semibold">
+            Step 2: add Codecov to your{' '}
+            <A
+              to={{
+                pageName: 'githubRepoActions',
+              }}
+              options={{ branch: data?.repository?.defaultBranch }}
+              isExternal
+              hook="GitHub-repo-actions-link"
+            >
+              GitHub Actions workflow yaml file
+            </A>
+          </h2>
+          <p>
+            After tests run, this will upload your coverage report to Codecov:
+          </p>
+        </div>
+        <div className="flex items-start justify-between overflow-auto rounded-md border-2 border-ds-gray-secondary bg-ds-gray-primary px-4 py-2 font-mono">
+          <pre className="whitespace-pre">{orgTokenActionString}</pre>
+          <CopyClipboard string={orgTokenActionString} />
+        </div>
+      </div>
+      <div>
+        <p>
+          After you committed your changes and ran the repo&apos;s CI/CD
+          pipeline. In your pull request, you should see two status checks and
+          PR comment.
+        </p>
+        <img
+          alt="codecov patch and project"
+          src={patchAndProject.toString()}
+          className="my-3 md:px-5"
+          loading="lazy"
+        />
+        <p>
+          Once merged to the default branch, subsequent pull requests will have
+          checks and report comment. Additionally, you&apos;ll find your repo
+          coverage dashboard here.
+        </p>
+        <p className="mt-6 border-l-2 border-ds-gray-secondary pl-4">
+          <span className="font-semibold">How was your setup experience?</span>{' '}
+          Let us know in{' '}
+          <A
+            to={{ pageName: 'repoConfigFeedback' }}
+            isExternal
+            hook="repo-config-feedback"
+          >
+            this issue
+          </A>
+        </p>
+      </div>
+    </div>
+  )
+}
+
+export default GitHubActionsOrgToken

--- a/src/pages/RepoPage/CoverageOnboarding/GitHubActions/GitHubActionsRepoToken.spec.tsx
+++ b/src/pages/RepoPage/CoverageOnboarding/GitHubActions/GitHubActionsRepoToken.spec.tsx
@@ -1,0 +1,183 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { render, screen } from '@testing-library/react'
+import { graphql } from 'msw'
+import { setupServer } from 'msw/node'
+import { Suspense } from 'react'
+import { MemoryRouter, Route } from 'react-router-dom'
+
+import GitHubActionsRepoToken from './GitHubActionsRepoToken'
+
+const mockGetRepo = {
+  owner: {
+    isCurrentUserPartOfOrg: true,
+    orgUploadToken: '9e6a6189-20f1-482d-ab62-ecfaa2629290',
+    repository: {
+      private: false,
+      uploadToken: '9e6a6189-20f1-482d-ab62-ecfaa2629295',
+      defaultBranch: 'main',
+      yaml: '',
+      activated: false,
+      oldestCommitAt: '',
+    },
+  },
+}
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      suspense: true,
+      retry: false,
+    },
+  },
+})
+const server = setupServer()
+
+const wrapper: React.FC<React.PropsWithChildren> = ({ children }) => (
+  <QueryClientProvider client={queryClient}>
+    <MemoryRouter initialEntries={['/gh/codecov/cool-repo/new']}>
+      <Route
+        path={[
+          '/:provider/:owner/:repo/new',
+          '/:provider/:owner/:repo/new/other-ci',
+        ]}
+      >
+        <Suspense fallback={null}>{children}</Suspense>
+      </Route>
+    </MemoryRouter>
+  </QueryClientProvider>
+)
+
+beforeAll(() => {
+  console.error = () => {}
+  server.listen()
+})
+afterEach(() => {
+  queryClient.clear()
+  server.resetHandlers()
+})
+afterAll(() => server.close())
+
+describe('GitHubActions', () => {
+  function setup() {
+    server.use(
+      graphql.query('GetRepo', (req, res, ctx) =>
+        res(ctx.status(200), ctx.data(mockGetRepo))
+      )
+    )
+  }
+
+  describe('step one', () => {
+    beforeEach(() => setup())
+
+    it('renders header', async () => {
+      render(<GitHubActionsRepoToken />, { wrapper })
+
+      const header = await screen.findByRole('heading', { name: /Step 1/ })
+      expect(header).toBeInTheDocument()
+
+      const repositorySecretLink = await screen.findByRole('link', {
+        name: /repository secret/,
+      })
+      expect(repositorySecretLink).toBeInTheDocument()
+      expect(repositorySecretLink).toHaveAttribute(
+        'href',
+        'https://github.com/codecov/cool-repo/settings/secrets/actions'
+      )
+    })
+
+    it('renders body', async () => {
+      render(<GitHubActionsRepoToken />, { wrapper })
+
+      const body = await screen.findByText(
+        /Admin required to access repo settings > secrets and variable > actions/
+      )
+      expect(body).toBeInTheDocument()
+    })
+
+    it('renders token box', async () => {
+      render(<GitHubActionsRepoToken />, { wrapper })
+
+      const codecovToken = await screen.findByText(/CODECOV_TOKEN=/)
+      expect(codecovToken).toBeInTheDocument()
+
+      const tokenValue = await screen.findByText(
+        /9e6a6189-20f1-482d-ab62-ecfaa2629295/
+      )
+      expect(tokenValue).toBeInTheDocument()
+    })
+  })
+
+  describe('step two', () => {
+    beforeEach(() => setup())
+
+    it('renders header', async () => {
+      render(<GitHubActionsRepoToken />, { wrapper })
+
+      const header = await screen.findByRole('heading', { name: /Step 2/ })
+      expect(header).toBeInTheDocument()
+
+      const GitHubActionsRepoTokenWorkflowLink = await screen.findByRole(
+        'link',
+        {
+          name: /GitHub Actions workflow/,
+        }
+      )
+      expect(GitHubActionsRepoTokenWorkflowLink).toBeInTheDocument()
+      expect(GitHubActionsRepoTokenWorkflowLink).toHaveAttribute(
+        'href',
+        'https://github.com/codecov/cool-repo/tree/main/.github/workflows'
+      )
+    })
+
+    it('renders yaml section', async () => {
+      render(<GitHubActionsRepoToken />, { wrapper })
+
+      const yamlBox = await screen.findByText(
+        /Upload coverage reports to Codecov/
+      )
+      expect(yamlBox).toBeInTheDocument()
+    })
+  })
+
+  describe('step three', () => {
+    beforeEach(() => setup())
+    it('renders first body', async () => {
+      render(<GitHubActionsRepoToken />, { wrapper })
+
+      const body = await screen.findByText(/After you committed your changes/)
+      expect(body).toBeInTheDocument()
+    })
+
+    it('renders second body', async () => {
+      render(<GitHubActionsRepoToken />, { wrapper })
+
+      const body = await screen.findByText(/Once merged to the/)
+      expect(body).toBeInTheDocument()
+    })
+
+    it('renders status check image', async () => {
+      render(<GitHubActionsRepoToken />, { wrapper })
+
+      const img = await screen.findByRole('img', {
+        name: 'codecov patch and project',
+      })
+      expect(img).toBeInTheDocument()
+    })
+  })
+
+  describe('ending', () => {
+    beforeEach(() => setup())
+    it('renders body', async () => {
+      render(<GitHubActionsRepoToken />, { wrapper })
+
+      const body = await screen.findByText(/How was your setup experience/)
+      expect(body).toBeInTheDocument()
+
+      const bodyLink = await screen.findByRole('link', { name: /this issue/ })
+      expect(bodyLink).toHaveAttribute(
+        'href',
+        'https://github.com/codecov/Codecov-user-feedback/issues/18'
+      )
+    })
+  })
+})

--- a/src/pages/RepoPage/CoverageOnboarding/GitHubActions/GitHubActionsRepoToken.tsx
+++ b/src/pages/RepoPage/CoverageOnboarding/GitHubActions/GitHubActionsRepoToken.tsx
@@ -37,8 +37,8 @@ function GitHubActionsRepoToken() {
             </A>
           </h2>
           <p className="text-base">
-            Admin required to access repo settings {'>'} secrets and variable
-            {' >'} actions
+            Admin required to access repo settings &gt; secrets and variable
+            &gt; actions
           </p>
         </div>
         <pre className="flex items-center gap-2 overflow-auto rounded-md border-2 border-ds-gray-secondary bg-ds-gray-primary px-4 py-2 font-mono">

--- a/src/pages/RepoPage/CoverageOnboarding/GitHubActions/GitHubActionsRepoToken.tsx
+++ b/src/pages/RepoPage/CoverageOnboarding/GitHubActions/GitHubActionsRepoToken.tsx
@@ -1,0 +1,106 @@
+import { useParams } from 'react-router-dom'
+
+import patchAndProject from 'assets/repoConfig/patch-and-project.svg'
+import { useRepo } from 'services/repo'
+import A from 'ui/A'
+import CopyClipboard from 'ui/CopyClipboard'
+
+const codecovActionString = `- name: Upload coverage reports to Codecov
+  uses: codecov/codecov-action@v3
+  env:
+    CODECOV_TOKEN: \${{ secrets.CODECOV_TOKEN }}
+`
+
+interface URLParams {
+  provider: string
+  owner: string
+  repo: string
+}
+
+function GitHubActionsRepoToken() {
+  const { provider, owner, repo } = useParams<URLParams>()
+  const { data } = useRepo({ provider, owner, repo })
+  const repoUploadToken = data?.repository?.uploadToken
+
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="flex flex-col gap-4">
+        <div>
+          <h2 className="text-base font-semibold">
+            Step 1: add repository token as{' '}
+            <A
+              to={{ pageName: 'githubRepoSecrets' }}
+              isExternal
+              hook="GitHub-repo-secrects-link"
+            >
+              repository secret
+            </A>
+          </h2>
+          <p className="text-base">
+            Admin required to access repo settings {'>'} secrets and variable
+            {' >'} actions
+          </p>
+        </div>
+        <pre className="flex items-center gap-2 overflow-auto rounded-md border-2 border-ds-gray-secondary bg-ds-gray-primary px-4 py-2 font-mono">
+          CODECOV_TOKEN={repoUploadToken}
+          <CopyClipboard string={repoUploadToken} />
+        </pre>
+      </div>
+      <div className="flex flex-col gap-4">
+        <div className="text-base">
+          <h2 className="font-semibold">
+            Step 2: add Codecov to your{' '}
+            <A
+              to={{
+                pageName: 'githubRepoActions',
+              }}
+              options={{ branch: data?.repository?.defaultBranch }}
+              isExternal
+              hook="GitHub-repo-actions-link"
+            >
+              GitHub Actions workflow yaml file
+            </A>
+          </h2>
+          <p>
+            After tests run, this will upload your coverage report to Codecov:
+          </p>
+        </div>
+        <div className="flex items-start justify-between overflow-auto rounded-md border-2 border-ds-gray-secondary bg-ds-gray-primary px-4 py-2 font-mono">
+          <pre className="whitespace-pre">{codecovActionString}</pre>
+          <CopyClipboard string={codecovActionString} />
+        </div>
+      </div>
+      <div>
+        <p>
+          After you committed your changes and ran the repo&apos;s CI/CD
+          pipeline. In your pull request, you should see two status checks and
+          PR comment.
+        </p>
+        <img
+          alt="codecov patch and project"
+          src={patchAndProject.toString()}
+          className="my-3 md:px-5"
+          loading="lazy"
+        />
+        <p>
+          Once merged to the default branch, subsequent pull requests will have
+          checks and report comment. Additionally, you&apos;ll find your repo
+          coverage dashboard here.
+        </p>
+        <p className="mt-6 border-l-2 border-ds-gray-secondary pl-4">
+          <span className="font-semibold">How was your setup experience?</span>{' '}
+          Let us know in{' '}
+          <A
+            to={{ pageName: 'repoConfigFeedback' }}
+            isExternal
+            hook="repo-config-feedback"
+          >
+            this issue
+          </A>
+        </p>
+      </div>
+    </div>
+  )
+}
+
+export default GitHubActionsRepoToken


### PR DESCRIPTION
# Description
if user has GUT already generated, and if feature flag is on, we show GUT docs otherwise; we show old docs.

# Notable Changes
- Rename old docs to reflect repo specific docs 
- Create new org upload token doc 
- Tests and some restructure to display the correct component 

# Screenshots
![Screenshot 2024-01-22 at 4 30 47 PM](https://github.com/codecov/gazebo/assets/91732700/099340db-b489-409f-8817-1429c5049714)


closes: https://github.com/codecov/engineering-team/issues/940 

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.