### PR TITLE
fix: Update gh actions with v4 yaml input for repo token

### DIFF
--- a/src/pages/RepoPage/CoverageOnboarding/GitHubActions/GitHubActions.spec.tsx
+++ b/src/pages/RepoPage/CoverageOnboarding/GitHubActions/GitHubActions.spec.tsx
@@ -1,9 +1,4 @@
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { render, screen } from '@testing-library/react'
-import { graphql } from 'msw'
-import { setupServer } from 'msw/node'
-import { Suspense } from 'react'
-import { MemoryRouter, Route } from 'react-router-dom'
 
 import { useFlags } from 'shared/featureFlags'
 
@@ -15,61 +10,9 @@ jest.mock('shared/featureFlags')
 
 const mockedNewRepoFlag = useFlags as jest.Mock<{ newRepoFlag: boolean }>
 
-const mockGetOrgUploadToken = (hasOrgUploadToken: boolean | null) => ({
-  owner: {
-    orgUploadToken: hasOrgUploadToken
-      ? '9e6a6189-20f1-482d-ab62-ecfaa2629290'
-      : null,
-  },
-})
-
-const queryClient = new QueryClient({
-  defaultOptions: {
-    queries: {
-      suspense: true,
-      retry: false,
-    },
-  },
-})
-const server = setupServer()
-
-const wrapper: React.FC<React.PropsWithChildren> = ({ children }) => (
-  <QueryClientProvider client={queryClient}>
-    <MemoryRouter initialEntries={['/gh/codecov/cool-repo/new']}>
-      <Route
-        path={[
-          '/:provider/:owner/:repo/new',
-          '/:provider/:owner/:repo/new/other-ci',
-        ]}
-      >
-        <Suspense fallback={null}>{children}</Suspense>
-      </Route>
-    </MemoryRouter>
-  </QueryClientProvider>
-)
-
-beforeAll(() => {
-  console.error = () => {}
-  server.listen()
-})
-afterEach(() => {
-  queryClient.clear()
-  server.resetHandlers()
-})
-afterAll(() => server.close())
-
 describe('GitHubActions', () => {
-  function setup(hasOrgUploadToken: boolean | null) {
-    mockedNewRepoFlag.mockReturnValue({ newRepoFlag: true })
-
-    server.use(
-      graphql.query('GetOrgUploadToken', (req, res, ctx) => {
-        return res(
-          ctx.status(200),
-          ctx.data(mockGetOrgUploadToken(hasOrgUploadToken))
-        )
-      })
-    )
+  function setup(show: boolean) {
+    mockedNewRepoFlag.mockReturnValue({ newRepoFlag: show })
   }
 
   describe('when org upload token is available', () => {
@@ -78,12 +21,12 @@ describe('GitHubActions', () => {
     })
 
     it('renders GitHubActionsOrgToken', async () => {
-      render(<GitHubActions />, { wrapper })
+      render(<GitHubActions />)
 
-      const githubActionsOrgToken = await screen.findByText(
+      const GitHubActionsOrgToken = await screen.findByText(
         'GitHubActionsOrgToken'
       )
-      expect(githubActionsOrgToken).toBeInTheDocument()
+      expect(GitHubActionsOrgToken).toBeInTheDocument()
     })
   })
 
@@ -93,12 +36,12 @@ describe('GitHubActions', () => {
     })
 
     it('renders GitHubActionsRepoToken', async () => {
-      render(<GitHubActions />, { wrapper })
+      render(<GitHubActions />)
 
-      const githubActionsRepoToken = await screen.findByText(
+      const GitHubActionsRepoToken = await screen.findByText(
         'GitHubActionsRepoToken'
       )
-      expect(githubActionsRepoToken).toBeInTheDocument()
+      expect(GitHubActionsRepoToken).toBeInTheDocument()
     })
   })
 })

--- a/src/pages/RepoPage/CoverageOnboarding/GitHubActions/GitHubActions.tsx
+++ b/src/pages/RepoPage/CoverageOnboarding/GitHubActions/GitHubActions.tsx
@@ -1,26 +1,12 @@
-import { useParams } from 'react-router-dom'
-
-import { useOrgUploadToken } from 'services/orgUploadToken'
 import { useFlags } from 'shared/featureFlags'
 
 import GitHubActionsOrgToken from './GitHubActionsOrgToken'
 import GitHubActionsRepoToken from './GitHubActionsRepoToken'
 
-interface URLParams {
-  provider: string
-  owner: string
-  repo: string
-}
-
 function GitHubActions() {
-  const { newRepoFlag } = useFlags({
+  const { newRepoFlag: showOrgToken } = useFlags({
     newRepoFlag: false,
   })
-
-  const { provider, owner } = useParams<URLParams>()
-  const { data: orgUploadToken } = useOrgUploadToken({ provider, owner })
-
-  const showOrgToken = newRepoFlag && orgUploadToken
 
   return showOrgToken ? <GitHubActionsOrgToken /> : <GitHubActionsRepoToken />
 }

--- a/src/pages/RepoPage/CoverageOnboarding/GitHubActions/GitHubActionsOrgToken.spec.tsx
+++ b/src/pages/RepoPage/CoverageOnboarding/GitHubActions/GitHubActionsOrgToken.spec.tsx
@@ -21,6 +21,14 @@ const mockGetRepo = {
   },
 }
 
+const mockGetOrgUploadToken = (hasOrgUploadToken: boolean | null) => ({
+  owner: {
+    orgUploadToken: hasOrgUploadToken
+      ? '9e6a6189-20f1-482d-ab62-ecfaa2629290'
+      : null,
+  },
+})
+
 const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
@@ -57,7 +65,7 @@ afterEach(() => {
 afterAll(() => server.close())
 
 describe('GitHubActionsOrgToken', () => {
-  function setup() {
+  function setup(hasOrgUploadToken: boolean | null) {
     server.use(
       graphql.query('GetRepo', (req, res, ctx) =>
         res(ctx.status(200), ctx.data(mockGetRepo))
@@ -65,57 +73,112 @@ describe('GitHubActionsOrgToken', () => {
       graphql.query('GetOrgUploadToken', (req, res, ctx) => {
         return res(
           ctx.status(200),
-          ctx.data({
-            owner: { orgUploadToken: '9e6a6189-20f1-482d-ab62-ecfaa2629290' },
-          })
+          ctx.data(mockGetOrgUploadToken(hasOrgUploadToken))
         )
       })
     )
   }
 
   describe('step one', () => {
-    beforeEach(() => setup())
+    describe('when org upload token exists', () => {
+      beforeEach(() => setup(true))
 
-    it('renders header', async () => {
-      render(<GitHubActionsOrgToken />, { wrapper })
+      it('renders header', async () => {
+        render(<GitHubActionsOrgToken />, { wrapper })
 
-      const header = await screen.findByRole('heading', { name: /Step 1/ })
-      expect(header).toBeInTheDocument()
+        const header = await screen.findByRole('heading', { name: /Step 1/ })
+        expect(header).toBeInTheDocument()
 
-      const repositorySecretLink = await screen.findByRole('link', {
-        name: /repository secret/,
+        const repositorySecretLink = await screen.findByRole('link', {
+          name: /repository secret/,
+        })
+        expect(repositorySecretLink).toBeInTheDocument()
+        expect(repositorySecretLink).toHaveAttribute(
+          'href',
+          'https://github.com/codecov/cool-repo/settings/secrets/actions'
+        )
       })
-      expect(repositorySecretLink).toBeInTheDocument()
-      expect(repositorySecretLink).toHaveAttribute(
-        'href',
-        'https://github.com/codecov/cool-repo/settings/secrets/actions'
-      )
+
+      it('renders body', async () => {
+        render(<GitHubActionsOrgToken />, { wrapper })
+
+        const body = await screen.findByText(
+          /Admin required to access repo settings > secrets and variable > actions/
+        )
+        expect(body).toBeInTheDocument()
+      })
+
+      it('renders token box', async () => {
+        render(<GitHubActionsOrgToken />, { wrapper })
+
+        const codecovToken = await screen.findByText(/CODECOV_TOKEN=/)
+        expect(codecovToken).toBeInTheDocument()
+
+        const tokenValue = await screen.findByText(
+          /9e6a6189-20f1-482d-ab62-ecfaa2629290/
+        )
+        expect(tokenValue).toBeInTheDocument()
+      })
+
+      it('renders global token copy', async () => {
+        render(<GitHubActionsOrgToken />, { wrapper })
+
+        const globalToken = await screen.findByText(/global token/)
+        expect(globalToken).toBeInTheDocument()
+      })
     })
 
-    it('renders body', async () => {
-      render(<GitHubActionsOrgToken />, { wrapper })
+    describe('when org upload token does not exist', () => {
+      beforeEach(() => setup(false))
 
-      const body = await screen.findByText(
-        /Admin required to access repo settings > secrets and variable > actions/
-      )
-      expect(body).toBeInTheDocument()
-    })
+      it('renders header', async () => {
+        render(<GitHubActionsOrgToken />, { wrapper })
 
-    it('renders token box', async () => {
-      render(<GitHubActionsOrgToken />, { wrapper })
+        const header = await screen.findByRole('heading', { name: /Step 1/ })
+        expect(header).toBeInTheDocument()
 
-      const codecovToken = await screen.findByText(/CODECOV_TOKEN=/)
-      expect(codecovToken).toBeInTheDocument()
+        const repositorySecretLink = await screen.findByRole('link', {
+          name: /repository secret/,
+        })
+        expect(repositorySecretLink).toBeInTheDocument()
+        expect(repositorySecretLink).toHaveAttribute(
+          'href',
+          'https://github.com/codecov/cool-repo/settings/secrets/actions'
+        )
+      })
 
-      const tokenValue = await screen.findByText(
-        /9e6a6189-20f1-482d-ab62-ecfaa2629290/
-      )
-      expect(tokenValue).toBeInTheDocument()
+      it('renders body', async () => {
+        render(<GitHubActionsOrgToken />, { wrapper })
+
+        const body = await screen.findByText(
+          /Admin required to access repo settings > secrets and variable > actions/
+        )
+        expect(body).toBeInTheDocument()
+      })
+
+      it('renders token box', async () => {
+        render(<GitHubActionsOrgToken />, { wrapper })
+
+        const codecovToken = await screen.findByText(/CODECOV_TOKEN=/)
+        expect(codecovToken).toBeInTheDocument()
+
+        const tokenValue = await screen.findByText(
+          /9e6a6189-20f1-482d-ab62-ecfaa2629295/
+        )
+        expect(tokenValue).toBeInTheDocument()
+      })
+
+      it('renders repo token copy', async () => {
+        render(<GitHubActionsOrgToken />, { wrapper })
+
+        const globalToken = await screen.findByText(/repository token/)
+        expect(globalToken).toBeInTheDocument()
+      })
     })
   })
 
   describe('step two', () => {
-    beforeEach(() => setup())
+    beforeEach(() => setup(true))
 
     it('renders header', async () => {
       render(<GitHubActionsOrgToken />, { wrapper })
@@ -147,7 +210,7 @@ describe('GitHubActionsOrgToken', () => {
   })
 
   describe('step three', () => {
-    beforeEach(() => setup())
+    beforeEach(() => setup(true))
     it('renders first body', async () => {
       render(<GitHubActionsOrgToken />, { wrapper })
 
@@ -173,7 +236,7 @@ describe('GitHubActionsOrgToken', () => {
   })
 
   describe('ending', () => {
-    beforeEach(() => setup())
+    beforeEach(() => setup(true))
     it('renders body', async () => {
       render(<GitHubActionsOrgToken />, { wrapper })
 

--- a/src/pages/RepoPage/CoverageOnboarding/GitHubActions/GitHubActionsOrgToken.tsx
+++ b/src/pages/RepoPage/CoverageOnboarding/GitHubActions/GitHubActionsOrgToken.tsx
@@ -17,6 +17,9 @@ function GitHubActionsOrgToken() {
   const { data } = useRepo({ provider, owner, repo })
   const { data: orgUploadToken } = useOrgUploadToken({ provider, owner })
 
+  const uploadToken = orgUploadToken ?? data?.repository?.uploadToken
+  const tokenCopy = orgUploadToken ? 'global' : 'repository'
+
   const orgTokenActionString = `- name: Upload coverage reports to Codecov
   uses: codecov/codecov-action@v4
   env:
@@ -29,7 +32,7 @@ function GitHubActionsOrgToken() {
       <div className="flex flex-col gap-4">
         <div>
           <h2 className="text-base font-semibold">
-            Step 1: add global token as{' '}
+            Step 1: add {tokenCopy} token as{' '}
             <A
               to={{ pageName: 'githubRepoSecrets' }}
               isExternal
@@ -44,8 +47,8 @@ function GitHubActionsOrgToken() {
           </p>
         </div>
         <pre className="flex items-center gap-2 overflow-auto rounded-md border-2 border-ds-gray-secondary bg-ds-gray-primary px-4 py-2 font-mono">
-          CODECOV_TOKEN={orgUploadToken}
-          <CopyClipboard string={orgUploadToken ?? ''} />
+          CODECOV_TOKEN={uploadToken}
+          <CopyClipboard string={uploadToken ?? ''} />
         </pre>
       </div>
       <div className="flex flex-col gap-4">


### PR DESCRIPTION
# Description
if we're showing repo token, show the new instructions for v4 release. 

# Notable Changes
 - copy changes 
 - tests

# Screenshots
<img width="1257" alt="Screenshot 2024-01-29 at 11 07 53 PM" src="https://github.com/codecov/gazebo/assets/91732700/763e7c8c-3b62-45ae-9f96-9f893f2cfa9e">


# Link to Sample Entry

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.