### PR TITLE
 fix: Bundle onboarding

### DIFF
--- a/src/pages/RepoPage/BundlesTab/BundleOnboarding/RollupOnboarding/RollupOnboarding.spec.tsx
+++ b/src/pages/RepoPage/BundlesTab/BundleOnboarding/RollupOnboarding/RollupOnboarding.spec.tsx
@@ -1,59 +1,130 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { render, screen } from '@testing-library/react'
+import { graphql } from 'msw'
+import { setupServer } from 'msw/node'
 import { MemoryRouter, Route } from 'react-router-dom'
 
 import RollupOnboarding from './RollupOnboarding'
 
+const mockGetRepo = {
+  owner: {
+    isCurrentUserPartOfOrg: true,
+    repository: {
+      private: false,
+      uploadToken: '9e6a6189-20f1-482d-ab62-ecfaa2629295',
+      defaultBranch: 'main',
+      yaml: '',
+      activated: false,
+      oldestCommitAt: '',
+    },
+  },
+}
+
+const mockGetOrgUploadToken = (hasOrgUploadToken: boolean | null) => ({
+  owner: {
+    orgUploadToken: hasOrgUploadToken
+      ? '9e6a6189-20f1-482d-ab62-ecfaa2629290'
+      : null,
+  },
+})
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      suspense: true,
+      retry: false,
+    },
+  },
+})
+const server = setupServer()
+
 const wrapper: React.FC<React.PropsWithChildren> = ({ children }) => (
-  <MemoryRouter initialEntries={['/gh/codecov/test-repo/bundles/new/rollup']}>
-    <Route path="/:provider/:owner/:repo/bundles/new/rollup">{children}</Route>
-  </MemoryRouter>
+  <QueryClientProvider client={queryClient}>
+    <MemoryRouter initialEntries={['/gh/codecov/test-repo/bundles/new']}>
+      <Route path="/:provider/:owner/:repo/bundles/new">{children}</Route>
+    </MemoryRouter>
+  </QueryClientProvider>
 )
 
