### PR TITLE
fix: Remove duplicate search box on flags tab

### DIFF
--- a/src/pages/RepoPage/FlagsTab/Header/Header.jsx
+++ b/src/pages/RepoPage/FlagsTab/Header/Header.jsx
@@ -6,7 +6,6 @@ import { useRepoBackfilled, useRepoFlagsSelect } from 'services/repo'
 import A from 'ui/A'
 import Icon from 'ui/Icon'
 import MultiSelect from 'ui/MultiSelect'
-import SearchField from 'ui/SearchField'
 import Select from 'ui/Select'
 
 import { TIME_OPTION_VALUES, TimeOptions } from '../constants'
@@ -43,7 +42,7 @@ const Header = ({ controlsDisabled, children }) => {
 
   return (
     <div className="flex flex-col justify-end divide-y divide-solid divide-ds-gray-secondary">
-      <div className="mb-4 grid w-2/3 divide-y divide-solid divide-ds-gray-secondary sm:w-full sm:grid-cols-2 sm:divide-x sm:divide-y-0 md:grid-cols-4">
+      <div className="grid w-2/3 divide-y divide-solid divide-ds-gray-secondary sm:w-full sm:grid-cols-2 sm:divide-x sm:divide-y-0 md:grid-cols-4">
         <div className="mr-4 flex flex-col justify-between gap-2 p-4 sm:border-l sm:border-ds-gray-secondary sm:py-0 md:border-l-0">
           <h3 className="text-sm font-semibold text-ds-gray-octonary">
             Configured flags
@@ -107,15 +106,6 @@ const Header = ({ controlsDisabled, children }) => {
         </p>
       </div>
       {children}
-      <div className="flex justify-end pt-4">
-        <SearchField
-          dataMarketing="flags-search"
-          disabled={controlsDisabled}
-          placeholder={'Search for flags'}
-          searchValue={params?.search}
-          setSearchValue={(search) => updateParams({ search })}
-        />
-      </div>
     </div>
   )
 }

--- a/src/pages/RepoPage/FlagsTab/Header/Header.spec.jsx
+++ b/src/pages/RepoPage/FlagsTab/Header/Header.spec.jsx
@@ -127,27 +127,6 @@ describe('Header', () => {
     })
   })
 
-  describe('Search', () => {
-    beforeEach(() => setup())
-
-    it('calls setSearchValue', async () => {
-      const { user, updateLocationMock } = setup()
-      render(<Header />, { wrapper })
-
-      const searchInput = screen.getByRole('textbox', {
-        name: 'Search for flags',
-      })
-      await user.click(searchInput)
-      await user.keyboard('flag1')
-
-      await waitFor(
-        () =>
-          expect(updateLocationMock).toHaveBeenCalledWith({ search: 'flag1' }),
-        { timeout: 600 }
-      )
-    })
-  })
-
   describe('Show by', () => {
     describe('Title', () => {
       beforeEach(() => setup())


### PR DESCRIPTION
# Description

Removes the search box from the flags tab as searching functionality is already provided by the flag selector.

Closes https://github.com/codecov/engineering-team/issues/1246

# Notable Changes

- Remove duplicate search box on flags tab

# Screenshots

Before:
![Screenshot 2024-03-11 at 17 19 32](https://github.com/codecov/gazebo/assets/159931558/a513d2ac-314c-4214-a76b-a1a1667827e1)

After:
![Screenshot 2024-03-11 at 17 18 54](https://github.com/codecov/gazebo/assets/159931558/14f1679b-3267-41c5-8d80-71bffb00bff1)
