### PR TITLE
fix: Commits and pulls tab sizing

### DIFF
--- a/src/pages/PullRequestPage/PullCoverage/routes/CommitsTab/CommitsTable/CommitsTable.tsx
+++ b/src/pages/PullRequestPage/PullCoverage/routes/CommitsTab/CommitsTable/CommitsTable.tsx
@@ -152,12 +152,23 @@ const CommitsTable = () => {
     <>
       <div className="tableui">
         <table>
+          <colgroup>
+            <col className="w-full @sm/table:w-5/12" />
+            <col className="@sm/table:w-1/12" />
+            <col className="@sm/table:w-2/12" />
+            <col className="@sm/table:w-2/12" />
+            <col className="@sm/table:w-1/12" />
+            {overview?.bundleAnalysisEnabled ? (
+              <col className="@sm/table:w-1/12" />
+            ) : null}
+          </colgroup>
           <thead>
             {table.getHeaderGroups().map((headerGroup) => (
               <tr key={headerGroup.id}>
                 {headerGroup.headers.map((header) => (
                   <th
                     key={header.id}
+                    scope="col"
                     className={cs({
                       'text-right': header.id !== 'name',
                     })}
@@ -186,7 +197,7 @@ const CommitsTable = () => {
                       key={cell.id}
                       className={cs('text-sm', {
                         'w-full max-w-0 font-medium @md/table:w-auto @md/table:max-w-none text-left':
-                          cell.column.id === 'title',
+                          cell.column.id === 'name',
                         'text-right': cell.column.id !== 'name',
                       })}
                     >

--- a/src/pages/PullRequestPage/PullCoverage/routes/CommitsTab/CommitsTable/createCommitsTableData.spec.tsx
+++ b/src/pages/PullRequestPage/PullCoverage/routes/CommitsTab/CommitsTable/createCommitsTableData.spec.tsx
@@ -101,15 +101,13 @@ describe('createCommitsTableData', () => {
         })
 
         expect(result[0]?.patch).toStrictEqual(
-          <div className="text-right">
-            <TotalsNumber
-              large={false}
-              light={false}
-              plain={true}
-              showChange={false}
-              value={100}
-            />
-          </div>
+          <TotalsNumber
+            large={false}
+            light={false}
+            plain={true}
+            showChange={false}
+            value={100}
+          />
         )
       })
 
@@ -145,15 +143,13 @@ describe('createCommitsTableData', () => {
           })
 
           expect(result[0]?.patch).toStrictEqual(
-            <div className="text-right">
-              <TotalsNumber
-                large={false}
-                light={false}
-                plain={true}
-                showChange={false}
-                value={0}
-              />
-            </div>
+            <TotalsNumber
+              large={false}
+              light={false}
+              plain={true}
+              showChange={false}
+              value={0}
+            />
           )
         })
       })
@@ -356,7 +352,7 @@ describe('createCommitsTableData', () => {
           pages: [{ commits: [commitData] }],
         })
 
-        expect(result[0]?.bundleAnalysis).toStrictEqual(<p>Upload: ❌</p>)
+        expect(result[0]?.bundleAnalysis).toStrictEqual(<>Upload: ❌</>)
       })
     })
 
@@ -389,7 +385,7 @@ describe('createCommitsTableData', () => {
           pages: [{ commits: [commitData] }],
         })
 
-        expect(result[0]?.bundleAnalysis).toStrictEqual(<p>Upload: ✅</p>)
+        expect(result[0]?.bundleAnalysis).toStrictEqual(<>Upload: ✅</>)
       })
     })
   })

