### PR TITLE
feat: Create pull coverage dropdown

### DIFF
--- a/src/pages/PullRequestPage/Dropdowns/PullCoverageDropdown.spec.tsx
+++ b/src/pages/PullRequestPage/Dropdowns/PullCoverageDropdown.spec.tsx
@@ -1,0 +1,291 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { graphql } from 'msw'
+import { setupServer } from 'msw/node'
+import { Suspense } from 'react'
+import { MemoryRouter, Route } from 'react-router-dom'
+
+import SummaryDropdown from 'ui/SummaryDropdown'
+
+import PullCoverageDropdown from './PullCoverageDropdown'
+
+const mockSummaryData = (patchTotals: {
+  missesCount: number | null
+  partialsCount: number | null
+}) => {
+  return {
+    owner: {
+      repository: {
+        __typename: 'Repository',
+        pull: {
+          compareWithBase: {
+            __typename: 'Comparison',
+            patchTotals,
+          },
+        },
+      },
+    },
+  }
+}
+
+const mockNoData = { owner: null }
+
+const mockFirstPullRequest = {
+  owner: {
+    repository: {
+      __typename: 'Repository',
+      pull: {
+        compareWithBase: {
+          __typename: 'FirstPullRequest',
+          message: 'First pull request',
+        },
+      },
+    },
+  },
+}
+
+const mockComparisonError = {
+  owner: {
+    repository: {
+      __typename: 'Repository',
+      pull: {
+        compareWithBase: {
+          __typename: 'MissingHeadCommit',
+          message: 'Missing head commit',
+        },
+      },
+    },
+  },
+}
+
+const server = setupServer()
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      retry: false,
+      suspense: true,
+    },
+  },
+})
+
+const wrapper: React.FC<React.PropsWithChildren> = ({ children }) => (
+  <QueryClientProvider client={queryClient}>
+    <MemoryRouter initialEntries={['/gh/codecov/test-repo/pull/123']}>
+      <Route path="/:provider/:owner/:repo/pull/:pullId">
+        <Suspense fallback={<div>Loading...</div>}>
+          <SummaryDropdown type="single">{children}</SummaryDropdown>
+        </Suspense>
+      </Route>
+    </MemoryRouter>
+  </QueryClientProvider>
+)
+
+beforeAll(() => {
+  server.listen()
+})
+
+afterEach(() => {
+  queryClient.clear()
+  server.resetHandlers()
+})
+
+afterAll(() => {
+  server.close()
+})
+
+interface SetupArgs {
+  noData?: boolean
+  comparisonError?: boolean
+  patchTotals?: {
+    missesCount: number | null
+    partialsCount: number | null
+  }
+  firstPullRequest?: boolean
+}
+
+describe('PullCoverageDropdown', () => {
+  function setup({
+    noData = false,
+    comparisonError = false,
+    patchTotals = { missesCount: 0, partialsCount: 0 },
+    firstPullRequest = false,
+  }: SetupArgs) {
+    const user = userEvent.setup()
+
+    server.use(
+      graphql.query('PullDropdownSummary', (req, res, ctx) => {
+        if (noData) {
+          return res(ctx.status(200), ctx.data(mockNoData))
+        } else if (comparisonError) {
+          return res(ctx.status(200), ctx.data(mockComparisonError))
+        } else if (firstPullRequest) {
+          return res(ctx.status(200), ctx.data(mockFirstPullRequest))
+        }
+
+        return res(ctx.status(200), ctx.data(mockSummaryData(patchTotals)))
+      })
+    )
+
+    return { user }
+  }
+
+  describe('renders summary message', () => {
+    describe('there are missing lines', () => {
+      it('renders missing lines message', async () => {
+        setup({ patchTotals: { missesCount: 10, partialsCount: 10 } })
+        render(
+          <PullCoverageDropdown>
+            <p>Passed child</p>
+          </PullCoverageDropdown>,
+          { wrapper }
+        )
+
+        const coverageReport = await screen.findByText(/Coverage Report:/)
+        expect(coverageReport).toBeInTheDocument()
+
+        const message = await screen.findByText(
+          /20 lines in your changes are missing coverage/
+        )
+        expect(message).toBeInTheDocument()
+      })
+    })
+
+    describe('there is one line missing', () => {
+      it('renders singular missing line message', async () => {
+        setup({ patchTotals: { missesCount: 1, partialsCount: 0 } })
+        render(
+          <PullCoverageDropdown>
+            <p>Passed child</p>
+          </PullCoverageDropdown>,
+          { wrapper }
+        )
+
+        const coverageReport = await screen.findByText(/Coverage Report:/)
+        expect(coverageReport).toBeInTheDocument()
+
+        const message = await screen.findByText(
+          /1 line in your changes are missing coverage/
+        )
+        expect(message).toBeInTheDocument()
+      })
+    })
+
+    describe('there are no missing lines', () => {
+      it('renders all lines covered message', async () => {
+        setup({ patchTotals: { missesCount: 0, partialsCount: 0 } })
+        render(
+          <PullCoverageDropdown>
+            <p>Passed child</p>
+          </PullCoverageDropdown>,
+          { wrapper }
+        )
+
+        const coverageReport = await screen.findByText(/Coverage Report:/)
+        expect(coverageReport).toBeInTheDocument()
+
+        const message = await screen.findByText(
+          /all modified lines are covered by tests/
+        )
+        expect(message).toBeInTheDocument()
+      })
+    })
+
+    describe('patch totals are null', () => {
+      it('renders all lines covered message', async () => {
+        setup({ patchTotals: { missesCount: null, partialsCount: null } })
+        render(
+          <PullCoverageDropdown>
+            <p>Passed child</p>
+          </PullCoverageDropdown>,
+          { wrapper }
+        )
+
+        const coverageReport = await screen.findByText(/Coverage Report:/)
+        expect(coverageReport).toBeInTheDocument()
+
+        const message = await screen.findByText(
+          /all modified lines are covered by tests/
+        )
+        expect(message).toBeInTheDocument()
+      })
+    })
+
+    describe('there is no data', () => {
+      it('renders unknown error message', async () => {
+        setup({ noData: true })
+        render(
+          <PullCoverageDropdown>
+            <p>Passed child</p>
+          </PullCoverageDropdown>,
+          { wrapper }
+        )
+
+        const coverageReport = await screen.findByText(/Coverage Report:/)
+        expect(coverageReport).toBeInTheDocument()
+
+        const message = await screen.findByText(/an unknown error has occurred/)
+        expect(message).toBeInTheDocument()
+      })
+    })
+
+    describe('there is a comparison error', () => {
+      it('renders error message', async () => {
+        setup({ comparisonError: true })
+        render(
+          <PullCoverageDropdown>
+            <p>Passed child</p>
+          </PullCoverageDropdown>,
+          { wrapper }
+        )
+
+        const coverageReport = await screen.findByText(/Coverage Report:/)
+        expect(coverageReport).toBeInTheDocument()
+
+        const message = await screen.findByText(/missing head commit/)
+        expect(message).toBeInTheDocument()
+      })
+    })
+
+    describe('there is a first pull request error', () => {
+      it('renders first pr message', async () => {
+        setup({ firstPullRequest: true })
+        render(
+          <PullCoverageDropdown>
+            <p>Passed child</p>
+          </PullCoverageDropdown>,
+          { wrapper }
+        )
+
+        const coverageReport = await screen.findByText(/Coverage Report:/)
+        expect(coverageReport).toBeInTheDocument()
+
+        const message = await screen.findByText(
+          /once merged to default, your following pull request and commits will include report details/
+        )
+        expect(message).toBeInTheDocument()
+      })
+    })
+  })
+
+  describe('expanding the dropdown', () => {
+    it('renders the passed children', async () => {
+      const { user } = setup({
+        patchTotals: { missesCount: 10, partialsCount: 10 },
+      })
+      render(
+        <PullCoverageDropdown>
+          <p>Passed child</p>
+        </PullCoverageDropdown>,
+        { wrapper }
+      )
+
+      const coverageReport = await screen.findByText(/Coverage Report:/)
+      expect(coverageReport).toBeInTheDocument()
+      await user.click(coverageReport)
+
+      const passedChild = await screen.findByText(/Passed child/)
+      expect(passedChild).toBeInTheDocument()
+    })
+  })
+})

