### PR TITLE
fix: Update to team plan when selecting team plan

### DIFF
--- a/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/UpgradeForm.jsx
+++ b/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/UpgradeForm.jsx
@@ -52,6 +52,7 @@ function UpgradeForm({ selectedPlan, setSelectedPlan }) {
       accountDetails,
       plans,
       trialStatus,
+      selectedPlan,
     }),
     resolver: zodResolver(
       getSchema({

--- a/src/shared/utils/upgradeForm.js
+++ b/src/shared/utils/upgradeForm.js
@@ -157,6 +157,7 @@ export const getDefaultValuesUpgradeForm = ({
   accountDetails,
   plans,
   trialStatus,
+  selectedPlan,
 }) => {
   const currentPlan = accountDetails?.plan
   const currentPlanValue = currentPlan?.value
@@ -178,7 +179,7 @@ export const getDefaultValuesUpgradeForm = ({
   let newPlan = proPlanYear?.value
   if (isSentryUpgrade && !isSentryPlan(currentPlanValue)) {
     newPlan = isMonthlyPlan ? sentryPlanMonth?.value : sentryPlanYear?.value
-  } else if (isTeamPlan(currentPlanValue)) {
+  } else if (isTeamPlan(currentPlanValue) || isTeamPlan(selectedPlan?.value)) {
     newPlan = isMonthlyPlan ? teamPlanMonth?.value : teamPlanYear?.value
   } else if (isPaidPlan(currentPlanValue)) {
     newPlan = currentPlanValue

--- a/src/shared/utils/upgradeForm.spec.js
+++ b/src/shared/utils/upgradeForm.spec.js
@@ -555,4 +555,27 @@ describe('shouldRenderCancelLink', () => {
       expect(value).toBeFalsy()
     })
   })
+
+  describe('user intended plan is Team', () => {
+    it('sets new plan to team', () => {
+      const accountDetails = {
+        plan: { value: Plans.USERS_BASIC, quantity: 1 },
+      }
+      const plans = [
+        { value: Plans.USERS_TEAMY },
+        { value: Plans.USERS_PR_INAPPY },
+      ]
+
+      const data = getDefaultValuesUpgradeForm({
+        accountDetails,
+        plans,
+        selectedPlan: { value: Plans.USERS_TEAMY },
+      })
+
+      expect(data).toStrictEqual({
+        newPlan: Plans.USERS_TEAMY,
+        seats: 2,
+      })
+    })
+  })
 })


### PR DESCRIPTION
# Description
We had it defaulting to pro plan when it's switching from pro to team, solution is to default to team plan when selecting team plan, not only if you're on team plan.

before

https://github.com/codecov/gazebo/assets/91732700/e9c97682-a1eb-4a20-832c-def4c55be195



After

https://github.com/codecov/gazebo/assets/91732700/9bf591d9-0a32-4011-b30c-47bb8bf89d85



# Link to Sample Entry

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.