### PR TITLE
feat: Setup beta badge for bundles tab

### DIFF
--- a/src/pages/RepoPage/RepoPageTabs.spec.tsx
+++ b/src/pages/RepoPage/RepoPageTabs.spec.tsx
@@ -182,10 +182,13 @@ describe('RepoPageTabs', () => {
         wrapper: wrapper('/gh/codecov/test-repo/bundles'),
       })
 
-      const tab = await screen.findByText('Bundles')
+      const tab = await screen.findByText(/Bundles/)
       expect(tab).toBeInTheDocument()
       expect(tab).toHaveAttribute('aria-current', 'page')
       expect(tab).toHaveAttribute('href', '/gh/codecov/test-repo/bundles')
+
+      const betaBadge = await screen.findByText('beta')
+      expect(betaBadge).toBeInTheDocument()
     })
   })
 
@@ -403,9 +406,9 @@ describe('useRepoTabs', () => {
         )
 
         const expectedTab = [
-          {
+          expect.objectContaining({
             pageName: 'bundles',
-          },
+          }),
         ]
         await waitFor(() =>
           expect(result.current).toEqual(expect.arrayContaining(expectedTab))
@@ -425,9 +428,9 @@ describe('useRepoTabs', () => {
         )
 
         const expectedTab = [
-          {
+          expect.objectContaining({
             pageName: 'bundles',
-          },
+          }),
         ]
         await waitFor(() =>
           expect(result.current).toEqual(expect.arrayContaining(expectedTab))
@@ -449,9 +452,9 @@ describe('useRepoTabs', () => {
         await waitForElementToBeRemoved(await screen.findByText('Loading'))
 
         const expectedTab = [
-          {
+          expect.objectContaining({
             pageName: 'bundles',
-          },
+          }),
         ]
         await waitFor(() =>
           expect(result.current).not.toEqual(
@@ -473,9 +476,9 @@ describe('useRepoTabs', () => {
         )
 
         const expectedTab = [
-          {
+          expect.objectContaining({
             pageName: 'bundles',
-          },
+          }),
         ]
         await waitFor(() =>
           expect(result.current).toEqual(expect.arrayContaining(expectedTab))
@@ -497,9 +500,9 @@ describe('useRepoTabs', () => {
         await waitForElementToBeRemoved(await screen.findByText('Loading'))
 
         const expectedTab = [
-          {
+          expect.objectContaining({
             pageName: 'bundles',
-          },
+          }),
         ]
         await waitFor(() =>
           expect(result.current).not.toEqual(

--- a/src/pages/RepoPage/RepoPageTabs.tsx
+++ b/src/pages/RepoPage/RepoPageTabs.tsx
@@ -3,6 +3,7 @@ import { useParams } from 'react-router-dom'
 import { useRepo, useRepoOverview } from 'services/repo'
 import { TierNames, useTier } from 'services/tier'
 import { useFlags } from 'shared/featureFlags'
+import Badge from 'ui/Badge'
 import TabNavigation from 'ui/TabNavigation'
 
 import {
@@ -23,7 +24,7 @@ interface UseRepoTabsArgs {
 
 interface TabArgs {
   pageName: string
-  children?: string
+  children?: React.ReactNode
   exact?: boolean
   location?: { pathname: string }
 }
@@ -69,7 +70,14 @@ export const useRepoTabs = ({ refetchEnabled }: UseRepoTabsArgs) => {
     (jsOrTsPresent || repoOverview?.bundleAnalysisEnabled) &&
     bundleAnalysisPrAndCommitPages
   ) {
-    tabs.push({ pageName: 'bundles' })
+    tabs.push({
+      pageName: 'bundles',
+      children: (
+        <>
+          Bundles <Badge>beta</Badge>
+        </>
+      ),
+    })
   }
 
   const hideFlagsTab = !!repoOverview?.private && tierData === TierNames.TEAM


### PR DESCRIPTION
# Description

Add in a badge to denote that the bundles tab is currently in beta.

GH codecov/engineering-team#1024

# Notable Changes

- Add beta badge to `RepoPageTabs`
- Update tests

# Screenshots

![Screenshot 2024-02-14 at 07 41 59](https://github.com/codecov/gazebo/assets/105234307/669bbb1e-c826-4c99-831b-9431fd8c7335)