--- a/src/pages/PullRequestPage/PullCoverage/routes/CommitsTab/CommitsTable/createCommitsTableData.tsx
+++ b/src/pages/PullRequestPage/PullCoverage/routes/CommitsTab/CommitsTable/createCommitsTableData.tsx
@@ -53,10 +53,10 @@ export const createCommitsTableData = ({
     let bundleAnalysis = undefined
     if (commit?.bundleAnalysisReport?.__typename === 'BundleAnalysisReport') {
       // this hex code is for ✅
-      bundleAnalysis = <p>Upload: &#x2705;</p>
+      bundleAnalysis = <>Upload: &#x2705;</>
     } else {
       // this hex code is for ❌
-      bundleAnalysis = <p>Upload: &#x274C;</p>
+      bundleAnalysis = <>Upload: &#x274C;</>
     }
 
     return {

--- a/src/pages/PullRequestPage/PullCoverage/routes/CommitsTab/CommitsTable/createCommitsTableData.tsx
+++ b/src/pages/PullRequestPage/PullCoverage/routes/CommitsTab/CommitsTable/createCommitsTableData.tsx
@@ -31,15 +31,13 @@ export const createCommitsTableData = ({
       patchPercentage =
         commit?.compareWithParent?.patchTotals?.percentCovered ?? 0
       patch = (
-        <div className="text-right">
-          <TotalsNumber
-            plain={true}
-            large={false}
-            light={false}
-            value={patchPercentage}
-            showChange={false}
-          />
-        </div>
+        <TotalsNumber
+          plain={true}
+          large={false}
+          light={false}
+          value={patchPercentage}
+          showChange={false}
+        />
       )
     }
 

--- a/src/pages/PullRequestPage/PullCoverage/routes/CommitsTab/CommitsTableTeam/CommitsTableTeam.tsx
+++ b/src/pages/PullRequestPage/PullCoverage/routes/CommitsTab/CommitsTableTeam/CommitsTableTeam.tsx
@@ -170,7 +170,14 @@ export default function CommitsTableTeam() {
               table.getRowModel().rows.map((row) => (
                 <tr key={row.id}>
                   {row.getVisibleCells().map((cell) => (
-                    <td key={cell.id}>
+                    <td
+                      key={cell.id}
+                      className={cs('text-sm', {
+                        'w-full max-w-0 font-medium @md/table:w-auto @md/table:max-w-none text-left':
+                          cell.column.id === 'name',
+                        'text-right': cell.column.id !== 'name',
+                      })}
+                    >
                       {flexRender(
                         cell.column.columnDef.cell,
                         cell.getContext()

--- a/src/pages/PullRequestPage/PullCoverage/routes/CommitsTab/CommitsTableTeam/createCommitsTableTeamData.spec.tsx
+++ b/src/pages/PullRequestPage/PullCoverage/routes/CommitsTab/CommitsTableTeam/createCommitsTableTeamData.spec.tsx
@@ -84,15 +84,13 @@ describe('createCommitsTableTeamData', () => {
         })
 
         expect(result[0]?.patch).toStrictEqual(
-          <div className="text-right">
-            <TotalsNumber
-              large={false}
-              light={false}
-              plain={true}
-              showChange={false}
-              value={100}
-            />
-          </div>
+          <TotalsNumber
+            large={false}
+            light={false}
+            plain={true}
+            showChange={false}
+            value={100}
+          />
         )
       })
 
@@ -120,15 +118,13 @@ describe('createCommitsTableTeamData', () => {
           })
 
           expect(result[0]?.patch).toStrictEqual(
-            <div className="text-right">
-              <TotalsNumber
-                large={false}
-                light={false}
-                plain={true}
-                showChange={false}
-                value={0}
-              />
-            </div>
+            <TotalsNumber
+              large={false}
+              light={false}
+              plain={true}
+              showChange={false}
+              value={0}
+            />
           )
         })
       })
@@ -225,9 +221,7 @@ describe('createCommitsTableTeamData', () => {
           pages: [{ commits: [commitData] }],
         })
 
-        expect(result[0]?.bundleAnalysis).toStrictEqual(
-          <p className="text-right">Upload: ❌</p>
-        )
+        expect(result[0]?.bundleAnalysis).toStrictEqual(<>Upload: ❌</>)
       })
     })
 
@@ -254,9 +248,7 @@ describe('createCommitsTableTeamData', () => {
           pages: [{ commits: [commitData] }],
         })
 
-        expect(result[0]?.bundleAnalysis).toStrictEqual(
-          <p className="text-right">Upload: ✅</p>
-        )
+        expect(result[0]?.bundleAnalysis).toStrictEqual(<>Upload: ✅</>)
       })
     })
   })

