### PR TITLE
Feat: #1053 - Unsure of Yaml Placement

### DIFF
--- a/src/pages/RepoPage/CoverageOnboarding/CircleCI/CircleCIOrgToken.spec.tsx
+++ b/src/pages/RepoPage/CoverageOnboarding/CircleCI/CircleCIOrgToken.spec.tsx
@@ -205,6 +205,13 @@ describe('CircleCIOrgToken', () => {
       const yamlCode = await screen.findByText(/codecov\/codecov@4.0.1/)
       expect(yamlCode).toBeInTheDocument()
     })
+
+    it('renders example blurb', async () => {
+      render(<CircleCIOrgToken />, { wrapper })
+
+      const blurb = await screen.findByTestId('example-blurb')
+      expect(blurb).toBeInTheDocument()
+    })
   })
 
   describe('step three', () => {

--- a/src/pages/RepoPage/CoverageOnboarding/CircleCI/CircleCIOrgToken.tsx
+++ b/src/pages/RepoPage/CoverageOnboarding/CircleCI/CircleCIOrgToken.tsx
@@ -7,6 +7,8 @@ import { providerToInternalProvider } from 'shared/utils/provider'
 import A from 'ui/A'
 import CopyClipboard from 'ui/CopyClipboard'
 
+import ExampleBlurb from '../ExampleBlurb'
+
 const orbsString = `orbs:
   codecov: codecov/codecov@4.0.1
 workflows:
@@ -93,6 +95,7 @@ function CircleCIOrgToken() {
           </A>
         </small>
       </div>
+      <ExampleBlurb />
       <div>
         <p>
           After you committed your changes and ran the repo&apos;s CI/CD

--- a/src/pages/RepoPage/CoverageOnboarding/CircleCI/CircleCIRepoToken.tsx
+++ b/src/pages/RepoPage/CoverageOnboarding/CircleCI/CircleCIRepoToken.tsx
@@ -6,6 +6,8 @@ import { providerToInternalProvider } from 'shared/utils/provider'
 import A from 'ui/A'
 import CopyClipboard from 'ui/CopyClipboard'
 
+import ExampleBlurb from '../ExampleBlurb'
+
 const orbsString = `orbs:
   codecov/codecov@3.2.4
 `
@@ -83,6 +85,7 @@ function CircleCIRepoToken() {
           </A>
         </small>
       </div>
+      <ExampleBlurb />
       <div>
         <p>
           After you committed your changes and ran the repo&apos;s CI/CD

--- a/src/pages/RepoPage/CoverageOnboarding/ExampleBlurb/ExampleBlurb.spec.tsx
+++ b/src/pages/RepoPage/CoverageOnboarding/ExampleBlurb/ExampleBlurb.spec.tsx
@@ -1,0 +1,64 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { render, screen } from '@testing-library/react'
+import { Suspense } from 'react'
+import { MemoryRouter, Route } from 'react-router-dom'
+
+import ExampleBlurb from './ExampleBlurb'
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      suspense: true,
+      retry: false,
+    },
+  },
+})
+
+const wrapper: React.FC<React.PropsWithChildren> = ({ children }) => (
+  <QueryClientProvider client={queryClient}>
+    <MemoryRouter initialEntries={['/gh/codecov/cool-repo/new']}>
+      <Route path={['/:provider/:owner/:repo/new']}>
+        <Suspense fallback={null}>{children}</Suspense>
+      </Route>
+    </MemoryRouter>
+  </QueryClientProvider>
+)
+
+describe('ExampleBlurb', () => {
+  it('renders correct example repo link', async () => {
+    render(<ExampleBlurb />, { wrapper })
+
+    const docsLink = await screen.findByRole('link', {
+      name: /repo here/,
+    })
+    expect(docsLink).toBeInTheDocument()
+    expect(docsLink).toHaveAttribute(
+      'href',
+      'https://github.com/codecov/example-python/blob/main/.github/workflows/ci.yml'
+    )
+  })
+  it('renders correct CLI link', async () => {
+    render(<ExampleBlurb />, { wrapper })
+
+    const docsLink = await screen.findByRole('link', {
+      name: /our CLI/,
+    })
+    expect(docsLink).toBeInTheDocument()
+    expect(docsLink).toHaveAttribute(
+      'href',
+      'https://github.com/codecov/codecov-action'
+    )
+  })
+  it('renders correct extension link', async () => {
+    render(<ExampleBlurb />, { wrapper })
+
+    const docsLink = await screen.findByRole('link', {
+      name: /YAML validator/,
+    })
+    expect(docsLink).toBeInTheDocument()
+    expect(docsLink).toHaveAttribute(
+      'href',
+      `https://marketplace.visualstudio.com/items?itemName=Codecov.codecov#:~:text=Codecov's%20official%20validator%20extension%20for,and%20configuration%20of%20new%20repositories.&text=Launch%20VS%20Code%20Quick%20Open,following%20command%2C%20and%20press%20enter.&text=Create%2C%20manage%2C%20and%20validate%20the,Code%20with%20our%20latest%20extension.`
+    )
+  })
+})