+beforeAll(() => {
+  server.listen()
+})
+
+afterEach(() => {
+  queryClient.clear()
+  server.resetHandlers()
+})
+
+afterAll(() => {
+  server.close()
+})
+
 describe('RollupOnboarding', () => {
+  function setup(hasOrgUploadToken: boolean | null) {
+    server.use(
+      graphql.query('GetRepo', (req, res, ctx) =>
+        res(ctx.status(200), ctx.data(mockGetRepo))
+      ),
+      graphql.query('GetOrgUploadToken', (req, res, ctx) => {
+        return res(
+          ctx.status(200),
+          ctx.data(mockGetOrgUploadToken(hasOrgUploadToken))
+        )
+      })
+    )
+  }
+
   describe('step 1', () => {
-    it('renders header', () => {
+    it('renders header', async () => {
+      setup(null)
       render(<RollupOnboarding />, { wrapper })
 
-      const stepText = screen.getByText('Step 1:')
+      const stepText = await screen.findByText('Step 1:')
       expect(stepText).toBeInTheDocument()
 
-      const headerText = screen.getByText('Install the Codecov Rollup Plugin')
+      const headerText = await screen.findByText(
+        'Install the Codecov Rollup Plugin'
+      )
       expect(headerText).toBeInTheDocument()
     })
 
-    it('renders body', () => {
+    it('renders body', async () => {
+      setup(null)
       render(<RollupOnboarding />, { wrapper })
 
-      const bodyText = screen.getByText(/To install the/)
+      const bodyText = await screen.findByText(/To install the/)
       expect(bodyText).toBeInTheDocument()
 
-      const pluginName = screen.getByText('@codecov/rollup-plugin')
+      const pluginName = await screen.findByText('@codecov/rollup-plugin')
       expect(pluginName).toBeInTheDocument()
     })
 
     describe('code blocks', () => {
-      it('renders npm install', () => {
+      it('renders npm install', async () => {
+        setup(null)
         render(<RollupOnboarding />, { wrapper })
 
-        const npmInstallCommand = screen.getByText(
+        const npmInstallCommand = await screen.findByText(
           'npm install @codecov/rollup-plugin --save-dev'
         )
         expect(npmInstallCommand).toBeInTheDocument()
       })
 
-      it('renders yarn install', () => {
+      it('renders yarn install', async () => {
+        setup(null)
         render(<RollupOnboarding />, { wrapper })
 
-        const yarnInstallCommand = screen.getByText(
+        const yarnInstallCommand = await screen.findByText(
           'yarn add @codecov/rollup-plugin --dev'
         )
         expect(yarnInstallCommand).toBeInTheDocument()
       })
 
-      it('renders pnpm install', () => {
+      it('renders pnpm install', async () => {
+        setup(null)
         render(<RollupOnboarding />, { wrapper })
 
-        const pnpmInstallCommand = screen.getByText(
+        const pnpmInstallCommand = await screen.findByText(
           'pnpm add @codecov/rollup-plugin --save-dev'
         )
         expect(pnpmInstallCommand).toBeInTheDocument()
@@ -62,135 +133,185 @@ describe('RollupOnboarding', () => {
   })
 
   describe('step 2', () => {
-    it('renders header', () => {
+    it('renders header', async () => {
+      setup(null)
       render(<RollupOnboarding />, { wrapper })
 
-      const stepText = screen.getByText('Step 2:')
+      const stepText = await screen.findByText('Step 2:')
       expect(stepText).toBeInTheDocument()
 
-      const headerText = screen.getByText('Configure the bundler plugin')
+      const headerText = await screen.findByText('Copy Codecov token')
       expect(headerText).toBeInTheDocument()
     })
 
-    it('renders body', () => {
+    it('renders body', async () => {
+      setup(null)
       render(<RollupOnboarding />, { wrapper })
 
-      const bodyText = screen.getByText(
-        /Import the bundler plugin, and add it to the end of your plugin array found inside your/
+      const bodyText = await screen.findByText(
+        /Set an environment variable in your build environment with the following upload token./
       )
       expect(bodyText).toBeInTheDocument()
-
-      const rollupConfig = screen.getByText('rollup.config.js')
-      expect(rollupConfig).toBeInTheDocument()
-
-      const note = screen.getByText('Note:')
-      expect(note).toBeInTheDocument()
-
-      const orgSettingsLink = screen.getByRole('link', { name: 'org settings' })
-      expect(orgSettingsLink).toBeInTheDocument()
-      expect(orgSettingsLink).toHaveAttribute(
-        'href',
-        '/account/gh/codecov/org-upload-token'
-      )
     })
 
-    it('renders plugin config', () => {
-      render(<RollupOnboarding />, { wrapper })
+    describe('there is an org token', () => {
+      it('renders code block with org token', async () => {
+        setup(true)
+        render(<RollupOnboarding />, { wrapper })
 
-      const pluginText = screen.getByText(/\/\/ rollup.config.js/)
-      expect(pluginText).toBeInTheDocument()
+        const token = await screen.findByText(
+          /9e6a6189-20f1-482d-ab62-ecfaa2629290/
+        )
+        expect(token).toBeInTheDocument()
+      })
+    })
+
+    describe('there is no org token', () => {
+      it('renders code block with repo token', async () => {
+        setup(false)
+        render(<RollupOnboarding />, { wrapper })
+
+        const token = await screen.findByText(
+          /9e6a6189-20f1-482d-ab62-ecfaa2629295/
+        )
+        expect(token).toBeInTheDocument()
+      })
     })
   })
 
   describe('step 3', () => {
-    it('renders header', () => {
+    it('renders header', async () => {
+      setup(null)
       render(<RollupOnboarding />, { wrapper })
 
-      const stepText = screen.getByText('Step 3:')
+      const stepText = await screen.findByText('Step 3:')
       expect(stepText).toBeInTheDocument()
 
-      const headerText = screen.getByText('Commit your latest changes')
+      const headerText = await screen.findByText('Configure the bundler plugin')
       expect(headerText).toBeInTheDocument()
     })
 
-    it('renders body', () => {
+    it('renders body', async () => {
+      setup(null)
       render(<RollupOnboarding />, { wrapper })
 
-      const bodyText = screen.getByText(
+      const bodyText = await screen.findByText(
+        /Import the bundler plugin, and add it to the end of your plugin array found inside your/
+      )
+      expect(bodyText).toBeInTheDocument()
+
+      const rollupConfig = await screen.findByText('rollup.config.js')
+      expect(rollupConfig).toBeInTheDocument()
+    })
+
+    it('renders plugin config', async () => {
+      setup(null)
+      render(<RollupOnboarding />, { wrapper })
+
+      const pluginText = await screen.findByText(/\/\/ rollup.config.js/)
+      expect(pluginText).toBeInTheDocument()
+    })
+  })
+
+  describe('step 4', () => {
+    it('renders header', async () => {
+      setup(null)
+      render(<RollupOnboarding />, { wrapper })
+
+      const stepText = await screen.findByText('Step 4:')
+      expect(stepText).toBeInTheDocument()
+
+      const headerText = await screen.findByText('Commit your latest changes')
+      expect(headerText).toBeInTheDocument()
+    })
+
+    it('renders body', async () => {
+      setup(null)
+      render(<RollupOnboarding />, { wrapper })
+
+      const bodyText = await screen.findByText(
         'The plugin requires at least one commit to be made to properly upload bundle analysis information up to Codecov.'
       )
       expect(bodyText).toBeInTheDocument()
     })
 
-    it('renders git commit', () => {
+    it('renders git commit', async () => {
+      setup(null)
       render(<RollupOnboarding />, { wrapper })
 
-      const gitCommit = screen.getByText(
+      const gitCommit = await screen.findByText(
         'git add -A && git commit -m "Added Codecov bundler plugin"'
       )
       expect(gitCommit).toBeInTheDocument()
     })
   })
 
-  describe('step 4', () => {
-    it('renders header', () => {
+  describe('step 5', () => {
+    it('renders header', async () => {
+      setup(null)
       render(<RollupOnboarding />, { wrapper })
 
-      const stepText = screen.getByText('Step 4:')
+      const stepText = await screen.findByText('Step 5:')
       expect(stepText).toBeInTheDocument()
 
-      const headerText = screen.getByText('Build the application')
+      const headerText = await screen.findByText('Build the application')
       expect(headerText).toBeInTheDocument()
     })
 
-    it('renders body', () => {
+    it('renders body', async () => {
+      setup(null)
       render(<RollupOnboarding />, { wrapper })
 
-      const bodyText = screen.getByText(
+      const bodyText = await screen.findByText(
         'When building your application the plugin will automatically upload the stats information to Codecov.'
       )
       expect(bodyText).toBeInTheDocument()
     })
 
     describe('renders code block', () => {
-      it('renders npm build', () => {
+      it('renders npm build', async () => {
+        setup(null)
         render(<RollupOnboarding />, { wrapper })
 
-        const npmBuild = screen.getByText('npm run build')
+        const npmBuild = await screen.findByText('npm run build')
         expect(npmBuild).toBeInTheDocument()
       })
 
-      it('renders yarn build', () => {
+      it('renders yarn build', async () => {
+        setup(null)
         render(<RollupOnboarding />, { wrapper })
 
-        const yarnBuild = screen.getByText('yarn run build')
+        const yarnBuild = await screen.findByText('yarn run build')
         expect(yarnBuild).toBeInTheDocument()
       })
 
-      it('renders pnpm build', () => {
+      it('renders pnpm build', async () => {
+        setup(null)
         render(<RollupOnboarding />, { wrapper })
 
-        const pnpmBuild = screen.getByText('pnpm run build')
+        const pnpmBuild = await screen.findByText('pnpm run build')
         expect(pnpmBuild).toBeInTheDocument()
       })
     })
   })
 
   describe('linking out to setup feedback', () => {
-    it('renders correct preview text', () => {
+    it('renders correct preview text', async () => {
+      setup(null)
       render(<RollupOnboarding />, { wrapper })
 
-      const text = screen.getByText(/How was your setup experience\?/)
+      const text = await screen.findByText(/How was your setup experience\?/)
       expect(text).toBeInTheDocument()
 
-      const letUsKnow = screen.getByText(/Let us know in/)
+      const letUsKnow = await screen.findByText(/Let us know in/)
       expect(letUsKnow).toBeInTheDocument()
     })
 
-    it('renders link', () => {
+    it('renders link', async () => {
+      setup(null)
       render(<RollupOnboarding />, { wrapper })
 
-      const link = screen.getByText('this issue')
+      const link = await screen.findByText('this issue')
       expect(link).toBeInTheDocument()
       expect(link).toHaveAttribute(
         'href',

--- a/src/pages/RepoPage/BundlesTab/BundleOnboarding/RollupOnboarding/RollupOnboarding.tsx
+++ b/src/pages/RepoPage/BundlesTab/BundleOnboarding/RollupOnboarding/RollupOnboarding.tsx
@@ -1,3 +1,7 @@
+import { useParams } from 'react-router-dom'
+
+import { useOrgUploadToken } from 'services/orgUploadToken'
+import { useRepo } from 'services/repo'
 import A from 'ui/A'
 import CopyClipboard from 'ui/CopyClipboard'
 
@@ -26,97 +30,143 @@ const npmBuild = `npm run build`
 const yarnBuild = `yarn run build`
 const pnpmBuild = `pnpm run build`
 
+const StepOne: React.FC = () => {
+  return (
+    <div className="pt-4">
+      <h2 className="pb-2 text-base">
+        <span className="font-semibold">Step 1:</span> Install the Codecov
+        Rollup Plugin
+      </h2>
+      <p className="pb-2 text-sm">
+        To install the{' '}
+        <span className="bg-ds-gray-primary px-1 font-mono">
+          @codecov/rollup-plugin
+        </span>{' '}
+        to your project, use one of the following commands.
+      </p>
+      <div className="flex flex-col gap-4">
+        <pre className="flex w-full items-center justify-between gap-2 overflow-auto whitespace-pre-wrap rounded-md border-2 border-ds-gray-secondary bg-ds-gray-primary px-4 py-2 font-mono">
+          {npmInstall} <CopyClipboard string={npmInstall} />
+        </pre>
+        <pre className="flex w-full items-center justify-between gap-2 overflow-auto whitespace-pre-wrap rounded-md border-2 border-ds-gray-secondary bg-ds-gray-primary px-4 py-2 font-mono">
+          {yarnInstall} <CopyClipboard string={yarnInstall} />
+        </pre>
+        <pre className="flex w-full items-center justify-between gap-2 overflow-auto whitespace-pre-wrap rounded-md border-2 border-ds-gray-secondary bg-ds-gray-primary px-4 py-2 font-mono">
+          {pnpmInstall} <CopyClipboard string={pnpmInstall} />
+        </pre>
+      </div>
+    </div>
+  )
+}
+
+const StepTwo: React.FC<{ uploadToken: string }> = ({ uploadToken }) => {
+  return (
+    <div className="pt-4">
+      <h2 className="pb-2 text-base">
+        <span className="font-semibold">Step 2:</span> Copy Codecov token
+      </h2>
+      <p className="pb-2 text-sm">
+        Set an environment variable in your build environment with the following
+        upload token.
+      </p>
+      <div className="flex flex-col gap-4">
+        <pre className="flex w-full items-center justify-between gap-2 overflow-auto whitespace-pre-wrap rounded-md border-2 border-ds-gray-secondary bg-ds-gray-primary px-4 py-2 font-mono">
+          CODECOV_TOKEN={uploadToken} <CopyClipboard string={uploadToken} />
+        </pre>
+      </div>
+    </div>
+  )
+}
+
+const StepThree: React.FC = () => {
+  return (
+    <div>
+      <h2 className="pb-2 text-base">
+        <span className="font-semibold">Step 3:</span> Configure the bundler
+        plugin
+      </h2>
+      <p className="pb-2 text-sm">
+        Import the bundler plugin, and add it to the end of your plugin array
+        found inside your{' '}
+        <span className="bg-ds-gray-primary px-1 font-mono">
+          rollup.config.js
+        </span>{' '}
+        file.
+      </p>
+      <pre className="flex items-start justify-between overflow-auto whitespace-pre rounded-md border-2 border-ds-gray-secondary bg-ds-gray-primary px-4 py-2 font-mono">
+        {pluginConfig}
+        <CopyClipboard string={pluginConfig} />
+      </pre>
+    </div>
+  )
+}
+
+const StepFour: React.FC = () => {
+  return (
+    <div>
+      <h2 className="pb-2 text-base">
+        <span className="font-semibold">Step 4:</span> Commit your latest
+        changes
+      </h2>
+      <p className="pb-2 text-sm">
+        The plugin requires at least one commit to be made to properly upload
+        bundle analysis information up to Codecov.
+      </p>
+      <pre className="flex w-full items-center justify-between gap-2 overflow-auto whitespace-pre-wrap rounded-md border-2 border-ds-gray-secondary bg-ds-gray-primary px-4 py-2 font-mono">
+        {commitString} <CopyClipboard string={commitString} />
+      </pre>
+    </div>
+  )
+}
+
+const StepFive: React.FC = () => {
+  return (
+    <div>
+      <h2 className="pb-2 text-base">
+        <span className="font-semibold">Step 5:</span> Build the application
+      </h2>
+      <p className="pb-2 text-sm">
+        When building your application the plugin will automatically upload the
+        stats information to Codecov.
+      </p>
+      <div className="flex flex-col gap-4">
+        <pre className="flex w-full items-center justify-between gap-2 overflow-auto whitespace-pre-wrap rounded-md border-2 border-ds-gray-secondary bg-ds-gray-primary px-4 py-2 font-mono">
+          {npmBuild} <CopyClipboard string={npmBuild} />
+        </pre>
+        <pre className="flex w-full items-center justify-between gap-2 overflow-auto whitespace-pre-wrap rounded-md border-2 border-ds-gray-secondary bg-ds-gray-primary px-4 py-2 font-mono">
+          {yarnBuild} <CopyClipboard string={yarnBuild} />
+        </pre>
+        <pre className="flex w-full items-center justify-between gap-2 overflow-auto whitespace-pre-wrap rounded-md border-2 border-ds-gray-secondary bg-ds-gray-primary px-4 py-2 font-mono">
+          {pnpmBuild} <CopyClipboard string={pnpmBuild} />
+        </pre>
+      </div>
+    </div>
+  )
+}
+
+interface URLParams {
+  provider: string
+  owner: string
+  repo: string
+}
+
 const RollupOnboarding: React.FC = () => {
+  const { provider, owner, repo } = useParams<URLParams>()
+  const { data: repoData } = useRepo({ provider, owner, repo })
+  const { data: orgUploadToken } = useOrgUploadToken({ provider, owner })
+
+  let uploadToken: string = repoData?.repository?.uploadToken
+  if (orgUploadToken) {
+    uploadToken = orgUploadToken
+  }
+
   return (
     <div className="flex flex-col gap-6">
-      <div className="pt-4">
-        <h2 className="pb-2 text-base">
-          <span className="font-semibold">Step 1:</span> Install the Codecov
-          Rollup Plugin
-        </h2>
-        <p className="pb-2 text-sm">
-          To install the{' '}
-          <span className="bg-ds-gray-primary px-1 font-mono">
-            @codecov/rollup-plugin
-          </span>{' '}
-          to your project, use one of the following commands.
-        </p>
-        <div className="flex flex-col gap-4">
-          <pre className="flex w-full items-center justify-between gap-2 overflow-auto whitespace-pre-wrap rounded-md border-2 border-ds-gray-secondary bg-ds-gray-primary px-4 py-2 font-mono">
-            {npmInstall} <CopyClipboard string={npmInstall} />
-          </pre>
-          <pre className="flex w-full items-center justify-between gap-2 overflow-auto whitespace-pre-wrap rounded-md border-2 border-ds-gray-secondary bg-ds-gray-primary px-4 py-2 font-mono">
-            {yarnInstall} <CopyClipboard string={yarnInstall} />
-          </pre>
-          <pre className="flex w-full items-center justify-between gap-2 overflow-auto whitespace-pre-wrap rounded-md border-2 border-ds-gray-secondary bg-ds-gray-primary px-4 py-2 font-mono">
-            {pnpmInstall} <CopyClipboard string={pnpmInstall} />
-          </pre>
-        </div>
-      </div>
-      <div>
-        <h2 className="pb-2 text-base">
-          <span className="font-semibold">Step 2:</span> Configure the bundler
-          plugin
-        </h2>
-        <p className="text-sm">
-          Import the bundler plugin, and add it to the end of your plugin array
-          found inside your{' '}
-          <span className="bg-ds-gray-primary px-1 font-mono">
-            rollup.config.js
-          </span>{' '}
-          file.
-        </p>
-        <p className="pb-2 pt-1 text-sm">
-          <span className="font-semibold">Note:</span> You can find your global
-          upload token inside your{' '}
-          <A
-            to={{ pageName: 'orgUploadToken' }}
-            target="_blank"
-            hook="rollup-onboarding-to-org-token"
-            isExternal={false}
-          >
-            org settings
-          </A>{' '}
-          on Codecov.
-        </p>
-        <pre className="flex items-start justify-between overflow-auto whitespace-pre rounded-md border-2 border-ds-gray-secondary bg-ds-gray-primary px-4 py-2 font-mono">
-          {pluginConfig}
-          <CopyClipboard string={pluginConfig} />
-        </pre>
-      </div>
-      <div>
-        <h2 className="pb-2 text-base">
-          <span className="font-semibold">Step 3:</span> Commit your latest
-          changes
-        </h2>
-        <p className="pb-2 text-sm">
-          The plugin requires at least one commit to be made to properly upload
-          bundle analysis information up to Codecov.
-        </p>
-        <pre className="flex w-full items-center justify-between gap-2 overflow-auto whitespace-pre-wrap rounded-md border-2 border-ds-gray-secondary bg-ds-gray-primary px-4 py-2 font-mono">
-          {commitString} <CopyClipboard string={commitString} />
-        </pre>
-      </div>
-      <div>
-        <h2 className="pb-2 text-base">
-          <span className="font-semibold">Step 4:</span> Build the application
-        </h2>
-        <p className="pb-2 text-sm">
-          When building your application the plugin will automatically upload
-          the stats information to Codecov.
-        </p>
-        <div className="flex flex-col gap-4">
-          <pre className="flex w-full items-center justify-between gap-2 overflow-auto whitespace-pre-wrap rounded-md border-2 border-ds-gray-secondary bg-ds-gray-primary px-4 py-2 font-mono">
-            {npmBuild} <CopyClipboard string={npmBuild} />
-          </pre>
-          <pre className="flex w-full items-center justify-between gap-2 overflow-auto whitespace-pre-wrap rounded-md border-2 border-ds-gray-secondary bg-ds-gray-primary px-4 py-2 font-mono">
-            {yarnBuild} <CopyClipboard string={yarnBuild} />
-          </pre>
-          <pre className="flex w-full items-center justify-between gap-2 overflow-auto whitespace-pre-wrap rounded-md border-2 border-ds-gray-secondary bg-ds-gray-primary px-4 py-2 font-mono">
-            {pnpmBuild} <CopyClipboard string={pnpmBuild} />
-          </pre>
-        </div>
-      </div>
+      <StepOne />
+      <StepTwo uploadToken={uploadToken} />
+      <StepThree />
+      <StepFour />
+      <StepFive />
       <div>
         <p className="border-l-2 border-ds-gray-secondary pl-4">
           <span className="font-semibold">How was your setup experience?</span>{' '}

--- a/src/pages/RepoPage/BundlesTab/BundleOnboarding/RollupOnboarding/RollupOnboarding.tsx
+++ b/src/pages/RepoPage/BundlesTab/BundleOnboarding/RollupOnboarding/RollupOnboarding.tsx
@@ -81,7 +81,7 @@ const RollupOnboarding: React.FC = () => {
         </p>
         <pre className="flex items-start justify-between overflow-auto whitespace-pre rounded-md border-2 border-ds-gray-secondary bg-ds-gray-primary px-4 py-2 font-mono">
           {pluginConfig}
-          <CopyClipboard string={pnpmInstall} />
+          <CopyClipboard string={pluginConfig} />
         </pre>
       </div>
       <div>

--- a/src/pages/RepoPage/BundlesTab/BundleOnboarding/ViteOnboarding/ViteOnboarding.spec.tsx
+++ b/src/pages/RepoPage/BundlesTab/BundleOnboarding/ViteOnboarding/ViteOnboarding.spec.tsx
@@ -1,59 +1,130 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { render, screen } from '@testing-library/react'
+import { graphql } from 'msw'
+import { setupServer } from 'msw/node'
 import { MemoryRouter, Route } from 'react-router-dom'
 
 import ViteOnboarding from './ViteOnboarding'
 
+const mockGetRepo = {
+  owner: {
+    isCurrentUserPartOfOrg: true,
+    repository: {
+      private: false,
+      uploadToken: '9e6a6189-20f1-482d-ab62-ecfaa2629295',
+      defaultBranch: 'main',
+      yaml: '',
+      activated: false,
+      oldestCommitAt: '',
+    },
+  },
+}
+
+const mockGetOrgUploadToken = (hasOrgUploadToken: boolean | null) => ({
+  owner: {
+    orgUploadToken: hasOrgUploadToken
+      ? '9e6a6189-20f1-482d-ab62-ecfaa2629290'
+      : null,
+  },
+})
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      suspense: true,
+      retry: false,
+    },
+  },
+})
+const server = setupServer()
+
 const wrapper: React.FC<React.PropsWithChildren> = ({ children }) => (
-  <MemoryRouter initialEntries={['/gh/codecov/test-repo/bundles/new']}>
-    <Route path="/:provider/:owner/:repo/bundles/new">{children}</Route>
-  </MemoryRouter>
+  <QueryClientProvider client={queryClient}>
+    <MemoryRouter initialEntries={['/gh/codecov/test-repo/bundles/new']}>
+      <Route path="/:provider/:owner/:repo/bundles/new">{children}</Route>
+    </MemoryRouter>
+  </QueryClientProvider>
 )
 
+beforeAll(() => {
+  server.listen()
+})
+
+afterEach(() => {
+  queryClient.clear()
+  server.resetHandlers()
+})
+
+afterAll(() => {
+  server.close()
+})
+
 describe('ViteOnboarding', () => {
+  function setup(hasOrgUploadToken: boolean | null) {
+    server.use(
+      graphql.query('GetRepo', (req, res, ctx) =>
+        res(ctx.status(200), ctx.data(mockGetRepo))
+      ),
+      graphql.query('GetOrgUploadToken', (req, res, ctx) => {
+        return res(
+          ctx.status(200),
+          ctx.data(mockGetOrgUploadToken(hasOrgUploadToken))
+        )
+      })
+    )
+  }
+
   describe('step 1', () => {
-    it('renders header', () => {
+    it('renders header', async () => {
+      setup(null)
       render(<ViteOnboarding />, { wrapper })
 
-      const stepText = screen.getByText('Step 1:')
+      const stepText = await screen.findByText('Step 1:')
       expect(stepText).toBeInTheDocument()
 
-      const headerText = screen.getByText('Install the Codecov Vite Plugin')
+      const headerText = await screen.findByText(
+        'Install the Codecov Vite Plugin'
+      )
       expect(headerText).toBeInTheDocument()
     })
 
-    it('renders body', () => {
+    it('renders body', async () => {
+      setup(null)
       render(<ViteOnboarding />, { wrapper })
 
-      const bodyText = screen.getByText(/To install the/)
+      const bodyText = await screen.findByText(/To install the/)
       expect(bodyText).toBeInTheDocument()
 
-      const pluginName = screen.getByText('@codecov/vite-plugin')
+      const pluginName = await screen.findByText('@codecov/vite-plugin')
       expect(pluginName).toBeInTheDocument()
     })
 
     describe('code blocks', () => {
-      it('renders npm install', () => {
+      it('renders npm install', async () => {
+        setup(null)
         render(<ViteOnboarding />, { wrapper })
 
-        const npmInstallCommand = screen.getByText(
+        const npmInstallCommand = await screen.findByText(
           'npm install @codecov/vite-plugin --save-dev'
         )
         expect(npmInstallCommand).toBeInTheDocument()
       })
 
-      it('renders yarn install', () => {
+      it('renders yarn install', async () => {
+        setup(null)
         render(<ViteOnboarding />, { wrapper })
 
-        const yarnInstallCommand = screen.getByText(
+        const yarnInstallCommand = await screen.findByText(
           'yarn add @codecov/vite-plugin --dev'
         )
         expect(yarnInstallCommand).toBeInTheDocument()
       })
 
-      it('renders pnpm install', () => {
+      it('renders pnpm install', async () => {
+        setup(null)
         render(<ViteOnboarding />, { wrapper })
 
-        const pnpmInstallCommand = screen.getByText(
+        const pnpmInstallCommand = await screen.findByText(
           'pnpm add @codecov/vite-plugin --save-dev'
         )
         expect(pnpmInstallCommand).toBeInTheDocument()
@@ -62,135 +133,185 @@ describe('ViteOnboarding', () => {
   })
 
   describe('step 2', () => {
-    it('renders header', () => {
+    it('renders header', async () => {
+      setup(null)
       render(<ViteOnboarding />, { wrapper })
 
-      const stepText = screen.getByText('Step 2:')
+      const stepText = await screen.findByText('Step 2:')
       expect(stepText).toBeInTheDocument()
 
-      const headerText = screen.getByText('Configure the bundler plugin')
+      const headerText = await screen.findByText('Copy Codecov token')
       expect(headerText).toBeInTheDocument()
     })
 
-    it('renders body', () => {
+    it('renders body', async () => {
+      setup(null)
       render(<ViteOnboarding />, { wrapper })
 
-      const bodyText = screen.getByText(
-        /Import the bundler plugin, and add it to the end of your plugin array found inside your/
+      const bodyText = await screen.findByText(
+        /Set an environment variable in your build environment with the following upload token./
       )
       expect(bodyText).toBeInTheDocument()
-
-      const viteConfig = screen.getByText('vite.config.js')
-      expect(viteConfig).toBeInTheDocument()
-
-      const note = screen.getByText('Note:')
-      expect(note).toBeInTheDocument()
-
-      const orgSettingsLink = screen.getByRole('link', { name: 'org settings' })
-      expect(orgSettingsLink).toBeInTheDocument()
-      expect(orgSettingsLink).toHaveAttribute(
-        'href',
-        '/account/gh/codecov/org-upload-token'
-      )
     })
 
-    it('renders plugin config', () => {
-      render(<ViteOnboarding />, { wrapper })
+    describe('there is an org token', () => {
+      it('renders code block with org token', async () => {
+        setup(true)
+        render(<ViteOnboarding />, { wrapper })
 
-      const pluginText = screen.getByText(/\/\/ vite.config.js/)
-      expect(pluginText).toBeInTheDocument()
+        const token = await screen.findByText(
+          /9e6a6189-20f1-482d-ab62-ecfaa2629290/
+        )
+        expect(token).toBeInTheDocument()
+      })
+    })
+
+    describe('there is no org token', () => {
+      it('renders code block with repo token', async () => {
+        setup(false)
+        render(<ViteOnboarding />, { wrapper })
+
+        const token = await screen.findByText(
+          /9e6a6189-20f1-482d-ab62-ecfaa2629295/
+        )
+        expect(token).toBeInTheDocument()
+      })
     })
   })
 
   describe('step 3', () => {
-    it('renders header', () => {
+    it('renders header', async () => {
+      setup(null)
       render(<ViteOnboarding />, { wrapper })
 
-      const stepText = screen.getByText('Step 3:')
+      const stepText = await screen.findByText('Step 3:')
       expect(stepText).toBeInTheDocument()
 
-      const headerText = screen.getByText('Commit your latest changes')
+      const headerText = await screen.findByText('Configure the bundler plugin')
       expect(headerText).toBeInTheDocument()
     })
 
-    it('renders body', () => {
+    it('renders body', async () => {
+      setup(null)
       render(<ViteOnboarding />, { wrapper })
 
-      const bodyText = screen.getByText(
+      const bodyText = await screen.findByText(
+        /Import the bundler plugin, and add it to the end of your plugin array found inside your/
+      )
+      expect(bodyText).toBeInTheDocument()
+
+      const viteConfig = await screen.findByText('vite.config.js')
+      expect(viteConfig).toBeInTheDocument()
+    })
+
+    it('renders plugin config', async () => {
+      setup(null)
+      render(<ViteOnboarding />, { wrapper })
+
+      const pluginText = await screen.findByText(/\/\/ vite.config.js/)
+      expect(pluginText).toBeInTheDocument()
+    })
+  })
+
+  describe('step 4', () => {
+    it('renders header', async () => {
+      setup(null)
+      render(<ViteOnboarding />, { wrapper })
+
+      const stepText = await screen.findByText('Step 4:')
+      expect(stepText).toBeInTheDocument()
+
+      const headerText = await screen.findByText('Commit your latest changes')
+      expect(headerText).toBeInTheDocument()
+    })
+
+    it('renders body', async () => {
+      setup(null)
+      render(<ViteOnboarding />, { wrapper })
+
+      const bodyText = await screen.findByText(
         'The plugin requires at least one commit to be made to properly upload bundle analysis information up to Codecov.'
       )
       expect(bodyText).toBeInTheDocument()
     })
 
-    it('renders git commit', () => {
+    it('renders git commit', async () => {
+      setup(null)
       render(<ViteOnboarding />, { wrapper })
 
-      const gitCommit = screen.getByText(
+      const gitCommit = await screen.findByText(
         'git add -A && git commit -m "Added Codecov bundler plugin"'
       )
       expect(gitCommit).toBeInTheDocument()
     })
   })
 
-  describe('step 4', () => {
-    it('renders header', () => {
+  describe('step 5', () => {
+    it('renders header', async () => {
+      setup(null)
       render(<ViteOnboarding />, { wrapper })
 
-      const stepText = screen.getByText('Step 4:')
+      const stepText = await screen.findByText('Step 5:')
       expect(stepText).toBeInTheDocument()
 
-      const headerText = screen.getByText('Build the application')
+      const headerText = await screen.findByText('Build the application')
       expect(headerText).toBeInTheDocument()
     })
 
-    it('renders body', () => {
+    it('renders body', async () => {
+      setup(null)
       render(<ViteOnboarding />, { wrapper })
 
-      const bodyText = screen.getByText(
+      const bodyText = await screen.findByText(
         'When building your application the plugin will automatically upload the stats information to Codecov.'
       )
       expect(bodyText).toBeInTheDocument()
     })
 
     describe('renders code block', () => {
-      it('renders npm build', () => {
+      it('renders npm build', async () => {
+        setup(null)
         render(<ViteOnboarding />, { wrapper })
 
-        const npmBuild = screen.getByText('npm run build')
+        const npmBuild = await screen.findByText('npm run build')
         expect(npmBuild).toBeInTheDocument()
       })
 
-      it('renders yarn build', () => {
+      it('renders yarn build', async () => {
+        setup(null)
         render(<ViteOnboarding />, { wrapper })
 
-        const yarnBuild = screen.getByText('yarn run build')
+        const yarnBuild = await screen.findByText('yarn run build')
         expect(yarnBuild).toBeInTheDocument()
       })
 
-      it('renders pnpm build', () => {
+      it('renders pnpm build', async () => {
+        setup(null)
         render(<ViteOnboarding />, { wrapper })
 
-        const pnpmBuild = screen.getByText('pnpm run build')
+        const pnpmBuild = await screen.findByText('pnpm run build')
         expect(pnpmBuild).toBeInTheDocument()
       })
     })
   })
 
   describe('linking out to setup feedback', () => {
-    it('renders correct preview text', () => {
+    it('renders correct preview text', async () => {
+      setup(null)
       render(<ViteOnboarding />, { wrapper })
 
-      const text = screen.getByText(/How was your setup experience\?/)
+      const text = await screen.findByText(/How was your setup experience\?/)
       expect(text).toBeInTheDocument()
 
-      const letUsKnow = screen.getByText(/Let us know in/)
+      const letUsKnow = await screen.findByText(/Let us know in/)
       expect(letUsKnow).toBeInTheDocument()
     })
 
-    it('renders link', () => {
+    it('renders link', async () => {
+      setup(null)
       render(<ViteOnboarding />, { wrapper })
 
-      const link = screen.getByText('this issue')
+      const link = await screen.findByText('this issue')
       expect(link).toBeInTheDocument()
       expect(link).toHaveAttribute(
         'href',

--- a/src/pages/RepoPage/BundlesTab/BundleOnboarding/ViteOnboarding/ViteOnboarding.tsx
+++ b/src/pages/RepoPage/BundlesTab/BundleOnboarding/ViteOnboarding/ViteOnboarding.tsx
@@ -1,3 +1,7 @@
+import { useParams } from 'react-router-dom'
+
+import { useOrgUploadToken } from 'services/orgUploadToken'
+import { useRepo } from 'services/repo'
 import A from 'ui/A'
 import CopyClipboard from 'ui/CopyClipboard'
 
@@ -13,9 +17,9 @@ export default defineConfig({
   plugins: [
     // Put the Codecov vite plugin after all other plugins
     codecovVitePlugin({
-      enableBundleAnalysis: import.meta.env.NODE_ENV === "production",
+      enableBundleAnalysis: process.env.NODE_ENV === "production",
       bundleName: "<bundle project name>",
-      uploadToken: import.meta.env.CODECOV_TOKEN,
+      uploadToken: process.env.CODECOV_TOKEN,
     }),
   ],
 });`
@@ -26,97 +30,143 @@ const npmBuild = `npm run build`
 const yarnBuild = `yarn run build`
 const pnpmBuild = `pnpm run build`
 
+const StepOne: React.FC = () => {
+  return (
+    <div className="pt-4">
+      <h2 className="pb-2 text-base">
+        <span className="font-semibold">Step 1:</span> Install the Codecov Vite
+        Plugin
+      </h2>
+      <p className="pb-2 text-sm">
+        To install the{' '}
+        <span className="bg-ds-gray-primary px-1 font-mono">
+          @codecov/vite-plugin
+        </span>{' '}
+        to your project, use one of the following commands.
+      </p>
+      <div className="flex flex-col gap-4">
+        <pre className="flex w-full items-center justify-between gap-2 overflow-auto whitespace-pre-wrap rounded-md border-2 border-ds-gray-secondary bg-ds-gray-primary px-4 py-2 font-mono">
+          {npmInstall} <CopyClipboard string={npmInstall} />
+        </pre>
+        <pre className="flex w-full items-center justify-between gap-2 overflow-auto whitespace-pre-wrap rounded-md border-2 border-ds-gray-secondary bg-ds-gray-primary px-4 py-2 font-mono">
+          {yarnInstall} <CopyClipboard string={yarnInstall} />
+        </pre>
+        <pre className="flex w-full items-center justify-between gap-2 overflow-auto whitespace-pre-wrap rounded-md border-2 border-ds-gray-secondary bg-ds-gray-primary px-4 py-2 font-mono">
+          {pnpmInstall} <CopyClipboard string={pnpmInstall} />
+        </pre>
+      </div>
+    </div>
+  )
+}
+
+const StepTwo: React.FC<{ uploadToken: string }> = ({ uploadToken }) => {
+  return (
+    <div className="pt-4">
+      <h2 className="pb-2 text-base">
+        <span className="font-semibold">Step 2:</span> Copy Codecov token
+      </h2>
+      <p className="pb-2 text-sm">
+        Set an environment variable in your build environment with the following
+        upload token.
+      </p>
+      <div className="flex flex-col gap-4">
+        <pre className="flex w-full items-center justify-between gap-2 overflow-auto whitespace-pre-wrap rounded-md border-2 border-ds-gray-secondary bg-ds-gray-primary px-4 py-2 font-mono">
+          CODECOV_TOKEN={uploadToken} <CopyClipboard string={uploadToken} />
+        </pre>
+      </div>
+    </div>
+  )
+}
+
+const StepThree: React.FC = () => {
+  return (
+    <div>
+      <h2 className="pb-2 text-base">
+        <span className="font-semibold">Step 3:</span> Configure the bundler
+        plugin
+      </h2>
+      <p className="pb-2 selection:text-sm">
+        Import the bundler plugin, and add it to the end of your plugin array
+        found inside your{' '}
+        <span className="bg-ds-gray-primary px-1 font-mono">
+          vite.config.js
+        </span>{' '}
+        file.
+      </p>
+      <pre className="flex items-start justify-between overflow-auto whitespace-pre rounded-md border-2 border-ds-gray-secondary bg-ds-gray-primary px-4 py-2 font-mono">
+        {pluginConfig}
+        <CopyClipboard string={pluginConfig} />
+      </pre>
+    </div>
+  )
+}
+
+const StepFour: React.FC = () => {
+  return (
+    <div>
+      <h2 className="pb-2 text-base">
+        <span className="font-semibold">Step 4:</span> Commit your latest
+        changes
+      </h2>
+      <p className="pb-2 text-sm">
+        The plugin requires at least one commit to be made to properly upload
+        bundle analysis information up to Codecov.
+      </p>
+      <pre className="flex w-full items-center justify-between gap-2 overflow-auto whitespace-pre-wrap rounded-md border-2 border-ds-gray-secondary bg-ds-gray-primary px-4 py-2 font-mono">
+        {commitString} <CopyClipboard string={commitString} />
+      </pre>
+    </div>
+  )
+}
+
+const StepFive: React.FC = () => {
+  return (
+    <div>
+      <h2 className="pb-2 text-base">
+        <span className="font-semibold">Step 5:</span> Build the application
+      </h2>
+      <p className="pb-2 text-sm">
+        When building your application the plugin will automatically upload the
+        stats information to Codecov.
+      </p>
+      <div className="flex flex-col gap-4">
+        <pre className="flex w-full items-center justify-between gap-2 overflow-auto whitespace-pre-wrap rounded-md border-2 border-ds-gray-secondary bg-ds-gray-primary px-4 py-2 font-mono">
+          {npmBuild} <CopyClipboard string={npmBuild} />
+        </pre>
+        <pre className="flex w-full items-center justify-between gap-2 overflow-auto whitespace-pre-wrap rounded-md border-2 border-ds-gray-secondary bg-ds-gray-primary px-4 py-2 font-mono">
+          {yarnBuild} <CopyClipboard string={yarnBuild} />
+        </pre>
+        <pre className="flex w-full items-center justify-between gap-2 overflow-auto whitespace-pre-wrap rounded-md border-2 border-ds-gray-secondary bg-ds-gray-primary px-4 py-2 font-mono">
+          {pnpmBuild} <CopyClipboard string={pnpmBuild} />
+        </pre>
+      </div>
+    </div>
+  )
+}
+
+interface URLParams {
+  provider: string
+  owner: string
+  repo: string
+}
+
 const ViteOnboarding: React.FC = () => {
+  const { provider, owner, repo } = useParams<URLParams>()
+  const { data: repoData } = useRepo({ provider, owner, repo })
+  const { data: orgUploadToken } = useOrgUploadToken({ provider, owner })
+
+  let uploadToken: string = repoData?.repository?.uploadToken
+  if (orgUploadToken) {
+    uploadToken = orgUploadToken
+  }
+
   return (
     <div className="flex flex-col gap-6">
-      <div className="pt-4">
-        <h2 className="pb-2 text-base">
-          <span className="font-semibold">Step 1:</span> Install the Codecov
-          Vite Plugin
-        </h2>
-        <p className="pb-2 text-sm">
-          To install the{' '}
-          <span className="bg-ds-gray-primary px-1 font-mono">
-            @codecov/vite-plugin
-          </span>{' '}
-          to your project, use one of the following commands.
-        </p>
-        <div className="flex flex-col gap-4">
-          <pre className="flex w-full items-center justify-between gap-2 overflow-auto whitespace-pre-wrap rounded-md border-2 border-ds-gray-secondary bg-ds-gray-primary px-4 py-2 font-mono">
-            {npmInstall} <CopyClipboard string={npmInstall} />
-          </pre>
-          <pre className="flex w-full items-center justify-between gap-2 overflow-auto whitespace-pre-wrap rounded-md border-2 border-ds-gray-secondary bg-ds-gray-primary px-4 py-2 font-mono">
-            {yarnInstall} <CopyClipboard string={yarnInstall} />
-          </pre>
-          <pre className="flex w-full items-center justify-between gap-2 overflow-auto whitespace-pre-wrap rounded-md border-2 border-ds-gray-secondary bg-ds-gray-primary px-4 py-2 font-mono">
-            {pnpmInstall} <CopyClipboard string={pnpmInstall} />
-          </pre>
-        </div>
-      </div>
-      <div>
-        <h2 className="pb-2 text-base">
-          <span className="font-semibold">Step 2:</span> Configure the bundler
-          plugin
-        </h2>
-        <p className="text-sm">
-          Import the bundler plugin, and add it to the end of your plugin array
-          found inside your{' '}
-          <span className="bg-ds-gray-primary px-1 font-mono">
-            vite.config.js
-          </span>{' '}
-          file.
-        </p>
-        <p className="pb-2 pt-1 text-sm">
-          <span className="font-semibold">Note:</span> You can find your global
-          upload token inside your{' '}
-          <A
-            to={{ pageName: 'orgUploadToken' }}
-            target="_blank"
-            hook="vite-onboarding-to-org-token"
-            isExternal={false}
-          >
-            org settings
-          </A>{' '}
-          on Codecov.
-        </p>
-        <pre className="flex items-start justify-between overflow-auto whitespace-pre rounded-md border-2 border-ds-gray-secondary bg-ds-gray-primary px-4 py-2 font-mono">
-          {pluginConfig}
-          <CopyClipboard string={pluginConfig} />
-        </pre>
-      </div>
-      <div>
-        <h2 className="pb-2 text-base">
-          <span className="font-semibold">Step 3:</span> Commit your latest
-          changes
-        </h2>
-        <p className="pb-2 text-sm">
-          The plugin requires at least one commit to be made to properly upload
-          bundle analysis information up to Codecov.
-        </p>
-        <pre className="flex w-full items-center justify-between gap-2 overflow-auto whitespace-pre-wrap rounded-md border-2 border-ds-gray-secondary bg-ds-gray-primary px-4 py-2 font-mono">
-          {commitString} <CopyClipboard string={commitString} />
-        </pre>
-      </div>
-      <div>
-        <h2 className="pb-2 text-base">
-          <span className="font-semibold">Step 4:</span> Build the application
-        </h2>
-        <p className="pb-2 text-sm">
-          When building your application the plugin will automatically upload
-          the stats information to Codecov.
-        </p>
-        <div className="flex flex-col gap-4">
-          <pre className="flex w-full items-center justify-between gap-2 overflow-auto whitespace-pre-wrap rounded-md border-2 border-ds-gray-secondary bg-ds-gray-primary px-4 py-2 font-mono">
-            {npmBuild} <CopyClipboard string={npmBuild} />
-          </pre>
-          <pre className="flex w-full items-center justify-between gap-2 overflow-auto whitespace-pre-wrap rounded-md border-2 border-ds-gray-secondary bg-ds-gray-primary px-4 py-2 font-mono">
-            {yarnBuild} <CopyClipboard string={yarnBuild} />
-          </pre>
-          <pre className="flex w-full items-center justify-between gap-2 overflow-auto whitespace-pre-wrap rounded-md border-2 border-ds-gray-secondary bg-ds-gray-primary px-4 py-2 font-mono">
-            {pnpmBuild} <CopyClipboard string={pnpmBuild} />
-          </pre>
-        </div>
-      </div>
+      <StepOne />
+      <StepTwo uploadToken={uploadToken} />
+      <StepThree />
+      <StepFour />
+      <StepFive />
       <div>
         <p className="border-l-2 border-ds-gray-secondary pl-4">
           <span className="font-semibold">How was your setup experience?</span>{' '}

--- a/src/pages/RepoPage/BundlesTab/BundleOnboarding/ViteOnboarding/ViteOnboarding.tsx
+++ b/src/pages/RepoPage/BundlesTab/BundleOnboarding/ViteOnboarding/ViteOnboarding.tsx
@@ -81,7 +81,7 @@ const ViteOnboarding: React.FC = () => {
         </p>
         <pre className="flex items-start justify-between overflow-auto whitespace-pre rounded-md border-2 border-ds-gray-secondary bg-ds-gray-primary px-4 py-2 font-mono">
           {pluginConfig}
-          <CopyClipboard string={pnpmInstall} />
+          <CopyClipboard string={pluginConfig} />
         </pre>
       </div>
       <div>

--- a/src/pages/RepoPage/BundlesTab/BundleOnboarding/WebpackOnboarding/WebpackOnboarding.tsx
+++ b/src/pages/RepoPage/BundlesTab/BundleOnboarding/WebpackOnboarding/WebpackOnboarding.tsx
@@ -1,3 +1,8 @@
+import React from 'react'
+import { useParams } from 'react-router-dom'
+
+import { useOrgUploadToken } from 'services/orgUploadToken'
+import { useRepo } from 'services/repo'
 import A from 'ui/A'
 import CopyClipboard from 'ui/CopyClipboard'
 
@@ -27,112 +32,158 @@ const npmBuild = `npm run build`
 const yarnBuild = `yarn run build`
 const pnpmBuild = `pnpm run build`
 
+const StepOne: React.FC = () => {
+  return (
+    <div className="pt-4">
+      <h2 className="pb-2 text-base">
+        <span className="font-semibold">Step 1:</span> Install the Codecov
+        Webpack Plugin
+      </h2>
+      <p className="pb-2 text-sm">
+        To install the{' '}
+        <span className="bg-ds-gray-primary px-1 font-mono">
+          @codecov/webpack-plugin
+        </span>{' '}
+        to your project, use one of the following commands.
+      </p>
+      <div className="flex flex-col gap-4">
+        <pre className="flex w-full items-center justify-between gap-2 overflow-auto whitespace-pre-wrap rounded-md border-2 border-ds-gray-secondary bg-ds-gray-primary px-4 py-2 font-mono">
+          {npmInstall} <CopyClipboard string={npmInstall} />
+        </pre>
+        <pre className="flex w-full items-center justify-between gap-2 overflow-auto whitespace-pre-wrap rounded-md border-2 border-ds-gray-secondary bg-ds-gray-primary px-4 py-2 font-mono">
+          {yarnInstall} <CopyClipboard string={yarnInstall} />
+        </pre>
+        <pre className="flex w-full items-center justify-between gap-2 overflow-auto whitespace-pre-wrap rounded-md border-2 border-ds-gray-secondary bg-ds-gray-primary px-4 py-2 font-mono">
+          {pnpmInstall} <CopyClipboard string={pnpmInstall} />
+        </pre>
+      </div>
+    </div>
+  )
+}
+
+const StepTwo: React.FC<{ uploadToken: string }> = ({ uploadToken }) => {
+  return (
+    <div className="pt-4">
+      <h2 className="pb-2 text-base">
+        <span className="font-semibold">Step 2:</span> Copy Codecov token
+      </h2>
+      <p className="pb-2 text-sm">
+        Set an environment variable in your build environment with the following
+        upload token.
+      </p>
+      <div className="flex flex-col gap-4">
+        <pre className="flex w-full items-center justify-between gap-2 overflow-auto whitespace-pre-wrap rounded-md border-2 border-ds-gray-secondary bg-ds-gray-primary px-4 py-2 font-mono">
+          CODECOV_TOKEN={uploadToken} <CopyClipboard string={uploadToken} />
+        </pre>
+      </div>
+    </div>
+  )
+}
+
+const StepThree: React.FC = () => {
+  return (
+    <div>
+      <h2 className="pb-2 text-base">
+        <span className="font-semibold">Step 3:</span> Configure the bundler
+        plugin
+      </h2>
+      <p className="pb-2 text-sm">
+        Import the bundler plugin, and add it to the end of your plugin array
+        found inside your{' '}
+        <span className="bg-ds-gray-primary px-1 font-mono">
+          webpack.config.js
+        </span>{' '}
+        file.
+      </p>
+      <p className="pb-2 text-sm">
+        For NextJS users, please see their docs for configuring Webpack inside
+        the{' '}
+        <span className="bg-ds-gray-primary px-1 font-mono">
+          next.config.js
+        </span>{' '}
+        file{' '}
+        <A
+          isExternal
+          to={{ pageName: 'nextJSCustomConfig' }}
+          hook="custom-next-webpack-config"
+        >
+          here.
+        </A>
+      </p>
+      <pre className="flex items-start justify-between overflow-auto whitespace-pre rounded-md border-2 border-ds-gray-secondary bg-ds-gray-primary px-4 py-2 font-mono">
+        {pluginConfig}
+        <CopyClipboard string={pluginConfig} />
+      </pre>
+    </div>
+  )
+}
+
+const StepFour: React.FC = () => {
+  return (
+    <div>
+      <h2 className="pb-2 text-base">
+        <span className="font-semibold">Step 4:</span> Commit your latest
+        changes
+      </h2>
+      <p className="pb-2 text-sm">
+        The plugin requires at least one commit to be made to properly upload
+        bundle analysis information up to Codecov.
+      </p>
+      <pre className="flex w-full items-center justify-between gap-2 overflow-auto whitespace-pre-wrap rounded-md border-2 border-ds-gray-secondary bg-ds-gray-primary px-4 py-2 font-mono">
+        {commitString} <CopyClipboard string={commitString} />
+      </pre>
+    </div>
+  )
+}
+
+const StepFive: React.FC = () => {
+  return (
+    <div>
+      <h2 className="pb-2 text-base">
+        <span className="font-semibold">Step 5:</span> Build the application
+      </h2>
+      <p className="pb-2 text-sm">
+        When building your application the plugin will automatically upload the
+        stats information to Codecov.
+      </p>
+      <div className="flex flex-col gap-4">
+        <pre className="flex w-full items-center justify-between gap-2 overflow-auto whitespace-pre-wrap rounded-md border-2 border-ds-gray-secondary bg-ds-gray-primary px-4 py-2 font-mono">
+          {npmBuild} <CopyClipboard string={npmBuild} />
+        </pre>
+        <pre className="flex w-full items-center justify-between gap-2 overflow-auto whitespace-pre-wrap rounded-md border-2 border-ds-gray-secondary bg-ds-gray-primary px-4 py-2 font-mono">
+          {yarnBuild} <CopyClipboard string={yarnBuild} />
+        </pre>
+        <pre className="flex w-full items-center justify-between gap-2 overflow-auto whitespace-pre-wrap rounded-md border-2 border-ds-gray-secondary bg-ds-gray-primary px-4 py-2 font-mono">
+          {pnpmBuild} <CopyClipboard string={pnpmBuild} />
+        </pre>
+      </div>
+    </div>
+  )
+}
+
+interface URLParams {
+  provider: string
+  owner: string
+  repo: string
+}
+
 const WebpackOnboarding: React.FC = () => {
+  const { provider, owner, repo } = useParams<URLParams>()
+  const { data: repoData } = useRepo({ provider, owner, repo })
+  const { data: orgUploadToken } = useOrgUploadToken({ provider, owner })
+
+  let uploadToken: string = repoData?.repository?.uploadToken
+  if (orgUploadToken) {
+    uploadToken = orgUploadToken
+  }
+
   return (
     <div className="flex flex-col gap-6">
-      <div className="pt-4">
-        <h2 className="pb-2 text-base">
-          <span className="font-semibold">Step 1:</span> Install the Codecov
-          Webpack Plugin
-        </h2>
-        <p className="pb-2 text-sm">
-          To install the{' '}
-          <span className="bg-ds-gray-primary px-1 font-mono">
-            @codecov/webpack-plugin
-          </span>{' '}
-          to your project, use one of the following commands.
-        </p>
-        <div className="flex flex-col gap-4">
-          <pre className="flex w-full items-center justify-between gap-2 overflow-auto whitespace-pre-wrap rounded-md border-2 border-ds-gray-secondary bg-ds-gray-primary px-4 py-2 font-mono">
-            {npmInstall} <CopyClipboard string={npmInstall} />
-          </pre>
-          <pre className="flex w-full items-center justify-between gap-2 overflow-auto whitespace-pre-wrap rounded-md border-2 border-ds-gray-secondary bg-ds-gray-primary px-4 py-2 font-mono">
-            {yarnInstall} <CopyClipboard string={yarnInstall} />
-          </pre>
-          <pre className="flex w-full items-center justify-between gap-2 overflow-auto whitespace-pre-wrap rounded-md border-2 border-ds-gray-secondary bg-ds-gray-primary px-4 py-2 font-mono">
-            {pnpmInstall} <CopyClipboard string={pnpmInstall} />
-          </pre>
-        </div>
-      </div>
-      <div>
-        <h2 className="pb-2 text-base">
-          <span className="font-semibold">Step 2:</span> Configure the bundler
-          plugin
-        </h2>
-        <p className="pb-2 text-sm">
-          Import the bundler plugin, and add it to the end of your plugin array
-          found inside your{' '}
-          <span className="bg-ds-gray-primary px-1 font-mono">
-            webpack.config.js
-          </span>{' '}
-          file.
-        </p>
-        <p className="pb-2 text-sm">
-          For NextJS users, please see their docs for configuring Webpack inside
-          the{' '}
-          <span className="bg-ds-gray-primary px-1 font-mono">
-            next.config.js
-          </span>{' '}
-          file{' '}
-          <A
-            isExternal
-            to={{ pageName: 'nextJSCustomConfig' }}
-            hook="custom-next-webpack-config"
-          >
-            here.
-          </A>
-        </p>
-        <p className="pb-2 text-sm">
-          <span className="font-semibold">Note:</span> You can find your global
-          upload token inside your{' '}
-          <A
-            to={{ pageName: 'orgUploadToken' }}
-            target="_blank"
-            hook="webpack-onboarding-to-org-token"
-            isExternal={false}
-          >
-            org settings
-          </A>{' '}
-          on Codecov.
-        </p>
-        <pre className="flex items-start justify-between overflow-auto whitespace-pre rounded-md border-2 border-ds-gray-secondary bg-ds-gray-primary px-4 py-2 font-mono">
-          {pluginConfig}
-          <CopyClipboard string={pluginConfig} />
-        </pre>
-      </div>
-      <div>
-        <h2 className="pb-2 text-base">
-          <span className="font-semibold">Step 3:</span> Commit your latest
-          changes
-        </h2>
-        <p className="pb-2 text-sm">
-          The plugin requires at least one commit to be made to properly upload
-          bundle analysis information up to Codecov.
-        </p>
-        <pre className="flex w-full items-center justify-between gap-2 overflow-auto whitespace-pre-wrap rounded-md border-2 border-ds-gray-secondary bg-ds-gray-primary px-4 py-2 font-mono">
-          {commitString} <CopyClipboard string={commitString} />
-        </pre>
-      </div>
-      <div>
-        <h2 className="pb-2 text-base">
-          <span className="font-semibold">Step 4:</span> Build the application
-        </h2>
-        <p className="pb-2 text-sm">
-          When building your application the plugin will automatically upload
-          the stats information to Codecov.
-        </p>
-        <div className="flex flex-col gap-4">
-          <pre className="flex w-full items-center justify-between gap-2 overflow-auto whitespace-pre-wrap rounded-md border-2 border-ds-gray-secondary bg-ds-gray-primary px-4 py-2 font-mono">
-            {npmBuild} <CopyClipboard string={npmBuild} />
-          </pre>
-          <pre className="flex w-full items-center justify-between gap-2 overflow-auto whitespace-pre-wrap rounded-md border-2 border-ds-gray-secondary bg-ds-gray-primary px-4 py-2 font-mono">
-            {yarnBuild} <CopyClipboard string={yarnBuild} />
-          </pre>
-          <pre className="flex w-full items-center justify-between gap-2 overflow-auto whitespace-pre-wrap rounded-md border-2 border-ds-gray-secondary bg-ds-gray-primary px-4 py-2 font-mono">
-            {pnpmBuild} <CopyClipboard string={pnpmBuild} />
-          </pre>
-        </div>
-      </div>
+      <StepOne />
+      <StepTwo uploadToken={uploadToken} />
+      <StepThree />
+      <StepFour />
+      <StepFive />
       <div>
         <p className="border-l-2 border-ds-gray-secondary pl-4">
           <span className="font-semibold">How was your setup experience?</span>{' '}

--- a/src/pages/RepoPage/BundlesTab/BundleOnboarding/WebpackOnboarding/WebpackOnboarding.tsx
+++ b/src/pages/RepoPage/BundlesTab/BundleOnboarding/WebpackOnboarding/WebpackOnboarding.tsx
@@ -97,7 +97,7 @@ const WebpackOnboarding: React.FC = () => {
         </p>
         <pre className="flex items-start justify-between overflow-auto whitespace-pre rounded-md border-2 border-ds-gray-secondary bg-ds-gray-primary px-4 py-2 font-mono">
           {pluginConfig}
-          <CopyClipboard string={pnpmInstall} />
+          <CopyClipboard string={pluginConfig} />
         </pre>
       </div>
       <div>


### PR DESCRIPTION
# Description

This PR updates onboarding to include a step for copying the org token, as well as fixing the big code block clipboard value. Sorry there are a lot of changes, but there are not major changes in functionality overall.

Closes codecov/engineering-team#1180

# Notable Changes

- Update `RollupOnboarding` to display Codecov token
- Update `ViteOnboarding` to display Codecov token
- Update `WebpackOnboarding` to display Codecov token

# Screenshots

<img width="1134" alt="Screenshot 2024-02-13 at 17 28 42" src="https://github.com/codecov/gazebo/assets/105234307/0795719f-389d-49a7-8a68-04a6cb08be32">
