### PR TITLE
fix: #1179 - Show commits page even when missing head report

### DIFF
--- a/src/pages/PullRequestPage/PullCoverage/PullCoverage.jsx
+++ b/src/pages/PullRequestPage/PullCoverage/PullCoverage.jsx
@@ -63,15 +63,12 @@ function PullCoverageContent() {
 
   const resultType = data?.pull?.compareWithBase?.__typename
 
-  if (
-    resultType !== ComparisonReturnType.SUCCESSFUL_COMPARISON &&
-    resultType !== ComparisonReturnType.FIRST_PULL_REQUEST
-  ) {
-    return <ErrorBanner errorType={resultType} />
-  }
-
   return (
     <Suspense fallback={<Loader />}>
+      {resultType !== ComparisonReturnType.SUCCESSFUL_COMPARISON &&
+      resultType !== ComparisonReturnType.FIRST_PULL_REQUEST ? (
+        <ErrorBanner errorType={resultType} />
+      ) : null}
       <Switch>
         <SentryRoute
           path={[

--- a/src/pages/PullRequestPage/PullCoverage/PullCoverage.spec.jsx
+++ b/src/pages/PullRequestPage/PullCoverage/PullCoverage.spec.jsx
@@ -229,7 +229,10 @@ describe('PullRequestPageContent', () => {
       const errorBanner = await screen.findByRole('heading', {
         name: 'Missing Base Commit',
       })
+      const filesChangedTab = await screen.findByText('FilesChangedTab')
+
       expect(errorBanner).toBeInTheDocument()
+      expect(filesChangedTab).toBeInTheDocument() // first tab on page
     })
   })
 

--- a/src/pages/PullRequestPage/PullCoverage/routes/FilesChangedTab/FilesChangedTab.tsx
+++ b/src/pages/PullRequestPage/PullCoverage/routes/FilesChangedTab/FilesChangedTab.tsx
@@ -49,7 +49,7 @@ function FilesChangedTab() {
 
   return (
     <Suspense fallback={<Loader />}>
-      <div className="flex justify-end bg-ds-gray-primary p-2">
+      <div className="flex justify-end">
         <ComponentsSelector />
       </div>
       <FilesChangedTable />

--- a/src/shared/FlagsNotConfigured/FlagsNotConfigured.jsx
+++ b/src/shared/FlagsNotConfigured/FlagsNotConfigured.jsx
@@ -3,7 +3,7 @@ import A from 'ui/A'
 
 function FlagsNotConfigured() {
   return (
-    <div className="mt-2 flex flex-col items-center justify-center gap-2 text-base text-ds-gray-octonary">
+    <div className="mt-8 flex flex-col items-center justify-center gap-2 text-base text-ds-gray-octonary">
       <div className="flex min-w-[60%] flex-col justify-center gap-2 text-center">
         <img
           alt="Flags feature not configured"


### PR DESCRIPTION
# Description

When we hit an error on the Pulls page, there's a top level error component that renders instead of any of the content pages, even though the inner navbar still shows.

This PR intends to change that behavior such that we show both the content pages AND the error component at the same time

There are also some very small margin tweaks for some minor polish due to this new behavior (video below)

closes: https://github.com/codecov/engineering-team/issues/1179

# Screenshots

https://github.com/codecov/gazebo/assets/159853603/ea2b09da-8ea4-41b2-b0d2-d99e5347249d

# Link to Sample Entry

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.