### PR TITLE
feat: Create bundle selector for bundles tab

### DIFF
--- a/src/pages/RepoPage/BundlesTab/BundleContent/BundleSummary/BranchSelector.spec.tsx
+++ b/src/pages/RepoPage/BundlesTab/BundleContent/BundleSummary/BranchSelector.spec.tsx
@@ -138,6 +138,7 @@ describe('BranchSelector', () => {
     const user = userEvent.setup()
     const fetchNextPage = jest.fn()
     const mockSearching = jest.fn()
+    const mockResetBundleSelect = jest.fn()
 
     const queryClient = new QueryClient({
       defaultOptions: {
@@ -202,13 +203,14 @@ describe('BranchSelector', () => {
       mockSearching,
       user,
       queryClient,
+      mockResetBundleSelect,
     }
   }
 
   describe('with populated data', () => {
     it('renders the branch selector', async () => {
-      const { queryClient } = setup()
-      render(<BranchSelector />, {
+      const { queryClient, mockResetBundleSelect } = setup()
+      render(<BranchSelector resetBundleSelect={mockResetBundleSelect} />, {
         wrapper: wrapper(queryClient),
       })
 
@@ -217,8 +219,8 @@ describe('BranchSelector', () => {
     })
 
     it('renders default branch as selected branch', async () => {
-      const { queryClient } = setup()
-      render(<BranchSelector />, {
+      const { queryClient, mockResetBundleSelect } = setup()
+      render(<BranchSelector resetBundleSelect={mockResetBundleSelect} />, {
         wrapper: wrapper(queryClient),
       })
 
@@ -227,8 +229,8 @@ describe('BranchSelector', () => {
     })
 
     it('renders the source commit short sha', async () => {
-      const { queryClient } = setup()
-      render(<BranchSelector />, {
+      const { queryClient, mockResetBundleSelect } = setup()
+      render(<BranchSelector resetBundleSelect={mockResetBundleSelect} />, {
         wrapper: wrapper(queryClient),
       })
 
@@ -240,8 +242,8 @@ describe('BranchSelector', () => {
   describe('navigating branches', () => {
     describe('user selects a branch', () => {
       it('navigates to the selected branch', async () => {
-        const { user, queryClient } = setup()
-        render(<BranchSelector />, {
+        const { user, queryClient, mockResetBundleSelect } = setup()
+        render(<BranchSelector resetBundleSelect={mockResetBundleSelect} />, {
           wrapper: wrapper(queryClient),
         })
 
@@ -263,8 +265,8 @@ describe('BranchSelector', () => {
 
     describe('user selects the default branch', () => {
       it('clears the branch from the url', async () => {
-        const { user, queryClient } = setup()
-        render(<BranchSelector />, {
+        const { user, queryClient, mockResetBundleSelect } = setup()
+        render(<BranchSelector resetBundleSelect={mockResetBundleSelect} />, {
           wrapper: wrapper(
             queryClient,
             '/gh/codecov/test-repo/bundles/branch-1'
@@ -284,20 +286,38 @@ describe('BranchSelector', () => {
         )
       })
     })
+
+    it('calls resetBundleSelect when a branch is selected', async () => {
+      const { user, queryClient, mockResetBundleSelect } = setup()
+      render(<BranchSelector resetBundleSelect={mockResetBundleSelect} />, {
+        wrapper: wrapper(queryClient),
+      })
+
+      const select = await screen.findByRole('button', {
+        name: 'bundle branch selector',
+      })
+      await user.click(select)
+
+      const branch = await screen.findByText('branch-1')
+      await user.click(branch)
+
+      expect(mockResetBundleSelect).toHaveBeenCalled()
+    })
   })
 
   describe('when onLoadMore is triggered', () => {
     describe('when there is not a next page', () => {
       it('does not call fetchNextPage', async () => {
-        const { user, fetchNextPage, queryClient } = setup({
-          hasNextPage: false,
-        })
+        const { user, fetchNextPage, queryClient, mockResetBundleSelect } =
+          setup({
+            hasNextPage: false,
+          })
 
         mockedUseIntersection.mockReturnValue({
           isIntersecting: true,
         })
 
-        render(<BranchSelector />, {
+        render(<BranchSelector resetBundleSelect={mockResetBundleSelect} />, {
           wrapper: wrapper(queryClient),
         })
 
@@ -312,15 +332,16 @@ describe('BranchSelector', () => {
 
     describe('there is a next page', () => {
       it('calls fetchNextPage', async () => {
-        const { fetchNextPage, user, queryClient } = setup({
-          hasNextPage: true,
-        })
+        const { fetchNextPage, user, queryClient, mockResetBundleSelect } =
+          setup({
+            hasNextPage: true,
+          })
 
         mockedUseIntersection.mockReturnValue({
           isIntersecting: true,
         })
 
-        render(<BranchSelector />, {
+        render(<BranchSelector resetBundleSelect={mockResetBundleSelect} />, {
           wrapper: wrapper(queryClient),
         })
 
@@ -336,8 +357,9 @@ describe('BranchSelector', () => {
 
   describe('user searches for branch', () => {
     it('calls the api with the search value', async () => {
-      const { mockSearching, user, queryClient } = setup()
-      render(<BranchSelector />, {
+      const { mockSearching, user, queryClient, mockResetBundleSelect } =
+        setup()
+      render(<BranchSelector resetBundleSelect={mockResetBundleSelect} />, {
         wrapper: wrapper(queryClient),
       })
 
@@ -355,8 +377,10 @@ describe('BranchSelector', () => {
 
   describe('when the branch is not found', () => {
     it('displays select a branch in the button', async () => {
-      const { queryClient } = setup({ nullOverview: true })
-      render(<BranchSelector />, {
+      const { queryClient, mockResetBundleSelect } = setup({
+        nullOverview: true,
+      })
+      render(<BranchSelector resetBundleSelect={mockResetBundleSelect} />, {
         wrapper: wrapper(queryClient),
       })
 

--- a/src/pages/RepoPage/BundlesTab/BundleContent/BundleSummary/BranchSelector.tsx
+++ b/src/pages/RepoPage/BundlesTab/BundleContent/BundleSummary/BranchSelector.tsx
@@ -18,7 +18,13 @@ interface URLParams {
 const getDecodedBranch = (branch?: string) =>
   !!branch ? decodeURIComponent(branch) : undefined
 
-const BranchSelector: React.FC = () => {
+interface BranchSelectorProps {
+  resetBundleSelect: () => void
+}
+
+const BranchSelector: React.FC<BranchSelectorProps> = ({
+  resetBundleSelect,
+}) => {
   const history = useHistory()
   const { bundles: bundlesLink } = useNavLinks()
   const { provider, owner, repo, branch } = useParams<URLParams>()
@@ -83,10 +89,12 @@ const BranchSelector: React.FC = () => {
           items={branchList?.branches ?? []}
           value={selection}
           onChange={(item: Branch) => {
+            resetBundleSelect()
             if (item?.name === overview?.defaultBranch) {
               history.push(bundlesLink.path())
             } else {
               history.push(
+                // @ts-expect-error - useNavLinks needs to be typed
                 bundlesLink.path({ branch: encodeURIComponent(item?.name) })
               )
             }

--- a/src/pages/RepoPage/BundlesTab/BundleContent/BundleSummary/BranchSelector.tsx
+++ b/src/pages/RepoPage/BundlesTab/BundleContent/BundleSummary/BranchSelector.tsx
@@ -74,7 +74,7 @@ const BranchSelector: React.FC<BranchSelectorProps> = ({
   }
 
   return (
-    <div className="min-w-[16rem]">
+    <div className="md:w-[16rem]">
       <h3 className="flex items-center gap-1 text-sm font-semibold text-ds-gray-octonary">
         <span className="text-ds-gray-quinary">
           <Icon name="branch" size="sm" variant="developer" />

--- a/src/pages/RepoPage/BundlesTab/BundleContent/BundleSummary/BundleSelector.spec.tsx
+++ b/src/pages/RepoPage/BundlesTab/BundleContent/BundleSummary/BundleSelector.spec.tsx
@@ -149,20 +149,6 @@ describe('BundleSelector', () => {
     })
   })
 
-  describe('when there is no overview data', () => {
-    it('renders disabled button', async () => {
-      setup({ nullOverview: true })
-      render(<BundleSelector />, {
-        wrapper: wrapper('/gh/codecov/test-repo/bundles'),
-      })
-
-      const select = await screen.findByRole('button', {
-        name: 'bundle tab bundle selector',
-      })
-      expect(select).toBeInTheDocument()
-    })
-  })
-
   describe('when there is branch data', () => {
     it('enables the select', async () => {
       setup({})

--- a/src/pages/RepoPage/BundlesTab/BundleContent/BundleSummary/BundleSelector.spec.tsx
+++ b/src/pages/RepoPage/BundlesTab/BundleContent/BundleSummary/BundleSelector.spec.tsx
@@ -149,7 +149,7 @@ describe('BundleSelector', () => {
     })
   })
 
-  describe('when there is branch data', () => {
+  describe('when there is bundle data', () => {
     it('enables the select', async () => {
       setup({})
       render(<BundleSelector />, { wrapper: wrapper() })
@@ -214,8 +214,8 @@ describe('BundleSelector', () => {
     })
 
     describe('user searches for bundle', () => {
-      describe('branch is found', () => {
-        it('renders the found branch', async () => {
+      describe('bundle is found', () => {
+        it('renders the found bundle', async () => {
           const { user } = setup({})
           render(<BundleSelector />, {
             wrapper: wrapper(),
@@ -234,7 +234,7 @@ describe('BundleSelector', () => {
         })
       })
 
-      describe('branch is not found', () => {
+      describe('bundle is not found', () => {
         it('displays no results found', async () => {
           const { user } = setup({})
           render(<BundleSelector />, {

--- a/src/pages/RepoPage/BundlesTab/BundleContent/BundleSummary/BundleSelector.spec.tsx
+++ b/src/pages/RepoPage/BundlesTab/BundleContent/BundleSummary/BundleSelector.spec.tsx
@@ -1,0 +1,297 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { graphql } from 'msw'
+import { setupServer } from 'msw/node'
+import { Suspense } from 'react'
+import { MemoryRouter, Route, useLocation } from 'react-router-dom'
+
+import BundleSelector from './BundleSelector'
+
+const mockRepoOverview = {
+  __typename: 'Repository',
+  private: false,
+  defaultBranch: 'main',
+  oldestCommitAt: '2022-10-10T11:59:59',
+  coverageEnabled: true,
+  bundleAnalysisEnabled: true,
+  languages: [],
+}
+
+const mockBundles = {
+  owner: {
+    repository: {
+      __typename: 'Repository',
+      branch: {
+        head: {
+          bundleAnalysisReport: {
+            __typename: 'BundleAnalysisReport',
+            bundles: [{ name: 'bundle1' }],
+          },
+        },
+      },
+    },
+  },
+}
+
+const mockBadBundles = {
+  owner: {
+    repository: {
+      __typename: 'Repository',
+      branch: {
+        head: {
+          commitid: '543a5268dce725d85be7747c0f9b61e9a68dea57',
+          bundleAnalysisReport: {
+            __typename: 'MissingHeadReport',
+            message: 'missing head report',
+          },
+        },
+      },
+    },
+  },
+}
+
+const server = setupServer()
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      retry: false,
+      suspense: true,
+    },
+  },
+})
+
+let testLocation: ReturnType<typeof useLocation>
+const wrapper =
+  (
+    initialEntries = '/gh/codecov/test-repo/bundles/test-branch'
+  ): React.FC<React.PropsWithChildren> =>
+  ({ children }) =>
+    (
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter initialEntries={[initialEntries]}>
+          <Route
+            path={[
+              '/:provider/:owner/:repo/bundles/:branch/:bundle',
+              '/:provider/:owner/:repo/bundles/:branch',
+              '/:provider/:owner/:repo/bundles/',
+            ]}
+          >
+            <Suspense fallback={<p>Loading</p>}>{children}</Suspense>
+          </Route>
+          <Route
+            path="*"
+            render={({ location }) => {
+              testLocation = location
+              return null
+            }}
+          />
+        </MemoryRouter>
+      </QueryClientProvider>
+    )
+
+beforeAll(() => {
+  server.listen()
+})
+
+afterEach(() => {
+  queryClient.clear()
+  server.resetHandlers()
+})
+
+afterAll(() => {
+  server.close()
+})
+
+interface SetupArgs {
+  missingHeadReport?: boolean
+  nullOverview?: boolean
+}
+
+describe('BundleSelector', () => {
+  function setup({
+    missingHeadReport = false,
+    nullOverview = false,
+  }: SetupArgs) {
+    const user = userEvent.setup()
+
+    server.use(
+      graphql.query('GetRepoOverview', (req, res, ctx) => {
+        if (nullOverview) {
+          return res(ctx.status(200), ctx.data({ owner: null }))
+        }
+
+        return res(
+          ctx.status(200),
+          ctx.data({ owner: { repository: mockRepoOverview } })
+        )
+      }),
+      graphql.query('BranchBundlesNames', (req, res, ctx) => {
+        if (missingHeadReport) {
+          return res(ctx.status(200), ctx.data(mockBadBundles))
+        } else return res(ctx.status(200), ctx.data(mockBundles))
+      })
+    )
+
+    return { user }
+  }
+
+  describe('when there are no bundles', () => {
+    it('disables the select', async () => {
+      setup({ missingHeadReport: true })
+      render(<BundleSelector />, { wrapper: wrapper() })
+
+      const select = await screen.findByRole('button', {
+        name: 'bundle tab bundle selector',
+      })
+      expect(select).toBeInTheDocument()
+      expect(select).toBeDisabled()
+    })
+  })
+
+  describe('when there is no overview data', () => {
+    it('renders disabled button', async () => {
+      setup({ nullOverview: true })
+      render(<BundleSelector />, {
+        wrapper: wrapper('/gh/codecov/test-repo/bundles'),
+      })
+
+      const select = await screen.findByRole('button', {
+        name: 'bundle tab bundle selector',
+      })
+      expect(select).toBeInTheDocument()
+    })
+  })
+
+  describe('when there is branch data', () => {
+    it('enables the select', async () => {
+      setup({})
+      render(<BundleSelector />, { wrapper: wrapper() })
+
+      const select = await screen.findByRole('button', {
+        name: 'bundle tab bundle selector',
+      })
+      expect(select).toBeInTheDocument()
+      expect(select).not.toBeDisabled()
+    })
+
+    it('renders select bundle in button', async () => {
+      setup({})
+      render(<BundleSelector />, { wrapper: wrapper() })
+
+      const select = await screen.findByRole('button', {
+        name: 'bundle tab bundle selector',
+      })
+      expect(select).toBeInTheDocument()
+      expect(select).toHaveTextContent('Select bundle')
+    })
+
+    describe('bundle is set in the url', () => {
+      it('sets the button to that bundle', async () => {
+        setup({})
+        render(<BundleSelector />, {
+          wrapper: wrapper(
+            '/gh/codecov/test-repo/bundles/test-branch/test-bundle'
+          ),
+        })
+
+        const select = await screen.findByRole('button', {
+          name: 'bundle tab bundle selector',
+        })
+        expect(select).toBeInTheDocument()
+        expect(select).not.toBeDisabled()
+        expect(select).toHaveTextContent(/test-bundle/)
+      })
+    })
+
+    describe('navigating to a different bundle', () => {
+      describe('user selects a bundle', () => {
+        it('navigates to the selected bundle', async () => {
+          const { user } = setup({})
+          render(<BundleSelector />, { wrapper: wrapper() })
+
+          const select = await screen.findByRole('button', {
+            name: 'bundle tab bundle selector',
+          })
+          await user.click(select)
+
+          const bundle = await screen.findByText('bundle1')
+          await user.click(bundle)
+
+          await waitFor(() => {
+            expect(testLocation.pathname).toBe(
+              '/gh/codecov/test-repo/bundles/test-branch/bundle1'
+            )
+          })
+        })
+      })
+    })
+
+    describe('user searches for bundle', () => {
+      describe('branch is found', () => {
+        it('renders the found branch', async () => {
+          const { user } = setup({})
+          render(<BundleSelector />, {
+            wrapper: wrapper(),
+          })
+
+          const select = await screen.findByRole('button', {
+            name: 'bundle tab bundle selector',
+          })
+          await user.click(select)
+
+          const input = await screen.findByRole('combobox')
+          await user.type(input, 'bundle1')
+
+          const foundBundle = await screen.findByText('bundle1')
+          expect(foundBundle).toBeInTheDocument()
+        })
+      })
+
+      describe('branch is not found', () => {
+        it('displays no results found', async () => {
+          const { user } = setup({})
+          render(<BundleSelector />, {
+            wrapper: wrapper(),
+          })
+
+          const select = await screen.findByRole('button', {
+            name: 'bundle tab bundle selector',
+          })
+          await user.click(select)
+
+          const input = await screen.findByRole('combobox')
+          await user.type(input, 'searching for branch')
+
+          const notFound = await screen.findByText('No results found')
+          expect(notFound).toBeInTheDocument()
+        })
+      })
+
+      describe('user clears search', () => {
+        it('resets the select', async () => {
+          const { user } = setup({})
+          render(<BundleSelector />, {
+            wrapper: wrapper(),
+          })
+
+          const select = await screen.findByRole('button', {
+            name: 'bundle tab bundle selector',
+          })
+          await user.click(select)
+
+          const input = await screen.findByRole('combobox')
+          await user.type(input, 'test')
+
+          const notFound = await screen.findByText('No results found')
+          expect(notFound).toBeInTheDocument()
+
+          await user.type(input, '{backspace}{backspace}{backspace}{backspace}')
+
+          const bundles = await screen.findByText('bundle1')
+          expect(bundles).toBeInTheDocument()
+        })
+      })
+    })
+  })
+})

--- a/src/pages/RepoPage/BundlesTab/BundleContent/BundleSummary/BundleSelector.tsx
+++ b/src/pages/RepoPage/BundlesTab/BundleContent/BundleSummary/BundleSelector.tsx
@@ -1,0 +1,111 @@
+import { forwardRef, useState } from 'react'
+import { useHistory, useParams } from 'react-router-dom'
+
+import { useBranchBundlesNames } from 'services/branches/useBranchBundlesNames'
+import { useNavLinks } from 'services/navigation'
+import { useRepoOverview } from 'services/repo'
+import Select from 'ui/Select'
+
+interface URLParams {
+  provider: string
+  owner: string
+  repo: string
+  branch?: string
+  bundle?: string
+}
+
+// eslint-disable-next-line no-empty-pattern
+const BundleSelector = forwardRef(({}, ref) => {
+  const history = useHistory()
+  const [search, setSearch] = useState('')
+  const { bundles: bundlesLink } = useNavLinks()
+  const [bundlesState, setBundlesState] = useState<Array<string>>([])
+  const {
+    provider,
+    owner,
+    repo,
+    branch: branchParam,
+    bundle,
+  } = useParams<URLParams>()
+  const [selectedBundle, setSelectedBundle] = useState<string | undefined>(
+    () => {
+      if (bundle) {
+        return bundle
+      }
+      return undefined
+    }
+  )
+
+  const { data: overviewData } = useRepoOverview({
+    provider,
+    owner,
+    repo,
+  })
+
+  const branch = branchParam ?? overviewData?.defaultBranch ?? ''
+
+  const { data: bundleData, isLoading: bundlesIsLoading } =
+    useBranchBundlesNames({
+      provider,
+      owner,
+      repo,
+      branch,
+    })
+
+  // Note: There's no real way to test this as the data is resolved during
+  // suspense and the component is not rendered until the data is resolved.
+  const bundles = bundleData?.bundles ?? []
+
+  return (
+    <div className="md:w-[16rem]">
+      <h3 className="flex items-center gap-1 text-sm font-semibold text-ds-gray-octonary">
+        Bundle
+      </h3>
+      <span className="max-w-[16rem] text-sm">
+        <Select
+          ref={ref}
+          // @ts-expect-error
+          disabled={bundles.length === 0}
+          resourceName="bundle"
+          placeholder="Select bundle"
+          dataMarketing="bundle-selector-bundle-tab"
+          ariaName="bundle tab bundle selector"
+          variant="gray"
+          isLoading={bundlesIsLoading}
+          items={bundlesState}
+          value={selectedBundle ?? 'Select bundle'}
+          onChange={(name: string) => {
+            setSelectedBundle(name)
+            if (branch && name) {
+              history.push(
+                bundlesLink.path({
+                  // @ts-expect-error - useNavLinks needs to be typed
+                  branch,
+                  // @ts-expect-error - useNavLinks needs to be typed
+                  bundle: encodeURIComponent(name),
+                })
+              )
+            }
+          }}
+          onSearch={(term: string) => {
+            setSearch(term)
+            if (term !== '') {
+              setBundlesState(
+                bundles.filter((bundle) =>
+                  bundle.toLowerCase().includes(term.toLowerCase())
+                )
+              )
+            } else {
+              setBundlesState(bundles)
+            }
+          }}
+          searchValue={search}
+        />
+      </span>
+    </div>
+  )
+})
+
+BundleSelector.displayName = 'BundleSelector'
+
+export default BundleSelector

--- a/src/pages/RepoPage/BundlesTab/BundleContent/BundleSummary/BundleSummary.spec.tsx
+++ b/src/pages/RepoPage/BundlesTab/BundleContent/BundleSummary/BundleSummary.spec.tsx
@@ -53,6 +53,22 @@ const mockBranches = {
   },
 }
 
+const mockBranchBundles = {
+  owner: {
+    repository: {
+      __typename: 'Repository',
+      branch: {
+        head: {
+          bundleAnalysisReport: {
+            __typename: 'BundleAnalysisReport',
+            bundles: [{ name: 'bundle1' }],
+          },
+        },
+      },
+    },
+  },
+}
+
 const server = setupServer()
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -115,6 +131,9 @@ describe('BundleSummary', () => {
           ctx.status(200),
           ctx.data({ owner: { repository: mockBranches } })
         )
+      }),
+      graphql.query('BranchBundlesNames', (req, res, ctx) => {
+        return res(ctx.status(200), ctx.data(mockBranchBundles))
       })
     )
   }

--- a/src/pages/RepoPage/BundlesTab/BundleContent/BundleSummary/BundleSummary.spec.tsx
+++ b/src/pages/RepoPage/BundlesTab/BundleContent/BundleSummary/BundleSummary.spec.tsx
@@ -1,7 +1,9 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { render, screen } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
+import { userEvent } from '@testing-library/user-event'
 import { graphql } from 'msw'
 import { setupServer } from 'msw/node'
+import { Suspense } from 'react'
 import { MemoryRouter, Route } from 'react-router-dom'
 
 import BundleSummary from './BundleSummary'
@@ -79,20 +81,26 @@ const queryClient = new QueryClient({
   },
 })
 
-const wrapper: React.FC<React.PropsWithChildren> = ({ children }) => (
-  <QueryClientProvider client={queryClient}>
-    <MemoryRouter initialEntries={['/gh/codecov/test-repo/bundles']}>
-      <Route
-        path={[
-          '/:provider/:owner/:repo/bundles/:branch',
-          '/:provider/:owner/:repo/bundles',
-        ]}
-      >
-        {children}
-      </Route>
-    </MemoryRouter>
-  </QueryClientProvider>
-)
+const wrapper =
+  (
+    initialEntries = '/gh/codecov/test-repo/bundles/test-branch'
+  ): React.FC<React.PropsWithChildren> =>
+  ({ children }) =>
+    (
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter initialEntries={[initialEntries]}>
+          <Route
+            path={[
+              '/:provider/:owner/:repo/bundles/:branch/:bundle',
+              '/:provider/:owner/:repo/bundles/:branch',
+              '/:provider/:owner/:repo/bundles/',
+            ]}
+          >
+            <Suspense fallback={<p>Loading</p>}>{children}</Suspense>
+          </Route>
+        </MemoryRouter>
+      </QueryClientProvider>
+    )
 
 beforeAll(() => {
   server.listen()
@@ -109,6 +117,8 @@ afterAll(() => {
 
 describe('BundleSummary', () => {
   function setup() {
+    const user = userEvent.setup()
+
     server.use(
       graphql.query('GetRepoOverview', (req, res, ctx) =>
         res(
@@ -136,11 +146,13 @@ describe('BundleSummary', () => {
         return res(ctx.status(200), ctx.data(mockBranchBundles))
       })
     )
+
+    return { user }
   }
 
   it('renders branch selector', async () => {
     setup()
-    render(<BundleSummary />, { wrapper })
+    render(<BundleSummary />, { wrapper: wrapper() })
 
     const branchSelector = await screen.findByRole('button', {
       name: 'bundle branch selector',
@@ -148,9 +160,19 @@ describe('BundleSummary', () => {
     expect(branchSelector).toBeInTheDocument()
   })
 
+  it('renders bundle selector', async () => {
+    setup()
+    render(<BundleSummary />, { wrapper: wrapper() })
+
+    const bundleSelector = await screen.findByRole('button', {
+      name: 'bundle tab bundle selector',
+    })
+    expect(bundleSelector).toBeInTheDocument()
+  })
+
   it('renders total size', async () => {
     setup()
-    render(<BundleSummary />, { wrapper })
+    render(<BundleSummary />, { wrapper: wrapper() })
 
     const totalSize = await screen.findByText(/Total size/)
     expect(totalSize).toBeInTheDocument()
@@ -158,7 +180,7 @@ describe('BundleSummary', () => {
 
   it('renders gzip', async () => {
     setup()
-    render(<BundleSummary />, { wrapper })
+    render(<BundleSummary />, { wrapper: wrapper() })
 
     const gzipSize = await screen.findByText(/gzip size/)
     expect(gzipSize).toBeInTheDocument()
@@ -166,7 +188,7 @@ describe('BundleSummary', () => {
 
   it('renders download time', async () => {
     setup()
-    render(<BundleSummary />, { wrapper })
+    render(<BundleSummary />, { wrapper: wrapper() })
 
     const downloadTime = await screen.findByText(/Download time/)
     expect(downloadTime).toBeInTheDocument()
@@ -174,9 +196,37 @@ describe('BundleSummary', () => {
 
   it('renders modules', async () => {
     setup()
-    render(<BundleSummary />, { wrapper })
+    render(<BundleSummary />, { wrapper: wrapper() })
 
     const modules = await screen.findByText(/Modules/)
     expect(modules).toBeInTheDocument()
+  })
+
+  describe('user interacts with branch and bundle selectors', () => {
+    describe('user selects a branch', () => {
+      it('resets the bundle selector', async () => {
+        const { user } = setup()
+        render(<BundleSummary />, {
+          wrapper: wrapper('/gh/codecov/test-repo/bundles/main/bundle1'),
+        })
+
+        const bundleSelector = await screen.findByRole('button', {
+          name: 'bundle tab bundle selector',
+        })
+        expect(bundleSelector).toHaveTextContent(/bundle1/)
+
+        const branchSelector = await screen.findByRole('button', {
+          name: 'bundle branch selector',
+        })
+        await user.click(branchSelector)
+
+        const newBranch = await screen.findByText('branch-1')
+        await user.click(newBranch)
+
+        await waitFor(() =>
+          expect(bundleSelector).toHaveTextContent(/Select bundle/)
+        )
+      })
+    })
   })
 })

--- a/src/pages/RepoPage/BundlesTab/BundleContent/BundleSummary/BundleSummary.tsx
+++ b/src/pages/RepoPage/BundlesTab/BundleContent/BundleSummary/BundleSummary.tsx
@@ -13,8 +13,8 @@ const BundleSummary: React.FC = () => {
   }, [])
 
   return (
-    <div className="flex flex-row gap-8 py-4">
-      <div className="flex flex-row gap-4">
+    <div className="flex flex-col gap-8 py-4 md:flex-row">
+      <div className="flex flex-col gap-4 md:flex-row">
         <BranchSelector resetBundleSelect={resetBundleSelect} />
         <BundleSelector ref={bundleSelectRef} />
       </div>

--- a/src/pages/RepoPage/BundlesTab/BundleContent/BundleSummary/BundleSummary.tsx
+++ b/src/pages/RepoPage/BundlesTab/BundleContent/BundleSummary/BundleSummary.tsx
@@ -1,12 +1,22 @@
+import { useCallback, useRef } from 'react'
+
 import { SummaryField, SummaryRoot } from 'ui/Summary'
 
 import BranchSelector from './BranchSelector'
+import BundleSelector from './BundleSelector'
 
 const BundleSummary: React.FC = () => {
+  const bundleSelectRef = useRef<{ resetSelected: () => void }>(null)
+
+  const resetBundleSelect = useCallback(() => {
+    bundleSelectRef.current?.resetSelected()
+  }, [])
+
   return (
     <div className="flex flex-row gap-8 py-4">
       <div className="flex flex-row gap-4">
-        <BranchSelector />
+        <BranchSelector resetBundleSelect={resetBundleSelect} />
+        <BundleSelector ref={bundleSelectRef} />
       </div>
       <SummaryRoot>
         <SummaryField>

--- a/src/pages/RepoPage/RepoPage.spec.tsx
+++ b/src/pages/RepoPage/RepoPage.spec.tsx
@@ -98,6 +98,8 @@ const wrapper =
               path={[
                 '/:provider/:owner/:repo/blob/:ref/:path+',
                 '/:provider/:owner/:repo/commits',
+                '/:provider/:owner/:repo/bundles/:branch/:bundle',
+                '/:provider/:owner/:repo/bundles/:branch',
                 '/:provider/:owner/:repo/bundles',
                 '/:provider/:owner/:repo/flags',
                 '/:provider/:owner/:repo/new',
@@ -321,6 +323,119 @@ describe('RepoPage', () => {
 
           const coverage = await screen.findByText('CoverageTab')
           expect(coverage).toBeInTheDocument()
+        })
+      })
+
+      describe('testing bundles branch and bundle path', () => {
+        describe('bundles are enabled', () => {
+          it('renders bundles tab', async () => {
+            const { queryClient } = setup({
+              language: 'javascript',
+            })
+            render(<RepoPage />, {
+              wrapper: wrapper({
+                queryClient,
+                initialEntries:
+                  '/gh/codecov/cool-repo/bundles/test-branch/test-bundle',
+              }),
+            })
+
+            const bundlesTab = await screen.findByText('BundlesTab')
+            expect(bundlesTab).toBeInTheDocument()
+          })
+        })
+
+        describe('bundles are disabled', () => {
+          it('renders bundles tab', async () => {
+            const { queryClient } = setup({
+              bundleAnalysisEnabled: false,
+              language: 'javascript',
+            })
+            render(<RepoPage />, {
+              wrapper: wrapper({
+                queryClient,
+                initialEntries:
+                  '/gh/codecov/cool-repo/bundles/test-branch/test-bundle',
+              }),
+            })
+
+            const bundlesTab = await screen.findByText('BundlesTab')
+            expect(bundlesTab).toBeInTheDocument()
+          })
+
+          describe('there is no js or ts present', () => {
+            it('redirects to coverage tab', async () => {
+              const { queryClient } = setup({
+                bundleAnalysisEnabled: false,
+                coverageEnabled: true,
+              })
+              render(<RepoPage />, {
+                wrapper: wrapper({
+                  queryClient,
+                  initialEntries:
+                    '/gh/codecov/cool-repo/bundles/test-branch/test-bundle',
+                }),
+              })
+
+              const coverage = await screen.findByText('CoverageTab')
+              expect(coverage).toBeInTheDocument()
+            })
+          })
+        })
+      })
+
+      describe('testing bundles branch path', () => {
+        describe('bundles are enabled', () => {
+          it('renders bundles tab', async () => {
+            const { queryClient } = setup({
+              language: 'javascript',
+            })
+            render(<RepoPage />, {
+              wrapper: wrapper({
+                queryClient,
+                initialEntries: '/gh/codecov/cool-repo/bundles/test-branch',
+              }),
+            })
+
+            const bundlesTab = await screen.findByText('BundlesTab')
+            expect(bundlesTab).toBeInTheDocument()
+          })
+        })
+
+        describe('bundles are disabled', () => {
+          it('renders bundles tab', async () => {
+            const { queryClient } = setup({
+              bundleAnalysisEnabled: false,
+              language: 'javascript',
+            })
+            render(<RepoPage />, {
+              wrapper: wrapper({
+                queryClient,
+                initialEntries: '/gh/codecov/cool-repo/bundles/test-branch',
+              }),
+            })
+
+            const bundlesTab = await screen.findByText('BundlesTab')
+            expect(bundlesTab).toBeInTheDocument()
+          })
+
+          describe('there is no js or ts present', () => {
+            it('redirects to coverage tab', async () => {
+              const { queryClient } = setup({
+                bundleAnalysisEnabled: false,
+                coverageEnabled: true,
+              })
+              render(<RepoPage />, {
+                wrapper: wrapper({
+                  queryClient,
+                  initialEntries: '/gh/codecov/cool-repo/bundles/test-branch',
+                }),
+              })
+
+              const coverage = await screen.findByText('CoverageTab')
+              expect(coverage).toBeInTheDocument()
+            })
+          })
         })
       })
 

--- a/src/pages/RepoPage/RepoPage.tsx
+++ b/src/pages/RepoPage/RepoPage.tsx
@@ -88,7 +88,11 @@ function Routes({
         )}
         {bundleAnalysisEnabled && bundleAnalysisPrAndCommitPages ? (
           <SentryRoute
-            path={[`${path}/bundles/:branch`, `${path}/bundles`]}
+            path={[
+              `${path}/bundles/:branch/:bundle`,
+              `${path}/bundles/:branch`,
+              `${path}/bundles`,
+            ]}
             exact
           >
             <BundlesTab />

--- a/src/services/branches/useBranchBundlesNames.spec.tsx
+++ b/src/services/branches/useBranchBundlesNames.spec.tsx
@@ -19,7 +19,7 @@ const mockRepoOverview = {
   },
 }
 
-const mockBranchBundleSummary = {
+const mockBranchBundles = {
   owner: {
     repository: {
       __typename: 'Repository',
@@ -116,7 +116,7 @@ describe('useBranchBundlesNames', () => {
           return res(ctx.status(200), ctx.data(mockNullOwner))
         }
 
-        return res(ctx.status(200), ctx.data(mockBranchBundleSummary))
+        return res(ctx.status(200), ctx.data(mockBranchBundles))
       }),
       graphql.query('GetRepoOverview', (req, res, ctx) => {
         return res(ctx.status(200), ctx.data(mockRepoOverview))

--- a/src/services/navigation/useNavLinks/useNavLinks.js
+++ b/src/services/navigation/useNavLinks/useNavLinks.js
@@ -701,15 +701,26 @@ export function useNavLinks() {
     },
     bundles: {
       path: (
-        { provider = p, owner = o, repo = r, branch } = {
+        {
+          provider = p,
+          owner = o,
+          repo = r,
+          branch = undefined,
+          bundle = undefined,
+        } = {
           provider: p,
           owner: o,
           repo: r,
         }
       ) => {
+        if (branch && bundle) {
+          return `/${provider}/${owner}/${repo}/bundles/${branch}/${bundle}`
+        }
+
         if (branch) {
           return `/${provider}/${owner}/${repo}/bundles/${branch}`
         }
+
         return `/${provider}/${owner}/${repo}/bundles`
       },
       text: 'Bundles',

--- a/src/services/navigation/useNavLinks/useNavLinks.spec.js
+++ b/src/services/navigation/useNavLinks/useNavLinks.spec.js
@@ -1804,6 +1804,22 @@ describe('useNavLinks', () => {
         expect(path).toBe('/gh/codecov/cool-repo/bundles/test-branch')
       })
     })
+
+    describe('passing branch and bundle option', () => {
+      it('appends the branch and bundle param', () => {
+        const { result } = renderHook(() => useNavLinks(), {
+          wrapper: wrapper('/gh/codecov/cool-repo'),
+        })
+
+        const path = result.current.bundles.path({
+          branch: 'test-branch',
+          bundle: 'test-bundle',
+        })
+        expect(path).toBe(
+          '/gh/codecov/cool-repo/bundles/test-branch/test-bundle'
+        )
+      })
+    })
   })
 
   describe('bundle onboarding', () => {

--- a/src/ui/Select/Select.jsx
+++ b/src/ui/Select/Select.jsx
@@ -164,7 +164,7 @@ const Select = forwardRef(
             className={cs(SelectClasses.button, ButtonVariantClass[variant])}
             {...getToggleButtonProps()}
           >
-            <span className="inline-flex items-center gap-1">
+            <span className="inline-flex items-center gap-1 overflow-hidden">
               {buttonIcon}
               {renderButton()}
             </span>


### PR DESCRIPTION
# Description

This PR creates a bundle selector for the upcoming changes to the bundles tab. When you select a bundle it sets the branch and bundle param in the URL. If you select a new branch we reset the bundle select to it's empty state and update the URL accordingly.

>[!note]
> Requires #2614

Closes codecov/engineering-team#1203

# Notable Changes

- Create new `BundleSelector` component
- Update `BundleSummary` and `BranchSelector` to create ref and pass it around for resetting the `BundleSelector`
- Few styling tweaks
- Create/Update tests

# Screenshots

https://github.com/codecov/gazebo/assets/105234307/0c0f5e07-19a3-498d-b930-6c15cd6b64c4