### PR TITLE
ref: Remove old deprecated format time to string

### DIFF
--- a/src/pages/PullRequestPage/PullBundleAnalysis/PullBundleHeadTable/PullBundleHeadTable.spec.tsx
+++ b/src/pages/PullRequestPage/PullBundleAnalysis/PullBundleHeadTable/PullBundleHeadTable.spec.tsx
@@ -202,7 +202,7 @@ describe('PullBundleHeadTable', () => {
         setup()
         render(<PullBundleHeadTable />, { wrapper })
 
-        const loadTime = await screen.findByText('200s')
+        const loadTime = await screen.findByText('200ms')
         expect(loadTime).toBeInTheDocument()
       })
     })

--- a/src/pages/PullRequestPage/PullBundleAnalysis/PullBundleHeadTable/PullBundleHeadTable.tsx
+++ b/src/pages/PullRequestPage/PullBundleAnalysis/PullBundleHeadTable/PullBundleHeadTable.tsx
@@ -13,7 +13,7 @@ import { useParams } from 'react-router-dom'
 import { usePullBundleHeadList } from 'services/pull/usePullBundleHeadList'
 import {
   formatSizeToString,
-  formatTimeToStringDeprecated,
+  formatTimeToString,
 } from 'shared/utils/bundleAnalysis'
 import Icon from 'ui/Icon'
 
@@ -45,7 +45,7 @@ const columns = [
   }),
   columnHelper.accessor('loadTime', {
     header: 'Estimated load time (3G)',
-    cell: (info) => formatTimeToStringDeprecated(info.getValue()),
+    cell: (info) => formatTimeToString(info.getValue()),
   }),
 ]
 

--- a/src/pages/RepoPage/BundlesTab/BundleContent/BundleContent.spec.tsx
+++ b/src/pages/RepoPage/BundlesTab/BundleContent/BundleContent.spec.tsx
@@ -39,9 +39,19 @@ const mockBranchBundles = {
           commitid: '543a5268dce725d85be7747c0f9b61e9a68dea57',
           bundleAnalysisReport: {
             __typename: 'BundleAnalysisReport',
-            sizeTotal: 100,
-            loadTimeTotal: 200,
-            bundles: [{ name: 'bundle1', sizeTotal: 50, loadTimeTotal: 100 }],
+            bundleData: {
+              loadTime: { threeG: 200 },
+              size: { uncompress: 100 },
+            },
+            bundles: [
+              {
+                name: 'bundle1',
+                bundleData: {
+                  loadTime: { threeG: 100 },
+                  size: { uncompress: 50 },
+                },
+              },
+            ],
           },
         },
       },
@@ -268,7 +278,7 @@ describe('BundleContent', () => {
           const bundleSize = await screen.findByText(/50B/)
           expect(bundleSize).toBeInTheDocument()
 
-          const bundleLoadTime = await screen.findByText(/100s/)
+          const bundleLoadTime = await screen.findByText(/100ms/)
           expect(bundleLoadTime).toBeInTheDocument()
         })
       })

--- a/src/pages/RepoPage/BundlesTab/BundleContent/BundleSummaryOld/BundleSummaryOld.spec.tsx
+++ b/src/pages/RepoPage/BundlesTab/BundleContent/BundleSummaryOld/BundleSummaryOld.spec.tsx
@@ -41,9 +41,20 @@ const mockBranchBundles = (
           commitid,
           bundleAnalysisReport: {
             __typename: 'BundleAnalysisReport',
-            sizeTotal: 100,
-            loadTimeTotal: 200,
-            bundles: [{ name: 'bundle1', sizeTotal: 50, loadTimeTotal: 100 }],
+
+            bundleData: {
+              loadTime: { threeG: 200 },
+              size: { uncompress: 100 },
+            },
+            bundles: [
+              {
+                name: 'bundle1',
+                bundleData: {
+                  loadTime: { threeG: 100 },
+                  size: { uncompress: 50 },
+                },
+              },
+            ],
           },
         },
       },

