### PR TITLE
feat: Fetch product status in use pull page data

### DIFF
--- a/src/pages/PullRequestPage/FirstPullBanner/FirstPullBanner.spec.tsx
+++ b/src/pages/PullRequestPage/FirstPullBanner/FirstPullBanner.spec.tsx
@@ -41,6 +41,8 @@ const mockPullData = ({ resultType }: SetupArgs) => {
       owner: {
         repository: {
           __typename: 'Repository',
+          coverageEnabled: true,
+          bundleAnalysisEnabled: true,
           pull: {
             pullId: 1,
             head: {
@@ -60,6 +62,8 @@ const mockPullData = ({ resultType }: SetupArgs) => {
     owner: {
       repository: {
         __typename: 'Repository',
+        coverageEnabled: true,
+        bundleAnalysisEnabled: true,
         pull: {
           pullId: 1,
           head: {

--- a/src/pages/PullRequestPage/PullCoverage/PullCoverage.spec.jsx
+++ b/src/pages/PullRequestPage/PullCoverage/PullCoverage.spec.jsx
@@ -30,10 +30,10 @@ const mockPullData = (resultType) => {
   if (resultType === ComparisonReturnType.MISSING_BASE_COMMIT) {
     return {
       owner: {
-        isCurrentUserPartOfOrg: true,
         repository: {
           __typename: 'Repository',
-          private: false,
+          coverageEnabled: true,
+          bundleAnalysisEnabled: true,
           pull: {
             pullId: 1,
             head: {
@@ -51,10 +51,10 @@ const mockPullData = (resultType) => {
 
   return {
     owner: {
-      isCurrentUserPartOfOrg: true,
       repository: {
         __typename: 'Repository',
-        private: false,
+        coverageEnabled: true,
+        bundleAnalysisEnabled: true,
         pull: {
           pullId: 1,
           head: {
@@ -79,7 +79,8 @@ const mockPullDataTeam = {
     isCurrentUserPartOfOrg: true,
     repository: {
       __typename: 'Repository',
-      private: false,
+      coverageEnabled: true,
+      bundleAnalysisEnabled: true,
       pull: {
         pullId: 1,
         head: {

--- a/src/pages/PullRequestPage/PullCoverage/PullCoverageTabs/PullCoverageTabs.spec.jsx
+++ b/src/pages/PullRequestPage/PullCoverage/PullCoverageTabs/PullCoverageTabs.spec.jsx
@@ -58,6 +58,8 @@ const mockPullData = {
   owner: {
     repository: {
       __typename: 'Repository',
+      coverageEnabled: true,
+      bundleAnalysisEnabled: true,
       pull: {
         pullId: 1,
         head: {

--- a/src/pages/PullRequestPage/PullCoverage/PullCoverageTabs/hooks/useTabsCounts.spec.js
+++ b/src/pages/PullRequestPage/PullCoverage/PullCoverageTabs/hooks/useTabsCounts.spec.js
@@ -69,6 +69,8 @@ const mockPullData = {
     isCurrentUserPartOfOrg: true,
     repository: {
       __typename: 'Repository',
+      coverageEnabled: true,
+      bundleAnalysisEnabled: true,
       pull: {
         pullId: 1,
         head: {

--- a/src/pages/PullRequestPage/PullRequestPage.spec.jsx
+++ b/src/pages/PullRequestPage/PullRequestPage.spec.jsx
@@ -112,6 +112,8 @@ describe('PullRequestPage', () => {
               owner: {
                 repository: {
                   __typename: 'Repository',
+                  coverageEnabled: true,
+                  bundleAnalysisEnabled: true,
                   pull: mockPullPageDataTeam,
                 },
               },
@@ -125,6 +127,8 @@ describe('PullRequestPage', () => {
             owner: {
               repository: {
                 __typename: 'Repository',
+                coverageEnabled: true,
+                bundleAnalysisEnabled: true,
                 pull: pullData,
               },
             },

--- a/src/pages/PullRequestPage/hooks/usePullPageData.spec.tsx
+++ b/src/pages/PullRequestPage/hooks/usePullPageData.spec.tsx
@@ -9,6 +9,8 @@ const mockPullData = {
   owner: {
     repository: {
       __typename: 'Repository',
+      coverageEnabled: true,
+      bundleAnalysisEnabled: true,
       pull: {
         pullId: 1,
         head: {
@@ -31,6 +33,8 @@ const mockPullDataTeam = {
   owner: {
     repository: {
       __typename: 'Repository',
+      coverageEnabled: true,
+      bundleAnalysisEnabled: true,
       pull: {
         pullId: 1,
         head: {
@@ -149,6 +153,8 @@ describe('usePullPageData', () => {
 
           await waitFor(() =>
             expect(result.current.data).toStrictEqual({
+              coverageEnabled: true,
+              bundleAnalysisEnabled: true,
               pull: {
                 pullId: 1,
                 head: {
@@ -190,6 +196,8 @@ describe('usePullPageData', () => {
 
           await waitFor(() =>
             expect(result.current.data).toStrictEqual({
+              coverageEnabled: null,
+              bundleAnalysisEnabled: null,
               pull: null,
             })
           )
@@ -331,6 +339,8 @@ describe('usePullPageData', () => {
 
         await waitFor(() =>
           expect(result.current.data).toStrictEqual({
+            coverageEnabled: true,
+            bundleAnalysisEnabled: true,
             pull: {
               pullId: 1,
               head: {

--- a/src/pages/PullRequestPage/hooks/usePullPageData.tsx
+++ b/src/pages/PullRequestPage/hooks/usePullPageData.tsx
@@ -18,6 +18,8 @@ import A from 'ui/A'
 
 const RepositorySchema = z.object({
   __typename: z.literal('Repository'),
+  coverageEnabled: z.boolean().nullable(),
+  bundleAnalysisEnabled: z.boolean().nullable(),
   pull: z
     .object({
       pullId: z.number(),
@@ -63,11 +65,18 @@ const PullPageDataSchema = z.object({
 })
 
 const query = `
-query PullPageData($owner: String!, $repo: String!, $pullId: Int!, $isTeamPlan: Boolean!) {
+query PullPageData(
+  $owner: String!
+  $repo: String!
+  $pullId: Int!
+  $isTeamPlan: Boolean!
+) {
   owner(username: $owner) {
     repository(name: $repo) {
       __typename
       ... on Repository {
+        coverageEnabled
+        bundleAnalysisEnabled
         pull(id: $pullId) {
           pullId
           head {
@@ -185,8 +194,15 @@ export const usePullPageData = ({
           })
         }
 
+        const pull = data?.owner?.repository?.pull ?? null
+        const coverageEnabled = data?.owner?.repository?.coverageEnabled ?? null
+        const bundleAnalysisEnabled =
+          data?.owner?.repository?.bundleAnalysisEnabled ?? null
+
         return {
-          pull: data?.owner?.repository?.pull ?? null,
+          pull,
+          coverageEnabled,
+          bundleAnalysisEnabled,
         }
       }),
   })


### PR DESCRIPTION
# Description

This PR updates the `usePullPageData` to also fetch the fields to see if coverage or bundle analysis is enabled for future use on the PR page.

GH codecov/engineering-team#997

# Notable Changes

- Update `usePullPageData` to fetch product status checks
- Update related tests