### PR TITLE
fix: Remove redirect from coverage onboarding

### DIFF
--- a/src/pages/RepoPage/CoverageOnboarding/NewRepoTab.jsx
+++ b/src/pages/RepoPage/CoverageOnboarding/NewRepoTab.jsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types'
 import { lazy, Suspense } from 'react'
-import { Redirect, Switch, useParams } from 'react-router-dom'
+import { Switch, useParams } from 'react-router-dom'
 
 import { SentryRoute } from 'sentry'
 
@@ -70,12 +70,8 @@ function NewRepoTab() {
   const { data } = useRepo({ provider, owner, repo })
   const { hardRedirect } = useRedirect({ href: `/${provider}` })
 
-  // if the repo has commits redirect to coverage tab
-  if (data?.repository?.active) {
-    return <Redirect to={`/${provider}/${owner}/${repo}`} />
-  }
   // if no upload token redirect
-  else if (!data?.repository?.uploadToken) {
+  if (!data?.repository?.uploadToken) {
     hardRedirect()
     return <NotFound />
   }

--- a/src/pages/RepoPage/CoverageOnboarding/NewRepoTab.spec.jsx
+++ b/src/pages/RepoPage/CoverageOnboarding/NewRepoTab.spec.jsx
@@ -175,18 +175,6 @@ describe('NewRepoTab', () => {
   })
 
   describe('testing redirects', () => {
-    describe('repo has commits', () => {
-      beforeEach(() => setup({ hasCommits: true }))
-
-      it('redirects to repo page', async () => {
-        render(<NewRepoTab />, { wrapper: wrapper() })
-
-        await waitFor(() =>
-          expect(testLocation.pathname).toBe('/gh/codecov/cool-repo')
-        )
-      })
-    })
-
     describe('repo does not have an upload token', () => {
       it('redirects to provider', async () => {
         const { hardRedirect } = setup({ noUploadToken: true })


### PR DESCRIPTION
# Description

We shouldn't redirect from the new repo page component if the repo is active.