### PR TITLE
feat: Upate `/new` page tabs with learn more link

### DIFF
--- a/src/pages/RepoPage/CoverageOnboarding/CircleCI/CircleCIOrgToken.spec.tsx
+++ b/src/pages/RepoPage/CoverageOnboarding/CircleCI/CircleCIOrgToken.spec.tsx
@@ -235,6 +235,15 @@ describe('CircleCIOrgToken', () => {
 
   describe('ending', () => {
     beforeEach(() => setup(true))
+    it('renders quick start link', async () => {
+      render(<CircleCIOrgToken />, { wrapper })
+
+      const link = await screen.findByRole('link', { name: /learn more/ })
+      expect(link).toHaveAttribute(
+        'href',
+        'https://docs.codecov.com/docs/quick-start'
+      )
+    })
     it('renders body', async () => {
       render(<CircleCIOrgToken />, { wrapper })
 

--- a/src/pages/RepoPage/CoverageOnboarding/CircleCI/CircleCIOrgToken.tsx
+++ b/src/pages/RepoPage/CoverageOnboarding/CircleCI/CircleCIOrgToken.tsx
@@ -110,6 +110,13 @@ function CircleCIOrgToken() {
           checks and report comment. Additionally, you&apos;ll find your repo
           coverage dashboard here.
         </p>
+        <p className="mt-6">
+          Visit our guide to{' '}
+          <A to={{ pageName: 'quickStart' }} isExternal hook="quick-start-link">
+            learn more
+          </A>{' '}
+          about integrating Codecov into your CI/CD workflow.
+        </p>
         <p className="mt-6 border-l-2 border-ds-gray-secondary pl-4">
           <span className="font-semibold">How was your setup experience?</span>{' '}
           Let us know in{' '}

--- a/src/pages/RepoPage/CoverageOnboarding/GitHubActions/GitHubActionsOrgToken.spec.tsx
+++ b/src/pages/RepoPage/CoverageOnboarding/GitHubActions/GitHubActionsOrgToken.spec.tsx
@@ -244,6 +244,15 @@ describe('GitHubActionsOrgToken', () => {
 
   describe('ending', () => {
     beforeEach(() => setup(true))
+    it('renders quick start link', async () => {
+      render(<GitHubActionsOrgToken />, { wrapper })
+
+      const link = await screen.findByRole('link', { name: /learn more/ })
+      expect(link).toHaveAttribute(
+        'href',
+        'https://docs.codecov.com/docs/quick-start'
+      )
+    })
     it('renders body', async () => {
       render(<GitHubActionsOrgToken />, { wrapper })
 

--- a/src/pages/RepoPage/CoverageOnboarding/GitHubActions/GitHubActionsOrgToken.tsx
+++ b/src/pages/RepoPage/CoverageOnboarding/GitHubActions/GitHubActionsOrgToken.tsx
@@ -92,6 +92,13 @@ function GitHubActionsOrgToken() {
           checks and report comment. Additionally, you&apos;ll find your repo
           coverage dashboard here.
         </p>
+        <p className="mt-6">
+          Visit our guide to{' '}
+          <A to={{ pageName: 'quickStart' }} isExternal hook="quick-start-link">
+            learn more
+          </A>{' '}
+          about integrating Codecov into your CI/CD workflow.
+        </p>
         <p className="mt-6 border-l-2 border-ds-gray-secondary pl-4">
           <span className="font-semibold">How was your setup experience?</span>{' '}
           Let us know in{' '}

--- a/src/pages/RepoPage/CoverageOnboarding/OtherCI/OtherCIOrgToken.spec.tsx
+++ b/src/pages/RepoPage/CoverageOnboarding/OtherCI/OtherCIOrgToken.spec.tsx
@@ -244,6 +244,15 @@ describe('OtherCIOrgToken', () => {
 
   describe('ending', () => {
     beforeEach(() => setup())
+    it('renders quick start link', async () => {
+      render(<OtherCIOrgToken />, { wrapper })
+
+      const link = await screen.findByRole('link', { name: /learn more/ })
+      expect(link).toHaveAttribute(
+        'href',
+        'https://docs.codecov.com/docs/quick-start'
+      )
+    })
     it('renders body', async () => {
       render(<OtherCIOrgToken />, { wrapper })
 

--- a/src/pages/RepoPage/CoverageOnboarding/OtherCI/OtherCIOrgToken.tsx
+++ b/src/pages/RepoPage/CoverageOnboarding/OtherCI/OtherCIOrgToken.tsx
@@ -63,6 +63,13 @@ function OtherCIOrgToken() {
           checks and report comment. Additionally, you&apos;ll find your repo
           coverage dashboard here.
         </p>
+        <p className="mt-6">
+          Visit our guide to{' '}
+          <A to={{ pageName: 'quickStart' }} isExternal hook="quick-start-link">
+            learn more
+          </A>{' '}
+          about integrating Codecov into your CI/CD workflow.
+        </p>
         <p className="mt-6 border-l-2 border-ds-gray-secondary pl-4">
           <span className="font-semibold">How was your setup experience?</span>{' '}
           Let us know in{' '}

--- a/src/services/navigation/useNavLinks/useStaticNavLinks.js
+++ b/src/services/navigation/useNavLinks/useStaticNavLinks.js
@@ -317,5 +317,11 @@ export function useStaticNavLinks() {
       isExternalLink: true,
       openNewTab: true,
     },
+    quickStart: {
+      text: 'Quick Start',
+      path: () => 'https://docs.codecov.com/docs/quick-start',
+      isExternalLink: true,
+      openNewTab: true,
+    },
   }
 }

--- a/src/services/navigation/useNavLinks/useStaticNavLinks.spec.js
+++ b/src/services/navigation/useNavLinks/useStaticNavLinks.spec.js
@@ -73,6 +73,7 @@ describe('useStaticNavLinks', () => {
       ${links.feedback}                      | ${'https://github.com/codecov/feedback/discussions'}
       ${links.nextJSCustomConfig}            | ${'https://nextjs.org/docs/app/api-reference/next-config-js/webpack'}
       ${links.bundleConfigFeedback}          | ${'https://github.com/codecov/feedback/issues/270'}
+      ${links.quickStart}                    | ${'https://docs.codecov.com/docs/quick-start'}
     `('static links return path', ({ link, outcome }) => {
       it(`${link.text}: Returns the correct link`, () => {
         expect(link.path()).toBe(outcome)


### PR DESCRIPTION
# Description
- Add quick-start link 
- Include link in /new tabs 

# Screenshots
<img width="1407" alt="Screenshot 2024-02-20 at 12 43 21 PM" src="https://github.com/codecov/gazebo/assets/91732700/78a8dd68-d353-4c17-b0f8-e70358e0c4b3">
<img width="1407" alt="Screenshot 2024-02-20 at 12 36 24 PM" src="https://github.com/codecov/gazebo/assets/91732700/603820a1-e664-4b4f-9b46-adf2f90e5e30">
<img width="1407" alt="Screenshot 2024-02-20 at 12 30 33 PM" src="https://github.com/codecov/gazebo/assets/91732700/8a0244c7-594f-4d8e-b45f-c90190632b02">


# Link to Sample Entry

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.