### PR TITLE
feat: add Sentry metrics to network error boundary

### DIFF
--- a/src/layouts/shared/NetworkErrorBoundary/NetworkErrorBoundary.jsx
+++ b/src/layouts/shared/NetworkErrorBoundary/NetworkErrorBoundary.jsx
@@ -14,6 +14,10 @@ import img403 from './assets/error-403.svg'
 import img404 from './assets/error-404.svg'
 import img500 from './assets/error-500.svg'
 import styles from './NetworkErrorBoundary.module.css'
+import {
+  sendGraphQLErrorMetrics,
+  sendNetworkErrorMetrics,
+} from './networkErrorMetrics'
 
 const errorToUI = {
   401: {
@@ -151,10 +155,15 @@ class NetworkErrorBoundary extends Component {
     // if the error is not a network error, we don't do anything and
     // another error boundary will take it from there
     if (Object.keys(errorToUI).includes(String(error.status))) {
+      sendNetworkErrorMetrics(error.status)
       return { hasNetworkError: true, error }
     }
-    if (Object.keys(graphQLErrorToUI).includes(error.__typename))
+
+    if (Object.keys(graphQLErrorToUI).includes(error.__typename)) {
+      sendGraphQLErrorMetrics(error.__typename)
       return { hasGraphqlError: true, error }
+    }
+
     return {}
   }
 

--- a/src/layouts/shared/NetworkErrorBoundary/NetworkErrorBoundary.spec.jsx
+++ b/src/layouts/shared/NetworkErrorBoundary/NetworkErrorBoundary.spec.jsx
@@ -190,7 +190,7 @@ describe('NetworkErrorBoundary', () => {
 
       await waitFor(() =>
         expect(Sentry.metrics.increment).toHaveBeenCalledWith(
-          'network_errors.401',
+          'network_errors.network_status.401',
           1,
           undefined
         )
@@ -249,7 +249,7 @@ describe('NetworkErrorBoundary', () => {
 
       await waitFor(() =>
         expect(Sentry.metrics.increment).toHaveBeenCalledWith(
-          'network_errors.403',
+          'network_errors.network_status.403',
           1,
           undefined
         )
@@ -325,7 +325,7 @@ describe('NetworkErrorBoundary', () => {
 
       await waitFor(() =>
         expect(Sentry.metrics.increment).toHaveBeenCalledWith(
-          'network_errors.404',
+          'network_errors.network_status.404',
           1,
           undefined
         )
@@ -401,7 +401,7 @@ describe('NetworkErrorBoundary', () => {
 
       await waitFor(() =>
         expect(Sentry.metrics.increment).toHaveBeenCalledWith(
-          'network_errors.500',
+          'network_errors.network_status.500',
           1,
           undefined
         )
@@ -447,7 +447,7 @@ describe('NetworkErrorBoundary', () => {
 
       await waitFor(() =>
         expect(Sentry.metrics.increment).toHaveBeenCalledWith(
-          'network_errors.unauthenticated_error',
+          'network_errors.graphql.unauthenticated_error',
           1,
           undefined
         )

--- a/src/layouts/shared/NetworkErrorBoundary/NetworkErrorBoundary.spec.jsx
+++ b/src/layouts/shared/NetworkErrorBoundary/NetworkErrorBoundary.spec.jsx
@@ -1,5 +1,6 @@
+import * as Sentry from '@sentry/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { render, screen } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { Component, useState } from 'react'
 import { MemoryRouter, useHistory } from 'react-router-dom'
@@ -114,11 +115,8 @@ describe('NetworkErrorBoundary', () => {
   }
 
   describe('when rendered with children', () => {
-    beforeEach(() => {
-      setup()
-    })
-
     it('renders the children', () => {
+      setup()
       render(<App status={200} />, { wrapper: wrapper() })
 
       expect(screen.getByText(/things are good/)).toBeInTheDocument()
@@ -180,6 +178,24 @@ describe('NetworkErrorBoundary', () => {
       const returnButton = await screen.findByText('Return to previous page')
       expect(returnButton).toBeInTheDocument()
     })
+
+    it('sends metric to sentry', async () => {
+      const { user } = setup()
+      render(<App status={401} detail="not authenticated" />, {
+        wrapper: wrapper(),
+      })
+
+      const textBox = await screen.findByRole('textbox')
+      await user.type(textBox, 'fail')
+
+      await waitFor(() =>
+        expect(Sentry.metrics.increment).toHaveBeenCalledWith(
+          'network_errors.401',
+          1,
+          undefined
+        )
+      )
+    })
   })
 
   describe('when the children component has a 403 error', () => {
@@ -220,6 +236,24 @@ describe('NetworkErrorBoundary', () => {
 
       const button = await screen.findByText('Return to previous page')
       expect(button).toBeInTheDocument()
+    })
+
+    it('sends metric to sentry', async () => {
+      const { user } = setup()
+      render(<App status={403} detail="you not admin" />, {
+        wrapper: wrapper(),
+      })
+
+      const textBox = await screen.findByRole('textbox')
+      await user.type(textBox, 'fail')
+
+      await waitFor(() =>
+        expect(Sentry.metrics.increment).toHaveBeenCalledWith(
+          'network_errors.403',
+          1,
+          undefined
+        )
+      )
     })
   })
 
@@ -279,6 +313,24 @@ describe('NetworkErrorBoundary', () => {
         expect(button).toBeInTheDocument()
       })
     })
+
+    it('sends metric to sentry', async () => {
+      const { user } = setup()
+      render(<App status={404} detail="not found" />, {
+        wrapper: wrapper(),
+      })
+
+      const textBox = await screen.findByRole('textbox')
+      await user.type(textBox, 'fail')
+
+      await waitFor(() =>
+        expect(Sentry.metrics.increment).toHaveBeenCalledWith(
+          'network_errors.404',
+          1,
+          undefined
+        )
+      )
+    })
   })
 
   describe('when the children component has a 500 error', () => {
@@ -337,6 +389,24 @@ describe('NetworkErrorBoundary', () => {
         expect(button).toBeInTheDocument()
       })
     })
+
+    it('sends metric to sentry', async () => {
+      const { user } = setup()
+      render(<App status={500} detail="internal server error" />, {
+        wrapper: wrapper(),
+      })
+
+      const textBox = await screen.findByRole('textbox')
+      await user.type(textBox, 'fail')
+
+      await waitFor(() =>
+        expect(Sentry.metrics.increment).toHaveBeenCalledWith(
+          'network_errors.500',
+          1,
+          undefined
+        )
+      )
+    })
   })
 
   describe('when the children component has an UnauthenticatedError GraphQL error', () => {
@@ -364,6 +434,24 @@ describe('NetworkErrorBoundary', () => {
 
       const button = await screen.findByText('Return to previous page')
       expect(button).toBeInTheDocument()
+    })
+
+    it('sends metric to sentry', async () => {
+      const { user } = setup()
+      render(<App typename="UnauthenticatedError" />, {
+        wrapper: wrapper(),
+      })
+
+      const textBox = await screen.findByRole('textbox')
+      await user.type(textBox, 'fail')
+
+      await waitFor(() =>
+        expect(Sentry.metrics.increment).toHaveBeenCalledWith(
+          'network_errors.unauthenticated_error',
+          1,
+          undefined
+        )
+      )
     })
   })
 

--- a/src/layouts/shared/NetworkErrorBoundary/networkErrorMetrics.spec.ts
+++ b/src/layouts/shared/NetworkErrorBoundary/networkErrorMetrics.spec.ts
@@ -1,0 +1,54 @@
+import * as Sentry from '@sentry/react'
+
+import {
+  sendGraphQLErrorMetrics,
+  sendNetworkErrorMetrics,
+} from './networkErrorMetrics'
+
+describe('networkErrorMetrics', () => {
+  describe('sendNetworkErrorMetrics', () => {
+    it('should send network error metrics', () => {
+      sendNetworkErrorMetrics(401)
+
+      expect(Sentry.metrics.increment).toHaveBeenCalledWith(
+        'network_errors.network_status.401',
+        1,
+        undefined
+      )
+    })
+  })
+})
+
+describe('sendGraphQLErrorMetrics', () => {
+  describe('sendGraphQLErrorMetrics', () => {
+    it('should send UnauthenticatedError metrics', () => {
+      sendGraphQLErrorMetrics('UnauthenticatedError')
+
+      expect(Sentry.metrics.increment).toHaveBeenCalledWith(
+        'network_errors.graphql.unauthenticated_error',
+        1,
+        undefined
+      )
+    })
+
+    it('should send UnauthorizedError metrics', () => {
+      sendGraphQLErrorMetrics('UnauthorizedError')
+
+      expect(Sentry.metrics.increment).toHaveBeenCalledWith(
+        'network_errors.graphql.unauthorized_error',
+        1,
+        undefined
+      )
+    })
+
+    it('should send NotFoundError metrics', () => {
+      sendGraphQLErrorMetrics('NotFoundError')
+
+      expect(Sentry.metrics.increment).toHaveBeenCalledWith(
+        'network_errors.graphql.not_found_error',
+        1,
+        undefined
+      )
+    })
+  })
+})

--- a/src/layouts/shared/NetworkErrorBoundary/networkErrorMetrics.ts
+++ b/src/layouts/shared/NetworkErrorBoundary/networkErrorMetrics.ts
@@ -1,0 +1,47 @@
+import { metrics } from 'shared/utils/metrics'
+
+type SupportNetworkStatusCodes = 401 | 403 | 404 | 500
+
+export const sendNetworkErrorMetrics = (status: SupportNetworkStatusCodes) => {
+  if (status === 401) {
+    metrics.increment('network_errors.401', 1)
+    return
+  }
+
+  if (status === 403) {
+    metrics.increment('network_errors.403', 1)
+    return
+  }
+
+  if (status === 404) {
+    metrics.increment('network_errors.404', 1)
+    return
+  }
+
+  if (status === 500) {
+    metrics.increment('network_errors.500', 1)
+    return
+  }
+}
+
+type GraphQLErrorCodes =
+  | 'UnauthenticatedError'
+  | 'UnauthorizedError'
+  | 'NotFoundError'
+
+export const sendGraphQLErrorMetrics = (status: GraphQLErrorCodes) => {
+  if (status === 'UnauthenticatedError') {
+    metrics.increment('network_errors.unauthenticated_error', 1)
+    return
+  }
+
+  if (status === 'UnauthorizedError') {
+    metrics.increment('network_errors.unauthorized_error', 1)
+    return
+  }
+
+  if (status === 'NotFoundError') {
+    metrics.increment('network_errors.not_found_error', 1)
+    return
+  }
+}

--- a/src/layouts/shared/NetworkErrorBoundary/networkErrorMetrics.ts
+++ b/src/layouts/shared/NetworkErrorBoundary/networkErrorMetrics.ts
@@ -3,25 +3,7 @@ import { metrics } from 'shared/utils/metrics'
 type SupportNetworkStatusCodes = 401 | 403 | 404 | 500
 
 export const sendNetworkErrorMetrics = (status: SupportNetworkStatusCodes) => {
-  if (status === 401) {
-    metrics.increment('network_errors.401', 1)
-    return
-  }
-
-  if (status === 403) {
-    metrics.increment('network_errors.403', 1)
-    return
-  }
-
-  if (status === 404) {
-    metrics.increment('network_errors.404', 1)
-    return
-  }
-
-  if (status === 500) {
-    metrics.increment('network_errors.500', 1)
-    return
-  }
+  metrics.increment(`network_errors.network_status.${status}`, 1)
 }
 
 type GraphQLErrorCodes =
@@ -31,17 +13,17 @@ type GraphQLErrorCodes =
 
 export const sendGraphQLErrorMetrics = (status: GraphQLErrorCodes) => {
   if (status === 'UnauthenticatedError') {
-    metrics.increment('network_errors.unauthenticated_error', 1)
+    metrics.increment('network_errors.graphql.unauthenticated_error', 1)
     return
   }
 
   if (status === 'UnauthorizedError') {
-    metrics.increment('network_errors.unauthorized_error', 1)
+    metrics.increment('network_errors.graphql.unauthorized_error', 1)
     return
   }
 
   if (status === 'NotFoundError') {
-    metrics.increment('network_errors.not_found_error', 1)
+    metrics.increment('network_errors.graphql.not_found_error', 1)
     return
   }
 }

--- a/src/shared/utils/metrics.ts
+++ b/src/shared/utils/metrics.ts
@@ -65,13 +65,17 @@ type IncrementKeys = {
     }
   }
   network_errors: {
-    '401': string
-    '403': string
-    '404': string
-    '500': string
-    unauthenticated_error: string
-    unauthorized_error: string
-    not_found_error: string
+    network_status: {
+      '401': string
+      '403': string
+      '404': string
+      '500': string
+    }
+    graphql: {
+      unauthenticated_error: string
+      unauthorized_error: string
+      not_found_error: string
+    }
   }
 }
 

--- a/src/shared/utils/metrics.ts
+++ b/src/shared/utils/metrics.ts
@@ -64,6 +64,15 @@ type IncrementKeys = {
       }
     }
   }
+  network_errors: {
+    '401': string
+    '403': string
+    '404': string
+    '500': string
+    unauthenticated_error: string
+    unauthorized_error: string
+    not_found_error: string
+  }
 }
 
 type SetKeys = {


### PR DESCRIPTION
# Description

After todays eng retro I threw together this quick PR so we can start collecting some basic metrics from the network error boundary so we can setup some alerts for when things catch on fire.

# Notable Changes

- Add in new metrics keys to `metrics.ts`
- Add in helper function
- Update `NetworkErrorBoundary` to send the metrics