### PR TITLE
Fix: Update to default to 10 if pro plan already exceeds 10 users 

### DIFF
--- a/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/Controllers/TeamPlanController/TeamPlanController.spec.tsx
+++ b/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/Controllers/TeamPlanController/TeamPlanController.spec.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { render, screen } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { graphql, rest } from 'msw'
 import { setupServer } from 'msw/node'
@@ -278,6 +278,25 @@ describe('TeamPlanController', () => {
           /Next Billing Date/
         )
         expect(nextBillingDateTitle).toBeInTheDocument()
+      })
+    })
+
+    describe('when seats are greater than 10', () => {
+      const props = {
+        setFormValue: jest.fn(),
+        register: jest.fn(),
+        newPlan: Plans.USERS_TEAMM,
+        seats: 12,
+        errors: { seats: { message: '' } },
+      }
+
+      it('limits the seats to 10', async () => {
+        setup({ planValue: Plans.USERS_TEAMM })
+        render(<TeamPlanController {...props} />, { wrapper: wrapper() })
+
+        await waitFor(() =>
+          expect(props.setFormValue).toHaveBeenCalledWith('seats', '10')
+        )
       })
     })
 

--- a/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/Controllers/TeamPlanController/TeamPlanController.tsx
+++ b/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/Controllers/TeamPlanController/TeamPlanController.tsx
@@ -35,6 +35,10 @@ const PlanController: React.FC<PlanControllerProps> = ({
   const { data: accountDetails } = useAccountDetails({ provider, owner })
   const nextBillingDate = getNextBillingDate(accountDetails)
 
+  if (seats > 10) {
+    setFormValue('seats', '10')
+  }
+
   return (
     <>
       <div className="flex flex-col gap-2">


### PR DESCRIPTION
# Description
Before 

https://github.com/codecov/gazebo/assets/91732700/5b40d039-6477-4e28-b19c-f02de41d727c

After

https://github.com/codecov/gazebo/assets/91732700/21ecedd8-d7af-48c9-802a-42eb8a65e750

# Link to Sample Entry
this is a temp fix, i'm working on refactoring extract seats so that each seats input its own value 


<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.