### PR TITLE
don't get planData if user is not in org

### DIFF
--- a/src/shared/GlobalTopBanners/TrialBanner/TrialBanner.tsx
+++ b/src/shared/GlobalTopBanners/TrialBanner/TrialBanner.tsx
@@ -45,15 +45,14 @@ const TrialBanner: React.FC = () => {
     providerString = provider
   }
 
-  const { data: planData } = usePlanData({
-    provider: providerString,
-    owner: owner || '',
-    opts: { enabled: enableQuery },
-  })
-
   const { data: ownerData } = useOwner({
     username: owner,
     opts: { enabled: enableQuery },
+  })
+  const { data: planData } = usePlanData({
+    provider: providerString,
+    owner: owner || '',
+    opts: { enabled: ownerData?.isCurrentUserPartOfOrg },
   })
 
   const planValue = planData?.plan?.value


### PR DESCRIPTION
# Description

TrialBanner is called by anyone visiting a org page, this change make it so that we don't retrieve the plan data of the org for users not belonging in the org. This change is necessary because in the API there is a change that hides plan / planData / hasPrivateRepos.

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.