### PR TITLE
fix: update discount schema with proper zod object

### DIFF
--- a/src/services/account/mocks.js
+++ b/src/services/account/mocks.js
@@ -98,7 +98,13 @@ export const accountDetailsObject = {
     cancel_at_period_end: false,
     current_period_end: 1636479475,
     customer: {
-      discount: 25,
+      id: 'blahblah',
+      discount: {
+        name: 'yep',
+        percent_off: 25,
+        duration_in_months: 12,
+        expires: 1,
+      },
       email: 'niceone@gmail.com',
     },
     collection_method: null,
@@ -204,7 +210,13 @@ export const accountDetailsParsedObj = {
     cancelAtPeriodEnd: false,
     currentPeriodEnd: 1636479475,
     customer: {
-      discount: 25,
+      id: 'blahblah',
+      discount: {
+        name: 'yep',
+        percentOff: 25,
+        durationInMonths: 12,
+        expires: 1,
+      },
       email: 'niceone@gmail.com',
     },
     collectionMethod: null,

--- a/src/services/account/useAccountDetails.ts
+++ b/src/services/account/useAccountDetails.ts
@@ -77,8 +77,15 @@ export const SubscriptionDetailSchema = z
     currentPeriodEnd: z.number(),
     customer: z
       .object({
-        // TODO: fix this. This has a different shape in the backend, not just an int
-        discount: z.number().nullish(),
+        id: z.string(),
+        discount: z
+          .object({
+            name: z.string(),
+            percentOff: z.number(),
+            durationInMonths: z.number(),
+            expires: z.number(),
+          })
+          .nullish(),
         email: z.string(),
       })
       .nullable(),


### PR DESCRIPTION
# Description

updates the discount schema used in the `account-details` rest endpoint with the proper keys

# Code Example

# Notable Changes

N/A, copied directly from the serializer here: https://github.com/codecov/codecov-api/blob/daacd21fe6982c5f53f941669299dbe086c58a75/api/internal/owner/serializers.py#L83-L102

Additionally updated the mocks for the UT to account for this update

# Screenshots

# Link to Sample Entry

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.