### PR TITLE
feat: Add deleted file status to files changed tables

### DIFF
--- a/src/pages/CommitDetailPage/CommitCoverage/CommitCoverageSummary/CommitCoverageSummary.spec.jsx
+++ b/src/pages/CommitDetailPage/CommitCoverage/CommitCoverageSummary/CommitCoverageSummary.spec.jsx
@@ -69,8 +69,9 @@ const commit = (state = 'complete') => ({
       __typename: 'ImpactedFiles',
       results: [
         {
-          patchCoverage: { coverage: 75 },
           headName: 'flag1/mafs.js',
+          isCriticalFile: false,
+          patchCoverage: { coverage: 75 },
           baseCoverage: { coverage: 100 },
           headCoverage: { coverage: 90 },
         },

--- a/src/pages/CommitDetailPage/CommitCoverage/CommitCoverageSummary/hooks/useCommitForSummary.spec.js
+++ b/src/pages/CommitDetailPage/CommitCoverage/CommitCoverageSummary/hooks/useCommitForSummary.spec.js
@@ -94,8 +94,9 @@ const data = {
         __typename: 'ImpactedFiles',
         results: [
           {
-            patchCoverage: { coverage: 75 },
             headName: 'flag1/mafs.js',
+            isCriticalFile: false,
+            patchCoverage: { coverage: 75 },
             baseCoverage: { coverage: 100 },
             headCoverage: { coverage: 90.9090909090909 },
           },

--- a/src/pages/CommitDetailPage/CommitCoverage/routes/FilesChangedTab/FilesChangedTable/FilesChangedTable.spec.tsx
+++ b/src/pages/CommitDetailPage/CommitCoverage/routes/FilesChangedTab/FilesChangedTable/FilesChangedTable.spec.tsx
@@ -115,6 +115,7 @@ describe('FilesChangedTable', () => {
       results: [
         {
           headName: 'src/index2.py',
+          isCriticalFile: false,
           baseCoverage: {
             coverage: 62.5,
           },
@@ -173,6 +174,7 @@ describe('FilesChangedTable', () => {
       results: [
         {
           headName: '',
+          isCriticalFile: false,
           baseCoverage: null,
           headCoverage: null,
           patchCoverage: null,
@@ -188,12 +190,12 @@ describe('FilesChangedTable', () => {
       expect(coverage).not.toBeInTheDocument()
     })
 
-    it('renders no available data copy', async () => {
+    it('renders dashes', async () => {
       const { queryClient } = setup(mockEmptyData)
       render(<FilesChangedTable />, { wrapper: wrapper(queryClient) })
 
-      const copy = await screen.findByText('No data')
-      expect(copy).toBeInTheDocument()
+      const copy = await screen.findAllByText('-')
+      expect(copy).toHaveLength(3)
     })
   })
 
@@ -203,6 +205,7 @@ describe('FilesChangedTable', () => {
       results: [
         {
           headName: '',
+          isCriticalFile: false,
           baseCoverage: null,
           headCoverage: {
             coverage: 67,
@@ -297,6 +300,7 @@ describe('FilesChangedTable', () => {
       results: [
         {
           headName: 'src/index2.py',
+          isCriticalFile: false,
           baseCoverage: {
             coverage: 62.5,
           },
@@ -330,6 +334,7 @@ describe('FilesChangedTable', () => {
       results: [
         {
           headName: '',
+          isCriticalFile: false,
           baseCoverage: null,
           headCoverage: null,
           patchCoverage: null,
@@ -346,12 +351,65 @@ describe('FilesChangedTable', () => {
     })
   })
 
+  describe('highlights critical files', () => {
+    it('renders critical file', async () => {
+      const { queryClient } = setup({
+        __typename: 'ImpactedFiles',
+        results: [
+          {
+            headName: 'src/main.rs',
+            isCriticalFile: true,
+            baseCoverage: {
+              coverage: 40.0,
+            },
+            headCoverage: {
+              coverage: 50.0,
+            },
+            patchCoverage: {
+              coverage: 100.0,
+            },
+          },
+        ],
+      })
+      render(<FilesChangedTable />, { wrapper: wrapper(queryClient) })
+
+      const criticalFile = await screen.findByText(/Critical file/)
+      expect(criticalFile).toBeInTheDocument()
+    })
+
+    it('renders non-critical file', async () => {
+      const { queryClient } = setup({
+        __typename: 'ImpactedFiles',
+        results: [
+          {
+            headName: 'src/main.rs',
+            isCriticalFile: false,
+            baseCoverage: {
+              coverage: 40.0,
+            },
+            headCoverage: {
+              coverage: 50.0,
+            },
+            patchCoverage: {
+              coverage: 100.0,
+            },
+          },
+        ],
+      })
+      render(<FilesChangedTable />, { wrapper: wrapper(queryClient) })
+
+      const criticalFile = screen.queryByText(/Critical file/)
+      expect(criticalFile).not.toBeInTheDocument()
+    })
+  })
+
   describe('flags query param is set', () => {
     const mockData = {
       __typename: 'ImpactedFiles',
       results: [
         {
           headName: 'src/index2.py',
+          isCriticalFile: false,
           baseCoverage: {
             coverage: 62.5,
           },
@@ -396,6 +454,7 @@ describe('FilesChangedTable', () => {
       results: [
         {
           headName: 'src/index2.py',
+          isCriticalFile: false,
           baseCoverage: {
             coverage: 62.5,
           },
@@ -441,6 +500,7 @@ describe('FilesChangedTable', () => {
       results: [
         {
           headName: 'src/index2.py',
+          isCriticalFile: false,
           baseCoverage: {
             coverage: 62.5,
           },
@@ -453,6 +513,7 @@ describe('FilesChangedTable', () => {
         },
         {
           headName: 'src/index3.py',
+          isCriticalFile: false,
           baseCoverage: {
             coverage: 64.5,
           },

--- a/src/pages/CommitDetailPage/CommitCoverage/routes/FilesChangedTab/FilesChangedTable/FilesChangedTable.spec.tsx
+++ b/src/pages/CommitDetailPage/CommitCoverage/routes/FilesChangedTab/FilesChangedTable/FilesChangedTable.spec.tsx
@@ -403,6 +403,52 @@ describe('FilesChangedTable', () => {
     })
   })
 
+  describe('highlights deleted files', () => {
+    it('renders deleted file', async () => {
+      const { queryClient } = setup({
+        __typename: 'ImpactedFiles',
+        results: [
+          {
+            headName: 'src/main.rs',
+            isCriticalFile: false,
+            baseCoverage: null,
+            headCoverage: null,
+            patchCoverage: null,
+          },
+        ],
+      })
+      render(<FilesChangedTable />, { wrapper: wrapper(queryClient) })
+
+      const deletedFile = await screen.findByText(/Deleted file/)
+      expect(deletedFile).toBeInTheDocument()
+    })
+
+    it('renders non-deleted file', async () => {
+      const { queryClient } = setup({
+        __typename: 'ImpactedFiles',
+        results: [
+          {
+            headName: 'src/main.rs',
+            isCriticalFile: false,
+            baseCoverage: {
+              coverage: 40.0,
+            },
+            headCoverage: {
+              coverage: 50.0,
+            },
+            patchCoverage: {
+              coverage: 100.0,
+            },
+          },
+        ],
+      })
+      render(<FilesChangedTable />, { wrapper: wrapper(queryClient) })
+
+      const deletedFile = screen.queryByText(/Deleted file/)
+      expect(deletedFile).not.toBeInTheDocument()
+    })
+  })
+
   describe('flags query param is set', () => {
     const mockData = {
       __typename: 'ImpactedFiles',

--- a/src/pages/CommitDetailPage/CommitCoverage/routes/FilesChangedTab/FilesChangedTable/FilesChangedTable.tsx
+++ b/src/pages/CommitDetailPage/CommitCoverage/routes/FilesChangedTab/FilesChangedTable/FilesChangedTable.tsx
@@ -105,17 +105,21 @@ function getColumns({ commitId }: { commitId: string }) {
               </span>
             )}
             {/* @ts-expect-error */}
-            <A
-              to={{
-                pageName: 'commitFileDiff',
-                options: {
-                  commit: commitId,
-                  tree: headName,
-                },
-              }}
-            >
-              {headName}
-            </A>
+            {isDeletedFile ? (
+              <>{headName}</>
+            ) : (
+              <A
+                to={{
+                  pageName: 'commitFileDiff',
+                  options: {
+                    commit: commitId,
+                    tree: headName,
+                  },
+                }}
+              >
+                {headName}
+              </A>
+            )}
             {row.original?.isCriticalFile && (
               <span className="ml-2 h-fit flex-none rounded border border-ds-gray-tertiary p-1 text-xs text-ds-gray-senary">
                 Critical file

--- a/src/pages/CommitDetailPage/CommitCoverage/routes/FilesChangedTab/FilesChangedTable/FilesChangedTable.tsx
+++ b/src/pages/CommitDetailPage/CommitCoverage/routes/FilesChangedTab/FilesChangedTable/FilesChangedTable.tsx
@@ -30,7 +30,7 @@ const CommitFileDiff = lazy(() => import('../shared/CommitFileDiff'))
 const columnHelper = createColumnHelper<ImpactedFileType>()
 
 const isNumericValue = (value: string) =>
-  value === 'patchPercentage' || value === 'head' || value === 'change'
+  value === 'patchPercentage' || value === 'coverage' || value === 'change'
 
 function getFilter(sorting: Array<{ id: string; desc: boolean }>) {
   const state = sorting.at(0)
@@ -79,27 +79,31 @@ function getColumns({ commitId }: { commitId: string }) {
       header: 'Name',
       cell: ({ getValue, row }) => {
         const headName = getValue()
+        const isDeletedFile = row.original?.headCoverage === null
+
         return (
-          <div className="flex flex-row break-all">
-            <span
-              data-action="clickable"
-              data-testid="file-diff-expand"
-              className={cs(
-                'inline-flex items-center gap-1 font-sans hover:underline focus:ring-2',
-                {
-                  'text-ds-blue': row.getIsExpanded(),
-                }
-              )}
-              {...{
-                onClick: row.getToggleExpandedHandler(),
-              }}
-            >
-              <Icon
-                size="md"
-                name={row.getIsExpanded() ? 'chevronDown' : 'chevronRight'}
-                variant="solid"
-              />
-            </span>
+          <div className="flex flex-row items-center break-all">
+            {!isDeletedFile && (
+              <span
+                data-action="clickable"
+                data-testid="file-diff-expand"
+                className={cs(
+                  'inline-flex items-center gap-1 font-sans hover:underline focus:ring-2',
+                  {
+                    'text-ds-blue': row.getIsExpanded(),
+                  }
+                )}
+                {...{
+                  onClick: row.getToggleExpandedHandler(),
+                }}
+              >
+                <Icon
+                  size="md"
+                  name={row.getIsExpanded() ? 'chevronDown' : 'chevronRight'}
+                  variant="solid"
+                />
+              </span>
+            )}
             {/* @ts-expect-error */}
             <A
               to={{
@@ -112,6 +116,16 @@ function getColumns({ commitId }: { commitId: string }) {
             >
               {headName}
             </A>
+            {row.original?.isCriticalFile && (
+              <span className="ml-2 h-fit flex-none rounded border border-ds-gray-tertiary p-1 text-xs text-ds-gray-senary">
+                Critical file
+              </span>
+            )}
+            {isDeletedFile && (
+              <div className="ml-2 h-fit flex-none rounded border border-ds-gray-tertiary p-1 text-xs text-ds-gray-senary">
+                Deleted file
+              </div>
+            )}
           </div>
         )
       },
@@ -189,9 +203,7 @@ function getColumns({ commitId }: { commitId: string }) {
               />
             )
           } else {
-            return (
-              <span className="ml-4 text-sm text-ds-gray-quinary">No data</span>
-            )
+            return <>-</>
           }
         },
       }

--- a/src/pages/CommitDetailPage/CommitCoverage/routes/FilesChangedTab/FilesChangedTable/FilesChangedTable.tsx
+++ b/src/pages/CommitDetailPage/CommitCoverage/routes/FilesChangedTab/FilesChangedTable/FilesChangedTable.tsx
@@ -30,7 +30,7 @@ const CommitFileDiff = lazy(() => import('../shared/CommitFileDiff'))
 const columnHelper = createColumnHelper<ImpactedFileType>()
 
 const isNumericValue = (value: string) =>
-  value === 'patchPercentage' || value === 'coverage' || value === 'change'
+  value === 'patchPercentage' || value === 'head' || value === 'change'
 
 function getFilter(sorting: Array<{ id: string; desc: boolean }>) {
   const state = sorting.at(0)
@@ -47,7 +47,7 @@ function getFilter(sorting: Array<{ id: string; desc: boolean }>) {
       }
     }
 
-    if (state.id === 'coverage') {
+    if (state.id === 'head') {
       return {
         direction,
         parameter: OrderingParameter.HEAD_COVERAGE,
@@ -83,7 +83,7 @@ function getColumns({ commitId }: { commitId: string }) {
 
         return (
           <div className="flex flex-row items-center break-all">
-            {!isDeletedFile && (
+            {!isDeletedFile ? (
               <span
                 data-action="clickable"
                 data-testid="file-diff-expand"
@@ -103,7 +103,7 @@ function getColumns({ commitId }: { commitId: string }) {
                   variant="solid"
                 />
               </span>
-            )}
+            ) : null}
             {isDeletedFile ? (
               <>{headName}</>
             ) : (
@@ -120,22 +120,22 @@ function getColumns({ commitId }: { commitId: string }) {
                 {headName}
               </A>
             )}
-            {row.original?.isCriticalFile && (
+            {row.original?.isCriticalFile ? (
               <span className="ml-2 h-fit flex-none rounded border border-ds-gray-tertiary p-1 text-xs text-ds-gray-senary">
                 Critical file
               </span>
-            )}
-            {isDeletedFile && (
+            ) : null}
+            {isDeletedFile ? (
               <div className="ml-2 h-fit flex-none rounded border border-ds-gray-tertiary p-1 text-xs text-ds-gray-senary">
                 Deleted file
               </div>
-            )}
+            ) : null}
           </div>
         )
       },
     }),
     columnHelper.accessor('headCoverage.coverage', {
-      id: 'coverage',
+      id: 'head',
       header: 'HEAD',
       cell: ({ getValue }) => {
         const value = getValue()
@@ -240,7 +240,7 @@ interface URLParams {
 export default function FilesChangedTable() {
   const [expanded, setExpanded] = useState<ExpandedState>({})
   const [sorting, setSorting] = useState<SortingState>([
-    { id: 'coverage', desc: false },
+    { id: 'head', desc: false },
   ])
   const { provider, owner, repo, commit: commitSha } = useParams<URLParams>()
   const location = useLocation()

--- a/src/pages/CommitDetailPage/CommitCoverage/routes/FilesChangedTab/FilesChangedTable/FilesChangedTable.tsx
+++ b/src/pages/CommitDetailPage/CommitCoverage/routes/FilesChangedTab/FilesChangedTable/FilesChangedTable.tsx
@@ -104,10 +104,10 @@ function getColumns({ commitId }: { commitId: string }) {
                 />
               </span>
             )}
-            {/* @ts-expect-error */}
             {isDeletedFile ? (
               <>{headName}</>
             ) : (
+              /* @ts-expect-error */
               <A
                 to={{
                   pageName: 'commitFileDiff',

--- a/src/pages/CommitDetailPage/CommitCoverage/routes/IndirectChangesTab/IndirectChangesTable/IndirectChangesTable.spec.tsx
+++ b/src/pages/CommitDetailPage/CommitCoverage/routes/IndirectChangesTab/IndirectChangesTable/IndirectChangesTable.spec.tsx
@@ -105,6 +105,7 @@ describe('IndirectChangesTable', () => {
       results: [
         {
           headName: 'src/index2.py',
+          isCriticalFile: false,
           baseCoverage: {
             coverage: 62.5,
           },
@@ -183,6 +184,7 @@ describe('IndirectChangesTable', () => {
       results: [
         {
           headName: '',
+          isCriticalFile: false,
           baseCoverage: null,
           headCoverage: {
             coverage: 67,
@@ -253,6 +255,7 @@ describe('IndirectChangesTable', () => {
       results: [
         {
           headName: 'src/index2.py',
+          isCriticalFile: false,
           baseCoverage: {
             coverage: 62.5,
           },
@@ -347,6 +350,58 @@ describe('IndirectChangesTable', () => {
 
       const loader = screen.getByTestId('spinner')
       expect(loader).toBeInTheDocument()
+    })
+  })
+
+  describe('highlights critical files', () => {
+    it('renders critical file', async () => {
+      const { queryClient } = setup({
+        __typename: 'ImpactedFiles',
+        results: [
+          {
+            headName: 'src/main.rs',
+            isCriticalFile: true,
+            baseCoverage: {
+              coverage: 40.0,
+            },
+            headCoverage: {
+              coverage: 50.0,
+            },
+            patchCoverage: {
+              coverage: 100.0,
+            },
+          },
+        ],
+      })
+      render(<IndirectChangesTable />, { wrapper: wrapper(queryClient) })
+
+      const criticalFile = await screen.findByText(/Critical file/)
+      expect(criticalFile).toBeInTheDocument()
+    })
+
+    it('renders non-critical file', async () => {
+      const { queryClient } = setup({
+        __typename: 'ImpactedFiles',
+        results: [
+          {
+            headName: 'src/main.rs',
+            isCriticalFile: false,
+            baseCoverage: {
+              coverage: 40.0,
+            },
+            headCoverage: {
+              coverage: 50.0,
+            },
+            patchCoverage: {
+              coverage: 100.0,
+            },
+          },
+        ],
+      })
+      render(<IndirectChangesTable />, { wrapper: wrapper(queryClient) })
+
+      const criticalFile = screen.queryByText(/Critical file/)
+      expect(criticalFile).not.toBeInTheDocument()
     })
   })
 })

--- a/src/pages/CommitDetailPage/CommitCoverage/routes/IndirectChangesTab/IndirectChangesTable/IndirectChangesTable.tsx
+++ b/src/pages/CommitDetailPage/CommitCoverage/routes/IndirectChangesTab/IndirectChangesTable/IndirectChangesTable.tsx
@@ -66,11 +66,11 @@ function getColumns({ commitid }: { commitid: string }) {
                 {headName}
               </A>
             </div>
-            {row.original?.isCriticalFile && (
+            {row.original?.isCriticalFile ? (
               <span className="flex-none self-center rounded border border-ds-gray-tertiary p-1 text-xs text-ds-gray-senary">
                 Critical file
               </span>
-            )}
+            ) : null}
           </div>
         )
       },

--- a/src/pages/CommitDetailPage/CommitCoverage/routes/IndirectChangesTab/IndirectChangesTable/IndirectChangesTable.tsx
+++ b/src/pages/CommitDetailPage/CommitCoverage/routes/IndirectChangesTab/IndirectChangesTable/IndirectChangesTable.tsx
@@ -66,6 +66,11 @@ function getColumns({ commitid }: { commitid: string }) {
                 {headName}
               </A>
             </div>
+            {row.original?.isCriticalFile && (
+              <span className="flex-none self-center rounded border border-ds-gray-tertiary p-1 text-xs text-ds-gray-senary">
+                Critical file
+              </span>
+            )}
           </div>
         )
       },

--- a/src/pages/PullRequestPage/PullCoverage/routes/FilesChangedTab/FilesChanged/FilesChangedTable/FilesChangedTable.spec.tsx
+++ b/src/pages/PullRequestPage/PullCoverage/routes/FilesChangedTab/FilesChanged/FilesChangedTable/FilesChangedTable.spec.tsx
@@ -381,7 +381,7 @@ describe('FilesChangedTable', () => {
       const { queryClient } = setup()
       render(<FilesChangedTable />, { wrapper: wrapper(queryClient) })
 
-      const criticalFile = await screen.findByText('Critical File')
+      const criticalFile = await screen.findByText('Critical file')
       expect(criticalFile).toBeInTheDocument()
     })
 
@@ -430,8 +430,63 @@ describe('FilesChangedTable', () => {
       const file = await screen.findByText('flag1/src/App.tsx')
       expect(file).toBeInTheDocument()
 
-      const nonCriticalFile = screen.queryByText('Critical File')
+      const nonCriticalFile = screen.queryByText('Critical file')
       expect(nonCriticalFile).not.toBeInTheDocument()
+    })
+  })
+
+  describe('highlights deleted files', () => {
+    it('renders non-deleted file', async () => {
+      const { queryClient } = setup({})
+      render(<FilesChangedTable />, { wrapper: wrapper(queryClient) })
+
+      const deletedFile = screen.queryByText('Deleted file')
+      expect(deletedFile).not.toBeInTheDocument()
+    })
+
+    it('renders deleted file', async () => {
+      const { queryClient } = setup({
+        overrideComparison: {
+          state: 'complete',
+          __typename: 'Comparison',
+          flagComparisons: [],
+          patchTotals: {
+            percentCovered: 92.12,
+          },
+          baseTotals: {
+            percentCovered: 98.25,
+          },
+          headTotals: {
+            percentCovered: 78.33,
+          },
+          impactedFiles: {
+            __typename: 'ImpactedFiles',
+            results: [
+              {
+                isCriticalFile: false,
+                missesCount: 0,
+                fileName: 'src/App.tsx',
+                headName: 'flag1/src/App.tsx',
+                baseCoverage: {
+                  percentCovered: 45.38,
+                },
+                headCoverage: null,
+                patchCoverage: null,
+                changeCoverage: null,
+              },
+            ],
+          },
+          changeCoverage: 38.94,
+          hasDifferentNumberOfHeadAndBaseReports: true,
+        },
+      })
+      render(<FilesChangedTable />, { wrapper: wrapper(queryClient) })
+
+      const file = await screen.findByText('flag1/src/App.tsx')
+      expect(file).toBeInTheDocument()
+
+      const deletedFile = await screen.findByText('Deleted file')
+      expect(deletedFile).toBeInTheDocument()
     })
   })
 

--- a/src/pages/PullRequestPage/PullCoverage/routes/FilesChangedTab/FilesChanged/FilesChangedTable/FilesChangedTable.tsx
+++ b/src/pages/PullRequestPage/PullCoverage/routes/FilesChangedTab/FilesChanged/FilesChangedTable/FilesChangedTable.tsx
@@ -91,39 +91,49 @@ function getColumns({ pullId }: { pullId: string }) {
       header: 'Name',
       cell: ({ getValue, row }) => {
         const headName = getValue()
+        const isDeletedFile = row.original?.headCoverage === null
 
         return (
-          <div className="flex flex-row break-all">
-            <span
-              data-action="clickable"
-              data-testid="file-diff-expand"
-              className={cs(
-                'inline-flex items-center gap-1 font-sans hover:underline focus:ring-2',
-                {
-                  'text-ds-blue': row.getIsExpanded(),
-                }
-              )}
-              onClick={row.getToggleExpandedHandler()}
-            >
-              <Icon
-                size="md"
-                name={row.getIsExpanded() ? 'chevronDown' : 'chevronRight'}
-                variant="solid"
-              />
-            </span>
-            {/* @ts-expect-error */}
-            <A
-              to={{
-                pageName: 'pullFileView',
-                options: { pullId, tree: headName },
-              }}
-            >
-              {headName}
-            </A>
-            {row.original?.isCriticalFile && (
-              <span className="ml-2 rounded border border-ds-gray-tertiary p-1 text-xs text-ds-gray-senary">
-                Critical File
+          <div className="flex flex-row items-center break-all">
+            {!isDeletedFile && (
+              <span
+                data-action="clickable"
+                data-testid="file-diff-expand"
+                className={cs(
+                  'inline-flex items-center gap-1 font-sans hover:underline focus:ring-2',
+                  {
+                    'text-ds-blue': row.getIsExpanded(),
+                  }
+                )}
+                onClick={row.getToggleExpandedHandler()}
+              >
+                <Icon
+                  size="md"
+                  name={row.getIsExpanded() ? 'chevronDown' : 'chevronRight'}
+                  variant="solid"
+                />
               </span>
+            )}
+            {/* @ts-expect-error */}
+            {
+              <A
+                to={{
+                  pageName: 'pullFileView',
+                  options: { pullId, tree: headName },
+                }}
+              >
+                {headName}
+              </A>
+            }
+            {row.original?.isCriticalFile && (
+              <span className="ml-2 h-fit flex-none rounded border border-ds-gray-tertiary p-1 text-xs text-ds-gray-senary">
+                Critical file
+              </span>
+            )}
+            {isDeletedFile && (
+              <div className="ml-2 h-fit flex-none rounded border border-ds-gray-tertiary p-1 text-xs text-ds-gray-senary">
+                Deleted file
+              </div>
             )}
           </div>
         )
@@ -132,7 +142,13 @@ function getColumns({ pullId }: { pullId: string }) {
     columnHelper.accessor('missesCount', {
       id: 'missedLines',
       header: 'Missed lines',
-      cell: ({ renderValue }) => renderValue(),
+      cell: ({ renderValue, row }) => {
+        if (row.original?.headCoverage === null) {
+          // File was deleted, render a dash.
+          return <>-</>
+        }
+        return renderValue()
+      },
     }),
     columnHelper.accessor('headCoverage.percentCovered', {
       id: 'head',

--- a/src/pages/PullRequestPage/PullCoverage/routes/FilesChangedTab/FilesChanged/FilesChangedTable/FilesChangedTable.tsx
+++ b/src/pages/PullRequestPage/PullCoverage/routes/FilesChangedTab/FilesChanged/FilesChangedTable/FilesChangedTable.tsx
@@ -114,10 +114,10 @@ function getColumns({ pullId }: { pullId: string }) {
                 />
               </span>
             )}
-            {/* @ts-expect-error */}
             {isDeletedFile ? (
               <>{headName}</>
             ) : (
+              /* @ts-expect-error */
               <A
                 to={{
                   pageName: 'pullFileView',

--- a/src/pages/PullRequestPage/PullCoverage/routes/FilesChangedTab/FilesChanged/FilesChangedTable/FilesChangedTable.tsx
+++ b/src/pages/PullRequestPage/PullCoverage/routes/FilesChangedTab/FilesChanged/FilesChangedTable/FilesChangedTable.tsx
@@ -115,16 +115,14 @@ function getColumns({ pullId }: { pullId: string }) {
               </span>
             )}
             {/* @ts-expect-error */}
-            {
-              <A
-                to={{
-                  pageName: 'pullFileView',
-                  options: { pullId, tree: headName },
-                }}
-              >
-                {headName}
-              </A>
-            }
+            <A
+              to={{
+                pageName: 'pullFileView',
+                options: { pullId, tree: headName },
+              }}
+            >
+              {headName}
+            </A>
             {row.original?.isCriticalFile && (
               <span className="ml-2 h-fit flex-none rounded border border-ds-gray-tertiary p-1 text-xs text-ds-gray-senary">
                 Critical file

--- a/src/pages/PullRequestPage/PullCoverage/routes/FilesChangedTab/FilesChanged/FilesChangedTable/FilesChangedTable.tsx
+++ b/src/pages/PullRequestPage/PullCoverage/routes/FilesChangedTab/FilesChanged/FilesChangedTable/FilesChangedTable.tsx
@@ -95,7 +95,7 @@ function getColumns({ pullId }: { pullId: string }) {
 
         return (
           <div className="flex flex-row items-center break-all">
-            {!isDeletedFile && (
+            {!isDeletedFile ? (
               <span
                 data-action="clickable"
                 data-testid="file-diff-expand"
@@ -113,7 +113,7 @@ function getColumns({ pullId }: { pullId: string }) {
                   variant="solid"
                 />
               </span>
-            )}
+            ) : null}
             {isDeletedFile ? (
               <>{headName}</>
             ) : (
@@ -127,16 +127,16 @@ function getColumns({ pullId }: { pullId: string }) {
                 {headName}
               </A>
             )}
-            {row.original?.isCriticalFile && (
+            {row.original?.isCriticalFile ? (
               <span className="ml-2 h-fit flex-none rounded border border-ds-gray-tertiary p-1 text-xs text-ds-gray-senary">
                 Critical file
               </span>
-            )}
-            {isDeletedFile && (
+            ) : null}
+            {isDeletedFile ? (
               <div className="ml-2 h-fit flex-none rounded border border-ds-gray-tertiary p-1 text-xs text-ds-gray-senary">
                 Deleted file
               </div>
-            )}
+            ) : null}
           </div>
         )
       },
@@ -145,8 +145,7 @@ function getColumns({ pullId }: { pullId: string }) {
       id: 'missedLines',
       header: 'Missed lines',
       cell: ({ renderValue, row }) => {
-        if (row.original?.headCoverage === null) {
-          // File was deleted, render a dash.
+        if (!row.original?.headCoverage) {
           return <>-</>
         }
         return renderValue()

--- a/src/pages/PullRequestPage/PullCoverage/routes/FilesChangedTab/FilesChanged/FilesChangedTable/FilesChangedTable.tsx
+++ b/src/pages/PullRequestPage/PullCoverage/routes/FilesChangedTab/FilesChanged/FilesChangedTable/FilesChangedTable.tsx
@@ -115,14 +115,18 @@ function getColumns({ pullId }: { pullId: string }) {
               </span>
             )}
             {/* @ts-expect-error */}
-            <A
-              to={{
-                pageName: 'pullFileView',
-                options: { pullId, tree: headName },
-              }}
-            >
-              {headName}
-            </A>
+            {isDeletedFile ? (
+              <>{headName}</>
+            ) : (
+              <A
+                to={{
+                  pageName: 'pullFileView',
+                  options: { pullId, tree: headName },
+                }}
+              >
+                {headName}
+              </A>
+            )}
             {row.original?.isCriticalFile && (
               <span className="ml-2 h-fit flex-none rounded border border-ds-gray-tertiary p-1 text-xs text-ds-gray-senary">
                 Critical file

--- a/src/pages/PullRequestPage/PullCoverage/routes/IndirectChangesTab/IndirectChangedFiles/IndirectChangedFiles.spec.tsx
+++ b/src/pages/PullRequestPage/PullCoverage/routes/IndirectChangesTab/IndirectChangedFiles/IndirectChangedFiles.spec.tsx
@@ -305,6 +305,54 @@ describe('IndirectChangedFiles', () => {
         const criticalFileLabel = await screen.findByText(/Critical file/i)
         expect(criticalFileLabel).toBeInTheDocument()
       })
+
+      it('does not render the critical file label', async () => {
+        setup({
+          state: 'complete',
+          __typename: 'Comparison',
+          flagComparisons: [],
+          patchTotals: {
+            percentCovered: 92.12,
+          },
+          baseTotals: {
+            percentCovered: 98.25,
+          },
+          headTotals: {
+            percentCovered: 78.33,
+          },
+          impactedFiles: {
+            __typename: 'ImpactedFiles',
+            results: [
+              {
+                isCriticalFile: false,
+                missesCount: 3,
+                fileName: 'mafs.js',
+                headName: 'flag1/mafs.js',
+                baseCoverage: {
+                  percentCovered: 45.38,
+                },
+                headCoverage: {
+                  percentCovered: 90.23,
+                },
+                patchCoverage: {
+                  percentCovered: 27.43,
+                },
+                changeCoverage: 41,
+              },
+            ],
+          },
+          changeCoverage: 38.94,
+          hasDifferentNumberOfHeadAndBaseReports: true,
+        })
+        render(<IndirectChangedFiles />, { wrapper: wrapper() })
+
+        await waitFor(() =>
+          expect(screen.queryByTestId('spinner')).not.toBeInTheDocument()
+        )
+
+        const criticalFileLabel = screen.queryByText(/Critical file/i)
+        expect(criticalFileLabel).not.toBeInTheDocument()
+      })
     })
   })
 

--- a/src/pages/PullRequestPage/PullCoverage/routes/IndirectChangesTab/IndirectChangedFiles/IndirectChangedFiles.spec.tsx
+++ b/src/pages/PullRequestPage/PullCoverage/routes/IndirectChangesTab/IndirectChangedFiles/IndirectChangedFiles.spec.tsx
@@ -302,7 +302,7 @@ describe('IndirectChangedFiles', () => {
           expect(screen.queryByTestId('spinner')).not.toBeInTheDocument()
         )
 
-        const criticalFileLabel = await screen.findByText(/Critical File/i)
+        const criticalFileLabel = await screen.findByText(/Critical file/i)
         expect(criticalFileLabel).toBeInTheDocument()
       })
     })

--- a/src/pages/PullRequestPage/PullCoverage/routes/IndirectChangesTab/IndirectChangedFiles/IndirectChangedFiles.tsx
+++ b/src/pages/PullRequestPage/PullCoverage/routes/IndirectChangesTab/IndirectChangedFiles/IndirectChangedFiles.tsx
@@ -22,7 +22,6 @@ import NameColumn from './NameColumn/NameColumn'
 
 import FileDiff from '../FileDiff'
 
-
 interface ImpactedFile {
   missesCount: number | undefined
   headCoverage?: number | null | undefined
@@ -61,8 +60,8 @@ function getColumns() {
               </A>
             </div>
             {row.original.isCriticalFile && (
-              <span className="self-center rounded border border-ds-gray-tertiary p-1 text-xs text-ds-gray-senary">
-                Critical File
+              <span className="flex-none self-center rounded border border-ds-gray-tertiary p-1 text-xs text-ds-gray-senary">
+                Critical file
               </span>
             )}
           </div>

--- a/src/pages/PullRequestPage/PullCoverage/routes/IndirectChangesTab/IndirectChangedFiles/IndirectChangedFiles.tsx
+++ b/src/pages/PullRequestPage/PullCoverage/routes/IndirectChangesTab/IndirectChangedFiles/IndirectChangedFiles.tsx
@@ -59,11 +59,11 @@ function getColumns() {
                 {getValue()}
               </A>
             </div>
-            {row.original.isCriticalFile && (
+            {row.original.isCriticalFile ? (
               <span className="flex-none self-center rounded border border-ds-gray-tertiary p-1 text-xs text-ds-gray-senary">
                 Critical file
               </span>
-            )}
+            ) : null}
           </div>
         )
       },

--- a/src/services/commit/useCommit.tsx
+++ b/src/services/commit/useCommit.tsx
@@ -79,6 +79,7 @@ const UploadsSchema = z.object({
 const ImpactedFileSchema = z
   .object({
     headName: z.string().nullable(),
+    isCriticalFile: z.boolean(),
     patchCoverage: CoverageObjSchema.nullable(),
     baseCoverage: CoverageObjSchema.nullable(),
     headCoverage: CoverageObjSchema.nullable(),
@@ -233,6 +234,7 @@ query Commit(
                 __typename
                 ... on ImpactedFiles {
                   results {
+                    isCriticalFile
                     patchCoverage {
                       coverage: percentCovered
                     }


### PR DESCRIPTION
# Description

Adds a 'Deleted file' status indicator to the files changed tables for both pull and commit. Also adds the 'Critical file' status indicator to the files changed table for commit and the indirect changes tables for both pull and commit, bringing these tables into alignment.

[Designs](https://www.figma.com/file/pt7RLbHw7XLDp2SOAVDyQm/Untitled?type=design&node-id=2%3A287&mode=design&t=3MqbcG0Cl4vXv5ZM-1)

Closes https://github.com/codecov/engineering-team/issues/1087

# Notable Changes

- Add deleted file status to files changed tables
- Only show file link and drop down toggle on non-deleted files
- Unify status indicators across files changed/indirect changes tables

# Screenshots

![pulls table](https://github.com/codecov/gazebo/assets/159931558/9c204d63-c89d-48fe-9fb8-18d92cbdbf29)

![Commits table](https://github.com/codecov/gazebo/assets/159931558/c445763e-d05d-4a0c-b5d9-411b32b4751e)
