### PR TITLE
feat: Add branch route param to bundles route

### DIFF
--- a/src/pages/RepoPage/BundlesTab/BundleContent/BundleSummary/BundleSummary.tsx
+++ b/src/pages/RepoPage/BundlesTab/BundleContent/BundleSummary/BundleSummary.tsx
@@ -1,4 +1,7 @@
+import { useHistory } from 'react-router-dom'
+
 import { Branch } from 'services/branches'
+import { useNavLinks } from 'services/navigation'
 import A from 'ui/A'
 import Icon from 'ui/Icon'
 import Select from 'ui/Select'
@@ -7,7 +10,11 @@ import { SummaryField, SummaryRoot } from 'ui/Summary'
 import { useBundleSummary } from './hooks/useBundleSummary'
 
 const BundleSummary: React.FC = () => {
+  const { bundles } = useNavLinks()
+  const history = useHistory()
+
   const {
+    defaultBranch,
     branchSelectorProps,
     setBranchSearchTerm,
     branchList,
@@ -30,13 +37,19 @@ const BundleSummary: React.FC = () => {
           </h3>
           <span className="min-w-[16rem] text-sm">
             <Select
-              dataMarketing="branch-selector-repo-page"
+              dataMarketing="branch-selector-bundle-tab"
               {...branchSelectorProps}
               // @ts-expect-error Select needs to be typed
               ariaName="bundle branch selector"
-              // TODO: Update this to update navigation once branches have been
-              // added to the route
-              onChange={(item: Branch) => {}}
+              onChange={(item: Branch) => {
+                if (item?.name === defaultBranch) {
+                  history.push(bundles.path())
+                } else {
+                  history.push(
+                    bundles.path({ branch: encodeURIComponent(item?.name) })
+                  )
+                }
+              }}
               variant="gray"
               renderItem={(item: Branch) => <span>{item?.name}</span>}
               isLoading={branchListIsFetching}

--- a/src/pages/RepoPage/RepoPage.tsx
+++ b/src/pages/RepoPage/RepoPage.tsx
@@ -87,7 +87,10 @@ function Routes({
           </SentryRoute>
         )}
         {bundleAnalysisEnabled && bundleAnalysisPrAndCommitPages ? (
-          <SentryRoute path={`${path}/bundles`} exact>
+          <SentryRoute
+            path={[`${path}/bundles/:branch`, `${path}/bundles`]}
+            exact
+          >
             <BundlesTab />
           </SentryRoute>
         ) : jsOrTsPresent && bundleAnalysisPrAndCommitPages ? (

--- a/src/services/navigation/useNavLinks/useNavLinks.js
+++ b/src/services/navigation/useNavLinks/useNavLinks.js
@@ -701,12 +701,17 @@ export function useNavLinks() {
     },
     bundles: {
       path: (
-        { provider = p, owner = o, repo = r } = {
+        { provider = p, owner = o, repo = r, branch } = {
           provider: p,
           owner: o,
           repo: r,
         }
-      ) => `/${provider}/${owner}/${repo}/bundles`,
+      ) => {
+        if (branch) {
+          return `/${provider}/${owner}/${repo}/bundles/${branch}`
+        }
+        return `/${provider}/${owner}/${repo}/bundles`
+      },
       text: 'Bundles',
     },
     bundleOnboarding: {

--- a/src/services/navigation/useNavLinks/useNavLinks.spec.js
+++ b/src/services/navigation/useNavLinks/useNavLinks.spec.js
@@ -35,6 +35,7 @@ const wrapper =
         <Route path="/admin/:provider/:owner/users">{children}</Route>
         <Route path="/account/:provider/:owner">{children}</Route>
         <Route path="/account/:provider/:owner/billing">{children}</Route>
+        <Route path="/:provider/:owner/:repo/bundles/:branch">{children}</Route>
         <Route path="/:provider/:owner/:repo/bundles">{children}</Route>
       </MemoryRouter>
     )
@@ -1791,6 +1792,17 @@ describe('useNavLinks', () => {
         repo: 'test-repo',
       })
       expect(path).toBe('/bb/test-owner/test-repo/bundles')
+    })
+
+    describe('passing branch option', () => {
+      it('appends the branch param', () => {
+        const { result } = renderHook(() => useNavLinks(), {
+          wrapper: wrapper('/gh/codecov/cool-repo'),
+        })
+
+        const path = result.current.bundles.path({ branch: 'test-branch' })
+        expect(path).toBe('/gh/codecov/cool-repo/bundles/test-branch')
+      })
     })
   })
 


### PR DESCRIPTION
# Description

This PR updates the Bundle Summary branch selector to update the URL with the selected branch from the branch selector, as well as add in the `/:branch` param to the routes for the bundles tab.

>[!note]
> Requires: #2605, #2606, #2607

Closes codecov/engineering-team#1215

# Notable Changes

- Add `branch` option to `bundles` route in `useNavLinks`
- Update branch context selector to update the branch in the `BundleSummary`
- Update tests