--- a/src/pages/PullRequestPage/Dropdowns/PullCoverageDropdown.tsx
+++ b/src/pages/PullRequestPage/Dropdowns/PullCoverageDropdown.tsx
@@ -1,0 +1,104 @@
+import isNumber from 'lodash/isNumber'
+import { useParams } from 'react-router-dom'
+
+import { usePullCoverageDropdownSummary } from 'services/pull/usePullCoverageDropdownSummary'
+import SummaryDropdown from 'ui/SummaryDropdown'
+
+interface URLParams {
+  provider: string
+  owner: string
+  repo: string
+  pullId: string
+}
+
+interface CoverageMessageProps {
+  missesCount?: number
+  partialsCount?: number
+  errorType?: string
+  errorMsg?: string
+}
+
+const CoverageMessage: React.FC<CoverageMessageProps> = ({
+  missesCount,
+  partialsCount,
+  errorType,
+  errorMsg,
+}) => {
+  if (errorType === 'FirstPullRequest') {
+    return (
+      <>
+        once merged to default, your following pull request and commits will
+        include report details &#x2139;
+      </>
+    )
+  }
+
+  if (errorType && errorMsg) {
+    return <>{errorMsg.toLowerCase()} &#x26A0;</>
+  }
+
+  if (isNumber(missesCount) && isNumber(partialsCount)) {
+    const totalCount = missesCount + partialsCount
+
+    if (totalCount === 0) {
+      return <>all modified lines are covered by tests &#x2705;</>
+    }
+
+    if (totalCount === 1) {
+      return (
+        <>{totalCount} line in your changes are missing coverage &#x26A0;</>
+      )
+    }
+
+    return <>{totalCount} lines in your changes are missing coverage &#x26A0;</>
+  }
+
+  return <>an unknown error has occurred</>
+}
+
+const PullCoverageDropdown: React.FC<React.PropsWithChildren> = ({
+  children,
+}) => {
+  const { provider, owner, repo, pullId } = useParams<URLParams>()
+  const { data } = usePullCoverageDropdownSummary({
+    provider,
+    owner,
+    repo,
+    pullId: +pullId,
+  })
+
+  let missesCount: number | undefined
+  let partialsCount: number | undefined
+  if (data?.pull?.compareWithBase?.__typename === 'Comparison') {
+    missesCount = data.pull?.compareWithBase?.patchTotals?.missesCount ?? 0
+    partialsCount = data.pull?.compareWithBase?.patchTotals?.partialsCount ?? 0
+  }
+
+  let errorMsg: string | undefined = undefined
+  let errorType: string | undefined = undefined
+  if (data?.pull?.compareWithBase?.__typename !== 'Comparison') {
+    errorType = data?.pull?.compareWithBase?.__typename
+    errorMsg = data?.pull?.compareWithBase?.message
+  }
+
+  return (
+    <SummaryDropdown.Item value="coverage">
+      <SummaryDropdown.Trigger>
+        <p className="flex w-full flex-col sm:flex-row sm:gap-1">
+          <span className="font-semibold">Coverage Report: </span>
+          <CoverageMessage
+            missesCount={missesCount}
+            partialsCount={partialsCount}
+            errorType={errorType}
+            errorMsg={errorMsg}
+          />
+        </p>
+      </SummaryDropdown.Trigger>
+      <SummaryDropdown.Content className="py-2">
+        {children}
+      </SummaryDropdown.Content>
+    </SummaryDropdown.Item>
+  )
+}
+
+export default PullCoverageDropdown

