### PR TITLE
fix: Rollup tab navigation in bundles onboarding is broken

### DIFF
--- a/src/pages/RepoPage/RepoPage.tsx
+++ b/src/pages/RepoPage/RepoPage.tsx
@@ -101,7 +101,7 @@ function Routes({
           <SentryRoute
             path={[
               `${path}/bundles/new`,
-              `${path}bundles/new/rollup`,
+              `${path}/bundles/new/rollup`,
               `${path}/bundles/new/webpack`,
             ]}
             exact


### PR DESCRIPTION
Fix the broken tab navigation to Rollup bundle onboarding
