### PR TITLE
feat: Create bundles tab summary section

### DIFF
--- a/src/pages/RepoPage/BundlesTab/BundleContent/BundleSummary/BundleDetails.spec.tsx
+++ b/src/pages/RepoPage/BundlesTab/BundleContent/BundleSummary/BundleDetails.spec.tsx
@@ -1,0 +1,227 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { render, screen } from '@testing-library/react'
+import { graphql } from 'msw'
+import { setupServer } from 'msw/node'
+import { Suspense } from 'react'
+import { MemoryRouter, Route } from 'react-router-dom'
+
+import BundleDetails from './BundleDetails'
+
+const mockRepoOverview = {
+  owner: {
+    repository: {
+      __typename: 'Repository',
+      private: false,
+      defaultBranch: 'main',
+      oldestCommitAt: '2022-10-10T11:59:59',
+      coverageEnabled: false,
+      bundleAnalysisEnabled: false,
+      languages: ['javascript'],
+    },
+  },
+}
+
+const mockBundleSummary = {
+  owner: {
+    repository: {
+      __typename: 'Repository',
+      branch: {
+        head: {
+          bundleAnalysisReport: {
+            __typename: 'BundleAnalysisReport',
+            bundle: {
+              name: 'bundle1',
+              moduleCount: 10,
+              sizeTotal: 1000,
+              bundleData: {
+                loadTime: {
+                  threeG: 1000,
+                  highSpeed: 500,
+                },
+                size: {
+                  gzip: 1000,
+                  uncompress: 2000,
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+}
+
+const mockNoSummary = { owner: null }
+
+const server = setupServer()
+const queryClient = new QueryClient({
+  defaultOptions: { queries: { retry: false, suspense: true } },
+})
+
+const wrapper: React.FC<React.PropsWithChildren> = ({ children }) => (
+  <QueryClientProvider client={queryClient}>
+    <MemoryRouter
+      initialEntries={[
+        '/gh/codecov/test.-repo/bundles/test.-branch/test.-bundle',
+      ]}
+    >
+      <Route path="/:provider/:owner/:repo/bundles/:branch/:bundle">
+        <Suspense fallback={null}>{children}</Suspense>
+      </Route>
+    </MemoryRouter>
+  </QueryClientProvider>
+)
+
+beforeAll(() => {
+  server.listen()
+})
+
+afterEach(() => {
+  queryClient.clear()
+  server.resetHandlers()
+})
+
+afterAll(() => {
+  server.close()
+})
+
+interface SetupArgs {
+  noSummary?: boolean
+}
+
+describe('BundleDetails', () => {
+  function setup({ noSummary = false }: SetupArgs) {
+    server.use(
+      graphql.query('BundleSummary', (req, res, ctx) => {
+        if (noSummary) {
+          return res(ctx.status(200), ctx.data(mockNoSummary))
+        }
+        return res(ctx.status(200), ctx.data(mockBundleSummary))
+      }),
+      graphql.query('GetRepoOverview', (req, res, ctx) => {
+        return res(ctx.status(200), ctx.data(mockRepoOverview))
+      })
+    )
+  }
+
+  describe('there is summary data', () => {
+    describe('rendering titles', () => {
+      it('renders total size', async () => {
+        setup({})
+        render(<BundleDetails />, { wrapper })
+
+        const totalSize = await screen.findByText('Total size')
+        expect(totalSize).toBeInTheDocument()
+      })
+
+      it('renders gzip size', async () => {
+        setup({})
+        render(<BundleDetails />, { wrapper })
+
+        const gzipSize = await screen.findByText('gzip size (est.)')
+        expect(gzipSize).toBeInTheDocument()
+      })
+
+      it('renders download time', async () => {
+        setup({})
+        render(<BundleDetails />, { wrapper })
+
+        const downloadTime = await screen.findByText('Download time (est.)')
+        expect(downloadTime).toBeInTheDocument()
+      })
+
+      it('renders modules', async () => {
+        setup({})
+        render(<BundleDetails />, { wrapper })
+
+        const modules = await screen.findByText('Modules')
+        expect(modules).toBeInTheDocument()
+      })
+    })
+
+    describe('rendering details', () => {
+      it('renders total size', async () => {
+        setup({})
+        render(<BundleDetails />, { wrapper })
+
+        const totalSize = await screen.findByText('2kB')
+        expect(totalSize).toBeInTheDocument()
+      })
+
+      it('renders gzip size', async () => {
+        setup({})
+        render(<BundleDetails />, { wrapper })
+
+        const gzipSize = await screen.findByText('1kB')
+        expect(gzipSize).toBeInTheDocument()
+      })
+
+      it('renders download time', async () => {
+        setup({})
+        render(<BundleDetails />, { wrapper })
+
+        const downloadTime = await screen.findByText(/1,000ms | 500ms/)
+        expect(downloadTime).toBeInTheDocument()
+
+        const downloadTimeBreakdown = await screen.findByText(
+          /(3G | high speed)/
+        )
+        expect(downloadTimeBreakdown).toBeInTheDocument()
+      })
+
+      it('renders modules', async () => {
+        setup({})
+        render(<BundleDetails />, { wrapper })
+
+        const modules = await screen.findByText('10')
+        expect(modules).toBeInTheDocument()
+      })
+    })
+  })
+
+  describe('there is no summary data', () => {
+    describe('rendering titles', () => {
+      it('renders total size', async () => {
+        setup({ noSummary: true })
+        render(<BundleDetails />, { wrapper })
+
+        const totalSize = await screen.findByText('Total size')
+        expect(totalSize).toBeInTheDocument()
+      })
+
+      it('renders gzip size', async () => {
+        setup({ noSummary: true })
+        render(<BundleDetails />, { wrapper })
+
+        const gzipSize = await screen.findByText('gzip size (est.)')
+        expect(gzipSize).toBeInTheDocument()
+      })
+
+      it('renders download time', async () => {
+        setup({ noSummary: true })
+        render(<BundleDetails />, { wrapper })
+
+        const downloadTime = await screen.findByText('Download time (est.)')
+        expect(downloadTime).toBeInTheDocument()
+      })
+
+      it('renders modules', async () => {
+        setup({ noSummary: true })
+        render(<BundleDetails />, { wrapper })
+
+        const modules = await screen.findByText('Modules')
+        expect(modules).toBeInTheDocument()
+      })
+    })
+
+    describe('rendering details', () => {
+      it('renders four dashes', async () => {
+        setup({ noSummary: true })
+        render(<BundleDetails />, { wrapper })
+
+        const dashes = await screen.findAllByText('-')
+        expect(dashes).toHaveLength(4)
+      })
+    })
+  })
+})

--- a/src/pages/RepoPage/BundlesTab/BundleContent/BundleSummary/BundleDetails.tsx
+++ b/src/pages/RepoPage/BundlesTab/BundleContent/BundleSummary/BundleDetails.tsx
@@ -1,0 +1,113 @@
+import { useParams } from 'react-router-dom'
+
+import { useBundleSummary } from 'services/bundleAnalysis/useBundleSummary'
+import {
+  formatSizeToString,
+  formatTimeToString,
+} from 'shared/utils/bundleAnalysis'
+import { SummaryField, SummaryRoot } from 'ui/Summary'
+
+const NoDetails: React.FC = () => {
+  return (
+    <SummaryRoot>
+      <SummaryField>
+        <h3 className="text-center text-sm font-semibold">Total size</h3>
+        <div className="flex items-center justify-center">-</div>
+        <div />
+      </SummaryField>
+      <SummaryField>
+        <h3 className="text-center text-sm font-semibold">gzip size (est.)</h3>
+        <div className="flex items-center justify-center">-</div>
+        <div />
+      </SummaryField>
+      <SummaryField>
+        <h3 className="text-center text-sm font-semibold">
+          Download time (est.)
+        </h3>
+        <div className="flex items-center justify-center">-</div>
+        <div />
+      </SummaryField>
+      <SummaryField>
+        <h3 className="text-center text-sm font-semibold">Modules</h3>
+        <div className="flex items-center justify-center">-</div>
+        <div />
+      </SummaryField>
+    </SummaryRoot>
+  )
+}
+
+interface URLParams {
+  provider: string
+  owner: string
+  repo: string
+  branch?: string
+  bundle?: string
+}
+
+const BundleDetails: React.FC = () => {
+  const {
+    provider,
+    owner,
+    repo,
+    branch,
+    bundle: bundleParam,
+  } = useParams<URLParams>()
+
+  const bundle = bundleParam ?? ''
+
+  const { data: summaryData } = useBundleSummary({
+    provider,
+    owner,
+    repo,
+    branch,
+    bundle,
+    opts: { enabled: bundle !== '' },
+  })
+
+  if (!bundle || !summaryData || !summaryData.bundleSummary) {
+    return <NoDetails />
+  }
+
+  const summary = summaryData.bundleSummary
+
+  return (
+    <SummaryRoot>
+      <SummaryField>
+        <h3 className="text-center text-sm font-semibold">Total size</h3>
+        <div className="flex items-center justify-center">
+          {formatSizeToString(summary.bundleData.size.uncompress)}
+        </div>
+        <div />
+      </SummaryField>
+      <SummaryField>
+        <h3 className="text-center text-sm font-semibold">gzip size (est.)</h3>
+        <div className="flex items-center justify-center">
+          {formatSizeToString(summary.bundleData.size.gzip)}
+        </div>
+        <div />
+      </SummaryField>
+      <SummaryField>
+        <h3 className="text-center text-sm font-semibold">
+          Download time (est.)
+        </h3>
+        <div className="flex flex-col items-center justify-center">
+          <p>
+            {formatTimeToString(summary.bundleData.loadTime.threeG)} |{' '}
+            {formatTimeToString(summary.bundleData.loadTime.highSpeed)}
+          </p>
+          <p className="text-xs">(3G | high speed)</p>
+        </div>
+        <div />
+      </SummaryField>
+      <SummaryField>
+        <h3 className="text-center text-sm font-semibold">Modules</h3>
+        <div className="flex items-center justify-center">
+          {summary.moduleCount}
+        </div>
+        <div />
+      </SummaryField>
+    </SummaryRoot>
+  )
+}
+
+export default BundleDetails

--- a/src/pages/RepoPage/BundlesTab/BundleContent/BundleSummary/BundleDetails.tsx
+++ b/src/pages/RepoPage/BundlesTab/BundleContent/BundleSummary/BundleDetails.tsx
@@ -7,7 +7,7 @@ import {
 } from 'shared/utils/bundleAnalysis'
 import { SummaryField, SummaryRoot } from 'ui/Summary'
 
-const NoDetails: React.FC = () => {
+export const NoDetails: React.FC = () => {
   return (
     <SummaryRoot>
       <SummaryField>

--- a/src/pages/RepoPage/BundlesTab/BundleContent/BundleSummary/BundleSelector.tsx
+++ b/src/pages/RepoPage/BundlesTab/BundleContent/BundleSummary/BundleSelector.tsx
@@ -30,7 +30,7 @@ const BundleSelector = forwardRef(({}, ref) => {
   const [selectedBundle, setSelectedBundle] = useState<string | undefined>(
     () => {
       if (bundle) {
-        return bundle
+        return decodeURIComponent(bundle)
       }
       return undefined
     }

--- a/src/pages/RepoPage/BundlesTab/BundleContent/BundleSummary/BundleSelector.tsx
+++ b/src/pages/RepoPage/BundlesTab/BundleContent/BundleSummary/BundleSelector.tsx
@@ -6,6 +6,30 @@ import { useNavLinks } from 'services/navigation'
 import { useRepoOverview } from 'services/repo'
 import Select from 'ui/Select'
 
+export const BundleSelectorSkeleton: React.FC = () => {
+  return (
+    <div className="md:w-[16rem]">
+      <h3 className="flex items-center gap-1 text-sm font-semibold text-ds-gray-octonary">
+        Bundle
+      </h3>
+      <span className="max-w-[16rem] text-sm">
+        <Select
+          // @ts-expect-error
+          disabled={true}
+          resourceName="bundle"
+          placeholder="Select bundle"
+          dataMarketing="bundle-selector-bundle-tab"
+          ariaName="bundle tab bundle selector"
+          variant="gray"
+          isLoading={false}
+          items={[]}
+          value={'Select bundle'}
+        />
+      </span>
+    </div>
+  )
+}
+
 interface URLParams {
   provider: string
   owner: string

--- a/src/pages/RepoPage/BundlesTab/BundleContent/BundleSummary/BundleSummary.spec.tsx
+++ b/src/pages/RepoPage/BundlesTab/BundleContent/BundleSummary/BundleSummary.spec.tsx
@@ -18,6 +18,36 @@ const mockRepoOverview = {
   languages: [],
 }
 
+const mockBundleSummary = {
+  owner: {
+    repository: {
+      __typename: 'Repository',
+      branch: {
+        head: {
+          bundleAnalysisReport: {
+            __typename: 'BundleAnalysisReport',
+            bundle: {
+              name: 'bundle1',
+              moduleCount: 10,
+              sizeTotal: 1000,
+              bundleData: {
+                loadTime: {
+                  threeG: 1000,
+                  highSpeed: 500,
+                },
+                size: {
+                  gzip: 1000,
+                  uncompress: 2000,
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+}
+
 const mockBranch = {
   branch: {
     name: 'main',
@@ -144,6 +174,9 @@ describe('BundleSummary', () => {
       }),
       graphql.query('BranchBundlesNames', (req, res, ctx) => {
         return res(ctx.status(200), ctx.data(mockBranchBundles))
+      }),
+      graphql.query('BundleSummary', (req, res, ctx) => {
+        return res(ctx.status(200), ctx.data(mockBundleSummary))
       })
     )
 

--- a/src/pages/RepoPage/BundlesTab/BundleContent/BundleSummary/BundleSummary.tsx
+++ b/src/pages/RepoPage/BundlesTab/BundleContent/BundleSummary/BundleSummary.tsx
@@ -1,8 +1,7 @@
 import { useCallback, useRef } from 'react'
 
-import { SummaryField, SummaryRoot } from 'ui/Summary'
-
 import BranchSelector from './BranchSelector'
+import BundleDetails from './BundleDetails'
 import BundleSelector from './BundleSelector'
 
 const BundleSummary: React.FC = () => {
@@ -13,25 +12,12 @@ const BundleSummary: React.FC = () => {
   }, [])
 
   return (
-    <div className="flex flex-col gap-8 py-4 md:flex-row">
+    <div className="flex flex-col gap-8 py-4 md:flex-row md:justify-between">
       <div className="flex flex-col gap-4 md:flex-row">
         <BranchSelector resetBundleSelect={resetBundleSelect} />
         <BundleSelector ref={bundleSelectRef} />
       </div>
-      <SummaryRoot>
-        <SummaryField>
-          <p className="text-sm font-semibold">Total size</p>
-        </SummaryField>
-        <SummaryField>
-          <p className="text-sm font-semibold">gzip size</p>
-        </SummaryField>
-        <SummaryField>
-          <p className="text-sm font-semibold">Download time</p>
-        </SummaryField>
-        <SummaryField>
-          <p className="text-sm font-semibold">Modules</p>
-        </SummaryField>
-      </SummaryRoot>
+      <BundleDetails />
     </div>
   )
 }

--- a/src/pages/RepoPage/BundlesTab/BundleContent/BundleSummary/BundleSummary.tsx
+++ b/src/pages/RepoPage/BundlesTab/BundleContent/BundleSummary/BundleSummary.tsx
@@ -1,8 +1,11 @@
-import { useCallback, useRef } from 'react'
+import { lazy, Suspense, useCallback, useRef } from 'react'
 
 import BranchSelector from './BranchSelector'
-import BundleDetails from './BundleDetails'
-import BundleSelector from './BundleSelector'
+import { NoDetails } from './BundleDetails'
+import { BundleSelectorSkeleton } from './BundleSelector'
+
+const BundleDetails = lazy(() => import('./BundleDetails'))
+const BundleSelector = lazy(() => import('./BundleSelector'))
 
 const BundleSummary: React.FC = () => {
   const bundleSelectRef = useRef<{ resetSelected: () => void }>(null)
@@ -15,9 +18,13 @@ const BundleSummary: React.FC = () => {
     <div className="flex flex-col gap-8 py-4 md:flex-row md:justify-between">
       <div className="flex flex-col gap-4 md:flex-row">
         <BranchSelector resetBundleSelect={resetBundleSelect} />
-        <BundleSelector ref={bundleSelectRef} />
+        <Suspense fallback={<BundleSelectorSkeleton />}>
+          <BundleSelector ref={bundleSelectRef} />
+        </Suspense>
       </div>
-      <BundleDetails />
+      <Suspense fallback={<NoDetails />}>
+        <BundleDetails />
+      </Suspense>
     </div>
   )
 }

--- a/src/services/bundleAnalysis/index.ts
+++ b/src/services/bundleAnalysis/index.ts
@@ -1,2 +1,5 @@
 export * from './useBranchBundleSummary'
 export * from './useBranchBundlesNames'
+export * from './useBundleAssetModules'
+export * from './useBundleAssets'
+export * from './useBundleSummary'

--- a/src/services/bundleAnalysis/useBranchBundleSummary.spec.tsx
+++ b/src/services/bundleAnalysis/useBranchBundleSummary.spec.tsx
@@ -138,12 +138,15 @@ describe('useBranchBundleSummary', () => {
             provider: 'gh',
             owner: 'codecov',
             repo: 'codecov',
+            branch: 'cool-branch',
           }),
         { wrapper }
       )
 
       await waitFor(() => expect(passedBranch).toHaveBeenCalled())
-      await waitFor(() => expect(passedBranch).toHaveBeenCalledWith('main'))
+      await waitFor(() =>
+        expect(passedBranch).toHaveBeenCalledWith('cool-branch')
+      )
     })
   })
 
@@ -156,15 +159,12 @@ describe('useBranchBundleSummary', () => {
             provider: 'gh',
             owner: 'codecov',
             repo: 'codecov',
-            branch: 'cool-branch',
           }),
         { wrapper }
       )
 
       await waitFor(() => expect(passedBranch).toHaveBeenCalled())
-      await waitFor(() =>
-        expect(passedBranch).toHaveBeenCalledWith('cool-branch')
-      )
+      await waitFor(() => expect(passedBranch).toHaveBeenCalledWith('main'))
     })
   })
 

--- a/src/services/bundleAnalysis/useBundleSummary.tsx
+++ b/src/services/bundleAnalysis/useBundleSummary.tsx
@@ -5,6 +5,7 @@ import { MissingHeadReportSchema } from 'services/comparison'
 import {
   RepoNotFoundErrorSchema,
   RepoOwnerNotActivatedErrorSchema,
+  useRepoOverview,
 } from 'services/repo'
 import Api from 'shared/api/api'
 import type { NetworkErrorObject } from 'shared/api/helpers'
@@ -118,17 +119,32 @@ interface UseBundleSummaryArgs {
   provider: string
   owner: string
   repo: string
-  branch: string
+  branch?: string
   bundle: string
+  opts?: {
+    enabled?: boolean
+  }
 }
 
 export const useBundleSummary = ({
   provider,
   owner,
   repo,
-  branch,
+  branch: branchParam,
   bundle,
+  opts = {},
 }: UseBundleSummaryArgs) => {
+  const { data: overview } = useRepoOverview({
+    provider,
+    owner,
+    repo,
+    opts: {
+      enabled: !branchParam,
+    },
+  })
+
+  const branch = branchParam ?? overview?.defaultBranch
+
   return useQuery({
     queryKey: ['BundleSummary', provider, owner, repo, branch, bundle],
     queryFn: ({ signal }) =>
@@ -186,5 +202,6 @@ export const useBundleSummary = ({
 
         return { bundleSummary }
       }),
+    enabled: opts?.enabled,
   })
 }

--- a/src/services/repo/useRepoOverview.tsx
+++ b/src/services/repo/useRepoOverview.tsx
@@ -139,6 +139,6 @@ export function useRepoOverview({
         }
       })
     },
-    enabled: opts?.enabled,
+    enabled: !!opts?.enabled,
   })
 }

--- a/src/services/repo/useRepoOverview.tsx
+++ b/src/services/repo/useRepoOverview.tsx
@@ -57,12 +57,16 @@ interface UseRepoOverviewArgs {
   provider: string
   owner: string
   repo: string
+  opts?: {
+    enabled?: boolean
+  }
 }
 
 export function useRepoOverview({
   provider,
   owner,
   repo,
+  opts = {},
 }: UseRepoOverviewArgs) {
   return useQuery({
     queryKey: ['GetRepoOverview', provider, owner, repo],
@@ -135,5 +139,6 @@ export function useRepoOverview({
         }
       })
     },
+    enabled: opts?.enabled,
   })
 }

--- a/src/services/repo/useRepoOverview.tsx
+++ b/src/services/repo/useRepoOverview.tsx
@@ -68,6 +68,11 @@ export function useRepoOverview({
   repo,
   opts = {},
 }: UseRepoOverviewArgs) {
+  let enabled = true
+  if (opts?.enabled !== undefined) {
+    enabled = opts.enabled
+  }
+
   return useQuery({
     queryKey: ['GetRepoOverview', provider, owner, repo],
     queryFn: ({ signal }) => {
@@ -139,6 +144,6 @@ export function useRepoOverview({
         }
       })
     },
-    enabled: !!opts?.enabled,
+    enabled,
   })
 }

--- a/src/ui/Select/Select.jsx
+++ b/src/ui/Select/Select.jsx
@@ -164,7 +164,7 @@ const Select = forwardRef(
             className={cs(SelectClasses.button, ButtonVariantClass[variant])}
             {...getToggleButtonProps()}
           >
-            <span className="inline-flex items-center gap-1 overflow-hidden">
+            <span className="inline-flex items-center gap-1 truncate">
               {buttonIcon}
               {renderButton()}
             </span>


### PR DESCRIPTION
# Description

This PR adds in a new `BundlesDetail` component that is used in the top right of the updated bundles tab.

Closes codecov/engineering-team#1207

# Notable Changes

- Create new `BundlesDetail` component
- Few tweaks to `useBundleSummary` hook
- Few small tweaks here and there
- Update to tests

# Screenshots

<img width="1343" alt="Screenshot 2024-02-23 at 20 45 28" src="https://github.com/codecov/gazebo/assets/105234307/a16b6014-e3d8-497c-b803-d1a484cc0a50">