--- a/src/services/pull/usePullCoverageDropdownSummary.spec.tsx
+++ b/src/services/pull/usePullCoverageDropdownSummary.spec.tsx
@@ -118,17 +118,12 @@ describe('usePullCoverageDropdownSummary', () => {
       )
 
       const expectedResult = {
-        owner: {
-          repository: {
-            __typename: 'Repository',
-            pull: {
-              compareWithBase: {
-                __typename: 'Comparison',
-                patchTotals: {
-                  missesCount: 1,
-                  partialsCount: 2,
-                },
-              },
+        pull: {
+          compareWithBase: {
+            __typename: 'Comparison',
+            patchTotals: {
+              missesCount: 1,
+              partialsCount: 2,
             },
           },
         },
@@ -155,7 +150,7 @@ describe('usePullCoverageDropdownSummary', () => {
       )
 
       await waitFor(() =>
-        expect(result.current.data).toStrictEqual({ owner: null })
+        expect(result.current.data).toStrictEqual({ pull: null })
       )
     })
   })

--- a/src/services/pull/usePullCoverageDropdownSummary.tsx
+++ b/src/services/pull/usePullCoverageDropdownSummary.tsx
@@ -161,7 +161,11 @@ export function usePullCoverageDropdownSummary({
           })
         }
 
-        return data
+        const pull = data?.owner?.repository?.pull ?? null
+
+        return {
+          pull,
+        }
       }),
   })
 }


### PR DESCRIPTION
# Description

This PR creates the first of two dropdowns for the pull request page, creating one to summarize the coverage information. This dropdown will be used later when putting everything all together on the PR page soon.

GH codecov/engineering-team#997

# Notable Changes

- Create new `PullCoverageDropdownSummary`
- Update `usePullCoverageDropdownSummary` to return just the pull
- Create/update tests

# Screenshots

![Screenshot 2024-01-30 at 10 16 50](https://github.com/codecov/gazebo/assets/105234307/80b5079f-a7f2-4fb6-8b87-f4b2b039d776)