### PR TITLE
fix: Pull bundle text size and warning icons

### DIFF
--- a/src/pages/CommitDetailPage/CommitBundleAnalysis/BundleMessage/BundleMessage.tsx
+++ b/src/pages/CommitDetailPage/CommitBundleAnalysis/BundleMessage/BundleMessage.tsx
@@ -38,7 +38,7 @@ const BundleMessage: React.FC = () => {
     return (
       <>
         <span className="font-semibold">Bundle report: </span>
-        {comparison?.message.toLowerCase()} &#x26A0;
+        {comparison?.message.toLowerCase()} &#x26A0;&#xFE0F;
       </>
     )
   }
@@ -80,7 +80,7 @@ const BundleMessage: React.FC = () => {
   return (
     <>
       <span className="font-semibold">Bundle report: </span>an unknown error
-      occurred &#x26A0;
+      occurred &#x26A0;&#xFE0F;
     </>
   )
 }

--- a/src/pages/CommitDetailPage/Dropdowns/CommitCoverageDropdown.tsx
+++ b/src/pages/CommitDetailPage/Dropdowns/CommitCoverageDropdown.tsx
@@ -23,9 +23,13 @@ const CoverageMessage: React.FC = () => {
 
   if (uploadErrorCount && uploadErrorCount > 0) {
     if (uploadErrorCount === 1) {
-      return <>{uploadErrorCount} upload has failed to process &#x26A0;</>
+      return (
+        <>{uploadErrorCount} upload has failed to process &#x26A0;&#xFE0F;</>
+      )
     }
-    return <>{uploadErrorCount} uploads have failed to process &#x26A0;</>
+    return (
+      <>{uploadErrorCount} uploads have failed to process &#x26A0;&#xFE0F;</>
+    )
   }
 
   if (comparison?.__typename === 'FirstPullRequest') {
@@ -38,7 +42,7 @@ const CoverageMessage: React.FC = () => {
   }
 
   if (comparison?.__typename !== 'Comparison' && comparison?.message) {
-    return <>{comparison?.message?.toLowerCase()} &#x26A0;</>
+    return <>{comparison?.message?.toLowerCase()} &#x26A0;&#xFE0F;</>
   }
 
   if (comparison?.__typename === 'Comparison') {
@@ -51,13 +55,21 @@ const CoverageMessage: React.FC = () => {
     }
 
     if (totalCount === 1) {
-      return <>{totalCount} line in your changes is missing coverage &#x26A0;</>
+      return (
+        <>
+          {totalCount} line in your changes is missing coverage &#x26A0;&#xFE0F;
+        </>
+      )
     }
 
-    return <>{totalCount} lines in your changes are missing coverage &#x26A0;</>
+    return (
+      <>
+        {totalCount} lines in your changes are missing coverage &#x26A0;&#xFE0F;
+      </>
+    )
   }
 
-  return <>an unknown error has occurred &#x26A0;</>
+  return <>an unknown error has occurred &#x26A0;&#xFE0F;</>
 }
 
 const CommitCoverageDropdown: React.FC<React.PropsWithChildren> = ({

--- a/src/pages/PullRequestPage/Dropdowns/PullBundleDropdown.tsx
+++ b/src/pages/PullRequestPage/Dropdowns/PullBundleDropdown.tsx
@@ -8,7 +8,7 @@ const PullBundleDropdown: React.FC<React.PropsWithChildren> = ({
   return (
     <SummaryDropdown.Item value="bundle-analysis">
       <SummaryDropdown.Trigger>
-        <p className="flex w-full flex-col sm:flex-row sm:gap-1">
+        <p className="flex w-full flex-col text-base sm:flex-row sm:gap-1">
           <BundleMessage />
         </p>
       </SummaryDropdown.Trigger>

--- a/src/pages/PullRequestPage/Dropdowns/PullCoverageDropdown.tsx
+++ b/src/pages/PullRequestPage/Dropdowns/PullCoverageDropdown.tsx
@@ -34,7 +34,7 @@ const CoverageMessage: React.FC<CoverageMessageProps> = ({
   }
 
   if (errorType && errorMsg) {
-    return <>{errorMsg.toLowerCase()} &#x26A0;</>
+    return <>{errorMsg.toLowerCase()} &#x26A0;&#xFE0F;</>
   }
 
   if (isNumber(missesCount) && isNumber(partialsCount)) {
@@ -46,11 +46,18 @@ const CoverageMessage: React.FC<CoverageMessageProps> = ({
 
     if (totalCount === 1) {
       return (
-        <>{totalCount} line in your changes are missing coverage &#x26A0;</>
+        <>
+          {totalCount} line in your changes are missing coverage
+          &#x26A0;&#xFE0F;
+        </>
       )
     }
 
-    return <>{totalCount} lines in your changes are missing coverage &#x26A0;</>
+    return (
+      <>
+        {totalCount} lines in your changes are missing coverage &#x26A0;&#xFE0F;
+      </>
+    )
   }
 
   return <>an unknown error has occurred</>
@@ -84,7 +91,7 @@ const PullCoverageDropdown: React.FC<React.PropsWithChildren> = ({
   return (
     <SummaryDropdown.Item value="coverage">
       <SummaryDropdown.Trigger>
-        <p className="flex w-full flex-col sm:flex-row sm:gap-1">
+        <p className="flex w-full flex-col text-base sm:flex-row sm:gap-1">
           <span className="font-semibold">Coverage report: </span>
           <CoverageMessage
             missesCount={missesCount}

--- a/src/pages/PullRequestPage/PullBundleAnalysis/BundleMessage/BundleMessage.tsx
+++ b/src/pages/PullRequestPage/PullBundleAnalysis/BundleMessage/BundleMessage.tsx
@@ -38,7 +38,7 @@ const BundleMessage: React.FC = () => {
     return (
       <>
         <span className="font-semibold">Bundle report: </span>
-        {comparison?.message?.toLowerCase()} &#x26A0;
+        {comparison?.message?.toLowerCase()} &#x26A0;&#xFE0F;
       </>
     )
   }
@@ -77,7 +77,7 @@ const BundleMessage: React.FC = () => {
   return (
     <>
       <span className="font-semibold">Bundle report: </span>an unknown error
-      occurred &#x26A0;
+      occurred &#x26A0;&#xFE0F;
     </>
   )
 }

--- a/src/pages/PullRequestPage/PullBundleAnalysis/PullBundleAnalysis.tsx
+++ b/src/pages/PullRequestPage/PullBundleAnalysis/PullBundleAnalysis.tsx
@@ -34,7 +34,7 @@ const PullBundleAnalysis: React.FC = () => {
 
   return (
     <>
-      <p className="flex w-full items-center gap-2 bg-ds-gray-primary px-2 py-4">
+      <p className="flex w-full items-center gap-2 bg-ds-gray-primary px-2 py-4 text-base">
         <BundleMessage />
       </p>
       <Suspense fallback={<Loader />}>

--- a/src/pages/RepoPage/BundlesTab/BundleContent/BundleSummary/BundleSummary.tsx
+++ b/src/pages/RepoPage/BundlesTab/BundleContent/BundleSummary/BundleSummary.tsx
@@ -57,7 +57,7 @@ const BundleSummary: React.FC = () => {
     <div className="bg-ds-gray-primary p-4">
       <p className="w-full text-base">
         <span className="font-semibold">Report: </span>
-        {message.toLowerCase()} &#x26A0;
+        {message.toLowerCase()} &#x26A0;&#xFE0F;
       </p>
       {isString(branchHead?.commitid) ? (
         <p className="pt-2 text-sm">


### PR DESCRIPTION
# Description

This PR updates the warning icons to display the correct icons, as well as fix the text size for the pull dropdowns and bundle only pulls tab.

GH codecov/engineering-team#996
GH codecov/engineering-team#997
GH codecov/engineering-team#1024


# Notable Changes

- Fix warning icons
- Fix pull bundles text size

# Screenshots

![Screenshot 2024-02-13 at 13 55 23](https://github.com/codecov/gazebo/assets/105234307/7d81db04-48b5-4826-8228-3c97e8274df6)

![Screenshot 2024-02-13 at 13 52 13](https://github.com/codecov/gazebo/assets/105234307/aabd638c-9b89-4676-bc6c-26a647de110e)