--- a/src/pages/RepoPage/BundlesTab/BundleContent/BundleSummaryOld/BundleSummaryOld.tsx
+++ b/src/pages/RepoPage/BundlesTab/BundleContent/BundleSummaryOld/BundleSummaryOld.tsx
@@ -23,7 +23,8 @@ const BundleSummaryOld: React.FC = () => {
 
   if (branchHead?.bundleAnalysisReport?.__typename === 'BundleAnalysisReport') {
     const shortSha = branchHead?.commitid?.slice(0, 7)
-    const sizeTotal = branchHead?.bundleAnalysisReport?.sizeTotal
+    const sizeTotal =
+      branchHead?.bundleAnalysisReport?.bundleData?.size?.uncompress
 
     return (
       <div className="bg-ds-gray-primary p-4">

--- a/src/pages/RepoPage/BundlesTab/BundleContent/BundleTable/BundleTable.spec.tsx
+++ b/src/pages/RepoPage/BundlesTab/BundleContent/BundleTable/BundleTable.spec.tsx
@@ -31,9 +31,19 @@ const mockBranchBundles = {
           commitid: '543a5268dce725d85be7747c0f9b61e9a68dea57',
           bundleAnalysisReport: {
             __typename: 'BundleAnalysisReport',
-            sizeTotal: 100,
-            loadTimeTotal: 200,
-            bundles: [{ name: 'bundle1', sizeTotal: 50, loadTimeTotal: 100 }],
+            bundleData: {
+              loadTime: { threeG: 200 },
+              size: { uncompress: 100 },
+            },
+            bundles: [
+              {
+                name: 'bundle1',
+                bundleData: {
+                  loadTime: { threeG: 100 },
+                  size: { uncompress: 50 },
+                },
+              },
+            ],
           },
         },
       },
@@ -50,8 +60,10 @@ const mockBranchBundlesEmpty = {
           commitid: '543a5268dce725d85be7747c0f9b61e9a68dea57',
           bundleAnalysisReport: {
             __typename: 'BundleAnalysisReport',
-            sizeTotal: 0,
-            loadTimeTotal: 0,
+            bundleData: {
+              loadTime: { threeG: 0 },
+              size: { uncompress: 0 },
+            },
             bundles: [],
           },
         },
@@ -194,7 +206,7 @@ describe('BundleTable', () => {
         setup()
         render(<BundleTable />, { wrapper })
 
-        const loadTime = await screen.findByText('100s')
+        const loadTime = await screen.findByText('100ms')
         expect(loadTime).toBeInTheDocument()
       })
     })

--- a/src/pages/RepoPage/BundlesTab/BundleContent/BundleTable/BundleTable.tsx
+++ b/src/pages/RepoPage/BundlesTab/BundleContent/BundleTable/BundleTable.tsx
@@ -13,7 +13,7 @@ import { useParams } from 'react-router-dom'
 import { useBranchBundleSummary } from 'services/bundleAnalysis'
 import {
   formatSizeToString,
-  formatTimeToStringDeprecated,
+  formatTimeToString,
 } from 'shared/utils/bundleAnalysis'
 import Icon from 'ui/Icon'
 
@@ -44,7 +44,7 @@ const columns = [
   }),
   columnHelper.accessor('loadTime', {
     header: 'Estimated load time (3G)',
-    cell: (info) => formatTimeToStringDeprecated(info.getValue()),
+    cell: (info) => formatTimeToString(info.getValue()),
   }),
 ]
 
@@ -62,8 +62,8 @@ export const useTableData = () => {
 
     return data?.branch?.head?.bundleAnalysisReport?.bundles?.map((bundle) => ({
       name: bundle.name,
-      currSize: bundle.sizeTotal,
-      loadTime: bundle.loadTimeTotal,
+      currSize: bundle.bundleData.size.uncompress,
+      loadTime: bundle.bundleData.loadTime.threeG,
     }))
   }, [data])
 }

