### PR TITLE
feat: Redirect to general login instead of github

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -147,7 +147,7 @@ const MainAppRoutes = () => (
           <EnterpriseLandingPage />
         </BaseLayout>
       ) : (
-        <Redirect to="/login/gh" />
+        <Redirect to="/login" />
       )}
     </SentryRoute>
     <SentryRoute path="*">

--- a/src/App.spec.jsx
+++ b/src/App.spec.jsx
@@ -285,7 +285,7 @@ describe('App', () => {
         pathname: '/',
         expected: {
           page: /LoginPage/i,
-          location: '/login/gh',
+          location: '/login',
           search: '',
         },
       },

--- a/src/layouts/Header/Dropdown.spec.jsx
+++ b/src/layouts/Header/Dropdown.spec.jsx
@@ -95,7 +95,7 @@ describe('Dropdown', () => {
 
         const link = screen.getByText('Sign Out')
         expect(link).toBeVisible()
-        expect(link).toHaveAttribute('href', '/logout/gh')
+        expect(link).toHaveAttribute('href', '/logout')
       })
 
       it('removes session expiry tracking key on sign out', async () => {
@@ -171,7 +171,7 @@ describe('Dropdown', () => {
 
         const link = screen.getByText('Sign Out')
         expect(link).toBeVisible()
-        expect(link).toHaveAttribute('href', '/logout/gl')
+        expect(link).toHaveAttribute('href', '/logout')
       })
 
       it('does not show manage app access link', async () => {

--- a/src/services/navigation/useNavLinks/useNavLinks.js
+++ b/src/services/navigation/useNavLinks/useNavLinks.js
@@ -25,9 +25,7 @@ export function useNavLinks() {
   return {
     signOut: {
       text: 'Sign Out',
-      path: ({ provider = p } = { provider: p }) => {
-        return `${config.API_URL}/logout/${provider}`
-      },
+      path: () => `${config.API_URL}/logout`,
       isExternalLink: true,
     },
     signIn: {

--- a/src/services/navigation/useNavLinks/useNavLinks.spec.js
+++ b/src/services/navigation/useNavLinks/useNavLinks.spec.js
@@ -42,22 +42,13 @@ const wrapper =
 
 describe('useNavLinks', () => {
   describe('Sign Out', () => {
-    it('returns the correct link with nothing passed', () => {
+    it('returns the correct link', () => {
       const { result } = renderHook(() => useNavLinks(), {
         wrapper: wrapper('/gl/doggo/squirrel-locator'),
       })
 
       const path = result.current.signOut.path()
-      expect(path).toBe('/logout/gl')
-    })
-
-    it('can override the params', () => {
-      const { result } = renderHook(() => useNavLinks(), {
-        wrapper: wrapper('/gl/doggo/squirrel-locator'),
-      })
-
-      const path = result.current.signOut.path({ provider: 'bb' })
-      expect(path).toBe('/logout/bb')
+      expect(path).toBe('/logout')
     })
   })
 


### PR DESCRIPTION
# Description

Updates the redirect from `/` to go to `/login` instead of `/login/gh`.

Closes https://github.com/codecov/engineering-team/issues/1244

# Notable Changes

- Change base route's redirect

