### PR TITLE
fix: Swap to using repo overview instead of settings

### DIFF
--- a/src/pages/CommitDetailPage/CommitCoverage/UploadsCard/useUploads/useUploads.js
+++ b/src/pages/CommitDetailPage/CommitCoverage/UploadsCard/useUploads/useUploads.js
@@ -1,14 +1,14 @@
 import { useParams } from 'react-router-dom'
 
 import { useCommit } from 'services/commit'
-import { useRepoSettings } from 'services/repo'
+import { useRepoOverview } from 'services/repo'
 import { TierNames, useTier } from 'services/tier'
 import { useFlags } from 'shared/featureFlags'
 import { extractUploads } from 'shared/utils/extractUploads'
 
 export function useUploads() {
   const { provider, owner, repo, commit } = useParams()
-  const { data: settings } = useRepoSettings()
+  const { data: overview } = useRepoOverview({ provider, owner, repo })
   const { multipleTiers } = useFlags({
     multipleTiers: false,
   })
@@ -16,9 +16,7 @@ export function useUploads() {
 
   // TODO: We need backend functionality to properly manage access to carryforward flags for team tier members
   const isTeamPlan =
-    multipleTiers &&
-    tierData === TierNames.TEAM &&
-    settings?.repository?.private
+    multipleTiers && tierData === TierNames.TEAM && overview?.private
 
   const { data } = useCommit({
     provider,

--- a/src/pages/CommitDetailPage/CommitCoverage/UploadsCard/useUploads/useUploads.spec.js
+++ b/src/pages/CommitDetailPage/CommitCoverage/UploadsCard/useUploads/useUploads.spec.js
@@ -18,6 +18,20 @@ import { useUploads } from './useUploads'
 
 jest.mock('shared/featureFlags')
 
+const mockOverview = {
+  owner: {
+    repository: {
+      __typename: 'Repository',
+      private: true,
+      defaultBranch: 'main',
+      oldestCommitAt: '2022-10-10T11:59:59',
+      coverageEnabled: true,
+      bundleAnalysisEnabled: true,
+      languages: ['typescript'],
+    },
+  },
+}
+
 const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
@@ -60,13 +74,8 @@ describe('useUploads', () => {
           })
         )
       }),
-      graphql.query('GetRepoSettings', (req, res, ctx) => {
-        return res(
-          ctx.status(200),
-          ctx.data({
-            owner: { repository: { private: true } },
-          })
-        )
+      graphql.query('GetRepoOverview', (req, res, ctx) => {
+        return res(ctx.status(200), ctx.data(mockOverview))
       })
     )
   }

--- a/src/pages/PullRequestPage/PullCoverage/PullCoverage.jsx
+++ b/src/pages/PullRequestPage/PullCoverage/PullCoverage.jsx
@@ -4,7 +4,7 @@ import { Redirect, Switch, useParams } from 'react-router-dom'
 import { SentryRoute } from 'sentry'
 
 import SilentNetworkErrorWrapper from 'layouts/shared/SilentNetworkErrorWrapper'
-import { useRepoSettings } from 'services/repo'
+import { useRepoOverview } from 'services/repo'
 import { TierNames, useTier } from 'services/tier'
 import { useFlags } from 'shared/featureFlags'
 import { ComparisonReturnType } from 'shared/utils/comparison'
@@ -35,15 +35,13 @@ const Loader = () => (
 
 function PullCoverageContent() {
   const { owner, repo, pullId, provider } = useParams()
-  const { data: settings } = useRepoSettings()
+  const { data: overview } = useRepoOverview({ provider, owner, repo })
   const { multipleTiers } = useFlags({
     multipleTiers: false,
   })
   const { data: tierData } = useTier({ provider, owner })
   const isTeamPlan =
-    multipleTiers &&
-    tierData === TierNames.TEAM &&
-    settings?.repository?.private
+    multipleTiers && tierData === TierNames.TEAM && overview?.private
 
   const { data } = usePullPageData({
     provider,
@@ -128,15 +126,13 @@ function PullCoverageContent() {
 
 function PullCoverage() {
   const { owner, repo, pullId, provider } = useParams()
-  const { data: settings } = useRepoSettings()
+  const { data: overview } = useRepoOverview({ provider, owner, repo })
   const { multipleTiers } = useFlags({
     multipleTiers: false,
   })
   const { data: tierData } = useTier({ provider, owner })
   const isTeamPlan =
-    multipleTiers &&
-    tierData === TierNames.TEAM &&
-    settings?.repository?.private
+    multipleTiers && tierData === TierNames.TEAM && overview?.private
 
   const { data } = usePullPageData({
     provider,

--- a/src/pages/PullRequestPage/PullCoverage/PullCoverage.spec.jsx
+++ b/src/pages/PullRequestPage/PullCoverage/PullCoverage.spec.jsx
@@ -114,6 +114,20 @@ const mockPullDataTeam = {
   },
 }
 
+const mockOverview = {
+  owner: {
+    repository: {
+      __typename: 'Repository',
+      private: true,
+      defaultBranch: 'main',
+      oldestCommitAt: '2022-10-10T11:59:59',
+      coverageEnabled: true,
+      bundleAnalysisEnabled: true,
+      languages: ['typescript'],
+    },
+  },
+}
+
 const queryClient = new QueryClient({
   defaultOptions: { queries: { retry: false } },
 })
@@ -165,13 +179,8 @@ describe('PullRequestPageContent', () => {
         }
         return res(ctx.status(200), ctx.data(mockPullData(resultType)))
       }),
-      graphql.query('GetRepoSettings', (req, res, ctx) => {
-        return res(
-          ctx.status(200),
-          ctx.data({
-            owner: { repository: { private: true } },
-          })
-        )
+      graphql.query('GetRepoOverview', (req, res, ctx) => {
+        return res(ctx.status(200), ctx.data(mockOverview))
       }),
       graphql.query('OwnerTier', (req, res, ctx) => {
         return res(

--- a/src/pages/PullRequestPage/PullCoverage/PullCoverageTabs/PullCoverageTabs.spec.jsx
+++ b/src/pages/PullRequestPage/PullCoverage/PullCoverageTabs/PullCoverageTabs.spec.jsx
@@ -11,6 +11,20 @@ import PullCoverageTabs from './PullCoverageTabs'
 
 jest.mock('shared/featureFlags')
 
+const mockOverview = (privateRepo = false) => ({
+  owner: {
+    repository: {
+      __typename: 'Repository',
+      private: privateRepo,
+      defaultBranch: 'main',
+      oldestCommitAt: '2022-10-10T11:59:59',
+      coverageEnabled: true,
+      bundleAnalysisEnabled: true,
+      languages: ['typescript'],
+    },
+  },
+})
+
 const mockCommits = {
   owner: {
     repository: {
@@ -186,13 +200,8 @@ describe('PullCoverageTabs', () => {
           })
         )
       }),
-      graphql.query('GetRepoSettings', (req, res, ctx) => {
-        return res(
-          ctx.status(200),
-          ctx.data({
-            owner: { repository: { private: privateRepo } },
-          })
-        )
+      graphql.query('GetRepoOverview', (req, res, ctx) => {
+        return res(ctx.status(200), ctx.data(mockOverview(privateRepo)))
       }),
       graphql.query('FlagsSelect', (req, res, ctx) => {
         return res(ctx.status(200), ctx.data(mockFlagsResponse))

--- a/src/pages/PullRequestPage/PullRequestPage.spec.tsx
+++ b/src/pages/PullRequestPage/PullRequestPage.spec.tsx
@@ -122,6 +122,20 @@ const mockPullBADropdownSummary = {
   },
 }
 
+const mockOverview = (privateRepo = false) => ({
+  owner: {
+    repository: {
+      __typename: 'Repository',
+      private: privateRepo,
+      defaultBranch: 'main',
+      oldestCommitAt: '2022-10-10T11:59:59',
+      coverageEnabled: true,
+      bundleAnalysisEnabled: true,
+      languages: ['typescript'],
+    },
+  },
+})
+
 const queryClient = new QueryClient({
   defaultOptions: { queries: { retry: false, suspense: true } },
 })
@@ -207,13 +221,8 @@ describe('PullRequestPage', () => {
           })
         )
       }),
-      graphql.query('GetRepoSettings', (req, res, ctx) => {
-        return res(
-          ctx.status(200),
-          ctx.data({
-            owner: { repository: { private: privateRepo } },
-          })
-        )
+      graphql.query('GetRepoOverview', (req, res, ctx) => {
+        return res(ctx.status(200), ctx.data(mockOverview(privateRepo)))
       }),
       graphql.query('OwnerTier', (req, res, ctx) => {
         return res(

--- a/src/pages/PullRequestPage/PullRequestPage.tsx
+++ b/src/pages/PullRequestPage/PullRequestPage.tsx
@@ -3,7 +3,7 @@ import { lazy, Suspense } from 'react'
 import { useLocation, useParams } from 'react-router-dom'
 
 import NotFound from 'pages/NotFound'
-import { useRepoSettings } from 'services/repo'
+import { useRepoOverview } from 'services/repo'
 import { TierNames, useTier } from 'services/tier'
 import { useFlags } from 'shared/featureFlags'
 import Breadcrumb from 'ui/Breadcrumb'
@@ -47,13 +47,11 @@ function PullRequestPage() {
     bundleAnalysisPrAndCommitPages: false,
   })
 
-  const { data: settings } = useRepoSettings()
+  const { data: overview } = useRepoOverview({ provider, owner, repo })
 
   const { data: tierData } = useTier({ provider, owner })
   const isTeamPlan =
-    multipleTiers &&
-    tierData === TierNames.TEAM &&
-    settings?.repository?.private
+    multipleTiers && tierData === TierNames.TEAM && overview?.private
 
   const { data, isLoading } = usePullPageData({
     provider,


### PR DESCRIPTION
# Description

In `useRepoSettings` there's a field that requires a user to be authenticated, however we're using it on pages where we cannot be sure a user will be authenticated. This PR replaces the use of `useRepoSetttings` to `useRepoOverview` that does not require a user to be authenticated.

# Notable Changes

- Update `PullCoverageTabs`
- Update `PullCoverage`
- Update `PullRequestPage`
- Update `useUploads`
