### PR TITLE
fix: Move fetching of org upload token to a different hook

### DIFF
--- a/src/pages/AccountSettings/tabs/OrgUploadToken/OrgUploadToken.jsx
+++ b/src/pages/AccountSettings/tabs/OrgUploadToken/OrgUploadToken.jsx
@@ -1,6 +1,6 @@
 import { useParams } from 'react-router-dom'
 
-import { useOwner } from 'services/user'
+import { useOrgUploadToken } from 'services/orgUploadToken'
 import A from 'ui/A'
 import Banner from 'ui/Banner'
 
@@ -8,9 +8,8 @@ import GenerateOrgUploadToken from './GenerateOrgUploadToken'
 import RegenerateOrgUploadToken from './RegenerateOrgUploadToken'
 
 function OrgUploadToken() {
-  const { owner } = useParams()
-  const { data: ownerData } = useOwner({ username: owner })
-  const orgUploadToken = ownerData?.orgUploadToken
+  const { provider, owner } = useParams()
+  const { data: orgUploadToken } = useOrgUploadToken({ provider, owner })
 
   return (
     <div className="flex flex-col gap-4">

--- a/src/pages/AccountSettings/tabs/OrgUploadToken/OrgUploadToken.spec.jsx
+++ b/src/pages/AccountSettings/tabs/OrgUploadToken/OrgUploadToken.spec.jsx
@@ -51,8 +51,8 @@ afterAll(() => {
 
 describe('OrgUploadToken', () => {
   function setup(
-    { orgUploadToken = undefined, error = null, isAdmin = true } = {
-      orgUploadToken: undefined,
+    { orgUploadToken = null, error = null, isAdmin = true } = {
+      orgUploadToken: null,
       error: null,
       isAdmin: true,
     }
@@ -70,8 +70,17 @@ describe('OrgUploadToken', () => {
           ctx.data({
             owner: {
               ...mockOwner.owner,
-              orgUploadToken: orgUploadToken,
               isAdmin: isAdmin,
+            },
+          })
+        )
+      }),
+      graphql.query('GetOrgUploadToken', (req, res, ctx) => {
+        return res(
+          ctx.status(200),
+          ctx.data({
+            owner: {
+              orgUploadToken: orgUploadToken,
             },
           })
         )

--- a/src/pages/RepoPage/CoverageOnboarding/GitHubActions/GitHubActions.spec.tsx
+++ b/src/pages/RepoPage/CoverageOnboarding/GitHubActions/GitHubActions.spec.tsx
@@ -15,20 +15,11 @@ jest.mock('shared/featureFlags')
 
 const mockedNewRepoFlag = useFlags as jest.Mock<{ newRepoFlag: boolean }>
 
-const mockGetRepo = (hasOrgUploadToken: boolean | null) => ({
+const mockGetOrgUploadToken = (hasOrgUploadToken: boolean | null) => ({
   owner: {
-    isCurrentUserPartOfOrg: true,
     orgUploadToken: hasOrgUploadToken
       ? '9e6a6189-20f1-482d-ab62-ecfaa2629290'
       : null,
-    repository: {
-      private: false,
-      uploadToken: '9e6a6189-20f1-482d-ab62-ecfaa2629295',
-      defaultBranch: 'main',
-      yaml: '',
-      activated: false,
-      oldestCommitAt: '',
-    },
   },
 })
 
@@ -72,9 +63,12 @@ describe('GitHubActions', () => {
     mockedNewRepoFlag.mockReturnValue({ newRepoFlag: true })
 
     server.use(
-      graphql.query('GetRepo', (req, res, ctx) =>
-        res(ctx.status(200), ctx.data(mockGetRepo(hasOrgUploadToken)))
-      )
+      graphql.query('GetOrgUploadToken', (req, res, ctx) => {
+        return res(
+          ctx.status(200),
+          ctx.data(mockGetOrgUploadToken(hasOrgUploadToken))
+        )
+      })
     )
   }
 

--- a/src/pages/RepoPage/CoverageOnboarding/GitHubActions/GitHubActions.tsx
+++ b/src/pages/RepoPage/CoverageOnboarding/GitHubActions/GitHubActions.tsx
@@ -1,6 +1,6 @@
 import { useParams } from 'react-router-dom'
 
-import { useRepo } from 'services/repo'
+import { useOrgUploadToken } from 'services/orgUploadToken'
 import { useFlags } from 'shared/featureFlags'
 
 import GitHubActionsOrgToken from './GitHubActionsOrgToken'
@@ -17,9 +17,10 @@ function GitHubActions() {
     newRepoFlag: false,
   })
 
-  const { provider, owner, repo } = useParams<URLParams>()
-  const { data } = useRepo({ provider, owner, repo })
-  const showOrgToken = newRepoFlag && data?.orgUploadToken
+  const { provider, owner } = useParams<URLParams>()
+  const { data: orgUploadToken } = useOrgUploadToken({ provider, owner })
+
+  const showOrgToken = newRepoFlag && orgUploadToken
 
   return showOrgToken ? <GitHubActionsOrgToken /> : <GitHubActionsRepoToken />
 }

--- a/src/pages/RepoPage/CoverageOnboarding/GitHubActions/GitHubActionsOrgToken.spec.tsx
+++ b/src/pages/RepoPage/CoverageOnboarding/GitHubActions/GitHubActionsOrgToken.spec.tsx
@@ -10,7 +10,6 @@ import GitHubActionsOrgToken from './GitHubActionsOrgToken'
 const mockGetRepo = {
   owner: {
     isCurrentUserPartOfOrg: true,
-    orgUploadToken: '9e6a6189-20f1-482d-ab62-ecfaa2629290',
     repository: {
       private: false,
       uploadToken: '9e6a6189-20f1-482d-ab62-ecfaa2629295',
@@ -62,7 +61,15 @@ describe('GitHubActionsOrgToken', () => {
     server.use(
       graphql.query('GetRepo', (req, res, ctx) =>
         res(ctx.status(200), ctx.data(mockGetRepo))
-      )
+      ),
+      graphql.query('GetOrgUploadToken', (req, res, ctx) => {
+        return res(
+          ctx.status(200),
+          ctx.data({
+            owner: { orgUploadToken: '9e6a6189-20f1-482d-ab62-ecfaa2629290' },
+          })
+        )
+      })
     )
   }
 

--- a/src/pages/RepoPage/CoverageOnboarding/GitHubActions/GitHubActionsOrgToken.tsx
+++ b/src/pages/RepoPage/CoverageOnboarding/GitHubActions/GitHubActionsOrgToken.tsx
@@ -1,6 +1,7 @@
 import { useParams } from 'react-router-dom'
 
 import patchAndProject from 'assets/repoConfig/patch-and-project.svg'
+import { useOrgUploadToken } from 'services/orgUploadToken'
 import { useRepo } from 'services/repo'
 import A from 'ui/A'
 import CopyClipboard from 'ui/CopyClipboard'
@@ -14,8 +15,7 @@ interface URLParams {
 function GitHubActionsOrgToken() {
   const { provider, owner, repo } = useParams<URLParams>()
   const { data } = useRepo({ provider, owner, repo })
-
-  const orgUploadToken = data?.orgUploadToken
+  const { data: orgUploadToken } = useOrgUploadToken({ provider, owner })
 
   const orgTokenActionString = `- name: Upload coverage reports to Codecov
   uses: codecov/codecov-action@v4
@@ -45,7 +45,7 @@ function GitHubActionsOrgToken() {
         </div>
         <pre className="flex items-center gap-2 overflow-auto rounded-md border-2 border-ds-gray-secondary bg-ds-gray-primary px-4 py-2 font-mono">
           CODECOV_TOKEN={orgUploadToken}
-          <CopyClipboard string={orgUploadToken} />
+          <CopyClipboard string={orgUploadToken ?? ''} />
         </pre>
       </div>
       <div className="flex flex-col gap-4">

--- a/src/services/orgUploadToken/index.js
+++ b/src/services/orgUploadToken/index.js
@@ -1,1 +1,2 @@
+export * from './useOrgUploadToken'
 export * from './useRegenerateOrgUploadToken'

--- a/src/services/orgUploadToken/useOrgUploadToken.spec.tsx
+++ b/src/services/orgUploadToken/useOrgUploadToken.spec.tsx
@@ -1,0 +1,138 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { renderHook, waitFor } from '@testing-library/react'
+import { graphql } from 'msw'
+import { setupServer } from 'msw/node'
+import type { ReactNode } from 'react'
+
+import { useOrgUploadToken } from './useOrgUploadToken'
+
+const mockOrgUploadToken = {
+  owner: {
+    orgUploadToken: 'cool-token-123',
+  },
+}
+
+const mockNullOwner = {
+  owner: null,
+}
+
+const mockUnsuccessfulParseError = {}
+
+const queryClient = new QueryClient({
+  defaultOptions: { queries: { retry: false } },
+})
+const server = setupServer()
+
+const wrapper = ({ children }: { children: ReactNode }) => (
+  <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+)
+
+beforeAll(() => {
+  server.listen()
+})
+
+afterEach(() => {
+  queryClient.clear()
+  server.resetHandlers()
+})
+
+afterAll(() => {
+  server.close()
+})
+
+interface SetupArgs {
+  isNullOwner?: boolean
+  isUnsuccessfulParseError?: boolean
+}
+
+describe('useOrgUploadToken', () => {
+  function setup({
+    isUnsuccessfulParseError = false,
+    isNullOwner = false,
+  }: SetupArgs) {
+    server.use(
+      graphql.query('GetOrgUploadToken', (req, res, ctx) => {
+        if (isUnsuccessfulParseError) {
+          return res(ctx.status(200), ctx.data(mockUnsuccessfulParseError))
+        } else if (isNullOwner) {
+          return res(ctx.status(200), ctx.data(mockNullOwner))
+        } else {
+          return res(ctx.status(200), ctx.data(mockOrgUploadToken))
+        }
+      })
+    )
+  }
+
+  describe('when useOrgUploadToken is called', () => {
+    describe('api returns valid response', () => {
+      describe('orgUploadToken field is resolved', () => {
+        it('returns the orgs upload token', async () => {
+          setup({})
+          const { result } = renderHook(
+            () =>
+              useOrgUploadToken({
+                provider: 'gh',
+                owner: 'codecov',
+              }),
+            { wrapper }
+          )
+
+          await waitFor(() => result.current.isSuccess)
+          await waitFor(() =>
+            expect(result.current.data).toEqual('cool-token-123')
+          )
+        })
+      })
+
+      describe('parent field is resolved as null', () => {
+        it('returns null value', async () => {
+          setup({ isNullOwner: true })
+
+          const { result } = renderHook(
+            () =>
+              useOrgUploadToken({
+                provider: 'gh',
+                owner: 'codecov',
+              }),
+            { wrapper }
+          )
+
+          await waitFor(() => expect(result.current.data).toBeNull())
+        })
+      })
+    })
+
+    describe('unsuccessful parse of zod schema', () => {
+      beforeEach(() => {
+        jest.spyOn(console, 'error')
+      })
+
+      afterEach(() => {
+        jest.resetAllMocks()
+      })
+
+      it('throws a 404', async () => {
+        setup({ isUnsuccessfulParseError: true })
+        const { result } = renderHook(
+          () =>
+            useOrgUploadToken({
+              provider: 'gh',
+              owner: 'codecov',
+            }),
+          {
+            wrapper,
+          }
+        )
+
+        await waitFor(() => expect(result.current.isError).toBeTruthy())
+        await waitFor(() =>
+          expect(result.current.error).toEqual(
+            expect.objectContaining({
+              status: 404,
+            })
+          )
+        )
+      })
+    })
+  })
+})

--- a/src/services/orgUploadToken/useOrgUploadToken.ts
+++ b/src/services/orgUploadToken/useOrgUploadToken.ts
@@ -1,0 +1,49 @@
+import { useQuery } from '@tanstack/react-query'
+import { z } from 'zod'
+
+import Api from 'shared/api'
+
+const RequestSchema = z.object({
+  owner: z
+    .object({
+      orgUploadToken: z.string().nullable(),
+    })
+    .nullable(),
+})
+
+const query = `query GetOrgUploadToken ($owner: String!) {
+  owner (username: $owner) {
+    orgUploadToken
+  }
+}`
+
+interface UseOrgUploadTokenArgs {
+  provider: string
+  owner: string
+}
+
+export const useOrgUploadToken = ({ provider, owner }: UseOrgUploadTokenArgs) =>
+  useQuery({
+    queryKey: ['GetOrgUploadToken', provider, owner],
+    queryFn: ({ signal }) =>
+      Api.graphql({
+        provider,
+        query,
+        signal,
+        variables: {
+          owner,
+        },
+      }).then((res) => {
+        const parsedRes = RequestSchema.safeParse(res?.data)
+
+        if (!parsedRes.success) {
+          return Promise.reject({
+            status: 404,
+            data: null,
+            dev: 'Failed parse for GetOrgUploadToken',
+          })
+        }
+
+        return parsedRes?.data?.owner?.orgUploadToken ?? null
+      }),
+  })

--- a/src/services/repo/useRepo.js
+++ b/src/services/repo/useRepo.js
@@ -9,7 +9,6 @@ function fetchRepoDetails({ provider, owner, repo, signal }) {
         isAdmin
         isCurrentUserPartOfOrg
         isCurrentUserActivated
-        orgUploadToken
         repository: repositoryDeprecated(name:$repo){
           private
           uploadToken
@@ -37,7 +36,6 @@ function fetchRepoDetails({ provider, owner, repo, signal }) {
       repository: res?.data?.owner?.repository,
       isCurrentUserPartOfOrg: res?.data?.owner?.isCurrentUserPartOfOrg,
       isCurrentUserActivated: res?.data?.owner?.isCurrentUserActivated,
-      orgUploadToken: res?.data?.owner?.orgUploadToken,
     }
   })
 }

--- a/src/services/user/useIsCurrentUserAnAdmin.spec.js
+++ b/src/services/user/useIsCurrentUserAnAdmin.spec.js
@@ -39,7 +39,6 @@ describe('useIsCurrentUserAnAdmin', () => {
           ctx.status(200),
           ctx.data({
             owner: {
-              orgUploadToken: 'token',
               ownerid: 123,
               username: 'cool-user',
               avatarUrl: 'http://127.0.0.1/avatar-url',

--- a/src/services/user/useOwner.js
+++ b/src/services/user/useOwner.js
@@ -11,7 +11,6 @@ export function useOwner({
   const query = `
       query DetailOwner($username: String!) {
         owner(username: $username) {
-          orgUploadToken
           ownerid
           username
           avatarUrl


### PR DESCRIPTION
# Description

This PR removes the `orgUploadToken` field from a couple of data fetching hooks, and move it to it's own hook that will fetch the token on it's own avoiding any unauthorized requests.

# Notable Changes

- Create a new hook to fetch the org upload token
- Remove `orgUploadToken` field from a couple of hooks
- Refactor components to grab the org upload token from new hook
- Update tests