### PR TITLE
fix: Remove feedback link form header 

### DIFF
--- a/src/layouts/Header/DesktopMenu.jsx
+++ b/src/layouts/Header/DesktopMenu.jsx
@@ -95,13 +95,6 @@ function DesktopMenu() {
         <A to={{ pageName: 'blog' }} variant="header" showExternalIcon={false}>
           Blog
         </A>
-        <A
-          to={{ pageName: 'feedback' }}
-          variant="header"
-          showExternalIcon={false}
-        >
-          Feedback
-        </A>
       </div>
       {!!currentUser ? (
         <div className="mx-2 flex items-center gap-4 md:mx-4">

--- a/src/layouts/Header/DesktopMenu.spec.jsx
+++ b/src/layouts/Header/DesktopMenu.spec.jsx
@@ -215,13 +215,6 @@ describe('DesktopMenu', () => {
     })
     expect(blogLink).toBeInTheDocument()
     expect(blogLink).toHaveAttribute('href', 'https://about.codecov.io/blog')
-
-    const feedback = await screen.findByText('Feedback')
-    expect(feedback).toBeInTheDocument()
-    expect(feedback).toHaveAttribute(
-      'href',
-      'https://github.com/codecov/feedback/discussions'
-    )
   })
 
   it('renders the dropdown when user is logged in', async () => {


### PR DESCRIPTION
# Description
Currently, we have 2 repeated "Feedback" links one located on the top nav, another one on the footer. We are adding a new "feedback" link on the banner here, see design here: https://github.com/codecov/engineering-team/issues/1065.
To avoid confusion, we should remove the "Feedback" link on the top nav.

# Notable Changes
remove the link, fix test 

# Screenshots
![Screenshot 2024-02-07 at 11 04 43 AM](https://github.com/codecov/gazebo/assets/91732700/e0e2b242-7870-4f2b-a265-36a100ce6549)

closes: https://github.com/codecov/engineering-team/issues/1069

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.