--- a/src/pages/RepoPage/CoverageOnboarding/ExampleBlurb/ExampleBlurb.tsx
+++ b/src/pages/RepoPage/CoverageOnboarding/ExampleBlurb/ExampleBlurb.tsx
@@ -2,7 +2,7 @@ import A from 'ui/A'
 
 const ExampleBlurb = () => {
   return (
-    <div>
+    <div data-testid="example-blurb">
       &#128193; See example{' '}
       <A
         to={{ pageName: 'codecovExampleWorkflow' }}

--- a/src/pages/RepoPage/CoverageOnboarding/ExampleBlurb/ExampleBlurb.tsx
+++ b/src/pages/RepoPage/CoverageOnboarding/ExampleBlurb/ExampleBlurb.tsx
@@ -1,0 +1,37 @@
+import A from 'ui/A'
+
+const ExampleBlurb = () => {
+  return (
+    <div>
+      &#128193; See example{' '}
+      <A
+        to={{ pageName: 'codecovExampleWorkflow' }}
+        isExternal
+        hook="codecov-workflow-intro"
+      >
+        repo here
+      </A>{' '}
+      and{' '}
+      <A
+        to={{ pageName: 'codecovActionRepo' }}
+        isExternal
+        hook="codecov-cli-intro"
+      >
+        our CLI.
+      </A>
+      <br />
+      <br />
+      &#128161; Checkout our{' '}
+      <A
+        to={{ pageName: 'codecovYamlValidator' }}
+        isExternal
+        hook="codecov-yaml-extension-intro"
+      >
+        YAML validator
+      </A>{' '}
+      VSCode extension
+    </div>
+  )
+}
+
+export default ExampleBlurb

--- a/src/pages/RepoPage/CoverageOnboarding/ExampleBlurb/index.ts
+++ b/src/pages/RepoPage/CoverageOnboarding/ExampleBlurb/index.ts
@@ -1,0 +1,1 @@
+export { default } from './ExampleBlurb'

--- a/src/pages/RepoPage/CoverageOnboarding/GitHubActions/GitHubActionsOrgToken.spec.tsx
+++ b/src/pages/RepoPage/CoverageOnboarding/GitHubActions/GitHubActionsOrgToken.spec.tsx
@@ -214,6 +214,13 @@ describe('GitHubActionsOrgToken', () => {
       const version = await screen.findByText(/v4.0.1/)
       expect(version).toBeInTheDocument()
     })
+
+    it('renders example blurb', async () => {
+      render(<GitHubActionsOrgToken />, { wrapper })
+
+      const blurb = await screen.findByTestId('example-blurb')
+      expect(blurb).toBeInTheDocument()
+    })
   })
 
   describe('step three', () => {

--- a/src/pages/RepoPage/CoverageOnboarding/GitHubActions/GitHubActionsOrgToken.tsx
+++ b/src/pages/RepoPage/CoverageOnboarding/GitHubActions/GitHubActionsOrgToken.tsx
@@ -6,6 +6,8 @@ import { useRepo } from 'services/repo'
 import A from 'ui/A'
 import CopyClipboard from 'ui/CopyClipboard'
 
+import ExampleBlurb from '../ExampleBlurb'
+
 interface URLParams {
   provider: string
   owner: string
@@ -75,6 +77,7 @@ function GitHubActionsOrgToken() {
           <CopyClipboard string={orgTokenActionString} />
         </div>
       </div>
+      <ExampleBlurb />
       <div>
         <p>
           After you committed your changes and ran the repo&apos;s CI/CD

--- a/src/pages/RepoPage/CoverageOnboarding/GitHubActions/GitHubActionsRepoToken.spec.tsx
+++ b/src/pages/RepoPage/CoverageOnboarding/GitHubActions/GitHubActionsRepoToken.spec.tsx
@@ -137,6 +137,13 @@ describe('GitHubActions', () => {
       )
       expect(yamlBox).toBeInTheDocument()
     })
+
+    it('renders example blurb', async () => {
+      render(<GitHubActionsRepoToken />, { wrapper })
+
+      const blurb = await screen.findByTestId('example-blurb')
+      expect(blurb).toBeInTheDocument()
+    })
   })
 
   describe('step three', () => {

--- a/src/pages/RepoPage/CoverageOnboarding/GitHubActions/GitHubActionsRepoToken.tsx
+++ b/src/pages/RepoPage/CoverageOnboarding/GitHubActions/GitHubActionsRepoToken.tsx
@@ -5,6 +5,8 @@ import { useRepo } from 'services/repo'
 import A from 'ui/A'
 import CopyClipboard from 'ui/CopyClipboard'
 
+import ExampleBlurb from '../ExampleBlurb'
+
 const codecovActionString = `- name: Upload coverage reports to Codecov
   uses: codecov/codecov-action@v3
   with:
@@ -70,6 +72,7 @@ function GitHubActionsRepoToken() {
           <CopyClipboard string={codecovActionString} />
         </div>
       </div>
+      <ExampleBlurb />
       <div>
         <p>
           After you committed your changes and ran the repo&apos;s CI/CD

--- a/src/pages/RepoPage/CoverageOnboarding/OtherCI/OtherCIOrgToken.spec.tsx
+++ b/src/pages/RepoPage/CoverageOnboarding/OtherCI/OtherCIOrgToken.spec.tsx
@@ -139,31 +139,38 @@ describe('OtherCIOrgToken', () => {
         })
       })
     })
+  })
 
-    describe('step two', () => {
-      it('renders header', async () => {
-        setup()
-        render(<OtherCIOrgToken />, { wrapper })
+  describe('step two', () => {
+    it('renders header', async () => {
+      setup()
+      render(<OtherCIOrgToken />, { wrapper })
 
-        const header = await screen.findByText(/Step 2/)
-        expect(header).toBeInTheDocument()
+      const header = await screen.findByText(/Step 2/)
+      expect(header).toBeInTheDocument()
 
-        const headerLink = await screen.findByRole('link', {
-          name: /uploader to your/,
-        })
-        expect(headerLink).toBeInTheDocument()
-        expect(headerLink).toHaveAttribute(
-          'href',
-          'https://docs.codecov.com/docs/codecov-uploader'
-        )
+      const headerLink = await screen.findByRole('link', {
+        name: /uploader to your/,
       })
+      expect(headerLink).toBeInTheDocument()
+      expect(headerLink).toHaveAttribute(
+        'href',
+        'https://docs.codecov.com/docs/codecov-uploader'
+      )
+    })
 
-      it('renders instruction box', async () => {
-        render(<OtherCIOrgToken />, { wrapper })
+    it('renders instruction box', async () => {
+      render(<OtherCIOrgToken />, { wrapper })
 
-        const box = await screen.findByTestId('instruction-box')
-        expect(box).toBeInTheDocument()
-      })
+      const box = await screen.findByTestId('instruction-box')
+      expect(box).toBeInTheDocument()
+    })
+
+    it('renders example blurb', async () => {
+      render(<OtherCIOrgToken />, { wrapper })
+
+      const blurb = await screen.findByTestId('example-blurb')
+      expect(blurb).toBeInTheDocument()
     })
   })
 

--- a/src/pages/RepoPage/CoverageOnboarding/OtherCI/OtherCIOrgToken.tsx
+++ b/src/pages/RepoPage/CoverageOnboarding/OtherCI/OtherCIOrgToken.tsx
@@ -7,6 +7,8 @@ import CopyClipboard from 'ui/CopyClipboard'
 
 import { InstructionBoxOrgToken } from './TerminalInstructions'
 
+import ExampleBlurb from '../ExampleBlurb'
+
 interface URLParams {
   provider: string
   owner: string
@@ -46,6 +48,7 @@ function OtherCIOrgToken() {
         </h2>
         <InstructionBoxOrgToken />
       </div>
+      <ExampleBlurb />
       <div>
         <h3 className="text-base font-semibold">
           Step 3: upload coverage to Codecov via CLI after your tests have run

--- a/src/pages/RepoPage/CoverageOnboarding/OtherCI/OtherCIRepoToken.spec.tsx
+++ b/src/pages/RepoPage/CoverageOnboarding/OtherCI/OtherCIRepoToken.spec.tsx
@@ -111,6 +111,13 @@ describe('OtherCI', () => {
       expect(box).toBeInTheDocument()
     })
 
+    it('renders example blurb', async () => {
+      render(<OtherCIRepoToken />, { wrapper })
+
+      const blurb = await screen.findByTestId('example-blurb')
+      expect(blurb).toBeInTheDocument()
+    })
+
     it('renders integrity check msg', async () => {
       render(<OtherCIRepoToken />, { wrapper })
 

--- a/src/pages/RepoPage/CoverageOnboarding/OtherCI/OtherCIRepoToken.tsx
+++ b/src/pages/RepoPage/CoverageOnboarding/OtherCI/OtherCIRepoToken.tsx
@@ -7,6 +7,8 @@ import CopyClipboard from 'ui/CopyClipboard'
 
 import { InstructionBoxRepoToken } from './TerminalInstructions'
 
+import ExampleBlurb from '../ExampleBlurb'
+
 interface URLParams {
   provider: string
   owner: string
@@ -57,6 +59,7 @@ function OtherCIRepoToken() {
           </p>
         </div>
       </div>
+      <ExampleBlurb />
       <div>
         <p>
           After you committed your changes and ran the repo&apos;s CI/CD

--- a/src/services/navigation/useNavLinks/useStaticNavLinks.js
+++ b/src/services/navigation/useNavLinks/useStaticNavLinks.js
@@ -329,5 +329,25 @@ export function useStaticNavLinks() {
       isExternalLink: true,
       openNewTab: true,
     },
+    codecovExampleWorkflow: {
+      text: 'Github Codecov Example workflow',
+      path: () =>
+        'https://github.com/codecov/example-python/blob/main/.github/workflows/ci.yml',
+      isExternalLink: true,
+      openNewTab: true,
+    },
+    codecovActionRepo: {
+      text: 'Github Codecov Action Repo',
+      path: () => 'https://github.com/codecov/codecov-action',
+      isExternalLink: true,
+      openNewTab: true,
+    },
+    codecovYamlValidator: {
+      text: 'VSCode Yaml Validator Extension',
+      path: () =>
+        `https://marketplace.visualstudio.com/items?itemName=Codecov.codecov#:~:text=Codecov's%20official%20validator%20extension%20for,and%20configuration%20of%20new%20repositories.&text=Launch%20VS%20Code%20Quick%20Open,following%20command%2C%20and%20press%20enter.&text=Create%2C%20manage%2C%20and%20validate%20the,Code%20with%20our%20latest%20extension.`,
+      isExternalLink: true,
+      openNewTab: true,
+    },
   }
 }


### PR DESCRIPTION
# Description

Creates a new general "example blurb" component and adds to all the new repo pages

# Code Example

# Notable Changes

Adds 3 new URLs to our static nav links, a couple UTs for each clickable, and then a "presence" UT for all 6 components where the example blurb was added

# Screenshots

https://github.com/codecov/gazebo/assets/159853603/7303b1ee-f39e-4ece-9cbe-4b293da4692a

https://github.com/codecov/gazebo/assets/159853603/bed5e372-e4bb-40ac-b6a1-628347d4bf6d


# Link to Sample Entry

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.