--- a/src/services/bundleAnalysis/useBranchBundleSummary.spec.tsx
+++ b/src/services/bundleAnalysis/useBranchBundleSummary.spec.tsx
@@ -28,8 +28,6 @@ const mockBranchBundleSummary = {
           commitid: '543a5268dce725d85be7747c0f9b61e9a68dea57',
           bundleAnalysisReport: {
             __typename: 'BundleAnalysisReport',
-            sizeTotal: 100,
-            loadTimeTotal: 200,
             bundleData: {
               loadTime: { threeG: 200 },
               size: { uncompress: 100 },

--- a/src/services/bundleAnalysis/useBranchBundleSummary.spec.tsx
+++ b/src/services/bundleAnalysis/useBranchBundleSummary.spec.tsx
@@ -30,7 +30,19 @@ const mockBranchBundleSummary = {
             __typename: 'BundleAnalysisReport',
             sizeTotal: 100,
             loadTimeTotal: 200,
-            bundles: [{ name: 'bundle1', sizeTotal: 50, loadTimeTotal: 100 }],
+            bundleData: {
+              loadTime: { threeG: 200 },
+              size: { uncompress: 100 },
+            },
+            bundles: [
+              {
+                name: 'bundle1',
+                bundleData: {
+                  loadTime: { threeG: 100 },
+                  size: { uncompress: 50 },
+                },
+              },
+            ],
           },
         },
       },
@@ -188,10 +200,18 @@ describe('useBranchBundleSummary', () => {
               commitid: '543a5268dce725d85be7747c0f9b61e9a68dea57',
               bundleAnalysisReport: {
                 __typename: 'BundleAnalysisReport',
-                sizeTotal: 100,
-                loadTimeTotal: 200,
+                bundleData: {
+                  loadTime: { threeG: 200 },
+                  size: { uncompress: 100 },
+                },
                 bundles: [
-                  { name: 'bundle1', sizeTotal: 50, loadTimeTotal: 100 },
+                  {
+                    name: 'bundle1',
+                    bundleData: {
+                      loadTime: { threeG: 100 },
+                      size: { uncompress: 50 },
+                    },
+                  },
                 ],
               },
             },

--- a/src/services/bundleAnalysis/useBranchBundleSummary.tsx
+++ b/src/services/bundleAnalysis/useBranchBundleSummary.tsx
@@ -13,14 +13,26 @@ import A from 'ui/A'
 
 const BundleSchema = z.object({
   name: z.string(),
-  sizeTotal: z.number(),
-  loadTimeTotal: z.number(),
+  bundleData: z.object({
+    loadTime: z.object({
+      threeG: z.number(),
+    }),
+    size: z.object({
+      uncompress: z.number(),
+    }),
+  }),
 })
 
 const BundleAnalysisReportSchema = z.object({
   __typename: z.literal('BundleAnalysisReport'),
-  sizeTotal: z.number(),
-  loadTimeTotal: z.number(),
+  bundleData: z.object({
+    loadTime: z.object({
+      threeG: z.number(),
+    }),
+    size: z.object({
+      uncompress: z.number(),
+    }),
+  }),
   bundles: z.array(BundleSchema),
 })
 
@@ -72,12 +84,24 @@ const query = `query BranchBundleSummaryData(
             bundleAnalysisReport {
               __typename
               ... on BundleAnalysisReport {
-                sizeTotal
-                loadTimeTotal
+                bundleData {
+                  loadTime {
+                    threeG
+                  }
+                  size {
+                    uncompress
+                  }
+                }
                 bundles {
                   name
-                  sizeTotal
-                  loadTimeTotal
+                  bundleData {
+                    loadTime {
+                      threeG
+                    }
+                    size {
+                      uncompress
+                    }
+                  }
                 }
               }
               ... on MissingHeadReport {

--- a/src/shared/utils/bundleAnalysis.spec.ts
+++ b/src/shared/utils/bundleAnalysis.spec.ts
@@ -1,8 +1,4 @@
-import {
-  formatSizeToString,
-  formatTimeToString,
-  formatTimeToStringDeprecated,
-} from './bundleAnalysis'
+import { formatSizeToString, formatTimeToString } from './bundleAnalysis'
 
 describe('formatSizeToString', () => {
   describe('size is less then one kilobyte', () => {
@@ -99,12 +95,5 @@ describe('formatTimeToString', () => {
       const time = formatTimeToString(123)
       expect(time).toBe('123ms')
     })
-  })
-})
-
-describe('formatTimeToStringDeprecated', () => {
-  it('returns time in seconds', () => {
-    const time = formatTimeToStringDeprecated(123)
-    expect(time).toBe('123s')
   })
 })

--- a/src/shared/utils/bundleAnalysis.ts
+++ b/src/shared/utils/bundleAnalysis.ts
@@ -57,10 +57,3 @@ export const formatTimeToString = (milliseconds: number) => {
     unit: 'millisecond',
   }).format(milliseconds)
 }
-
-export const formatTimeToStringDeprecated = (seconds: number) => {
-  return Intl.NumberFormat('en-US', {
-    ...formatSettings,
-    unit: 'second',
-  }).format(seconds)
-}


### PR DESCRIPTION
# Description

Small updates to use new GQL fields missed in previous updates, as well as moving to use the updated format time to string function.

# Notable Changes

- Remove old format time to string hook
- Update to use new format function
- Update components to use new functions
- Update tests