### PR TITLE
feat: Add BA column to commits team tables

### DIFF
--- a/src/pages/PullRequestPage/PullCoverage/routes/CommitsTab/CommitsTableTeam/CommitsTableTeam.spec.tsx
+++ b/src/pages/PullRequestPage/PullCoverage/routes/CommitsTab/CommitsTableTeam/CommitsTableTeam.spec.tsx
@@ -9,7 +9,14 @@ import { setupServer } from 'msw/node'
 import { mockIsIntersecting } from 'react-intersection-observer/test-utils'
 import { MemoryRouter, Route } from 'react-router-dom'
 
+import { useFlags } from 'shared/featureFlags'
+
 import CommitsTableTeam from './CommitsTableTeam'
+
+jest.mock('shared/featureFlags')
+const mockedUseFlags = useFlags as jest.Mock<{
+  bundleAnalysisPrAndCommitPages: boolean
+}>
 
 const mockRepoOverview = (bundleAnalysisEnabled = false) => ({
   owner: {
@@ -120,6 +127,10 @@ describe('CommitsTableTeam', () => {
     bundleAnalysisEnabled = false,
   }: SetupArgs) {
     const queryClient = new QueryClient()
+
+    mockedUseFlags.mockReturnValue({
+      bundleAnalysisPrAndCommitPages: true,
+    })
 
     server.use(
       graphql.query('GetRepoOverview', (req, res, ctx) => {

--- a/src/pages/PullRequestPage/PullCoverage/routes/CommitsTab/CommitsTableTeam/CommitsTableTeam.spec.tsx
+++ b/src/pages/PullRequestPage/PullCoverage/routes/CommitsTab/CommitsTableTeam/CommitsTableTeam.spec.tsx
@@ -300,7 +300,7 @@ describe('CommitsTableTeam', () => {
           wrapper: wrapper(queryClient),
         })
 
-        const bundleAnalysis = screen.queryByText('Bundle Analysis')
+        const bundleAnalysis = screen.queryByText('Upload: ❌')
         expect(bundleAnalysis).not.toBeInTheDocument()
       })
     })

--- a/src/pages/PullRequestPage/PullCoverage/routes/CommitsTab/CommitsTableTeam/CommitsTableTeam.tsx
+++ b/src/pages/PullRequestPage/PullCoverage/routes/CommitsTab/CommitsTableTeam/CommitsTableTeam.tsx
@@ -12,6 +12,7 @@ import { useParams } from 'react-router-dom'
 
 import { useCommitsTeam } from 'services/commits'
 import { useRepoOverview } from 'services/repo'
+import { useFlags } from 'shared/featureFlags'
 import Spinner from 'ui/Spinner'
 import 'ui/Table/Table.css'
 
@@ -76,6 +77,9 @@ export default function CommitsTableTeam() {
   const { provider, owner, repo, pullId } = useParams<URLParams>()
   const { ref, inView } = useInView()
   const { data: overview } = useRepoOverview({ provider, owner, repo })
+  const { bundleAnalysisPrAndCommitPages } = useFlags({
+    bundleAnalysisPrAndCommitPages: false,
+  })
 
   const {
     data: commitsData,
@@ -106,7 +110,8 @@ export default function CommitsTableTeam() {
   const columns = useMemo(() => {
     if (
       overview?.bundleAnalysisEnabled &&
-      !baseColumns.some((column) => column.id === 'bundleAnalysis')
+      !baseColumns.some((column) => column.id === 'bundleAnalysis') &&
+      bundleAnalysisPrAndCommitPages
     ) {
       return [
         ...baseColumns,
@@ -119,7 +124,7 @@ export default function CommitsTableTeam() {
     }
 
     return baseColumns
-  }, [overview?.bundleAnalysisEnabled])
+  }, [bundleAnalysisPrAndCommitPages, overview?.bundleAnalysisEnabled])
 
   const table = useReactTable({
     columns,

--- a/src/pages/PullRequestPage/PullCoverage/routes/CommitsTab/CommitsTableTeam/createCommitsTableTeamData.spec.tsx
+++ b/src/pages/PullRequestPage/PullCoverage/routes/CommitsTab/CommitsTableTeam/createCommitsTableTeamData.spec.tsx
@@ -45,6 +45,9 @@ describe('createCommitsTableTeamData', () => {
             __typename: 'MissingBaseCommit',
             message: 'Missing base commit',
           },
+          bundleAnalysisReport: {
+            __typename: 'MissingHeadReport',
+          },
         } as const
 
         const result = createCommitsTableTeamData({
@@ -70,6 +73,9 @@ describe('createCommitsTableTeamData', () => {
             patchTotals: {
               percentCovered: 100,
             },
+          },
+          bundleAnalysisReport: {
+            __typename: 'MissingHeadReport',
           },
         } as const
 
@@ -103,6 +109,9 @@ describe('createCommitsTableTeamData', () => {
               patchTotals: {
                 percentCovered: null,
               },
+            },
+            bundleAnalysisReport: {
+              __typename: 'MissingHeadReport',
             },
           } as const
 
@@ -142,6 +151,9 @@ describe('createCommitsTableTeamData', () => {
               percentCovered: 100,
             },
           },
+          bundleAnalysisReport: {
+            __typename: 'MissingHeadReport',
+          },
         } as const
 
         const result = createCommitsTableTeamData({
@@ -177,6 +189,9 @@ describe('createCommitsTableTeamData', () => {
               percentCovered: 100,
             },
           },
+          bundleAnalysisReport: {
+            __typename: 'MissingHeadReport',
+          },
         } as const
 
         const result = createCommitsTableTeamData({
@@ -185,6 +200,62 @@ describe('createCommitsTableTeamData', () => {
 
         expect(result[0]?.ciStatus).toStrictEqual(
           <CIStatus ciPassed={true} commitid="commit123" coverage={100} />
+        )
+      })
+    })
+
+    describe('bundleAnalysisReport __typename is not BundleAnalysisReport', () => {
+      it('returns no report uploaded', () => {
+        const commitData = {
+          ciPassed: null,
+          message: null,
+          commitid: 'commit-123',
+          createdAt: '2021-11-01T19:44:10.795533+00:00',
+          author: null,
+          compareWithParent: {
+            __typename: 'MissingBaseCommit',
+            message: 'Missing base commit',
+          },
+          bundleAnalysisReport: {
+            __typename: 'MissingHeadReport',
+          },
+        } as const
+
+        const result = createCommitsTableTeamData({
+          pages: [{ commits: [commitData] }],
+        })
+
+        expect(result[0]?.bundleAnalysis).toStrictEqual(
+          <p className="text-right">Upload: ❌</p>
+        )
+      })
+    })
+
+    describe('bundleAnalysisReport __typename is BundleAnalysisReport', () => {
+      it('returns successful upload', () => {
+        const commitData = {
+          ciPassed: null,
+          message: null,
+          commitid: 'commit-123',
+          createdAt: '2021-11-01T19:44:10.795533+00:00',
+          author: null,
+          compareWithParent: {
+            __typename: 'Comparison',
+            patchTotals: {
+              percentCovered: 100,
+            },
+          },
+          bundleAnalysisReport: {
+            __typename: 'BundleAnalysisReport',
+          },
+        } as const
+
+        const result = createCommitsTableTeamData({
+          pages: [{ commits: [commitData] }],
+        })
+
+        expect(result[0]?.bundleAnalysis).toStrictEqual(
+          <p className="text-right">Upload: ✅</p>
         )
       })
     })

--- a/src/pages/PullRequestPage/PullCoverage/routes/CommitsTab/CommitsTableTeam/createCommitsTableTeamData.tsx
+++ b/src/pages/PullRequestPage/PullCoverage/routes/CommitsTab/CommitsTableTeam/createCommitsTableTeamData.tsx
@@ -41,6 +41,13 @@ export const createCommitsTableTeamData = ({
       )
     }
 
+    let bundleAnalysis = undefined
+    if (commit?.bundleAnalysisReport?.__typename === 'BundleAnalysisReport') {
+      bundleAnalysis = <p className="text-right">Upload: &#x2705;</p>
+    } else {
+      bundleAnalysis = <p className="text-right">Upload: &#x274C;</p>
+    }
+
     return {
       name: (
         <Title
@@ -58,6 +65,7 @@ export const createCommitsTableTeamData = ({
         />
       ),
       patch,
+      bundleAnalysis,
     }
   })
 }

--- a/src/pages/RepoPage/CommitsTab/CommitsTab.spec.jsx
+++ b/src/pages/RepoPage/CommitsTab/CommitsTab.spec.jsx
@@ -169,6 +169,9 @@ const mockCommitTeamResponse = {
                   percentCovered: 80,
                 },
               },
+              bundleAnalysisReport: {
+                __typename: 'MissingHeadReport',
+              },
             },
           },
         ],

--- a/src/pages/RepoPage/CommitsTab/CommitsTableTeam/CommitsTableTeam.spec.tsx
+++ b/src/pages/RepoPage/CommitsTab/CommitsTableTeam/CommitsTableTeam.spec.tsx
@@ -11,6 +11,20 @@ import { MemoryRouter, Route } from 'react-router-dom'
 
 import CommitsTableTeam from './CommitsTableTeam'
 
+const mockRepoOverview = (bundleAnalysisEnabled = false) => ({
+  owner: {
+    repository: {
+      __typename: 'Repository',
+      private: false,
+      defaultBranch: 'main',
+      oldestCommitAt: '2022-10-10T11:59:59',
+      coverageEnabled: false,
+      bundleAnalysisEnabled,
+      languages: ['javascript'],
+    },
+  },
+})
+
 const node1 = {
   ciPassed: true,
   message: 'commit message 1',
@@ -25,6 +39,9 @@ const node1 = {
     patchTotals: {
       percentCovered: 80,
     },
+  },
+  bundleAnalysisReport: {
+    __typename: 'MissingHeadReport',
   },
 }
 
@@ -43,6 +60,9 @@ const node2 = {
       percentCovered: 90,
     },
   },
+  bundleAnalysisReport: {
+    __typename: 'BundleAnalysisReport',
+  },
 }
 
 const node3 = {
@@ -59,6 +79,9 @@ const node3 = {
     patchTotals: {
       percentCovered: 100,
     },
+  },
+  bundleAnalysisReport: {
+    __typename: 'BundleAnalysisReport',
   },
 }
 
@@ -88,13 +111,23 @@ afterAll(() => {
 
 interface SetupArgs {
   noEntries?: boolean
+  bundleAnalysisEnabled?: boolean
 }
 
 describe('CommitsTableTeam', () => {
-  function setup({ noEntries = false }: SetupArgs) {
+  function setup({
+    noEntries = false,
+    bundleAnalysisEnabled = false,
+  }: SetupArgs) {
     const queryClient = new QueryClient()
 
     server.use(
+      graphql.query('GetRepoOverview', (req, res, ctx) => {
+        return res(
+          ctx.status(200),
+          ctx.data(mockRepoOverview(bundleAnalysisEnabled))
+        )
+      }),
       graphql.query('GetCommitsTeam', (req, res, ctx) => {
         if (noEntries) {
           return res(
@@ -182,6 +215,30 @@ describe('CommitsTableTeam', () => {
       const patchColumn = await screen.findByText('Patch %')
       expect(patchColumn).toBeInTheDocument()
     })
+
+    describe('bundle analysis is enabled', () => {
+      it('renders bundle analysis column', async () => {
+        const { queryClient } = setup({ bundleAnalysisEnabled: true })
+        render(<CommitsTableTeam branch="main" states={[]} search="" />, {
+          wrapper: wrapper(queryClient),
+        })
+
+        const bundleAnalysis = await screen.findByText('Bundle Analysis')
+        expect(bundleAnalysis).toBeInTheDocument()
+      })
+    })
+
+    describe('bundle analysis is disabled', () => {
+      it('does not render the bundle analysis column', async () => {
+        const { queryClient } = setup({ bundleAnalysisEnabled: false })
+        render(<CommitsTableTeam branch="main" states={[]} search="" />, {
+          wrapper: wrapper(queryClient),
+        })
+
+        const bundleAnalysis = screen.queryByText('Bundle Analysis')
+        expect(bundleAnalysis).not.toBeInTheDocument()
+      })
+    })
   })
 
   describe('renders table body', () => {
@@ -222,6 +279,30 @@ describe('CommitsTableTeam', () => {
 
       const patchColumn = await screen.findByText('80.00%')
       expect(patchColumn).toBeInTheDocument()
+    })
+
+    describe('bundle analysis is enabled', () => {
+      it('renders bundle analysis column', async () => {
+        const { queryClient } = setup({ bundleAnalysisEnabled: true })
+        render(<CommitsTableTeam branch="main" states={[]} search="" />, {
+          wrapper: wrapper(queryClient),
+        })
+
+        const bundleAnalysis = await screen.findByText('Upload: ❌')
+        expect(bundleAnalysis).toBeInTheDocument()
+      })
+    })
+
+    describe('bundle analysis is disabled', () => {
+      it('does not render the bundle analysis column', async () => {
+        const { queryClient } = setup({ bundleAnalysisEnabled: false })
+        render(<CommitsTableTeam branch="main" states={[]} search="" />, {
+          wrapper: wrapper(queryClient),
+        })
+
+        const bundleAnalysis = screen.queryByText('Bundle Analysis')
+        expect(bundleAnalysis).not.toBeInTheDocument()
+      })
     })
   })
 

--- a/src/pages/RepoPage/CommitsTab/CommitsTableTeam/CommitsTableTeam.spec.tsx
+++ b/src/pages/RepoPage/CommitsTab/CommitsTableTeam/CommitsTableTeam.spec.tsx
@@ -9,7 +9,14 @@ import { setupServer } from 'msw/node'
 import { mockIsIntersecting } from 'react-intersection-observer/test-utils'
 import { MemoryRouter, Route } from 'react-router-dom'
 
+import { useFlags } from 'shared/featureFlags'
+
 import CommitsTableTeam from './CommitsTableTeam'
+
+jest.mock('shared/featureFlags')
+const mockedUseFlags = useFlags as jest.Mock<{
+  bundleAnalysisPrAndCommitPages: boolean
+}>
 
 const mockRepoOverview = (bundleAnalysisEnabled = false) => ({
   owner: {
@@ -120,6 +127,10 @@ describe('CommitsTableTeam', () => {
     bundleAnalysisEnabled = false,
   }: SetupArgs) {
     const queryClient = new QueryClient()
+
+    mockedUseFlags.mockReturnValue({
+      bundleAnalysisPrAndCommitPages: true,
+    })
 
     server.use(
       graphql.query('GetRepoOverview', (req, res, ctx) => {

--- a/src/pages/RepoPage/CommitsTab/CommitsTableTeam/CommitsTableTeam.spec.tsx
+++ b/src/pages/RepoPage/CommitsTab/CommitsTableTeam/CommitsTableTeam.spec.tsx
@@ -300,7 +300,7 @@ describe('CommitsTableTeam', () => {
           wrapper: wrapper(queryClient),
         })
 
-        const bundleAnalysis = screen.queryByText('Bundle Analysis')
+        const bundleAnalysis = screen.queryByText('Upload: ❌')
         expect(bundleAnalysis).not.toBeInTheDocument()
       })
     })

--- a/src/pages/RepoPage/CommitsTab/CommitsTableTeam/CommitsTableTeam.tsx
+++ b/src/pages/RepoPage/CommitsTab/CommitsTableTeam/CommitsTableTeam.tsx
@@ -15,6 +15,7 @@ import {
   useCommitsTeam,
 } from 'services/commits/useCommitsTeam'
 import { useRepoOverview } from 'services/repo'
+import { useFlags } from 'shared/featureFlags'
 import Spinner from 'ui/Spinner'
 
 import { createCommitsTableTeamData } from './createCommitsTableTeamData'
@@ -88,6 +89,9 @@ const CommitsTableTeam: React.FC<CommitsTableTeamProps> = ({
   const { provider, owner, repo } = useParams<URLParams>()
   const { ref, inView } = useInView()
   const { data: overview } = useRepoOverview({ provider, owner, repo })
+  const { bundleAnalysisPrAndCommitPages } = useFlags({
+    bundleAnalysisPrAndCommitPages: false,
+  })
 
   const {
     data: commitsData,
@@ -120,7 +124,8 @@ const CommitsTableTeam: React.FC<CommitsTableTeamProps> = ({
   const columns = useMemo(() => {
     if (
       overview?.bundleAnalysisEnabled &&
-      !baseColumns.some((column) => column.id === 'bundleAnalysis')
+      !baseColumns.some((column) => column.id === 'bundleAnalysis') &&
+      bundleAnalysisPrAndCommitPages
     ) {
       return [
         ...baseColumns,
@@ -133,7 +138,7 @@ const CommitsTableTeam: React.FC<CommitsTableTeamProps> = ({
     }
 
     return baseColumns
-  }, [overview?.bundleAnalysisEnabled])
+  }, [bundleAnalysisPrAndCommitPages, overview?.bundleAnalysisEnabled])
 
   const table = useReactTable({
     columns,

--- a/src/pages/RepoPage/CommitsTab/CommitsTableTeam/createCommitsTableTeamData.spec.tsx
+++ b/src/pages/RepoPage/CommitsTab/CommitsTableTeam/createCommitsTableTeamData.spec.tsx
@@ -45,6 +45,9 @@ describe('createCommitsTableTeamData', () => {
             __typename: 'MissingBaseCommit',
             message: 'Missing base commit',
           },
+          bundleAnalysisReport: {
+            __typename: 'MissingHeadReport',
+          },
         } as const
 
         const result = createCommitsTableTeamData({
@@ -70,6 +73,9 @@ describe('createCommitsTableTeamData', () => {
             patchTotals: {
               percentCovered: 100,
             },
+          },
+          bundleAnalysisReport: {
+            __typename: 'MissingHeadReport',
           },
         } as const
 
@@ -103,6 +109,9 @@ describe('createCommitsTableTeamData', () => {
               patchTotals: {
                 percentCovered: null,
               },
+            },
+            bundleAnalysisReport: {
+              __typename: 'MissingHeadReport',
             },
           } as const
 
@@ -142,6 +151,9 @@ describe('createCommitsTableTeamData', () => {
               percentCovered: 100,
             },
           },
+          bundleAnalysisReport: {
+            __typename: 'MissingHeadReport',
+          },
         } as const
 
         const result = createCommitsTableTeamData({
@@ -177,6 +189,9 @@ describe('createCommitsTableTeamData', () => {
               percentCovered: 100,
             },
           },
+          bundleAnalysisReport: {
+            __typename: 'MissingHeadReport',
+          },
         } as const
 
         const result = createCommitsTableTeamData({
@@ -185,6 +200,62 @@ describe('createCommitsTableTeamData', () => {
 
         expect(result[0]?.ciStatus).toStrictEqual(
           <CIStatus ciPassed={true} commitid="commit123" coverage={100} />
+        )
+      })
+    })
+
+    describe('bundleAnalysisReport __typename is not BundleAnalysisReport', () => {
+      it('returns no report uploaded', () => {
+        const commitData = {
+          ciPassed: null,
+          message: null,
+          commitid: 'commit-123',
+          createdAt: '2021-11-01T19:44:10.795533+00:00',
+          author: null,
+          compareWithParent: {
+            __typename: 'MissingBaseCommit',
+            message: 'Missing base commit',
+          },
+          bundleAnalysisReport: {
+            __typename: 'MissingHeadReport',
+          },
+        } as const
+
+        const result = createCommitsTableTeamData({
+          pages: [{ commits: [commitData] }],
+        })
+
+        expect(result[0]?.bundleAnalysis).toStrictEqual(
+          <p className="text-right">Upload: ❌</p>
+        )
+      })
+    })
+
+    describe('bundleAnalysisReport __typename is BundleAnalysisReport', () => {
+      it('returns successful upload', () => {
+        const commitData = {
+          ciPassed: null,
+          message: null,
+          commitid: 'commit-123',
+          createdAt: '2021-11-01T19:44:10.795533+00:00',
+          author: null,
+          compareWithParent: {
+            __typename: 'Comparison',
+            patchTotals: {
+              percentCovered: 100,
+            },
+          },
+          bundleAnalysisReport: {
+            __typename: 'BundleAnalysisReport',
+          },
+        } as const
+
+        const result = createCommitsTableTeamData({
+          pages: [{ commits: [commitData] }],
+        })
+
+        expect(result[0]?.bundleAnalysis).toStrictEqual(
+          <p className="text-right">Upload: ✅</p>
         )
       })
     })

--- a/src/pages/RepoPage/CommitsTab/CommitsTableTeam/createCommitsTableTeamData.tsx
+++ b/src/pages/RepoPage/CommitsTab/CommitsTableTeam/createCommitsTableTeamData.tsx
@@ -41,6 +41,13 @@ export const createCommitsTableTeamData = ({
       )
     }
 
+    let bundleAnalysis = undefined
+    if (commit?.bundleAnalysisReport?.__typename === 'BundleAnalysisReport') {
+      bundleAnalysis = <p className="text-right">Upload: &#x2705;</p>
+    } else {
+      bundleAnalysis = <p className="text-right">Upload: &#x274C;</p>
+    }
+
     return {
       name: (
         <Title
@@ -58,6 +65,7 @@ export const createCommitsTableTeamData = ({
         />
       ),
       patch,
+      bundleAnalysis,
     }
   })
 }

--- a/src/services/commits/useCommitsTeam.spec.tsx
+++ b/src/services/commits/useCommitsTeam.spec.tsx
@@ -47,6 +47,9 @@ const node1 = {
       percentCovered: 100,
     },
   },
+  bundleAnalysisReport: {
+    __typename: 'MissingHeadReport',
+  },
 }
 
 const node2 = {
@@ -64,6 +67,9 @@ const node2 = {
       percentCovered: 100,
     },
   },
+  bundleAnalysisReport: {
+    __typename: 'MissingHeadReport',
+  },
 }
 
 const node3 = {
@@ -80,6 +86,9 @@ const node3 = {
     patchTotals: {
       percentCovered: 100,
     },
+  },
+  bundleAnalysisReport: {
+    __typename: 'MissingHeadReport',
   },
 }
 


### PR DESCRIPTION
# Description

This PR updates the commits team tables to display a bundle analysis column if the user is uploading bundle analysis data to Codecov.

# Notable Changes

- Update pull request page commits team table to have bundle analysis column
- Update repo page commits tab team table to have bundle analysis column
- Update team commits hook to fetch bundle analysis data
- Update tests

# Screenshots

<img width="1293" alt="Screenshot 2024-03-01 at 11 47 19" src="https://github.com/codecov/gazebo/assets/105234307/af8bdaad-4b3e-4863-af2a-230146d142a7">

<img width="1293" alt="Screenshot 2024-03-01 at 11 32 25" src="https://github.com/codecov/gazebo/assets/105234307/256739ab-a063-4c9c-b676-8ea572f9dc24">