### PR TITLE
feat: support setting `GH_APP` in docker

### DIFF
--- a/docker/start-nginx.sh
+++ b/docker/start-nginx.sh
@@ -16,6 +16,7 @@ then
   GHE_SCHEME_BASE=${CODECOV_GHE_SCHEME:=https}
   GLE_SCHEME_BASE=${CODECOV_GLE_SCHEME:=https}
   BBS_SCHEME_BASE=${CODECOV_BBS_SCHEME:=https}
+  GITHUB_APP_BASE=${CODECOV_GITHUB_APP_SEARCH:=codecov}
   echo "Replacing ${SCHEME_BASE} for ${SCHEME} on ${API_BASE} and ${WEB_BASE}"
   sed -i "s/${SCHEME_BASE}:\/\/${API_BASE}/${SCHEME}:\/\/${CODECOV_API_HOST}/g" /var/www/app/gazebo/static/js/main.*
   sed -i "s/${SCHEME_BASE}:\/\/${WEB_BASE}/${SCHEME}:\/\/${CODECOV_BASE_HOST}/g" /var/www/app/gazebo/static/js/main.*
@@ -31,7 +32,10 @@ then
     echo "Replacing BBS ${BBS_SCHEME_BASE}://${BBS_BASE}"
     sed -i "s/r\.[a-zA-Z]\.BBS_URL/\"${BBS_SCHEME_BASE}:\/\/${BBS_BASE}\"/g" /var/www/app/gazebo/static/js/main.*
   fi
-
+  if [ -n "${CODECOV_GITHUB_APP}" ]; then
+    echo "Replacing Github App ${GITHUB_APP_BASE} with ${CODECOV_GITHUB_APP}"
+    sed -i "s/GH_APP:\"${GITHUB_APP_BASE}\"/GH_APP:\"${CODECOV_GITHUB_APP}\"/g" /var/www/app/gazebo/static/js/main.*
+  fi
   export DOLLAR='$'
   if [ "$CODECOV_FRONTEND_IPV6_DISABLED" ]; then
     echo 'Codecov frontend ipv6 disabled'


### PR DESCRIPTION
# Description

adds support for `CODECOV_GITHUB_APP` docker environment variable

fixes #2711


# Code Example

```
docker -e CODECOV_GITHUB_APP=codecov-example some-image-reference
```

# Notable Changes
When setting the `CODECOV_GITHUB_APP`, the github app linked out to when adding organizations is correct

# Screenshots
N/A

# Link to Sample Entry
N/A

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.