### PR TITLE
feat, fix: modify dropdown font size and add commit source

### DIFF
--- a/src/mocks/handlers.js
+++ b/src/mocks/handlers.js
@@ -332,6 +332,9 @@ graphql.query('PullBADropdownSummary', (req, res, ctx) => {
         repository: {
           __typename: 'Repository',
           pull: {
+            head: {
+              commitid: '2788fb9824b079807f7992f04482450c09774ec7',
+            },
             bundleAnalysisCompareWithBase: {
               __typename: 'BundleAnalysisComparison',
               sizeDelta: 1,

--- a/src/pages/PullRequestPage/Dropdowns/PullBundleDropdown.spec.tsx
+++ b/src/pages/PullRequestPage/Dropdowns/PullBundleDropdown.spec.tsx
@@ -17,6 +17,9 @@ const mockSummaryData = (sizeDelta: number) => ({
     repository: {
       __typename: 'Repository',
       pull: {
+        head: {
+          commitid: '2788fb9824b079807f7992f04482450c09774ec7',
+        },
         bundleAnalysisCompareWithBase: {
           __typename: 'BundleAnalysisComparison',
           sizeDelta,
@@ -32,6 +35,9 @@ const mockComparisonError = {
     repository: {
       __typename: 'Repository',
       pull: {
+        head: {
+          commitid: '2788fb9824b079807f7992f04482450c09774ec7',
+        },
         bundleAnalysisCompareWithBase: {
           __typename: 'MissingHeadCommit',
           message: 'Missing head commit',
@@ -46,6 +52,9 @@ const mockFirstPullRequest = {
     repository: {
       __typename: 'Repository',
       pull: {
+        head: {
+          commitid: '2788fb9824b079807f7992f04482450c09774ec7',
+        },
         bundleAnalysisCompareWithBase: {
           __typename: 'FirstPullRequest',
           message: 'First pull request',

--- a/src/pages/PullRequestPage/Dropdowns/PullBundleDropdown.tsx
+++ b/src/pages/PullRequestPage/Dropdowns/PullBundleDropdown.tsx
@@ -8,9 +8,7 @@ const PullBundleDropdown: React.FC<React.PropsWithChildren> = ({
   return (
     <SummaryDropdown.Item value="bundle-analysis">
       <SummaryDropdown.Trigger>
-        <p className="flex w-full flex-col text-base sm:flex-row sm:gap-1">
-          <BundleMessage />
-        </p>
+        <BundleMessage />
       </SummaryDropdown.Trigger>
       <SummaryDropdown.Content className="py-2">
         {children}

--- a/src/pages/PullRequestPage/Header/HeaderDefault/HeaderDefault.jsx
+++ b/src/pages/PullRequestPage/Header/HeaderDefault/HeaderDefault.jsx
@@ -22,7 +22,7 @@ function HeaderDefault() {
   return (
     <div className="flex flex-col justify-between gap-2 border-b border-ds-gray-secondary pb-2 text-xs md:flex-row">
       <div>
-        <h1 className="flex items-center gap-2 text-lg font-semibold">
+        <h1 className="flex items-center gap-2 text-xl font-semibold">
           {pull?.title}
           <span
             className={cs(

--- a/src/pages/PullRequestPage/Header/HeaderTeam/HeaderTeam.jsx
+++ b/src/pages/PullRequestPage/Header/HeaderTeam/HeaderTeam.jsx
@@ -24,7 +24,7 @@ function HeaderTeam() {
     <div className="flex flex-col justify-between gap-2 border-b border-ds-gray-secondary pb-2 text-xs md:flex-row">
       <div className="flex flex-row flex-wrap items-center gap-6 divide-x divide-ds-gray-secondary">
         <div>
-          <h1 className="flex items-center gap-2 text-lg font-semibold">
+          <h1 className="flex items-center gap-2 text-xl font-semibold">
             {pull?.title}
             <span
               className={cs(

--- a/src/pages/PullRequestPage/PullBundleAnalysis/BundleMessage/BundleMessage.spec.tsx
+++ b/src/pages/PullRequestPage/PullBundleAnalysis/BundleMessage/BundleMessage.spec.tsx
@@ -14,6 +14,9 @@ const mockSummaryData = (sizeDelta: number) => ({
     repository: {
       __typename: 'Repository',
       pull: {
+        head: {
+          commitid: '2788fb9824b079807f7992f04482450c09774ec7',
+        },
         bundleAnalysisCompareWithBase: {
           __typename: 'BundleAnalysisComparison',
           sizeDelta,
@@ -29,6 +32,9 @@ const mockComparisonError = {
     repository: {
       __typename: 'Repository',
       pull: {
+        head: {
+          commitid: '2788fb9824b079807f7992f04482450c09774ec7',
+        },
         bundleAnalysisCompareWithBase: {
           __typename: 'MissingHeadCommit',
           message: 'Missing head commit',
@@ -43,6 +49,9 @@ const mockFirstPullRequest = {
     repository: {
       __typename: 'Repository',
       pull: {
+        head: {
+          commitid: '2788fb9824b079807f7992f04482450c09774ec7',
+        },
         bundleAnalysisCompareWithBase: {
           __typename: 'FirstPullRequest',
           message: 'First pull request',

--- a/src/pages/PullRequestPage/PullBundleAnalysis/BundleMessage/BundleMessage.tsx
+++ b/src/pages/PullRequestPage/PullBundleAnalysis/BundleMessage/BundleMessage.tsx
@@ -2,12 +2,35 @@ import { useParams } from 'react-router-dom'
 
 import { usePullBADropdownSummary } from 'services/pull/usePullBADropdownSummary'
 import { formatSizeToString } from 'shared/utils/bundleAnalysis'
+import A from 'ui/A'
 
 interface URLParams {
   provider: string
   owner: string
   repo: string
   pullId: string
+}
+
+interface SourceCommitProps {
+  commitid: string
+}
+
+const SourceCommit: React.FC<SourceCommitProps> = ({ commitid }) => {
+  return (
+    <p className="text-start text-sm">
+      <span className="font-semibold">Source:</span> latest commit{' '}
+      <A
+        hook="bundles-tab-to-commit"
+        isExternal={false}
+        to={{
+          pageName: 'commit',
+          options: { commit: commitid },
+        }}
+      >
+        <span className="font-mono">{commitid?.slice(0, 7)}</span>
+      </A>
+    </p>
+  )
 }
 
 const BundleMessage: React.FC = () => {
@@ -19,15 +42,19 @@ const BundleMessage: React.FC = () => {
     pullId: +pullId,
   })
 
+  const commitid = data?.pull?.head?.commitid
   const comparison = data?.pull?.bundleAnalysisCompareWithBase
 
   if (comparison?.__typename === 'FirstPullRequest') {
     return (
-      <>
-        <span className="font-semibold">Bundle report: </span>
-        once merged to default, your following pull request and commits will
-        include report details &#x2139;
-      </>
+      <div className="text-start">
+        <p>
+          <span className="font-semibold">Bundle report: </span>
+          once merged to default, your following pull request and commits will
+          include report details &#x2139;
+        </p>
+        {commitid ? <SourceCommit commitid={commitid} /> : null}
+      </div>
     )
   }
 
@@ -36,10 +63,13 @@ const BundleMessage: React.FC = () => {
     comparison?.message
   ) {
     return (
-      <>
-        <span className="font-semibold">Bundle report: </span>
-        {comparison?.message?.toLowerCase()} &#x26A0;&#xFE0F;
-      </>
+      <div>
+        <p className="text-base">
+          <span className="font-semibold">Bundle report: </span>
+          {comparison?.message?.toLowerCase()} &#x26A0;&#xFE0F;
+        </p>
+        {commitid ? <SourceCommit commitid={commitid} /> : null}
+      </div>
     )
   }
 
@@ -48,37 +78,49 @@ const BundleMessage: React.FC = () => {
     const positiveSize = Math.abs(sizeDelta)
     if (sizeDelta < 0) {
       return (
-        <>
-          <span className="font-semibold">Bundle report: </span>
-          changes will decrease total bundle size by{' '}
-          {formatSizeToString(positiveSize)} &#x2139;
-        </>
+        <div>
+          <p className="text-base">
+            <span className="font-semibold">Bundle report: </span>
+            changes will decrease total bundle size by{' '}
+            {formatSizeToString(positiveSize)} &#x2139;
+          </p>
+          {commitid ? <SourceCommit commitid={commitid} /> : null}
+        </div>
       )
     }
 
     if (sizeDelta > 0) {
       return (
-        <>
-          <span className="font-semibold">Bundle report: </span>changes will
-          increase total bundle size by {formatSizeToString(positiveSize)}{' '}
-          &#x2139;
-        </>
+        <div>
+          <p className="text-base">
+            <span className="font-semibold">Bundle report: </span>changes will
+            increase total bundle size by {formatSizeToString(positiveSize)}{' '}
+            &#x2139;
+          </p>
+          {commitid ? <SourceCommit commitid={commitid} /> : null}
+        </div>
       )
     }
 
     return (
-      <>
-        <span className="font-semibold">Bundle report: </span>bundle size has no
-        change &#x2705;
-      </>
+      <div>
+        <p className="text-base">
+          <span className="font-semibold">Bundle report: </span>bundle size has
+          no change &#x2705;
+        </p>
+        {commitid ? <SourceCommit commitid={commitid} /> : null}
+      </div>
     )
   }
 
   return (
-    <>
-      <span className="font-semibold">Bundle report: </span>an unknown error
-      occurred &#x26A0;&#xFE0F;
-    </>
+    <div>
+      <p className="text-base">
+        <span className="font-semibold">Bundle report: </span>an unknown error
+        occurred &#x26A0;&#xFE0F;
+      </p>
+      {commitid ? <SourceCommit commitid={commitid} /> : null}
+    </div>
   )
 }
 

--- a/src/pages/PullRequestPage/PullBundleAnalysis/PullBundleAnalysis.spec.tsx
+++ b/src/pages/PullRequestPage/PullBundleAnalysis/PullBundleAnalysis.spec.tsx
@@ -56,6 +56,9 @@ const mockSummaryData = {
     repository: {
       __typename: 'Repository',
       pull: {
+        head: {
+          commitid: '2788fb9824b079807f7992f04482450c09774ec7',
+        },
         bundleAnalysisCompareWithBase: {
           __typename: 'BundleAnalysisComparison',
           sizeDelta: 10,

--- a/src/pages/PullRequestPage/PullBundleAnalysis/PullBundleAnalysis.tsx
+++ b/src/pages/PullRequestPage/PullBundleAnalysis/PullBundleAnalysis.tsx
@@ -100,9 +100,9 @@ const PullBundleAnalysis: React.FC = () => {
 
   return (
     <>
-      <p className="flex w-full items-center gap-2 bg-ds-gray-primary px-2 py-4 text-base">
+      <div className="flex w-full flex-col items-start bg-ds-gray-primary px-2 py-4 text-base">
         <BundleMessage />
-      </p>
+      </div>
       <BundleContent
         bundleCompareType={bundleCompareType}
         headHasBundle={headHasBundle}

--- a/src/pages/PullRequestPage/PullRequestPage.spec.tsx
+++ b/src/pages/PullRequestPage/PullRequestPage.spec.tsx
@@ -103,6 +103,9 @@ const mockPullBADropdownSummary = {
     repository: {
       __typename: 'Repository',
       pull: {
+        head: {
+          commitid: '2788fb9824b079807f7992f04482450c09774ec7',
+        },
         bundleAnalysisCompareWithBase: {
           __typename: 'BundleAnalysisComparison',
           sizeDelta: 1,

--- a/src/services/pull/usePullBADropdownSummary.spec.tsx
+++ b/src/services/pull/usePullBADropdownSummary.spec.tsx
@@ -10,6 +10,9 @@ const mockPullBASummaryData = {
     repository: {
       __typename: 'Repository',
       pull: {
+        head: {
+          commitid: '2788fb9824b079807f7992f04482450c09774ec7',
+        },
         bundleAnalysisCompareWithBase: {
           __typename: 'BundleAnalysisComparison',
           sizeDelta: 1,
@@ -117,6 +120,9 @@ describe('usePullBADropdownSummary', () => {
 
       const expectedResult = {
         pull: {
+          head: {
+            commitid: '2788fb9824b079807f7992f04482450c09774ec7',
+          },
           bundleAnalysisCompareWithBase: {
             __typename: 'BundleAnalysisComparison',
             sizeDelta: 1,

--- a/src/services/pull/usePullBADropdownSummary.tsx
+++ b/src/services/pull/usePullBADropdownSummary.tsx
@@ -36,6 +36,11 @@ const RepositorySchema = z.object({
   __typename: z.literal('Repository'),
   pull: z
     .object({
+      head: z
+        .object({
+          commitid: z.string(),
+        })
+        .nullable(),
       bundleAnalysisCompareWithBase:
         BundleAnalysisCompareWithParentSchema.nullable(),
     })
@@ -61,6 +66,9 @@ query PullBADropdownSummary($owner: String!, $repo: String!, $pullId: Int!) {
       __typename
       ... on Repository {
         pull(id: $pullId) {
+          head {
+            commitid
+          }
           bundleAnalysisCompareWithBase {
             __typename
             ... on BundleAnalysisComparison {

--- a/src/ui/TruncatedMessage/TruncatedMessage.tsx
+++ b/src/ui/TruncatedMessage/TruncatedMessage.tsx
@@ -18,7 +18,7 @@ const TruncatedMessage: React.FC<React.PropsWithChildren> = ({ children }) => {
         ref={ref}
         data-testid="truncate-message-pre"
         className={cs(
-          'text-lg font-semibold break-all whitespace-pre-wrap font-sans w-fit',
+          'text-xl font-semibold break-all whitespace-pre-wrap font-sans w-fit',
           {
             'line-clamp-1': label === TruncateStates.EXPAND,
           }


### PR DESCRIPTION
# Description

Update to show latest commit in pull bundle dropdown and message, also increase header size for commit and pull page headers.

Closes codecov/engineering-team#1224

# Notable Changes

- Add latest source to pull bundle dropdown and standalone message
- Increase Commit and PR Page header to `text-xl`

# Screenshots

<img width="1320" alt="Screenshot 2024-02-16 at 12 28 06" src="https://github.com/codecov/gazebo/assets/105234307/7fa6a773-d28d-4313-afc6-3d4b5649c091">

<img width="1320" alt="Screenshot 2024-02-16 at 12 27 54 1" src="https://github.com/codecov/gazebo/assets/105234307/e31dc865-3baa-4f3a-8bdc-c2c2f4839b1b">