--- a/src/pages/PullRequestPage/PullCoverage/routes/CommitsTab/CommitsTableTeam/createCommitsTableTeamData.tsx
+++ b/src/pages/PullRequestPage/PullCoverage/routes/CommitsTab/CommitsTableTeam/createCommitsTableTeamData.tsx
@@ -29,23 +29,21 @@ export const createCommitsTableTeamData = ({
       patchPercentage =
         commit?.compareWithParent?.patchTotals?.percentCovered ?? 0
       patch = (
-        <div className="text-right">
-          <TotalsNumber
-            plain={true}
-            large={false}
-            light={false}
-            value={patchPercentage}
-            showChange={false}
-          />
-        </div>
+        <TotalsNumber
+          plain={true}
+          large={false}
+          light={false}
+          value={patchPercentage}
+          showChange={false}
+        />
       )
     }
 
     let bundleAnalysis = undefined
     if (commit?.bundleAnalysisReport?.__typename === 'BundleAnalysisReport') {
-      bundleAnalysis = <p className="text-right">Upload: &#x2705;</p>
+      bundleAnalysis = <>Upload: &#x2705;</>
     } else {
-      bundleAnalysis = <p className="text-right">Upload: &#x274C;</p>
+      bundleAnalysis = <>Upload: &#x274C;</>
     }
 
     return {

--- a/src/pages/RepoPage/CommitsTab/CommitsTable/CommitsTable.tsx
+++ b/src/pages/RepoPage/CommitsTab/CommitsTable/CommitsTable.tsx
@@ -166,12 +166,23 @@ const CommitsTable: React.FC<CommitsTableProps> = ({
     <>
       <div className="tableui">
         <table>
+          <colgroup>
+            <col className="w-full @sm/table:w-5/12" />
+            <col className="@sm/table:w-1/12" />
+            <col className="@sm/table:w-2/12" />
+            <col className="@sm/table:w-2/12" />
+            <col className="@sm/table:w-1/12" />
+            {overview?.bundleAnalysisEnabled ? (
+              <col className="@sm/table:w-1/12" />
+            ) : null}
+          </colgroup>
           <thead>
             {table.getHeaderGroups().map((headerGroup) => (
               <tr key={headerGroup.id}>
                 {headerGroup.headers.map((header) => (
                   <th
                     key={header.id}
+                    scope="col"
                     className={cs({
                       'text-right': header.id !== 'name',
                     })}
@@ -199,8 +210,8 @@ const CommitsTable: React.FC<CommitsTableProps> = ({
                     <td
                       key={cell.id}
                       className={cs('text-sm', {
-                        'w-full max-w-0 font-medium @md/table:w-auto @md/table:max-w-none text-left':
-                          cell.column.id === 'title',
+                        'w-full max-w-0 font-medium @md/table:w-auto @md/table:max-w-none':
+                          cell.column.id === 'name',
                         'text-right': cell.column.id !== 'name',
                       })}
                     >

--- a/src/pages/RepoPage/CommitsTab/CommitsTable/createCommitsTableData.spec.tsx
+++ b/src/pages/RepoPage/CommitsTab/CommitsTable/createCommitsTableData.spec.tsx
@@ -101,15 +101,13 @@ describe('createCommitsTableData', () => {
         })
 
         expect(result[0]?.patch).toStrictEqual(
-          <div className="text-right">
-            <TotalsNumber
-              large={false}
-              light={false}
-              plain={true}
-              showChange={false}
-              value={100}
-            />
-          </div>
+          <TotalsNumber
+            large={false}
+            light={false}
+            plain={true}
+            showChange={false}
+            value={100}
+          />
         )
       })
 
@@ -145,15 +143,13 @@ describe('createCommitsTableData', () => {
           })
 
           expect(result[0]?.patch).toStrictEqual(
-            <div className="text-right">
-              <TotalsNumber
-                large={false}
-                light={false}
-                plain={true}
-                showChange={false}
-                value={0}
-              />
-            </div>
+            <TotalsNumber
+              large={false}
+              light={false}
+              plain={true}
+              showChange={false}
+              value={0}
+            />
           )
         })
       })
@@ -356,7 +352,7 @@ describe('createCommitsTableData', () => {
           pages: [{ commits: [commitData] }],
         })
 
-        expect(result[0]?.bundleAnalysis).toStrictEqual(<p>Upload: ❌</p>)
+        expect(result[0]?.bundleAnalysis).toStrictEqual(<>Upload: ❌</>)
       })
     })
 
@@ -389,7 +385,7 @@ describe('createCommitsTableData', () => {
           pages: [{ commits: [commitData] }],
         })
 
-        expect(result[0]?.bundleAnalysis).toStrictEqual(<p>Upload: ✅</p>)
+        expect(result[0]?.bundleAnalysis).toStrictEqual(<>Upload: ✅</>)
       })
     })
   })

