### PR TITLE
ref: Update commit bundle summary to use new data

### DIFF
--- a/src/pages/CommitDetailPage/CommitBundleAnalysis/BundleMessage/BundleMessage.spec.tsx
+++ b/src/pages/CommitDetailPage/CommitBundleAnalysis/BundleMessage/BundleMessage.spec.tsx
@@ -14,8 +14,14 @@ const mockSummaryData = (sizeDelta: number) => ({
       commit: {
         bundleAnalysisCompareWithParent: {
           __typename: 'BundleAnalysisComparison',
-          sizeDelta,
-          loadTimeDelta: 0,
+          bundleChange: {
+            loadTime: {
+              threeG: 0,
+            },
+            size: {
+              uncompress: sizeDelta,
+            },
+          },
         },
       },
     },

--- a/src/pages/CommitDetailPage/CommitBundleAnalysis/BundleMessage/BundleMessage.tsx
+++ b/src/pages/CommitDetailPage/CommitBundleAnalysis/BundleMessage/BundleMessage.tsx
@@ -45,9 +45,9 @@ const BundleMessage: React.FC = () => {
 
   if (
     comparison?.__typename === 'BundleAnalysisComparison' &&
-    isNumber(comparison?.sizeDelta)
+    isNumber(comparison?.bundleChange?.size?.uncompress)
   ) {
-    const sizeDelta = comparison?.sizeDelta
+    const sizeDelta = comparison.bundleChange.size.uncompress
     const positiveSize = Math.abs(sizeDelta)
     if (sizeDelta < 0) {
       return (

--- a/src/pages/CommitDetailPage/CommitBundleAnalysis/CommitBundleAnalysis.spec.tsx
+++ b/src/pages/CommitDetailPage/CommitBundleAnalysis/CommitBundleAnalysis.spec.tsx
@@ -54,8 +54,14 @@ const mockSummaryData = (sizeDelta: number) => ({
       commit: {
         bundleAnalysisCompareWithParent: {
           __typename: 'BundleAnalysisComparison',
-          sizeDelta,
-          loadTimeDelta: 0,
+          bundleChange: {
+            loadTime: {
+              threeG: 2,
+            },
+            size: {
+              uncompress: sizeDelta,
+            },
+          },
         },
       },
     },

--- a/src/pages/CommitDetailPage/CommitDetailPage.spec.tsx
+++ b/src/pages/CommitDetailPage/CommitDetailPage.spec.tsx
@@ -81,8 +81,14 @@ const mockBundleDropdownSummary = {
       commit: {
         bundleAnalysisCompareWithParent: {
           __typename: 'BundleAnalysisComparison',
-          sizeDelta: 10000,
-          loadTimeDelta: 0,
+          bundleChange: {
+            loadTime: {
+              threeG: 2,
+            },
+            size: {
+              uncompress: 10000,
+            },
+          },
         },
       },
     },

--- a/src/pages/CommitDetailPage/Dropdowns/CommitBundleDropdown.spec.tsx
+++ b/src/pages/CommitDetailPage/Dropdowns/CommitBundleDropdown.spec.tsx
@@ -17,8 +17,14 @@ const mockSummaryData = (sizeDelta: number) => ({
       commit: {
         bundleAnalysisCompareWithParent: {
           __typename: 'BundleAnalysisComparison',
-          sizeDelta,
-          loadTimeDelta: 0,
+          bundleChange: {
+            loadTime: {
+              threeG: 2,
+            },
+            size: {
+              uncompress: sizeDelta,
+            },
+          },
         },
       },
     },

--- a/src/services/commit/useCommitBADropdownSummary.spec.tsx
+++ b/src/services/commit/useCommitBADropdownSummary.spec.tsx
@@ -12,8 +12,14 @@ const mockCommitBASummaryData = {
       commit: {
         bundleAnalysisCompareWithParent: {
           __typename: 'BundleAnalysisComparison',
-          sizeDelta: 1,
-          loadTimeDelta: 2,
+          bundleChange: {
+            loadTime: {
+              threeG: 2,
+            },
+            size: {
+              uncompress: 1,
+            },
+          },
         },
       },
     },
@@ -119,8 +125,14 @@ describe('useCommitBADropdownSummary', () => {
         commit: {
           bundleAnalysisCompareWithParent: {
             __typename: 'BundleAnalysisComparison',
-            sizeDelta: 1,
-            loadTimeDelta: 2,
+            bundleChange: {
+              loadTime: {
+                threeG: 2,
+              },
+              size: {
+                uncompress: 1,
+              },
+            },
           },
         },
       }
@@ -180,7 +192,7 @@ describe('useCommitBADropdownSummary', () => {
         expect(result.current.error).toEqual(
           expect.objectContaining({
             status: 404,
-            data: null,
+            data: {},
           })
         )
       )


### PR DESCRIPTION
# Description

Small change to use new change field for the commit bundle dropdown summary.

# Notable Changes

- Update summary hook to fetch in data from new fields
- Update commit bundle message to access new fields
- Update tests