### PR TITLE
ref: Update commit bundle list and table

### DIFF
--- a/src/pages/CommitDetailPage/CommitBundleAnalysis/CommitBundleAnalysisTable/CommitBundleAnalysisTable.spec.tsx
+++ b/src/pages/CommitDetailPage/CommitBundleAnalysis/CommitBundleAnalysisTable/CommitBundleAnalysisTable.spec.tsx
@@ -21,18 +21,42 @@ const mockCommitBundleListData = {
             {
               name: 'bundle.js',
               changeType: 'added',
-              sizeDelta: 1,
-              sizeTotal: 3,
-              loadTimeDelta: 3,
-              loadTimeTotal: 4,
+              bundleChange: {
+                loadTime: {
+                  threeG: 3,
+                },
+                size: {
+                  uncompress: 1,
+                },
+              },
+              bundleData: {
+                loadTime: {
+                  threeG: 4,
+                },
+                size: {
+                  uncompress: 3,
+                },
+              },
             },
             {
               name: 'bundle.css',
               changeType: 'added',
-              sizeDelta: -1000,
-              sizeTotal: 3000,
-              loadTimeDelta: 33,
-              loadTimeTotal: 45,
+              bundleChange: {
+                loadTime: {
+                  threeG: 33,
+                },
+                size: {
+                  uncompress: -1000,
+                },
+              },
+              bundleData: {
+                loadTime: {
+                  threeG: 45,
+                },
+                size: {
+                  uncompress: 3000,
+                },
+              },
             },
           ],
         },

--- a/src/pages/CommitDetailPage/CommitBundleAnalysis/CommitBundleAnalysisTable/CommitBundleAnalysisTable.tsx
+++ b/src/pages/CommitDetailPage/CommitBundleAnalysis/CommitBundleAnalysisTable/CommitBundleAnalysisTable.tsx
@@ -79,9 +79,11 @@ export const useTableData = () => {
     return data?.commit?.bundleAnalysisCompareWithParent?.bundles?.map(
       (bundle) => ({
         name: bundle.name,
-        prevSize: bundle.sizeTotal - bundle.sizeDelta,
-        newSize: bundle.sizeTotal,
-        change: bundle.sizeDelta,
+        prevSize:
+          bundle.bundleData.size.uncompress -
+          bundle.bundleChange.size.uncompress,
+        newSize: bundle.bundleData.size.uncompress,
+        change: bundle.bundleChange.size.uncompress,
       })
     )
   }, [data])

--- a/src/services/commit/useCommitBundleList.spec.tsx
+++ b/src/services/commit/useCommitBundleList.spec.tsx
@@ -16,18 +16,42 @@ const mockCommitBundleListData = {
             {
               name: 'bundle.js',
               changeType: 'added',
-              sizeDelta: 1,
-              sizeTotal: 2,
-              loadTimeDelta: 3,
-              loadTimeTotal: 4,
+              bundleChange: {
+                loadTime: {
+                  threeG: 3,
+                },
+                size: {
+                  uncompress: 1,
+                },
+              },
+              bundleData: {
+                loadTime: {
+                  threeG: 4,
+                },
+                size: {
+                  uncompress: 2,
+                },
+              },
             },
             {
               name: 'bundle.css',
               changeType: 'removed',
-              sizeDelta: 5,
-              sizeTotal: 6,
-              loadTimeDelta: 7,
-              loadTimeTotal: 8,
+              bundleChange: {
+                loadTime: {
+                  threeG: 7,
+                },
+                size: {
+                  uncompress: 5,
+                },
+              },
+              bundleData: {
+                loadTime: {
+                  threeG: 8,
+                },
+                size: {
+                  uncompress: 6,
+                },
+              },
             },
           ],
         },
@@ -139,18 +163,42 @@ describe('useCommitBundleList', () => {
               {
                 name: 'bundle.js',
                 changeType: 'added',
-                sizeDelta: 1,
-                sizeTotal: 2,
-                loadTimeDelta: 3,
-                loadTimeTotal: 4,
+                bundleChange: {
+                  loadTime: {
+                    threeG: 3,
+                  },
+                  size: {
+                    uncompress: 1,
+                  },
+                },
+                bundleData: {
+                  loadTime: {
+                    threeG: 4,
+                  },
+                  size: {
+                    uncompress: 2,
+                  },
+                },
               },
               {
                 name: 'bundle.css',
                 changeType: 'removed',
-                sizeDelta: 5,
-                sizeTotal: 6,
-                loadTimeDelta: 7,
-                loadTimeTotal: 8,
+                bundleChange: {
+                  loadTime: {
+                    threeG: 7,
+                  },
+                  size: {
+                    uncompress: 5,
+                  },
+                },
+                bundleData: {
+                  loadTime: {
+                    threeG: 8,
+                  },
+                  size: {
+                    uncompress: 6,
+                  },
+                },
               },
             ],
           },
@@ -212,7 +260,7 @@ describe('useCommitBundleList', () => {
         expect(result.current.error).toEqual(
           expect.objectContaining({
             status: 404,
-            data: null,
+            data: {},
           })
         )
       )


### PR DESCRIPTION
# Description

This should be one of the last PRs to update the bundle related hooks to swap over to use new GQL fields from the API.

# Notable Changes

- Update commit bundle list hook
- Update commit bundle table
- Update tests