--- a/src/pages/RepoPage/CommitsTab/CommitsTable/createCommitsTableData.tsx
+++ b/src/pages/RepoPage/CommitsTab/CommitsTable/createCommitsTableData.tsx
@@ -53,10 +53,10 @@ export const createCommitsTableData = ({ pages }: CommitsTableData) => {
     let bundleAnalysis = undefined
     if (commit?.bundleAnalysisReport?.__typename === 'BundleAnalysisReport') {
       // this hex code is for ✅
-      bundleAnalysis = <p>Upload: &#x2705;</p>
+      bundleAnalysis = <>Upload: &#x2705;</>
     } else {
       // this hex code is for ❌
-      bundleAnalysis = <p>Upload: &#x274C;</p>
+      bundleAnalysis = <>Upload: &#x274C;</>
     }
 
     return {

--- a/src/pages/RepoPage/CommitsTab/CommitsTable/createCommitsTableData.tsx
+++ b/src/pages/RepoPage/CommitsTab/CommitsTable/createCommitsTableData.tsx
@@ -31,15 +31,13 @@ export const createCommitsTableData = ({ pages }: CommitsTableData) => {
       patchPercentage =
         commit?.compareWithParent?.patchTotals?.percentCovered ?? 0
       patch = (
-        <div className="text-right">
-          <TotalsNumber
-            plain={true}
-            large={false}
-            light={false}
-            value={patchPercentage}
-            showChange={false}
-          />
-        </div>
+        <TotalsNumber
+          plain={true}
+          large={false}
+          light={false}
+          value={patchPercentage}
+          showChange={false}
+        />
       )
     }
 

--- a/src/pages/RepoPage/CommitsTab/CommitsTableTeam/CommitsTableTeam.tsx
+++ b/src/pages/RepoPage/CommitsTab/CommitsTableTeam/CommitsTableTeam.tsx
@@ -184,7 +184,14 @@ const CommitsTableTeam: React.FC<CommitsTableTeamProps> = ({
               table.getRowModel().rows.map((row) => (
                 <tr key={row.id}>
                   {row.getVisibleCells().map((cell) => (
-                    <td key={cell.id}>
+                    <td
+                      key={cell.id}
+                      className={cs('text-sm', {
+                        'w-full max-w-0 font-medium @md/table:w-auto @md/table:max-w-none text-left':
+                          cell.column.id === 'name',
+                        'text-right': cell.column.id !== 'name',
+                      })}
+                    >
                       {flexRender(
                         cell.column.columnDef.cell,
                         cell.getContext()

--- a/src/pages/RepoPage/CommitsTab/CommitsTableTeam/createCommitsTableTeamData.spec.tsx
+++ b/src/pages/RepoPage/CommitsTab/CommitsTableTeam/createCommitsTableTeamData.spec.tsx
@@ -84,15 +84,13 @@ describe('createCommitsTableTeamData', () => {
         })
 
         expect(result[0]?.patch).toStrictEqual(
-          <div className="text-right">
-            <TotalsNumber
-              large={false}
-              light={false}
-              plain={true}
-              showChange={false}
-              value={100}
-            />
-          </div>
+          <TotalsNumber
+            large={false}
+            light={false}
+            plain={true}
+            showChange={false}
+            value={100}
+          />
         )
       })
 
@@ -120,15 +118,13 @@ describe('createCommitsTableTeamData', () => {
           })
 
           expect(result[0]?.patch).toStrictEqual(
-            <div className="text-right">
-              <TotalsNumber
-                large={false}
-                light={false}
-                plain={true}
-                showChange={false}
-                value={0}
-              />
-            </div>
+            <TotalsNumber
+              large={false}
+              light={false}
+              plain={true}
+              showChange={false}
+              value={0}
+            />
           )
         })
       })
@@ -225,9 +221,7 @@ describe('createCommitsTableTeamData', () => {
           pages: [{ commits: [commitData] }],
         })
 
-        expect(result[0]?.bundleAnalysis).toStrictEqual(
-          <p className="text-right">Upload: ❌</p>
-        )
+        expect(result[0]?.bundleAnalysis).toStrictEqual(<>Upload: ❌</>)
       })
     })
 
@@ -254,9 +248,7 @@ describe('createCommitsTableTeamData', () => {
           pages: [{ commits: [commitData] }],
         })
 
-        expect(result[0]?.bundleAnalysis).toStrictEqual(
-          <p className="text-right">Upload: ✅</p>
-        )
+        expect(result[0]?.bundleAnalysis).toStrictEqual(<>Upload: ✅</>)
       })
     })
   })

