### PR TITLE
fix: Sync page to pull in dynamic list of sync providers

### DIFF
--- a/src/pages/EnterpriseLandingPage/EnterpriseLandingPage.spec.tsx
+++ b/src/pages/EnterpriseLandingPage/EnterpriseLandingPage.spec.tsx
@@ -55,7 +55,7 @@ describe('EnterpriseLandingPage', () => {
     { sendProviders = true }: SetupArgs = { sendProviders: true }
   ) {
     server.use(
-      graphql.query('GetServiceProviders', (req, res, ctx) => {
+      graphql.query('GetLoginProviders', (req, res, ctx) => {
         if (sendProviders) {
           return res(ctx.status(200), ctx.data(mockServiceProviders))
         }

--- a/src/pages/EnterpriseLandingPage/EnterpriseLandingPage.tsx
+++ b/src/pages/EnterpriseLandingPage/EnterpriseLandingPage.tsx
@@ -1,14 +1,14 @@
 import rocketImg from 'assets/enterprise-rocket.png'
+import { useLoginProviders } from 'services/config/useLoginProviders'
 import { LoginProvidersEnum } from 'shared/utils/loginProviders'
 
 import ProviderCard from './ProviderCard/ProviderCard'
 import { useEnterpriseRedirect } from './useEnterpriseRedirect'
-import { useServiceProviders } from './useServiceProviders'
 
 function EnterpriseLandingPage() {
   useEnterpriseRedirect()
 
-  const { data } = useServiceProviders()
+  const { data } = useLoginProviders()
 
   return (
     <div className="flex flex-col gap-5">

--- a/src/pages/EnterpriseLandingPage/ProviderCard/ProviderCard.tsx
+++ b/src/pages/EnterpriseLandingPage/ProviderCard/ProviderCard.tsx
@@ -1,10 +1,9 @@
+import { EnterpriseLoginProviders } from 'services/config/useLoginProviders'
 import {
   loginProviderImage,
   LoginProvidersEnum,
 } from 'shared/utils/loginProviders'
 import Button from 'ui/Button'
-
-import { EnterpriseLoginProviders } from '../useServiceProviders'
 
 type LoginProviders = typeof LoginProvidersEnum
 

--- a/src/pages/SyncProviderPage/SyncButton.spec.tsx
+++ b/src/pages/SyncProviderPage/SyncButton.spec.tsx
@@ -14,8 +14,11 @@ describe('SyncButton', () => {
     it('renders sync button', () => {
       render(<SyncButton provider="gh" />, { wrapper })
 
-      const text = screen.getByText('Sync with Github')
-      expect(text).toBeInTheDocument()
+      const link = screen.getByRole('link', { name: /Sync with Github/ })
+
+      const expectedRedirect = encodeURIComponent('http://localhost/gh')
+      expect(link).toBeInTheDocument()
+      expect(link).toHaveAttribute('href', `/login/gh?to=${expectedRedirect}`)
     })
   })
 
@@ -23,8 +26,11 @@ describe('SyncButton', () => {
     it('renders sync button', () => {
       render(<SyncButton provider="gl" />, { wrapper })
 
-      const text = screen.getByText('Sync with Gitlab')
-      expect(text).toBeInTheDocument()
+      const link = screen.getByRole('link', { name: /Sync with Gitlab/ })
+
+      const expectedRedirect = encodeURIComponent('http://localhost/gl')
+      expect(link).toBeInTheDocument()
+      expect(link).toHaveAttribute('href', `/login/gl?to=${expectedRedirect}`)
     })
   })
 
@@ -32,8 +38,53 @@ describe('SyncButton', () => {
     it('renders sync button', () => {
       render(<SyncButton provider="bb" />, { wrapper })
 
-      const text = screen.getByText('Sync with BitBucket')
-      expect(text).toBeInTheDocument()
+      const link = screen.getByRole('link', { name: /Sync with BitBucket/ })
+
+      const expectedRedirect = encodeURIComponent('http://localhost/bb')
+      expect(link).toBeInTheDocument()
+      expect(link).toHaveAttribute('href', `/login/bb?to=${expectedRedirect}`)
+    })
+  })
+
+  describe('provider is set to ghe', () => {
+    it('renders sync button', () => {
+      render(<SyncButton provider="ghe" />, { wrapper })
+
+      const link = screen.getByRole('link', {
+        name: /Sync with Github Enterprise/,
+      })
+
+      const expectedRedirect = encodeURIComponent('http://localhost/ghe')
+      expect(link).toBeInTheDocument()
+      expect(link).toHaveAttribute('href', `/login/ghe?to=${expectedRedirect}`)
+    })
+  })
+
+  describe('provider is set to gle', () => {
+    it('renders sync button', () => {
+      render(<SyncButton provider="gle" />, { wrapper })
+
+      const link = screen.getByRole('link', {
+        name: /Sync with Gitlab Enterprise/,
+      })
+
+      const expectedRedirect = encodeURIComponent('http://localhost/gle')
+      expect(link).toBeInTheDocument()
+      expect(link).toHaveAttribute('href', `/login/gle?to=${expectedRedirect}`)
+    })
+  })
+
+  describe('provider is set to bbs', () => {
+    it('renders sync button', () => {
+      render(<SyncButton provider="bbs" />, { wrapper })
+
+      const link = screen.getByRole('link', {
+        name: /Sync with BitBucket Server/,
+      })
+
+      const expectedRedirect = encodeURIComponent('http://localhost/bbs')
+      expect(link).toBeInTheDocument()
+      expect(link).toHaveAttribute('href', `/login/bbs?to=${expectedRedirect}`)
     })
   })
 })

--- a/src/pages/SyncProviderPage/SyncButton.tsx
+++ b/src/pages/SyncProviderPage/SyncButton.tsx
@@ -2,7 +2,7 @@ import { useNavLinks } from 'services/navigation'
 import { providerImage, providerToName } from 'shared/utils/provider'
 
 interface SyncButtonProps {
-  provider: 'gh' | 'gl' | 'bb'
+  provider: 'gh' | 'gl' | 'bb' | 'ghe' | 'gle' | 'bbs'
 }
 
 const SyncButton: React.FC<SyncButtonProps> = ({ provider }) => {

--- a/src/pages/SyncProviderPage/SyncProviderPage.tsx
+++ b/src/pages/SyncProviderPage/SyncProviderPage.tsx
@@ -13,7 +13,7 @@ interface SyncButtonProps {
   hasSynced: boolean
 }
 
-function SyncButtons({ hasSynced }: SyncButtonProps) {
+const SyncButtons: React.FC<SyncButtonProps> = ({ hasSynced }) => {
   const { data: syncProviders } = useSyncProviders({ enabled: !hasSynced })
 
   if (isEmpty(syncProviders)) {
@@ -33,12 +33,16 @@ function SyncButtons({ hasSynced }: SyncButtonProps) {
     )
   }
 
-  return syncProviders?.map((provider) => (
-    <SyncButton key={provider} provider={provider} />
-  ))
+  return (
+    <>
+      {syncProviders?.map((provider) => (
+        <SyncButton key={provider} provider={provider} />
+      ))}
+    </>
+  )
 }
 
-function SyncProviderPage() {
+const SyncProviderPage: React.FC = () => {
   const { data: internalUser } = useInternalUser({})
 
   // will be false if 0 | undefined | null

--- a/src/pages/SyncProviderPage/SyncProviderPage.tsx
+++ b/src/pages/SyncProviderPage/SyncProviderPage.tsx
@@ -1,6 +1,7 @@
 import gt from 'lodash/gt'
 import { Redirect } from 'react-router-dom'
 
+import { useSyncProviders } from 'services/config'
 import { useInternalUser } from 'services/user/useInternalUser'
 import { loginProviderToShortName } from 'shared/utils/loginProviders'
 
@@ -12,6 +13,8 @@ function SyncProviderPage() {
   // will be false if 0 | undefined | null
   // will be true if greater than 1
   const hasSynced = gt(internalUser?.owners?.length, 0)
+
+  const { data: syncProviders } = useSyncProviders({ enabled: !hasSynced })
 
   // block all requests if flag is false
   // --
@@ -44,9 +47,9 @@ function SyncProviderPage() {
         </p>
       </div>
       <div className="mx-auto mt-2 w-96 space-y-4 border-t border-ds-gray-secondary pt-4">
-        <SyncButton provider="gh" />
-        <SyncButton provider="gl" />
-        <SyncButton provider="bb" />
+        {syncProviders?.map((provider) => (
+          <SyncButton key={provider} provider={provider} />
+        ))}
       </div>
     </div>
   )

--- a/src/pages/SyncProviderPage/SyncProviderPage.tsx
+++ b/src/pages/SyncProviderPage/SyncProviderPage.tsx
@@ -1,11 +1,42 @@
 import gt from 'lodash/gt'
+import isEmpty from 'lodash/isEmpty'
 import { Redirect } from 'react-router-dom'
 
 import { useSyncProviders } from 'services/config'
 import { useInternalUser } from 'services/user/useInternalUser'
 import { loginProviderToShortName } from 'shared/utils/loginProviders'
+import A from 'ui/A'
 
 import SyncButton from './SyncButton'
+
+interface SyncButtonProps {
+  hasSynced: boolean
+}
+
+function SyncButtons({ hasSynced }: SyncButtonProps) {
+  const { data: syncProviders } = useSyncProviders({ enabled: !hasSynced })
+
+  if (isEmpty(syncProviders)) {
+    return (
+      <p>
+        Unable to retrieve list of Git providers, please configure one in your
+        Codecov config YAML. See{' '}
+        <A
+          isExternal
+          hook="open-self-hosted-install-guide"
+          to={{ pageName: 'installSelfHosted' }}
+        >
+          Codecov Self-Hosted Install Guide
+        </A>
+        .
+      </p>
+    )
+  }
+
+  return syncProviders?.map((provider) => (
+    <SyncButton key={provider} provider={provider} />
+  ))
+}
 
 function SyncProviderPage() {
   const { data: internalUser } = useInternalUser({})
@@ -13,8 +44,6 @@ function SyncProviderPage() {
   // will be false if 0 | undefined | null
   // will be true if greater than 1
   const hasSynced = gt(internalUser?.owners?.length, 0)
-
-  const { data: syncProviders } = useSyncProviders({ enabled: !hasSynced })
 
   // block all requests if flag is false
   // --
@@ -47,9 +76,7 @@ function SyncProviderPage() {
         </p>
       </div>
       <div className="mx-auto mt-2 w-96 space-y-4 border-t border-ds-gray-secondary pt-4">
-        {syncProviders?.map((provider) => (
-          <SyncButton key={provider} provider={provider} />
-        ))}
+        <SyncButtons hasSynced={hasSynced} />
       </div>
     </div>
   )

--- a/src/services/config/index.ts
+++ b/src/services/config/index.ts
@@ -1,0 +1,1 @@
+export * from './useLoginProviders'

--- a/src/services/config/index.ts
+++ b/src/services/config/index.ts
@@ -1,1 +1,2 @@
 export * from './useLoginProviders'
+export * from './useSyncProviders'

--- a/src/services/config/useLoginProviders.spec.tsx
+++ b/src/services/config/useLoginProviders.spec.tsx
@@ -6,8 +6,8 @@ import { MemoryRouter, Route } from 'react-router-dom'
 
 import {
   EnterpriseLoginProviders,
-  useServiceProviders,
-} from './useServiceProviders'
+  useLoginProviders,
+} from './useLoginProviders'
 
 const server = setupServer()
 const queryClient = new QueryClient({
@@ -40,10 +40,10 @@ interface SetupArgs {
   hasParsingError?: boolean
 }
 
-describe('useServiceProviders', () => {
+describe('useLoginProviders', () => {
   function setup({ loginProviders, hasParsingError }: SetupArgs) {
     server.use(
-      graphql.query('GetServiceProviders', (req, res, ctx) => {
+      graphql.query('GetLoginProviders', (req, res, ctx) => {
         if (hasParsingError) {
           return res(ctx.status(200), ctx.data({ idk: true }))
         }
@@ -61,7 +61,7 @@ describe('useServiceProviders', () => {
       setup({
         loginProviders: ['GITHUB', 'GITLAB', 'BITBUCKET', 'OKTA'],
       })
-      const { result } = renderHook(() => useServiceProviders(), { wrapper })
+      const { result } = renderHook(() => useLoginProviders(), { wrapper })
 
       await waitFor(() => result.current.isSuccess)
 
@@ -86,7 +86,7 @@ describe('useServiceProviders', () => {
           'BITBUCKET_SERVER',
         ],
       })
-      const { result } = renderHook(() => useServiceProviders(), { wrapper })
+      const { result } = renderHook(() => useLoginProviders(), { wrapper })
 
       await waitFor(() => result.current.isSuccess)
 
@@ -120,7 +120,7 @@ describe('useServiceProviders', () => {
         hasParsingError: true,
       })
 
-      const { result } = renderHook(() => useServiceProviders(), { wrapper })
+      const { result } = renderHook(() => useLoginProviders(), { wrapper })
 
       await waitFor(() => expect(result.current.isError).toBeTruthy())
 

--- a/src/services/config/useLoginProviders.ts
+++ b/src/services/config/useLoginProviders.ts
@@ -17,29 +17,29 @@ export type EnterpriseLoginProviders = z.infer<
   typeof EnterpriseLoginProvidersUnionSchema
 >
 
-const GetServiceProvidersSchema = z.object({
+const GetLoginProvidersSchema = z.object({
   config: z.object({
     loginProviders: z.array(EnterpriseLoginProvidersUnionSchema),
   }),
 })
 
 const query = `
-query GetServiceProviders {
+query GetLoginProviders {
   config {
     loginProviders
   }
 }`
 
-export const useServiceProviders = () => {
+export const useLoginProviders = () => {
   return useQuery({
-    queryKey: ['GetServiceProviders'],
+    queryKey: ['GetLoginProviders'],
     queryFn: ({ signal }) =>
       Api.graphql({
         provider: 'gh',
         signal,
         query,
       }).then((res) => {
-        const parsedRes = GetServiceProvidersSchema.safeParse(res?.data)
+        const parsedRes = GetLoginProvidersSchema.safeParse(res?.data)
 
         if (!parsedRes.success) {
           return Promise.reject({

--- a/src/services/config/useSyncProviders.spec.tsx
+++ b/src/services/config/useSyncProviders.spec.tsx
@@ -1,0 +1,113 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { renderHook, waitFor } from '@testing-library/react'
+import { graphql } from 'msw'
+import { setupServer } from 'msw/node'
+import { MemoryRouter, Route } from 'react-router-dom'
+
+import { EnterpriseSyncProviders, useSyncProviders } from './useSyncProviders'
+
+const server = setupServer()
+const queryClient = new QueryClient({
+  defaultOptions: { queries: { retry: false } },
+})
+
+const wrapper: React.FC<React.PropsWithChildren> = ({ children }) => (
+  <QueryClientProvider client={queryClient}>
+    <MemoryRouter initialEntries={['/']}>
+      <Route path="/">{children}</Route>
+    </MemoryRouter>
+  </QueryClientProvider>
+)
+
+beforeAll(() => {
+  server.listen()
+})
+
+beforeEach(() => {
+  server.resetHandlers()
+  queryClient.clear()
+})
+
+afterAll(() => {
+  server.close()
+})
+
+interface SetupArgs {
+  syncProviders?: Array<EnterpriseSyncProviders>
+  hasParsingError?: boolean
+}
+
+describe('useSyncProviders', () => {
+  function setup({ syncProviders, hasParsingError }: SetupArgs) {
+    server.use(
+      graphql.query('GetSyncProviders', (req, res, ctx) => {
+        if (hasParsingError) {
+          return res(ctx.status(200), ctx.data({ idk: true }))
+        }
+
+        return res(
+          ctx.status(200),
+          ctx.data({ config: { syncProviders: syncProviders } })
+        )
+      })
+    )
+  }
+
+  describe('third party services are configured providers', () => {
+    it('returns data', async () => {
+      setup({
+        syncProviders: ['GITHUB', 'GITLAB', 'BITBUCKET'],
+      })
+      const { result } = renderHook(() => useSyncProviders({}), { wrapper })
+
+      await waitFor(() => result.current.isSuccess)
+
+      await waitFor(() =>
+        expect(result.current.data).toStrictEqual(['gh', 'gl', 'bb'])
+      )
+    })
+  })
+
+  describe('self hosted services are configured providers', () => {
+    it('returns data', async () => {
+      setup({
+        syncProviders: [
+          'GITHUB_ENTERPRISE',
+          'GITLAB_ENTERPRISE',
+          'BITBUCKET_SERVER',
+        ],
+      })
+      const { result } = renderHook(() => useSyncProviders({}), { wrapper })
+
+      await waitFor(() => result.current.isSuccess)
+
+      await waitFor(() =>
+        expect(result.current.data).toStrictEqual(['ghe', 'gle', 'bbs'])
+      )
+    })
+  })
+
+  describe('error parsing request', () => {
+    beforeAll(() => {
+      jest.spyOn(global.console, 'error')
+    })
+
+    afterAll(() => {
+      jest.resetAllMocks()
+    })
+
+    it('throws an error', async () => {
+      setup({
+        hasParsingError: true,
+      })
+
+      const { result } = renderHook(() => useSyncProviders({}), { wrapper })
+
+      await waitFor(() => expect(result.current.isError).toBeTruthy())
+
+      expect(result.current.error).toEqual(
+        expect.objectContaining({ status: 404 })
+      )
+    })
+  })
+})

--- a/src/services/config/useSyncProviders.ts
+++ b/src/services/config/useSyncProviders.ts
@@ -1,0 +1,86 @@
+import { useQuery } from '@tanstack/react-query'
+import { z } from 'zod'
+
+import Api from 'shared/api'
+
+const EnterpriseSyncProvidersUnionSchema = z.union([
+  z.literal('GITHUB'),
+  z.literal('GITHUB_ENTERPRISE'),
+  z.literal('GITLAB'),
+  z.literal('GITLAB_ENTERPRISE'),
+  z.literal('BITBUCKET'),
+  z.literal('BITBUCKET_SERVER'),
+])
+
+export type EnterpriseSyncProviders = z.infer<
+  typeof EnterpriseSyncProvidersUnionSchema
+>
+
+const GetSyncProvidersSchema = z.object({
+  config: z.object({
+    syncProviders: z.array(EnterpriseSyncProvidersUnionSchema),
+  }),
+})
+
+const query = `
+query GetSyncProviders {
+  config {
+    syncProviders
+  }
+}`
+
+interface UseSyncProvidersArgs {
+  enabled?: boolean
+}
+
+export const useSyncProviders = ({ enabled = true }: UseSyncProvidersArgs) => {
+  return useQuery({
+    queryKey: ['GetSyncProviders'],
+    queryFn: ({ signal }) => {
+      return Api.graphql({
+        provider: 'gh',
+        signal,
+        query,
+      }).then((res) => {
+        const parsedRes = GetSyncProvidersSchema.safeParse(res?.data)
+
+        if (!parsedRes.success) {
+          return Promise.reject({
+            status: 404,
+          })
+        }
+
+        const parsedProviders = parsedRes.data.config.syncProviders
+        const syncProviders: Array<'gh' | 'ghe' | 'gl' | 'gle' | 'bb' | 'bbs'> =
+          []
+
+        if (parsedProviders.includes('GITHUB')) {
+          syncProviders.push('gh')
+        }
+
+        if (parsedProviders.includes('GITHUB_ENTERPRISE')) {
+          syncProviders.push('ghe')
+        }
+
+        if (parsedProviders.includes('GITLAB')) {
+          syncProviders.push('gl')
+        }
+
+        if (parsedProviders.includes('GITLAB_ENTERPRISE')) {
+          syncProviders.push('gle')
+        }
+
+        if (parsedProviders.includes('BITBUCKET')) {
+          syncProviders.push('bb')
+        }
+
+        if (parsedProviders.includes('BITBUCKET_SERVER')) {
+          syncProviders.push('bbs')
+        }
+
+        return syncProviders
+      })
+    },
+    enabled,
+  })
+}

--- a/src/services/navigation/useNavLinks/useStaticNavLinks.js
+++ b/src/services/navigation/useNavLinks/useStaticNavLinks.js
@@ -349,5 +349,12 @@ export function useStaticNavLinks() {
       isExternalLink: true,
       openNewTab: true,
     },
+    installSelfHosted: {
+      text: 'Codecov Self-Hosted Installation Guide',
+      path: () =>
+        'https://docs.codecov.com/docs/installing-codecov-self-hosted',
+      isExternalLink: true,
+      openNewTab: true,
+    },
   }
 }

--- a/src/services/navigation/useNavLinks/useStaticNavLinks.spec.js
+++ b/src/services/navigation/useNavLinks/useStaticNavLinks.spec.js
@@ -75,7 +75,7 @@ describe('useStaticNavLinks', () => {
       ${links.bundleConfigFeedback}          | ${'https://github.com/codecov/feedback/issues/270'}
       ${links.termsOfService}                | ${`${config.MARKETING_BASE_URL}/terms-of-service`}
       ${links.quickStart}                    | ${'https://docs.codecov.com/docs/quick-start'}
-      
+      ${links.installSelfHosted}             | ${'https://docs.codecov.com/docs/installing-codecov-self-hosted'}
     `('static links return path', ({ link, outcome }) => {
       it(`${link.text}: Returns the correct link`, () => {
         expect(link.path()).toBe(outcome)

--- a/src/ui/Button/Button.jsx
+++ b/src/ui/Button/Button.jsx
@@ -151,17 +151,7 @@ function Button({
 
 Button.propTypes = {
   to: PropTypes.shape(AppLink.propTypes),
-  variant: PropTypes.oneOf([
-    'default',
-    'primary',
-    'danger',
-    'secondary',
-    'plain',
-    'github',
-    'gitlab',
-    'bitbucket',
-    'listbox',
-  ]),
+  variant: PropTypes.oneOf(Object.keys(variantClasses)),
   isLoading: PropTypes.bool,
   disabled: PropTypes.bool,
   hook: function (props, propName) {


### PR DESCRIPTION
# Description

This PR updates the `/sync` page to fetch the list of configured Git providers from the API so that Self-Hosted users who are have configured enterprise versions of the Git providers will also be able to limit what Git providers their users can sync with.

Closes codecov/engineering-team#910

# Notable Changes

- Rename `useServiceProviders` to `useLoginProviders`
- Create new `useSyncProviders` hook
- Update Sync page to fetch list of sync providers and display them
- Update `SyncButton` to support enterprise Git providers
- Create/Update tests

# Screenshots

Coming soon