### PR TITLE
[feat] Add metric to track app install shares

### DIFF
--- a/src/shared/GlobalTopBanners/RequestInstallBanner/RequestInstallBanner.tsx
+++ b/src/shared/GlobalTopBanners/RequestInstallBanner/RequestInstallBanner.tsx
@@ -1,3 +1,4 @@
+import { metrics } from '@sentry/react'
 import { useState } from 'react'
 import { useParams, useRouteMatch } from 'react-router-dom'
 
@@ -14,6 +15,7 @@ import TopBanner, { saveToLocalStorage } from 'ui/TopBanner'
 const APP_INSTALL_BANNER_KEY = 'request-install-banner'
 const COPY_APP_INSTALL_STRING =
   "Hello, could you help approve the installation of the Codecov app on GitHub for our organization? Here's the link: https://github.com/apps/codecov/installations/select_target"
+const SHARE_REQUEST_METRICS_KEY = 'user_shared_request'
 
 interface URLParams {
   provider: string
@@ -78,6 +80,7 @@ const RequestInstallBanner = () => {
             onClick={() => {
               // this has the side effect of hiding the banner
               setShowAppInstallModal(true)
+              metrics.increment(SHARE_REQUEST_METRICS_KEY)
             }}
           >
             Share Request


### PR DESCRIPTION
# Description

# Code Example

# Notable Changes

# Screenshots

# Link to Sample Entry

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.