--- a/src/pages/RepoPage/CommitsTab/CommitsTableTeam/createCommitsTableTeamData.tsx
+++ b/src/pages/RepoPage/CommitsTab/CommitsTableTeam/createCommitsTableTeamData.tsx
@@ -29,23 +29,21 @@ export const createCommitsTableTeamData = ({
       patchPercentage =
         commit?.compareWithParent?.patchTotals?.percentCovered ?? 0
       patch = (
-        <div className="text-right">
-          <TotalsNumber
-            plain={true}
-            large={false}
-            light={false}
-            value={patchPercentage}
-            showChange={false}
-          />
-        </div>
+        <TotalsNumber
+          plain={true}
+          large={false}
+          light={false}
+          value={patchPercentage}
+          showChange={false}
+        />
       )
     }
 
     let bundleAnalysis = undefined
     if (commit?.bundleAnalysisReport?.__typename === 'BundleAnalysisReport') {
-      bundleAnalysis = <p className="text-right">Upload: &#x2705;</p>
+      bundleAnalysis = <>Upload: &#x2705;</>
     } else {
-      bundleAnalysis = <p className="text-right">Upload: &#x274C;</p>
+      bundleAnalysis = <>Upload: &#x274C;</>
     }
 
     return {

--- a/src/pages/RepoPage/PullsTab/PullsTable/PullsTable.tsx
+++ b/src/pages/RepoPage/PullsTab/PullsTable/PullsTable.tsx
@@ -166,8 +166,13 @@ export default function PullsTableTeam() {
       <div className="tableui">
         <table>
           <colgroup>
-            <col className="w-full @sm/table:w-10/12" />
+            <col className="w-full @sm/table:w-6/12" />
             <col className="@sm/table:w-2/12" />
+            <col className="@sm/table:w-1/12" />
+            <col className="@sm/table:w-1/12" />
+            {overview?.bundleAnalysisEnabled ? (
+              <col className="@sm/table:w-1/12" />
+            ) : null}
           </colgroup>
           <thead>
             {table.getHeaderGroups().map((headerGroup) => (
@@ -205,8 +210,7 @@ export default function PullsTableTeam() {
                       className={cs('text-sm', {
                         'w-full max-w-0 font-medium @md/table:w-auto @md/table:max-w-none':
                           cell.column.id === 'title',
-                        'flex justify-end': cell.column.id === 'change',
-                        'text-right': cell.column.id === 'patch',
+                        'text-right': cell.column.id !== 'title',
                       })}
                     >
                       {flexRender(

--- a/src/pages/RepoPage/PullsTab/PullsTable/createPullsTableData.spec.tsx
+++ b/src/pages/RepoPage/PullsTab/PullsTable/createPullsTableData.spec.tsx
@@ -350,9 +350,7 @@ describe('createPullsTableData', () => {
           pulls: [pullData],
         })
 
-        expect(result[0]?.bundleAnalysis).toStrictEqual(
-          <p className="text-right">Upload: ❌</p>
-        )
+        expect(result[0]?.bundleAnalysis).toStrictEqual(<>Upload: ❌</>)
       })
     })
 
@@ -385,9 +383,7 @@ describe('createPullsTableData', () => {
           pulls: [pullData],
         })
 
-        expect(result[0]?.bundleAnalysis).toStrictEqual(
-          <p className="text-right">Upload: ✅</p>
-        )
+        expect(result[0]?.bundleAnalysis).toStrictEqual(<>Upload: ✅</>)
       })
     })
   })

