### PR TITLE
feat: Show invoice page when usesInvoice is true

### DIFF
--- a/src/pages/PlanPage/subRoutes/CurrentOrgPlan/BillingDetails/EmailAddress/EmailAddress.tsx
+++ b/src/pages/PlanPage/subRoutes/CurrentOrgPlan/BillingDetails/EmailAddress/EmailAddress.tsx
@@ -83,7 +83,6 @@ function EmailAddress() {
           />
           {errors?.newCustomerEmail && (
             <p className="rounded-md bg-ds-error-quinary p-3 text-ds-error-nonary">
-              {/* @ts-expect-error */}
               {errors?.newCustomerEmail?.message}
             </p>
           )}

--- a/src/pages/PlanPage/subRoutes/CurrentOrgPlan/CurrentOrgPlan.tsx
+++ b/src/pages/PlanPage/subRoutes/CurrentOrgPlan/CurrentOrgPlan.tsx
@@ -20,10 +20,10 @@ function CurrentOrgPlan() {
     owner,
   })
 
-  const shouldRenderBillingDetails = [
-    accountDetails?.planProvider !== 'github',
-    !accountDetails?.rootOrganization,
-  ].every(Boolean)
+  const shouldRenderBillingDetails =
+    (accountDetails?.planProvider !== 'github' &&
+      !accountDetails?.rootOrganization) ||
+    accountDetails?.usesInvoice
 
   return (
     <div className="w-full lg:w-4/5">

--- a/src/services/account/propTypes.js
+++ b/src/services/account/propTypes.js
@@ -2,7 +2,7 @@ import PropType from 'prop-types'
 
 export const invoicePropType = PropType.shape({
   created: PropType.number.isRequired,
-  dueDate: PropType.number.isRequired,
+  dueDate: PropType.number,
   total: PropType.number.isRequired,
   invoicePdf: PropType.string.isRequired,
 })

--- a/src/services/account/useAccountDetails.ts
+++ b/src/services/account/useAccountDetails.ts
@@ -175,12 +175,10 @@ export function useAccountDetails({
         // TODO: remove this bandage once we convert remaining useAccountDetails components to TS
         // including tests.
         if (process.env.REACT_APP_ZOD_IGNORE_TESTS === 'true') {
-          return res
+          return res as z.infer<typeof AccountDetailsSchema>
         }
 
         const parsedRes = AccountDetailsSchema.safeParse(res)
-
-        console.log(parsedRes)
 
         if (!parsedRes.success) {
           return Promise.reject({

--- a/src/services/account/useAccountDetails.ts
+++ b/src/services/account/useAccountDetails.ts
@@ -77,7 +77,7 @@ export const SubscriptionDetailSchema = z
     currentPeriodEnd: z.number(),
     customer: z
       .object({
-        discount: z.number(),
+        discount: z.number().nullable(),
         email: z.string(),
       })
       .nullable(),


### PR DESCRIPTION
# Description

shows the invoice and billing components when usesInvoice is true, regardless of the user's plan provider or rootOrganization.

# Code Example

# Notable Changes

Just adding a conditional to the component, one small thing I did was alias the zod shortcircuit thing with the schema so we could get the type inference throughout the app. I didn't realize it went away when I added the conditional so this is just to square away that front :) 

# Screenshots

<img width="1638" alt="Screenshot 2024-03-06 at 10 08 45 AM" src="https://github.com/codecov/gazebo/assets/159853603/5e7f3fd1-ce01-4245-b493-92422386fff9">


# Manual Testing

- Tested locally by going to the plans page
- From there, shortcircuited BillingDetails.tsx and LatestInvoiceCard.tsx with mock data (locally) to confirm it popped up as expected. 
- Screenshot above

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.