### PR TITLE
fix: Update repo token with v4 instructions for circle ci

### DIFF
--- a/src/pages/RepoPage/CoverageOnboarding/CircleCI/CircleCI.spec.tsx
+++ b/src/pages/RepoPage/CoverageOnboarding/CircleCI/CircleCI.spec.tsx
@@ -1,9 +1,4 @@
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { render, screen } from '@testing-library/react'
-import { graphql } from 'msw'
-import { setupServer } from 'msw/node'
-import { Suspense } from 'react'
-import { MemoryRouter, Route } from 'react-router-dom'
 
 import { useFlags } from 'shared/featureFlags'
 
@@ -15,61 +10,9 @@ jest.mock('shared/featureFlags')
 
 const mockedNewRepoFlag = useFlags as jest.Mock<{ newRepoFlag: boolean }>
 
-const mockGetOrgUploadToken = (hasOrgUploadToken: boolean | null) => ({
-  owner: {
-    orgUploadToken: hasOrgUploadToken
-      ? '9e6a6189-20f1-482d-ab62-ecfaa2629290'
-      : null,
-  },
-})
-
-const queryClient = new QueryClient({
-  defaultOptions: {
-    queries: {
-      suspense: true,
-      retry: false,
-    },
-  },
-})
-const server = setupServer()
-
-const wrapper: React.FC<React.PropsWithChildren> = ({ children }) => (
-  <QueryClientProvider client={queryClient}>
-    <MemoryRouter initialEntries={['/gh/codecov/cool-repo/new']}>
-      <Route
-        path={[
-          '/:provider/:owner/:repo/new',
-          '/:provider/:owner/:repo/new/other-ci',
-        ]}
-      >
-        <Suspense fallback={null}>{children}</Suspense>
-      </Route>
-    </MemoryRouter>
-  </QueryClientProvider>
-)
-
-beforeAll(() => {
-  console.error = () => {}
-  server.listen()
-})
-afterEach(() => {
-  queryClient.clear()
-  server.resetHandlers()
-})
-afterAll(() => server.close())
-
 describe('CircleCI', () => {
-  function setup(hasOrgUploadToken: boolean | null) {
-    mockedNewRepoFlag.mockReturnValue({ newRepoFlag: true })
-
-    server.use(
-      graphql.query('GetOrgUploadToken', (req, res, ctx) => {
-        return res(
-          ctx.status(200),
-          ctx.data(mockGetOrgUploadToken(hasOrgUploadToken))
-        )
-      })
-    )
+  function setup(show: boolean) {
+    mockedNewRepoFlag.mockReturnValue({ newRepoFlag: show })
   }
 
   describe('when org upload token is available', () => {
@@ -78,7 +21,7 @@ describe('CircleCI', () => {
     })
 
     it('renders CircleCIOrgToken', async () => {
-      render(<CircleCI />, { wrapper })
+      render(<CircleCI />)
 
       const CircleCIOrgToken = await screen.findByText('CircleCIOrgToken')
       expect(CircleCIOrgToken).toBeInTheDocument()
@@ -91,7 +34,7 @@ describe('CircleCI', () => {
     })
 
     it('renders CircleCIRepoToken', async () => {
-      render(<CircleCI />, { wrapper })
+      render(<CircleCI />)
 
       const CircleCIRepoToken = await screen.findByText('CircleCIRepoToken')
       expect(CircleCIRepoToken).toBeInTheDocument()

--- a/src/pages/RepoPage/CoverageOnboarding/CircleCI/CircleCI.tsx
+++ b/src/pages/RepoPage/CoverageOnboarding/CircleCI/CircleCI.tsx
@@ -1,25 +1,12 @@
-import { useParams } from 'react-router-dom'
-
-import { useOrgUploadToken } from 'services/orgUploadToken'
 import { useFlags } from 'shared/featureFlags'
 
 import CircleCIOrgToken from './CircleCIOrgToken'
 import CircleCIRepoToken from './CircleCIRepoToken'
 
-interface URLParams {
-  provider: string
-  owner: string
-}
-
 function CircleCI() {
-  const { newRepoFlag } = useFlags({
+  const { newRepoFlag: showOrgToken } = useFlags({
     newRepoFlag: false,
   })
-
-  const { provider, owner } = useParams<URLParams>()
-  const { data: orgUploadToken } = useOrgUploadToken({ provider, owner })
-
-  const showOrgToken = newRepoFlag && orgUploadToken
 
   return showOrgToken ? <CircleCIOrgToken /> : <CircleCIRepoToken />
 }

--- a/src/pages/RepoPage/CoverageOnboarding/CircleCI/CircleCIOrgToken.tsx
+++ b/src/pages/RepoPage/CoverageOnboarding/CircleCI/CircleCIOrgToken.tsx
@@ -29,7 +29,7 @@ function CircleCIOrgToken() {
   const { data: orgUploadToken } = useOrgUploadToken({ provider, owner })
 
   const uploadToken = orgUploadToken ?? data?.repository?.uploadToken
-  const tokenCopy = orgUploadToken ? 'organization' : 'repository'
+  const tokenCopy = orgUploadToken ? 'global' : 'repository'
 
   return (
     <div className="flex flex-col gap-6">

--- a/src/pages/RepoPage/CoverageOnboarding/CircleCI/CircleCIOrgToken.tsx
+++ b/src/pages/RepoPage/CoverageOnboarding/CircleCI/CircleCIOrgToken.tsx
@@ -28,12 +28,15 @@ function CircleCIOrgToken() {
   const { data } = useRepo({ provider, owner, repo })
   const { data: orgUploadToken } = useOrgUploadToken({ provider, owner })
 
+  const uploadToken = orgUploadToken ?? data?.repository?.uploadToken
+  const tokenCopy = orgUploadToken ? 'organization' : 'repository'
+
   return (
     <div className="flex flex-col gap-6">
       <div className="flex flex-col gap-3">
         <div>
           <h2 className="text-base font-semibold">
-            Step 1: add global token to{' '}
+            Step 1: add {tokenCopy} token to{' '}
             <A
               hook="circleCIEnvVarsLink"
               isExternal
@@ -51,8 +54,8 @@ function CircleCIOrgToken() {
           </p>
         </div>
         <pre className="flex items-center gap-2 overflow-auto rounded-md border-2 border-ds-gray-secondary bg-ds-gray-primary px-4 py-2 font-mono">
-          CODECOV_TOKEN={orgUploadToken}
-          <CopyClipboard string={orgUploadToken ?? ''} />
+          CODECOV_TOKEN={uploadToken}
+          <CopyClipboard string={uploadToken ?? ''} />
         </pre>
       </div>
       <div className="flex flex-col gap-3">


### PR DESCRIPTION
# Description
if we're showing repo token, we show new yaml instructions too. 

# Notable Changes
- update copy
- fix tests 

# Screenshots
<img width="1257" alt="Screenshot 2024-01-29 at 10 42 51 PM" src="https://github.com/codecov/gazebo/assets/91732700/1f0c21a2-3c26-49d9-8162-93ef10dba407">


# Link to Sample Entry

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.