--- a/src/pages/RepoPage/PullsTab/PullsTable/createPullsTableData.tsx
+++ b/src/pages/RepoPage/PullsTab/PullsTable/createPullsTableData.tsx
@@ -26,9 +26,9 @@ export const createPullsTableData = ({ pulls }: { pulls?: Array<Pull> }) => {
     if (
       pull?.head?.bundleAnalysisReport?.__typename === 'BundleAnalysisReport'
     ) {
-      bundleAnalysis = <p className="text-right">Upload: &#x2705;</p>
+      bundleAnalysis = <span>Upload: &#x2705;</span>
     } else {
-      bundleAnalysis = <p className="text-right">Upload: &#x274C;</p>
+      bundleAnalysis = <span>Upload: &#x274C;</span>
     }
 
     return {

--- a/src/pages/RepoPage/PullsTab/PullsTable/createPullsTableData.tsx
+++ b/src/pages/RepoPage/PullsTab/PullsTable/createPullsTableData.tsx
@@ -26,9 +26,9 @@ export const createPullsTableData = ({ pulls }: { pulls?: Array<Pull> }) => {
     if (
       pull?.head?.bundleAnalysisReport?.__typename === 'BundleAnalysisReport'
     ) {
-      bundleAnalysis = <span>Upload: &#x2705;</span>
+      bundleAnalysis = <>Upload: &#x2705;</>
     } else {
-      bundleAnalysis = <span>Upload: &#x274C;</span>
+      bundleAnalysis = <>Upload: &#x274C;</>
     }
 
     return {

--- a/src/pages/RepoPage/PullsTab/PullsTableTeam/PullsTableTeam.tsx
+++ b/src/pages/RepoPage/PullsTab/PullsTableTeam/PullsTableTeam.tsx
@@ -148,6 +148,9 @@ export default function PullsTableTeam() {
           <colgroup>
             <col className="w-full @sm/table:w-10/12" />
             <col className="@sm/table:w-2/12" />
+            {overview?.bundleAnalysisEnabled ? (
+              <col className="@sm/table:w-1/12" />
+            ) : null}
           </colgroup>
           <thead>
             {table.getHeaderGroups().map((headerGroup) => (
@@ -155,9 +158,9 @@ export default function PullsTableTeam() {
                 {headerGroup.headers.map((header) => (
                   <th key={header.id} scope="col">
                     <div
-                      className={cs('flex gap-1 items-center', {
-                        'flex-row-reverse justify-end': header.id === 'title',
-                        'justify-end': header.id === 'patch',
+                      className={cs('text-xs', {
+                        'text-left': header.id === 'title',
+                        'text-right': header.id !== 'title',
                       })}
                     >
                       {flexRender(
@@ -186,7 +189,7 @@ export default function PullsTableTeam() {
                       className={cs('text-sm', {
                         'w-full max-w-0 font-medium @md/table:w-auto @md/table:max-w-none':
                           cell.column.id === 'title',
-                        'justify-end': cell.column.id === 'patch',
+                        'text-right': cell.column.id !== 'title',
                       })}
                     >
                       {flexRender(

--- a/src/pages/RepoPage/PullsTab/PullsTableTeam/createPullsTableTeamData.spec.tsx
+++ b/src/pages/RepoPage/PullsTab/PullsTableTeam/createPullsTableTeamData.spec.tsx
@@ -87,15 +87,13 @@ describe('createPullsTableTeamData', () => {
         })
 
         expect(result[0]?.patch).toStrictEqual(
-          <div className="text-right">
-            <TotalsNumber
-              large={false}
-              light={false}
-              plain={true}
-              showChange={false}
-              value={100}
-            />
-          </div>
+          <TotalsNumber
+            large={false}
+            light={false}
+            plain={true}
+            showChange={false}
+            value={100}
+          />
         )
       })
 
@@ -125,15 +123,13 @@ describe('createPullsTableTeamData', () => {
           })
 
           expect(result[0]?.patch).toStrictEqual(
-            <div className="text-right">
-              <TotalsNumber
-                large={false}
-                light={false}
-                plain={true}
-                showChange={false}
-                value={0}
-              />
-            </div>
+            <TotalsNumber
+              large={false}
+              light={false}
+              plain={true}
+              showChange={false}
+              value={0}
+            />
           )
         })
       })
@@ -164,9 +160,7 @@ describe('createPullsTableTeamData', () => {
           pages: [{ pulls: [pullData] }],
         })
 
-        expect(result[0]?.bundleAnalysis).toStrictEqual(
-          <p className="text-right">Upload: ❌</p>
-        )
+        expect(result[0]?.bundleAnalysis).toStrictEqual(<>Upload: ❌</>)
       })
     })
 
@@ -195,9 +189,7 @@ describe('createPullsTableTeamData', () => {
           pages: [{ pulls: [pullData] }],
         })
 
-        expect(result[0]?.bundleAnalysis).toStrictEqual(
-          <p className="text-right">Upload: ✅</p>
-        )
+        expect(result[0]?.bundleAnalysis).toStrictEqual(<>Upload: ✅</>)
       })
     })
 

--- a/src/pages/RepoPage/PullsTab/PullsTableTeam/createPullsTableTeamData.tsx
+++ b/src/pages/RepoPage/PullsTab/PullsTableTeam/createPullsTableTeamData.tsx
@@ -27,15 +27,13 @@ export const createPullsTableTeamData = ({
       const patchPercentage =
         pull?.compareWithBase?.patchTotals?.percentCovered ?? 0
       patch = (
-        <div className="text-right">
-          <TotalsNumber
-            plain={true}
-            large={false}
-            light={false}
-            value={patchPercentage}
-            showChange={false}
-          />
-        </div>
+        <TotalsNumber
+          plain={true}
+          large={false}
+          light={false}
+          value={patchPercentage}
+          showChange={false}
+        />
       )
     }
 
@@ -43,9 +41,9 @@ export const createPullsTableTeamData = ({
     if (
       pull?.head?.bundleAnalysisReport?.__typename === 'BundleAnalysisReport'
     ) {
-      bundleAnalysis = <p className="text-right">Upload: &#x2705;</p>
+      bundleAnalysis = <>Upload: &#x2705;</>
     } else {
-      bundleAnalysis = <p className="text-right">Upload: &#x274C;</p>
+      bundleAnalysis = <>Upload: &#x274C;</>
     }
 
     const updatestamp = pull?.updatestamp ?? undefined


### PR DESCRIPTION
# Description

Some quick fixes to the commits and pulls tables.

# Notable Changes

- Update Commits table regular and team for both repo page and pulls page
- Update Pulls table regular and team

# Screenshots

Before:

![Screenshot 2024-03-05 at 09 22 48](https://github.com/codecov/gazebo/assets/105234307/4923340c-1019-4d49-92eb-bced35d2edff)

After:

![Screenshot 2024-03-05 at 09 22 44](https://github.com/codecov/gazebo/assets/105234307/e21965fa-a90a-4588-a22d-a1bbdc9defa3)

Before:

![Screenshot 2024-03-05 at 09 22 08](https://github.com/codecov/gazebo/assets/105234307/0ce588dd-7e55-4ffa-bc94-0937168d1920)

After:

![Screenshot 2024-03-05 at 09 22 12](https://github.com/codecov/gazebo/assets/105234307/80453179-e75a-44f5-887e-11a8907f53bf)