### PR TITLE
fix: Update other ci with v4 instructions

### DIFF
--- a/src/pages/RepoPage/CoverageOnboarding/OtherCI/OtherCI.spec.tsx
+++ b/src/pages/RepoPage/CoverageOnboarding/OtherCI/OtherCI.spec.tsx
@@ -1,9 +1,4 @@
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { render, screen } from '@testing-library/react'
-import { graphql } from 'msw'
-import { setupServer } from 'msw/node'
-import { Suspense } from 'react'
-import { MemoryRouter, Route } from 'react-router-dom'
 
 import { useFlags } from 'shared/featureFlags'
 
@@ -15,61 +10,9 @@ jest.mock('shared/featureFlags')
 
 const mockedNewRepoFlag = useFlags as jest.Mock<{ newRepoFlag: boolean }>
 
-const mockGetOrgUploadToken = (hasOrgUploadToken: boolean | null) => ({
-  owner: {
-    orgUploadToken: hasOrgUploadToken
-      ? '9e6a6189-20f1-482d-ab62-ecfaa2629290'
-      : null,
-  },
-})
-
-const queryClient = new QueryClient({
-  defaultOptions: {
-    queries: {
-      suspense: true,
-      retry: false,
-    },
-  },
-})
-const server = setupServer()
-
-const wrapper: React.FC<React.PropsWithChildren> = ({ children }) => (
-  <QueryClientProvider client={queryClient}>
-    <MemoryRouter initialEntries={['/gh/codecov/cool-repo/new']}>
-      <Route
-        path={[
-          '/:provider/:owner/:repo/new',
-          '/:provider/:owner/:repo/new/other-ci',
-        ]}
-      >
-        <Suspense fallback={null}>{children}</Suspense>
-      </Route>
-    </MemoryRouter>
-  </QueryClientProvider>
-)
-
-beforeAll(() => {
-  console.error = () => {}
-  server.listen()
-})
-afterEach(() => {
-  queryClient.clear()
-  server.resetHandlers()
-})
-afterAll(() => server.close())
-
 describe('OtherCI', () => {
-  function setup(hasOrgUploadToken: boolean | null) {
-    mockedNewRepoFlag.mockReturnValue({ newRepoFlag: true })
-
-    server.use(
-      graphql.query('GetOrgUploadToken', (req, res, ctx) => {
-        return res(
-          ctx.status(200),
-          ctx.data(mockGetOrgUploadToken(hasOrgUploadToken))
-        )
-      })
-    )
+  function setup(show: boolean) {
+    mockedNewRepoFlag.mockReturnValue({ newRepoFlag: show })
   }
 
   describe('when org upload token is available', () => {
@@ -78,7 +21,7 @@ describe('OtherCI', () => {
     })
 
     it('renders OtherCIOrgToken', async () => {
-      render(<OtherCI />, { wrapper })
+      render(<OtherCI />)
 
       const OtherCIOrgToken = await screen.findByText('OtherCIOrgToken')
       expect(OtherCIOrgToken).toBeInTheDocument()
@@ -91,7 +34,7 @@ describe('OtherCI', () => {
     })
 
     it('renders OtherCIRepoToken', async () => {
-      render(<OtherCI />, { wrapper })
+      render(<OtherCI />)
 
       const OtherCIRepoToken = await screen.findByText('OtherCIRepoToken')
       expect(OtherCIRepoToken).toBeInTheDocument()

--- a/src/pages/RepoPage/CoverageOnboarding/OtherCI/OtherCI.tsx
+++ b/src/pages/RepoPage/CoverageOnboarding/OtherCI/OtherCI.tsx
@@ -1,25 +1,12 @@
-import { useParams } from 'react-router-dom'
-
-import { useOrgUploadToken } from 'services/orgUploadToken'
 import { useFlags } from 'shared/featureFlags'
 
 import OtherCIOrgToken from './OtherCIOrgToken'
 import OtherCIRepoToken from './OtherCIRepoToken'
 
-interface URLParams {
-  provider: string
-  owner: string
-}
-
 function OtherCI() {
-  const { newRepoFlag } = useFlags({
+  const { newRepoFlag: showOrgToken } = useFlags({
     newRepoFlag: false,
   })
-
-  const { provider, owner } = useParams<URLParams>()
-  const { data: orgUploadToken } = useOrgUploadToken({ provider, owner })
-
-  const showOrgToken = newRepoFlag && orgUploadToken
 
   return showOrgToken ? <OtherCIOrgToken /> : <OtherCIRepoToken />
 }

--- a/src/pages/RepoPage/CoverageOnboarding/OtherCI/OtherCIOrgToken.tsx
+++ b/src/pages/RepoPage/CoverageOnboarding/OtherCI/OtherCIOrgToken.tsx
@@ -1,6 +1,7 @@
 import { useParams } from 'react-router-dom'
 
 import { useOrgUploadToken } from 'services/orgUploadToken'
+import { useRepo } from 'services/repo'
 import A from 'ui/A'
 import CopyClipboard from 'ui/CopyClipboard'
 
@@ -14,17 +15,21 @@ interface URLParams {
 
 function OtherCIOrgToken() {
   const { provider, owner, repo } = useParams<URLParams>()
+  const { data } = useRepo({ provider, owner, repo })
   const { data: orgUploadToken } = useOrgUploadToken({ provider, owner })
+
+  const uploadToken = orgUploadToken ?? data?.repository?.uploadToken
+  const tokenCopy = orgUploadToken ? 'global' : 'repository'
 
   return (
     <div className="flex flex-col gap-6">
       <div className="flex flex-col gap-3">
         <h2 className="text-base font-semibold">
-          Step 1: add global token as a secret to your CI Provider
+          Step 1: add {tokenCopy} token as a secret to your CI Provider
         </h2>
         <pre className="flex items-center gap-2 overflow-auto rounded-md border-2 border-ds-gray-secondary bg-ds-gray-primary px-4 py-2 font-mono">
-          CODECOV_TOKEN={orgUploadToken}
-          <CopyClipboard string={orgUploadToken ?? ''} />
+          CODECOV_TOKEN={uploadToken}
+          <CopyClipboard string={uploadToken ?? ''} />
         </pre>
       </div>
       <div className="flex flex-col gap-3">
@@ -48,7 +53,8 @@ function OtherCIOrgToken() {
         <pre className="mt-2 flex items-center gap-2 overflow-auto rounded-md border-2 border-ds-gray-secondary bg-ds-gray-primary px-4 py-2 font-mono">
           # upload to Codecov <br />
           # after your tests run <br />
-          codecovcli upload-process -t {orgUploadToken} -r {repo}
+          codecovcli upload-process -t {uploadToken}{' '}
+          {orgUploadToken && `-r ${repo}`}
         </pre>
       </div>
       <div>


### PR DESCRIPTION
# Description
if we're showing repo token, show new changes for the yaml (new ci version)

# Notable Changes
- copy changes
- tests

# Screenshots
<img width="1257" alt="Screenshot 2024-01-29 at 11 48 06 PM" src="https://github.com/codecov/gazebo/assets/91732700/078a36b9-5224-44b8-836f-edb4ccd0ef96">
<img width="1257" alt="Screenshot 2024-01-29 at 11 48 00 PM" src="https://github.com/codecov/gazebo/assets/91732700/2d38ae1a-0888-428f-b8a0-b214f490a892">


# Link to Sample Entry

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.