### PR TITLE
feat: Add bundle analysis column to pulls tables

### DIFF
--- a/src/pages/RepoPage/PullsTab/PullsTable/Coverage/Coverage.tsx
+++ b/src/pages/RepoPage/PullsTab/PullsTable/Coverage/Coverage.tsx
@@ -23,6 +23,9 @@ interface CoverageProps {
     totals?: {
       percentCovered: number | null
     } | null
+    bundleAnalysisReport?: {
+      __typename: string
+    } | null
   } | null
   pullId: number
   state: IconEnumState

--- a/src/pages/RepoPage/PullsTab/PullsTable/PullsTable.spec.tsx
+++ b/src/pages/RepoPage/PullsTab/PullsTable/PullsTable.spec.tsx
@@ -9,7 +9,14 @@ import { setupServer } from 'msw/node'
 import { mockIsIntersecting } from 'react-intersection-observer/test-utils'
 import { MemoryRouter, Route } from 'react-router-dom'
 
+import { useFlags } from 'shared/featureFlags'
+
 import PullsTable from './PullsTable'
+
+jest.mock('shared/featureFlags')
+const mockedUseFlags = useFlags as jest.Mock<{
+  bundleAnalysisPrAndCommitPages: boolean
+}>
 
 const mockRepoOverview = (bundleAnalysisEnabled = false) => ({
   owner: {
@@ -137,6 +144,10 @@ describe('PullsTable', () => {
     noEntries = false,
     bundleAnalysisEnabled = false,
   }: SetupArgs) {
+    mockedUseFlags.mockReturnValue({
+      bundleAnalysisPrAndCommitPages: true,
+    })
+
     const queryClient = new QueryClient()
 
     server.use(

--- a/src/pages/RepoPage/PullsTab/PullsTable/PullsTable.tsx
+++ b/src/pages/RepoPage/PullsTab/PullsTable/PullsTable.tsx
@@ -14,6 +14,7 @@ import { useLocationParams } from 'services/navigation'
 import { usePulls } from 'services/pulls'
 import 'ui/Table/Table.css'
 import { useRepoOverview } from 'services/repo'
+import { useFlags } from 'shared/featureFlags'
 import Spinner from 'ui/Spinner'
 
 import { createPullsTableData } from './createPullsTableData'
@@ -93,6 +94,9 @@ export default function PullsTableTeam() {
   // we really need to TS'ify and generic'ify useLocationParams
   const { params } = useLocationParams(defaultParams)
   const { data: overview } = useRepoOverview({ provider, owner, repo })
+  const { bundleAnalysisPrAndCommitPages } = useFlags({
+    bundleAnalysisPrAndCommitPages: false,
+  })
 
   const {
     data: pullsData,
@@ -131,7 +135,8 @@ export default function PullsTableTeam() {
   const columns = useMemo(() => {
     if (
       overview?.bundleAnalysisEnabled &&
-      !baseColumns.some((column) => column.id === 'bundleAnalysis')
+      !baseColumns.some((column) => column.id === 'bundleAnalysis') &&
+      bundleAnalysisPrAndCommitPages
     ) {
       return [
         ...baseColumns,
@@ -144,7 +149,7 @@ export default function PullsTableTeam() {
     }
 
     return baseColumns
-  }, [overview?.bundleAnalysisEnabled])
+  }, [bundleAnalysisPrAndCommitPages, overview?.bundleAnalysisEnabled])
 
   const table = useReactTable({
     columns,

--- a/src/pages/RepoPage/PullsTab/PullsTable/PullsTable.tsx
+++ b/src/pages/RepoPage/PullsTab/PullsTable/PullsTable.tsx
@@ -13,6 +13,7 @@ import { useParams } from 'react-router-dom'
 import { useLocationParams } from 'services/navigation'
 import { usePulls } from 'services/pulls'
 import 'ui/Table/Table.css'
+import { useRepoOverview } from 'services/repo'
 import Spinner from 'ui/Spinner'
 
 import { createPullsTableData } from './createPullsTableData'
@@ -41,9 +42,10 @@ const columnHelper = createColumnHelper<{
   patch: React.ReactElement
   coverage: React.ReactElement
   change: React.ReactElement
+  bundleAnalysis: React.ReactElement
 }>()
 
-const columns = [
+const baseColumns = [
   columnHelper.accessor('title', {
     id: 'title',
     header: () => 'Name',
@@ -90,6 +92,7 @@ export default function PullsTableTeam() {
   const { ref, inView } = useInView()
   // we really need to TS'ify and generic'ify useLocationParams
   const { params } = useLocationParams(defaultParams)
+  const { data: overview } = useRepoOverview({ provider, owner, repo })
 
   const {
     data: pullsData,
@@ -124,6 +127,24 @@ export default function PullsTableTeam() {
       }),
     [pullsData?.pulls]
   )
+
+  const columns = useMemo(() => {
+    if (
+      overview?.bundleAnalysisEnabled &&
+      !baseColumns.some((column) => column.id === 'bundleAnalysis')
+    ) {
+      return [
+        ...baseColumns,
+        columnHelper.accessor('bundleAnalysis', {
+          header: 'Bundle Analysis',
+          id: 'bundleAnalysis',
+          cell: ({ renderValue }) => renderValue(),
+        }),
+      ]
+    }
+
+    return baseColumns
+  }, [overview?.bundleAnalysisEnabled])
 
   const table = useReactTable({
     columns,

--- a/src/pages/RepoPage/PullsTab/PullsTable/createPullsTableData.spec.tsx
+++ b/src/pages/RepoPage/PullsTab/PullsTable/createPullsTableData.spec.tsx
@@ -59,6 +59,9 @@ describe('createPullsTableData', () => {
             totals: {
               percentCovered: 0,
             },
+            bundleAnalysisReport: {
+              __typename: 'MissingHeadReport',
+            },
           },
         } as const
 
@@ -127,6 +130,9 @@ describe('createPullsTableData', () => {
             totals: {
               percentCovered: 9,
             },
+            bundleAnalysisReport: {
+              __typename: 'MissingHeadReport',
+            },
           },
         } as const
 
@@ -162,6 +168,9 @@ describe('createPullsTableData', () => {
           head: {
             totals: {
               percentCovered: 9,
+            },
+            bundleAnalysisReport: {
+              __typename: 'MissingHeadReport',
             },
           },
         } as const
@@ -200,6 +209,9 @@ describe('createPullsTableData', () => {
             head: {
               totals: {
                 percentCovered: 9,
+              },
+              bundleAnalysisReport: {
+                __typename: 'MissingHeadReport',
               },
             },
           } as const
@@ -240,6 +252,9 @@ describe('createPullsTableData', () => {
             totals: {
               percentCovered: 9,
             },
+            bundleAnalysisReport: {
+              __typename: 'MissingHeadReport',
+            },
           },
         } as const
 
@@ -253,12 +268,16 @@ describe('createPullsTableData', () => {
               totals: {
                 percentCovered: 9,
               },
+              bundleAnalysisReport: {
+                __typename: 'MissingHeadReport',
+              },
             }}
             pullId={123}
             state={'OPEN'}
           />
         )
       })
+
       it('returns the title component', () => {
         const pullData = {
           author: {
@@ -276,6 +295,9 @@ describe('createPullsTableData', () => {
           head: {
             totals: {
               percentCovered: 0,
+            },
+            bundleAnalysisReport: {
+              __typename: 'MissingHeadReport',
             },
           },
         } as const
@@ -295,6 +317,76 @@ describe('createPullsTableData', () => {
             title="super cool pull request"
             updatestamp="2023-04-25T15:38:48.046832"
           />
+        )
+      })
+    })
+
+    describe('bundleAnalysisReport __typename is not BundleAnalysisReport', () => {
+      it('returns no report uploaded', () => {
+        const pullData = {
+          author: null,
+          pullId: 123,
+          state: 'OPEN',
+          updatestamp: null,
+          title: null,
+          compareWithBase: {
+            __typename: 'Comparison',
+            patchTotals: {
+              percentCovered: 100,
+            },
+            changeCoverage: 0,
+          },
+          head: {
+            totals: {
+              percentCovered: 9,
+            },
+            bundleAnalysisReport: {
+              __typename: 'MissingHeadReport',
+            },
+          },
+        } as const
+
+        const result = createPullsTableData({
+          pulls: [pullData],
+        })
+
+        expect(result[0]?.bundleAnalysis).toStrictEqual(
+          <p className="text-right">Upload: ❌</p>
+        )
+      })
+    })
+
+    describe('bundleAnalysisReport __typename is BundleAnalysisReport', () => {
+      it('returns successful upload', () => {
+        const pullData = {
+          author: null,
+          pullId: 123,
+          state: 'OPEN',
+          updatestamp: null,
+          title: null,
+          compareWithBase: {
+            __typename: 'Comparison',
+            patchTotals: {
+              percentCovered: 100,
+            },
+            changeCoverage: 0,
+          },
+          head: {
+            totals: {
+              percentCovered: 9,
+            },
+            bundleAnalysisReport: {
+              __typename: 'BundleAnalysisReport',
+            },
+          },
+        } as const
+
+        const result = createPullsTableData({
+          pulls: [pullData],
+        })
+
+        expect(result[0]?.bundleAnalysis).toStrictEqual(
+          <p className="text-right">Upload: ✅</p>
         )
       })
     })

--- a/src/pages/RepoPage/PullsTab/PullsTable/createPullsTableData.tsx
+++ b/src/pages/RepoPage/PullsTab/PullsTable/createPullsTableData.tsx
@@ -22,6 +22,15 @@ export const createPullsTableData = ({ pulls }: { pulls?: Array<Pull> }) => {
     const title = pull?.title ?? 'Pull Request'
     const pullId = pull?.pullId ?? NaN
 
+    let bundleAnalysis = undefined
+    if (
+      pull?.head?.bundleAnalysisReport?.__typename === 'BundleAnalysisReport'
+    ) {
+      bundleAnalysis = <p className="text-right">Upload: &#x2705;</p>
+    } else {
+      bundleAnalysis = <p className="text-right">Upload: &#x274C;</p>
+    }
+
     return {
       title: (
         <Title
@@ -61,6 +70,7 @@ export const createPullsTableData = ({ pulls }: { pulls?: Array<Pull> }) => {
           large={false}
         />
       ),
+      bundleAnalysis,
     }
   })
 }

--- a/src/pages/RepoPage/PullsTab/PullsTableTeam/PullsTableTeam.spec.tsx
+++ b/src/pages/RepoPage/PullsTab/PullsTableTeam/PullsTableTeam.spec.tsx
@@ -9,7 +9,14 @@ import { setupServer } from 'msw/node'
 import { mockIsIntersecting } from 'react-intersection-observer/test-utils'
 import { MemoryRouter, Route } from 'react-router-dom'
 
+import { useFlags } from 'shared/featureFlags'
+
 import PullsTableTeam from './PullsTableTeam'
+
+jest.mock('shared/featureFlags')
+const mockedUseFlags = useFlags as jest.Mock<{
+  bundleAnalysisPrAndCommitPages: boolean
+}>
 
 const mockRepoOverview = (bundleAnalysisEnabled = false) => ({
   owner: {
@@ -126,6 +133,9 @@ describe('PullsTableTeam', () => {
     bundleAnalysisEnabled = false,
   }: SetupArgs) {
     const queryClient = new QueryClient()
+    mockedUseFlags.mockReturnValue({
+      bundleAnalysisPrAndCommitPages: true,
+    })
 
     server.use(
       graphql.query('GetRepoOverview', (req, res, ctx) => {

--- a/src/pages/RepoPage/PullsTab/PullsTableTeam/PullsTableTeam.tsx
+++ b/src/pages/RepoPage/PullsTab/PullsTableTeam/PullsTableTeam.tsx
@@ -14,6 +14,7 @@ import { useLocationParams } from 'services/navigation'
 import { usePullsTeam } from 'services/pulls/usePullsTeam'
 import 'ui/Table/Table.css'
 import { useRepoOverview } from 'services/repo'
+import { useFlags } from 'shared/featureFlags'
 import Spinner from 'ui/Spinner'
 
 import { createPullsTableTeamData } from './createPullsTableTeamData'
@@ -73,6 +74,9 @@ export default function PullsTableTeam() {
   // we really need to TS'ify and generic'ify useLocationParams
   const { params } = useLocationParams(defaultParams)
   const { data: overview } = useRepoOverview({ provider, owner, repo })
+  const { bundleAnalysisPrAndCommitPages } = useFlags({
+    bundleAnalysisPrAndCommitPages: false,
+  })
 
   const {
     data: pullsData,
@@ -111,7 +115,8 @@ export default function PullsTableTeam() {
   const columns = useMemo(() => {
     if (
       overview?.bundleAnalysisEnabled &&
-      !baseColumns.some((column) => column.id === 'bundleAnalysis')
+      !baseColumns.some((column) => column.id === 'bundleAnalysis') &&
+      bundleAnalysisPrAndCommitPages
     ) {
       return [
         ...baseColumns,
@@ -124,7 +129,7 @@ export default function PullsTableTeam() {
     }
 
     return baseColumns
-  }, [overview?.bundleAnalysisEnabled])
+  }, [bundleAnalysisPrAndCommitPages, overview?.bundleAnalysisEnabled])
 
   const table = useReactTable({
     columns,

--- a/src/pages/RepoPage/PullsTab/PullsTableTeam/createPullsTableTeamData.spec.tsx
+++ b/src/pages/RepoPage/PullsTab/PullsTableTeam/createPullsTableTeamData.spec.tsx
@@ -44,6 +44,11 @@ describe('createPullsTableTeamData', () => {
             __typename: 'MissingBaseCommit',
             message: 'Missing base commit',
           },
+          head: {
+            bundleAnalysisReport: {
+              __typename: 'MissingHeadReport',
+            },
+          },
         } as const
 
         const result = createPullsTableTeamData({
@@ -68,6 +73,11 @@ describe('createPullsTableTeamData', () => {
             __typename: 'Comparison',
             patchTotals: {
               percentCovered: 100,
+            },
+          },
+          head: {
+            bundleAnalysisReport: {
+              __typename: 'MissingHeadReport',
             },
           },
         } as const
@@ -103,6 +113,11 @@ describe('createPullsTableTeamData', () => {
                 percentCovered: null,
               },
             },
+            head: {
+              bundleAnalysisReport: {
+                __typename: 'MissingHeadReport',
+              },
+            },
           } as const
 
           const result = createPullsTableTeamData({
@@ -124,6 +139,68 @@ describe('createPullsTableTeamData', () => {
       })
     })
 
+    describe('bundleAnalysisReport __typename is not BundleAnalysisReport', () => {
+      it('returns no report uploaded', () => {
+        const pullData = {
+          author: null,
+          pullId: 123,
+          state: 'OPEN',
+          updatestamp: null,
+          title: null,
+          compareWithBase: {
+            __typename: 'Comparison',
+            patchTotals: {
+              percentCovered: 100,
+            },
+          },
+          head: {
+            bundleAnalysisReport: {
+              __typename: 'MissingHeadReport',
+            },
+          },
+        } as const
+
+        const result = createPullsTableTeamData({
+          pages: [{ pulls: [pullData] }],
+        })
+
+        expect(result[0]?.bundleAnalysis).toStrictEqual(
+          <p className="text-right">Upload: ❌</p>
+        )
+      })
+    })
+
+    describe('bundleAnalysisReport __typename is BundleAnalysisReport', () => {
+      it('returns successful upload', () => {
+        const pullData = {
+          author: null,
+          pullId: 123,
+          state: 'OPEN',
+          updatestamp: null,
+          title: null,
+          compareWithBase: {
+            __typename: 'Comparison',
+            patchTotals: {
+              percentCovered: 100,
+            },
+          },
+          head: {
+            bundleAnalysisReport: {
+              __typename: 'BundleAnalysisReport',
+            },
+          },
+        } as const
+
+        const result = createPullsTableTeamData({
+          pages: [{ pulls: [pullData] }],
+        })
+
+        expect(result[0]?.bundleAnalysis).toStrictEqual(
+          <p className="text-right">Upload: ✅</p>
+        )
+      })
+    })
+
     describe('pull details are all non-null values', () => {
       it('returns the title component', () => {
         const pullData = {
@@ -138,6 +215,11 @@ describe('createPullsTableTeamData', () => {
           compareWithBase: {
             __typename: 'MissingBaseCommit',
             message: 'Missing base commit',
+          },
+          head: {
+            bundleAnalysisReport: {
+              __typename: 'MissingHeadReport',
+            },
           },
         } as const
 

--- a/src/pages/RepoPage/PullsTab/PullsTableTeam/createPullsTableTeamData.tsx
+++ b/src/pages/RepoPage/PullsTab/PullsTableTeam/createPullsTableTeamData.tsx
@@ -20,6 +20,7 @@ export const createPullsTableTeamData = ({
   if (isEmpty(pulls)) {
     return []
   }
+
   return pulls.filter(Boolean).map((pull) => {
     let patch = <p className="text-right">No report uploaded</p>
     if (pull?.compareWithBase?.__typename === 'Comparison') {
@@ -36,6 +37,15 @@ export const createPullsTableTeamData = ({
           />
         </div>
       )
+    }
+
+    let bundleAnalysis = undefined
+    if (
+      pull?.head?.bundleAnalysisReport?.__typename === 'BundleAnalysisReport'
+    ) {
+      bundleAnalysis = <p className="text-right">Upload: &#x2705;</p>
+    } else {
+      bundleAnalysis = <p className="text-right">Upload: &#x274C;</p>
     }
 
     const updatestamp = pull?.updatestamp ?? undefined
@@ -56,6 +66,7 @@ export const createPullsTableTeamData = ({
         />
       ),
       patch,
+      bundleAnalysis,
     }
   })
 }

--- a/src/services/pulls/usePulls.spec.tsx
+++ b/src/services/pulls/usePulls.spec.tsx
@@ -18,6 +18,9 @@ const node1 = {
     totals: {
       percentCovered: 90,
     },
+    bundleAnalysisReport: {
+      __typename: 'MissingHeadReport',
+    },
   },
   compareWithBase: {
     __typename: 'Comparison',
@@ -41,6 +44,9 @@ const node2 = {
     totals: {
       percentCovered: 90,
     },
+    bundleAnalysisReport: {
+      __typename: 'MissingHeadReport',
+    },
   },
   compareWithBase: {
     __typename: 'Comparison',
@@ -63,6 +69,9 @@ const node3 = {
   head: {
     totals: {
       percentCovered: 90,
+    },
+    bundleAnalysisReport: {
+      __typename: 'MissingHeadReport',
     },
   },
   compareWithBase: {

--- a/src/services/pulls/usePulls.tsx
+++ b/src/services/pulls/usePulls.tsx
@@ -47,10 +47,12 @@ const PullSchema = z
             percentCovered: z.number().nullable(),
           })
           .nullable(),
-        bundleAnalysisReport: z.discriminatedUnion('__typename', [
-          z.object({ __typename: z.literal('BundleAnalysisReport') }),
-          z.object({ __typename: z.literal('MissingHeadReport') }),
-        ]),
+        bundleAnalysisReport: z
+          .discriminatedUnion('__typename', [
+            z.object({ __typename: z.literal('BundleAnalysisReport') }),
+            z.object({ __typename: z.literal('MissingHeadReport') }),
+          ])
+          .nullable(),
       })
       .nullable(),
     compareWithBase: z

--- a/src/services/pulls/usePulls.tsx
+++ b/src/services/pulls/usePulls.tsx
@@ -47,6 +47,10 @@ const PullSchema = z
             percentCovered: z.number().nullable(),
           })
           .nullable(),
+        bundleAnalysisReport: z.discriminatedUnion('__typename', [
+          z.object({ __typename: z.literal('BundleAnalysisReport') }),
+          z.object({ __typename: z.literal('MissingHeadReport') }),
+        ]),
       })
       .nullable(),
     compareWithBase: z
@@ -138,8 +142,10 @@ query GetPulls(
                 totals {
                   percentCovered
                 }
+                bundleAnalysisReport {
+                  __typename
+                }
               }
-
               compareWithBase {
                 __typename
                 ... on Comparison {

--- a/src/services/pulls/usePullsTeam.spec.tsx
+++ b/src/services/pulls/usePullsTeam.spec.tsx
@@ -20,6 +20,11 @@ const node1 = {
       percentCovered: 87,
     },
   },
+  head: {
+    bundleAnalysisReport: {
+      __typename: 'MissingHeadReport',
+    },
+  },
 }
 
 const node2 = {
@@ -37,6 +42,11 @@ const node2 = {
       percentCovered: 87,
     },
   },
+  head: {
+    bundleAnalysisReport: {
+      __typename: 'MissingHeadReport',
+    },
+  },
 }
 
 const node3 = {
@@ -52,6 +62,11 @@ const node3 = {
     __typename: 'Comparison',
     patchTotals: {
       percentCovered: 87,
+    },
+  },
+  head: {
+    bundleAnalysisReport: {
+      __typename: 'MissingHeadReport',
     },
   },
 }

--- a/src/services/pulls/usePullsTeam.tsx
+++ b/src/services/pulls/usePullsTeam.tsx
@@ -40,6 +40,16 @@ const PullSchema = z
         avatarUrl: z.string(),
       })
       .nullable(),
+    head: z
+      .object({
+        bundleAnalysisReport: z
+          .discriminatedUnion('__typename', [
+            z.object({ __typename: z.literal('BundleAnalysisReport') }),
+            z.object({ __typename: z.literal('MissingHeadReport') }),
+          ])
+          .nullable(),
+      })
+      .nullable(),
     compareWithBase: z
       .discriminatedUnion('__typename', [
         z.object({
@@ -123,6 +133,11 @@ query GetPullsTeam(
               author {
                 username
                 avatarUrl
+              }
+              head {
+                bundleAnalysisReport {
+                  __typename
+                }
               }
               compareWithBase {
                 __typename


### PR DESCRIPTION
# Description

This PR updates the two pull tables for both pro/public, and team table versions to add in a conditional column for bundle analysis if enabled for a repo.

# Notable Changes

- Update `PullsTable`
- Update `PullsTableTeam`
- Update `usePulls`
- Update `usePullsTeam`
- Update tests

# Screenshots

Pro/Public table version:

<img width="1293" alt="Screenshot 2024-03-02 at 13 06 49" src="https://github.com/codecov/gazebo/assets/105234307/9f55e0b8-d195-4fdb-957c-eb2d39a90e39">

Team table version:

<img width="1293" alt="Screenshot 2024-03-02 at 13 08 09" src="https://github.com/codecov/gazebo/assets/105234307/f6f9aba9-245f-48c0-a10b-de0ac83f3fc6">