### PR TITLE
ref: Swap to using avg instead of max for analytics page

### DIFF
--- a/src/pages/AnalyticsPage/Chart/Chart.spec.jsx
+++ b/src/pages/AnalyticsPage/Chart/Chart.spec.jsx
@@ -4,6 +4,8 @@ import { graphql } from 'msw'
 import { setupServer } from 'msw/node'
 import { MemoryRouter, Route } from 'react-router-dom'
 
+import { TierNames } from 'services/tier'
+
 import Chart from './Chart'
 
 const queryClient = new QueryClient({
@@ -32,7 +34,7 @@ describe('Analytics coverage chart', () => {
       measurements: [
         {
           timestamp: '2020-01-01T00:00:00Z',
-          max: 91.11,
+          avg: 91.11,
         },
       ],
     },
@@ -43,11 +45,11 @@ describe('Analytics coverage chart', () => {
       measurements: [
         {
           timestamp: '2020-01-01T00:00:00Z',
-          max: 90.0,
+          avg: 90.0,
         },
         {
           timestamp: '2021-01-01T00:00:00Z',
-          max: 91.11,
+          avg: 91.11,
         },
       ],
     },
@@ -65,6 +67,12 @@ describe('Analytics coverage chart', () => {
         }
 
         return res(ctx.status(200), ctx.data(mockDataPoints))
+      }),
+      graphql.query('OwnerTier', (req, res, ctx) => {
+        return res(
+          ctx.status(200),
+          ctx.data({ owner: { tier: TierNames.PRO } })
+        )
       })
     )
   }

--- a/src/pages/AnalyticsPage/Chart/useCoverage.js
+++ b/src/pages/AnalyticsPage/Chart/useCoverage.js
@@ -28,14 +28,14 @@ export const useCoverage = ({ params, options = {} }) => {
     isPublic: shouldDisplayPublicReposOnly,
     opts: {
       select: (data) => {
-        if (data?.measurements?.[0]?.max === null) {
-          data.measurements[0].max = 0
+        if (data?.measurements?.[0]?.avg === null) {
+          data.measurements[0].avg = 0
         }
 
         // set prevPercent so we can reuse value if next value is null
         let prevPercent = data?.measurements?.[0]
         const coverage = data?.measurements?.map((measurement) => {
-          let coverage = measurement?.max ?? prevPercent
+          let coverage = measurement?.avg ?? prevPercent
 
           // can save on a few reassignments
           if (prevPercent !== coverage) {

--- a/src/pages/AnalyticsPage/Chart/useCoverage.spec.js
+++ b/src/pages/AnalyticsPage/Chart/useCoverage.spec.js
@@ -15,23 +15,23 @@ const mockRepoMeasurements = {
     measurements: [
       {
         timestamp: '2023-01-01T00:00:00+00:00',
-        max: 85,
+        avg: 85,
       },
       {
         timestamp: '2023-01-02T00:00:00+00:00',
-        max: 80,
+        avg: 80,
       },
       {
         timestamp: '2023-01-02T00:00:00+00:00',
-        max: null,
+        avg: null,
       },
       {
         timestamp: '2023-01-03T00:00:00+00:00',
-        max: 80,
+        avg: 80,
       },
       {
         timestamp: '2023-01-04T00:00:00+00:00',
-        max: 95,
+        avg: 95,
       },
     ],
   },
@@ -42,11 +42,11 @@ const mockNullFirstValRepoMeasurements = {
     measurements: [
       {
         timestamp: '2023-01-01T00:00:00+00:00',
-        max: null,
+        avg: null,
       },
       {
         timestamp: '2023-01-02T00:00:00+00:00',
-        max: 80,
+        avg: 80,
       },
     ],
   },
@@ -57,7 +57,7 @@ const mockPublicRepoMeasurements = {
     measurements: [
       {
         timestamp: '2023-01-02T00:00:00+00:00',
-        max: 80,
+        avg: 80,
       },
     ],
   },

--- a/src/services/charts/useReposCoverageMeasurements.spec.tsx
+++ b/src/services/charts/useReposCoverageMeasurements.spec.tsx
@@ -10,19 +10,19 @@ const mockReposMeasurements = {
     measurements: [
       {
         timestamp: '2023-01-01T00:00:00+00:00',
-        max: 85,
+        avg: 85,
       },
       {
         timestamp: '2023-01-02T00:00:00+00:00',
-        max: 80,
+        avg: 80,
       },
       {
         timestamp: '2023-01-03T00:00:00+00:00',
-        max: 90,
+        avg: 90,
       },
       {
         timestamp: '2023-01-04T00:00:00+00:00',
-        max: 100,
+        avg: 100,
       },
     ],
   },
@@ -78,19 +78,19 @@ describe('useReposCoverageMeasurements', () => {
         measurements: [
           {
             timestamp: '2023-01-01T00:00:00+00:00',
-            max: 85,
+            avg: 85,
           },
           {
             timestamp: '2023-01-02T00:00:00+00:00',
-            max: 80,
+            avg: 80,
           },
           {
             timestamp: '2023-01-03T00:00:00+00:00',
-            max: 90,
+            avg: 90,
           },
           {
             timestamp: '2023-01-04T00:00:00+00:00',
-            max: 100,
+            avg: 100,
           },
         ],
       }

--- a/src/services/charts/useReposCoverageMeasurements.ts
+++ b/src/services/charts/useReposCoverageMeasurements.ts
@@ -9,7 +9,7 @@ export const ReposCoverageMeasurementsConfig = z
     measurements: z.array(
       z.object({
         timestamp: z.string(),
-        max: z.number().nullish(),
+        avg: z.number().nullish(),
       })
     ),
   })
@@ -48,7 +48,7 @@ const query = `
         isPublic: $isPublic
       ) {
         timestamp
-        max
+        avg
       }
     }
   }


### PR DESCRIPTION
# Description

This PR swaps to using the `avg` coverage on the analytics page instead of the max.

# Notable Changes

- Swap to using `avg` instead of `max`