### PR TITLE
[fix] Make patch coverage on team plan nullable

### DIFF
--- a/src/services/pull/usePullTeam.tsx
+++ b/src/services/pull/usePullTeam.tsx
@@ -34,9 +34,11 @@ const ImpactedFilesOrdering = z.object({
   parameter: z.nativeEnum(OrderingParameter).optional(),
 })
 
-const CoverageObjSchema = z.object({
-  coverage: z.number().nullable(),
-})
+const CoverageObjSchema = z
+  .object({
+    coverage: z.number().nullable(),
+  })
+  .nullable()
 
 const ImpactedFileSchema = z
   .object({


### PR DESCRIPTION
# Description

Fixes https://github.com/codecov/internal-issues/issues/372. The zod schema was throwing an error when returned patch coverage is null and returning empty data. This change allows the coverage to be nullable similar to `usePull`.

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.