### PR TITLE
[fix] Show install help banner in global top banners

### DIFF
--- a/src/shared/GlobalTopBanners/GlobalTopBanners.spec.tsx
+++ b/src/shared/GlobalTopBanners/GlobalTopBanners.spec.tsx
@@ -5,6 +5,10 @@ import GlobalTopBanners from './GlobalTopBanners'
 jest.mock('./RequestInstallBanner', () => () => 'RequestInstallBanner')
 jest.mock('./TrialBanner', () => () => 'TrialBanner')
 jest.mock('./TeamPlanFeedbackBanner', () => () => 'TeamPlanFeedbackBanner')
+jest.mock(
+  '../../layouts/BaseLayout/InstallationHelpBanner',
+  () => () => 'InstallationHelpBanner'
+)
 
 describe('GlobalTopBanners', () => {
   it('renders sentry trial banner', async () => {
@@ -25,6 +29,13 @@ describe('GlobalTopBanners', () => {
     render(<GlobalTopBanners />)
 
     const banner = await screen.findByText(/TeamPlanFeedbackBanner/)
+    expect(banner).toBeInTheDocument()
+  })
+
+  it('renders installation help banner', async () => {
+    render(<GlobalTopBanners />)
+
+    const banner = await screen.findByText(/InstallationHelpBanner/)
     expect(banner).toBeInTheDocument()
   })
 })

--- a/src/shared/GlobalTopBanners/GlobalTopBanners.tsx
+++ b/src/shared/GlobalTopBanners/GlobalTopBanners.tsx
@@ -1,5 +1,6 @@
 import { lazy } from 'react'
 
+import InstallationHelpBanner from 'layouts/BaseLayout/InstallationHelpBanner'
 import SilentNetworkErrorWrapper from 'layouts/shared/SilentNetworkErrorWrapper'
 
 const RequestInstallBanner = lazy(() => import('./RequestInstallBanner'))
@@ -12,6 +13,7 @@ const GlobalTopBanners: React.FC = () => {
       <RequestInstallBanner />
       <TrialBanner />
       <TeamPlanFeedbackBanner />
+      <InstallationHelpBanner />
     </SilentNetworkErrorWrapper>
   )
 }


### PR DESCRIPTION
# Description

Also show the install help banner in global top banners in addition to the limited experience. This closes [#1393](https://github.com/codecov/engineering-team/issues/1393). 

<img width="1449" alt="Screenshot 2024-03-12 at 12 27 34 PM" src="https://github.com/codecov/gazebo/assets/148245014/b40d3d2d-9edb-4292-b35a-8f5189cefa5a">


<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.