### PR TITLE
Fix add in git push command to bundle onboarding

### DIFF
--- a/src/pages/RepoPage/BundlesTab/BundleOnboarding/BundleOnboarding.spec.tsx
+++ b/src/pages/RepoPage/BundlesTab/BundleOnboarding/BundleOnboarding.spec.tsx
@@ -12,10 +12,6 @@ import BundleOnboarding from './BundleOnboarding'
 jest.mock('shared/useRedirect')
 const mockedUseRedirect = useRedirect as jest.Mock
 
-jest.mock('./ViteOnboarding', () => () => <div>ViteOnboarding</div>)
-jest.mock('./RollupOnboarding', () => () => <div>RollupOnboarding</div>)
-jest.mock('./WebpackOnboarding', () => () => <div>WebpackOnboarding</div>)
-
 const mockGetRepo = (hasUploadToken: boolean, isActive: boolean) => ({
   owner: {
     isCurrentUserPartOfOrg: true,
@@ -38,6 +34,12 @@ const mockGetRepo = (hasUploadToken: boolean, isActive: boolean) => ({
     },
   },
 })
+
+const mockGetOrgUploadToken = {
+  owner: {
+    orgUploadToken: '9e6a6189-20f1-482d-ab62-ecfaa2629290',
+  },
+}
 
 const server = setupServer()
 const queryClient = new QueryClient({
@@ -104,7 +106,10 @@ describe('BundleOnboarding', () => {
     server.use(
       graphql.query('GetRepo', (req, res, ctx) =>
         res(ctx.status(200), ctx.data(mockGetRepo(hasUploadToken, hasCommits)))
-      )
+      ),
+      graphql.query('GetOrgUploadToken', (req, res, ctx) => {
+        return res(ctx.status(200), ctx.data(mockGetOrgUploadToken))
+      })
     )
 
     return { hardRedirect }
@@ -145,7 +150,9 @@ describe('BundleOnboarding', () => {
         setup({ hasCommits: true, hasUploadToken: true })
         render(<BundleOnboarding />, { wrapper: wrapper() })
 
-        const viteOnboarding = await screen.findByText('ViteOnboarding')
+        const viteOnboarding = await screen.findByText(
+          /Install the Codecov Vite Plugin/
+        )
         expect(viteOnboarding).toBeInTheDocument()
       })
     })
@@ -194,7 +201,9 @@ describe('BundleOnboarding', () => {
           wrapper: wrapper('/gh/codecov/test-repo/bundles/new/rollup'),
         })
 
-        const rollupOnboarding = await screen.findByText('RollupOnboarding')
+        const rollupOnboarding = await screen.findByText(
+          /Install the Codecov Rollup Plugin/
+        )
         expect(rollupOnboarding).toBeInTheDocument()
       })
     })
@@ -243,7 +252,9 @@ describe('BundleOnboarding', () => {
           wrapper: wrapper('/gh/codecov/test-repo/bundles/new/webpack'),
         })
 
-        const webpackOnboarding = await screen.findByText('WebpackOnboarding')
+        const webpackOnboarding = await screen.findByText(
+          /Install the Codecov Webpack Plugin/
+        )
         expect(webpackOnboarding).toBeInTheDocument()
       })
     })

--- a/src/pages/RepoPage/BundlesTab/BundleOnboarding/BundleOnboarding.tsx
+++ b/src/pages/RepoPage/BundlesTab/BundleOnboarding/BundleOnboarding.tsx
@@ -1,4 +1,4 @@
-import { lazy, Suspense } from 'react'
+import { Suspense } from 'react'
 import { Switch, useParams } from 'react-router-dom'
 
 import { SentryRoute } from 'sentry'
@@ -9,9 +9,9 @@ import { useRedirect } from 'shared/useRedirect'
 import Spinner from 'ui/Spinner'
 import TabNavigation from 'ui/TabNavigation'
 
-const ViteOnboarding = lazy(() => import('./ViteOnboarding'))
-const RollupOnboarding = lazy(() => import('./RollupOnboarding'))
-const WebpackOnboarding = lazy(() => import('./WebpackOnboarding'))
+import RollupOnboarding from './RollupOnboarding'
+import ViteOnboarding from './ViteOnboarding'
+import WebpackOnboarding from './WebpackOnboarding'
 
 interface URLParams {
   provider: string
@@ -35,23 +35,19 @@ const Content: React.FC = () => {
           { pageName: 'bundleWebpackOnboarding' },
         ]}
       />
-      <Switch>
-        <SentryRoute path="/:provider/:owner/:repo/bundles/new" exact>
-          <Suspense fallback={<Loader />}>
+      <Suspense fallback={<Loader />}>
+        <Switch>
+          <SentryRoute path="/:provider/:owner/:repo/bundles/new" exact>
             <ViteOnboarding />
-          </Suspense>
-        </SentryRoute>
-        <SentryRoute path="/:provider/:owner/:repo/bundles/new/rollup">
-          <Suspense fallback={<Loader />}>
+          </SentryRoute>
+          <SentryRoute path="/:provider/:owner/:repo/bundles/new/rollup">
             <RollupOnboarding />
-          </Suspense>
-        </SentryRoute>
-        <SentryRoute path="/:provider/:owner/:repo/bundles/new/webpack">
-          <Suspense fallback={<Loader />}>
+          </SentryRoute>
+          <SentryRoute path="/:provider/:owner/:repo/bundles/new/webpack">
             <WebpackOnboarding />
-          </Suspense>
-        </SentryRoute>
-      </Switch>
+          </SentryRoute>
+        </Switch>
+      </Suspense>
     </>
   )
 }

--- a/src/pages/RepoPage/BundlesTab/BundleOnboarding/RollupOnboarding/RollupOnboarding.spec.tsx
+++ b/src/pages/RepoPage/BundlesTab/BundleOnboarding/RollupOnboarding/RollupOnboarding.spec.tsx
@@ -355,7 +355,9 @@ describe('RollupOnboarding', () => {
       const stepText = await screen.findByText('Step 4:')
       expect(stepText).toBeInTheDocument()
 
-      const headerText = await screen.findByText('Commit your latest changes')
+      const headerText = await screen.findByText(
+        'Commit and push your latest changes'
+      )
       expect(headerText).toBeInTheDocument()
     })
 
@@ -374,7 +376,7 @@ describe('RollupOnboarding', () => {
       render(<RollupOnboarding />, { wrapper })
 
       const gitCommit = await screen.findByText(
-        'git add -A && git commit -m "Added Codecov bundler plugin"'
+        'git add -A && git commit -m "Added Codecov bundler plugin" && git push'
       )
       expect(gitCommit).toBeInTheDocument()
     })

--- a/src/pages/RepoPage/BundlesTab/BundleOnboarding/RollupOnboarding/RollupOnboarding.tsx
+++ b/src/pages/RepoPage/BundlesTab/BundleOnboarding/RollupOnboarding/RollupOnboarding.tsx
@@ -34,7 +34,7 @@ export default defineConfig({
   ],
 });`
 
-const commitString = `git add -A && git commit -m "Added Codecov bundler plugin"`
+const commitString = `git add -A && git commit -m "Added Codecov bundler plugin" && git push`
 
 const npmBuild = `npm run build`
 const yarnBuild = `yarn run build`
@@ -110,7 +110,7 @@ const StepTwo: React.FC<{ uploadToken: string }> = ({ uploadToken }) => {
         <pre className="flex basis-2/3 items-center justify-between gap-2 rounded-md border-2 border-ds-gray-secondary bg-ds-gray-primary px-4 py-2 font-mono">
           <div className="w-0 flex-1 overflow-hidden">{uploadToken}</div>
           <CopyClipboard
-            string={uploadToken ?? ''}
+            string={uploadToken}
             testIdExtension="-upload-token"
             onClick={() => {
               copiedTokenMetric('rollup')
@@ -155,8 +155,8 @@ const StepFour: React.FC = () => {
   return (
     <div>
       <h2 className="pb-2 text-base">
-        <span className="font-semibold">Step 4:</span> Commit your latest
-        changes
+        <span className="font-semibold">Step 4:</span> Commit and push your
+        latest changes
       </h2>
       <p className="pb-2 text-sm">
         The plugin requires at least one commit to be made to properly upload
@@ -233,10 +233,7 @@ const RollupOnboarding: React.FC = () => {
   const { data: repoData } = useRepo({ provider, owner, repo })
   const { data: orgUploadToken } = useOrgUploadToken({ provider, owner })
 
-  let uploadToken = repoData?.repository?.uploadToken
-  if (orgUploadToken) {
-    uploadToken = orgUploadToken
-  }
+  const uploadToken = orgUploadToken ?? repoData?.repository?.uploadToken ?? ''
 
   useEffect(() => {
     visitedOnboardingMetric('rollup')
@@ -245,7 +242,7 @@ const RollupOnboarding: React.FC = () => {
   return (
     <div className="flex flex-col gap-6">
       <StepOne />
-      <StepTwo uploadToken={uploadToken || ''} />
+      <StepTwo uploadToken={uploadToken} />
       <StepThree />
       <StepFour />
       <StepFive />

--- a/src/pages/RepoPage/BundlesTab/BundleOnboarding/ViteOnboarding/ViteOnboarding.spec.tsx
+++ b/src/pages/RepoPage/BundlesTab/BundleOnboarding/ViteOnboarding/ViteOnboarding.spec.tsx
@@ -355,7 +355,9 @@ describe('ViteOnboarding', () => {
       const stepText = await screen.findByText('Step 4:')
       expect(stepText).toBeInTheDocument()
 
-      const headerText = await screen.findByText('Commit your latest changes')
+      const headerText = await screen.findByText(
+        'Commit and push your latest changes'
+      )
       expect(headerText).toBeInTheDocument()
     })
 
@@ -374,7 +376,7 @@ describe('ViteOnboarding', () => {
       render(<ViteOnboarding />, { wrapper })
 
       const gitCommit = await screen.findByText(
-        'git add -A && git commit -m "Added Codecov bundler plugin"'
+        'git add -A && git commit -m "Added Codecov bundler plugin" && git push'
       )
       expect(gitCommit).toBeInTheDocument()
     })

--- a/src/pages/RepoPage/BundlesTab/BundleOnboarding/ViteOnboarding/ViteOnboarding.tsx
+++ b/src/pages/RepoPage/BundlesTab/BundleOnboarding/ViteOnboarding/ViteOnboarding.tsx
@@ -34,7 +34,7 @@ export default defineConfig({
   ],
 });`
 
-const commitString = `git add -A && git commit -m "Added Codecov bundler plugin"`
+const commitString = `git add -A && git commit -m "Added Codecov bundler plugin" && git push`
 
 const npmBuild = `npm run build`
 const yarnBuild = `yarn run build`
@@ -110,7 +110,7 @@ const StepTwo: React.FC<{ uploadToken: string }> = ({ uploadToken }) => {
         <pre className="flex basis-2/3 items-center justify-between gap-2 rounded-md border-2 border-ds-gray-secondary bg-ds-gray-primary px-4 py-2 font-mono">
           <div className="w-0 flex-1 overflow-hidden">{uploadToken}</div>
           <CopyClipboard
-            string={uploadToken ?? ''}
+            string={uploadToken}
             testIdExtension="-upload-token"
             onClick={() => {
               copiedTokenMetric('vite')
@@ -155,8 +155,8 @@ const StepFour: React.FC = () => {
   return (
     <div>
       <h2 className="pb-2 text-base">
-        <span className="font-semibold">Step 4:</span> Commit your latest
-        changes
+        <span className="font-semibold">Step 4:</span> Commit and push your
+        latest changes
       </h2>
       <p className="pb-2 text-sm">
         The plugin requires at least one commit to be made to properly upload
@@ -233,10 +233,7 @@ const ViteOnboarding: React.FC = () => {
   const { data: repoData } = useRepo({ provider, owner, repo })
   const { data: orgUploadToken } = useOrgUploadToken({ provider, owner })
 
-  let uploadToken = repoData?.repository?.uploadToken
-  if (orgUploadToken) {
-    uploadToken = orgUploadToken
-  }
+  const uploadToken = orgUploadToken ?? repoData?.repository?.uploadToken ?? ''
 
   useEffect(() => {
     visitedOnboardingMetric('vite')
@@ -245,7 +242,7 @@ const ViteOnboarding: React.FC = () => {
   return (
     <div className="flex flex-col gap-6">
       <StepOne />
-      <StepTwo uploadToken={uploadToken || ''} />
+      <StepTwo uploadToken={uploadToken} />
       <StepThree />
       <StepFour />
       <StepFive />

--- a/src/pages/RepoPage/BundlesTab/BundleOnboarding/WebpackOnboarding/WebpackOnboarding.spec.tsx
+++ b/src/pages/RepoPage/BundlesTab/BundleOnboarding/WebpackOnboarding/WebpackOnboarding.spec.tsx
@@ -355,7 +355,9 @@ describe('WebpackOnboarding', () => {
       const stepText = await screen.findByText('Step 4:')
       expect(stepText).toBeInTheDocument()
 
-      const headerText = await screen.findByText('Commit your latest changes')
+      const headerText = await screen.findByText(
+        'Commit and push your latest changes'
+      )
       expect(headerText).toBeInTheDocument()
     })
 
@@ -374,7 +376,7 @@ describe('WebpackOnboarding', () => {
       render(<WebpackOnboarding />, { wrapper })
 
       const gitCommit = await screen.findByText(
-        'git add -A && git commit -m "Added Codecov bundler plugin"'
+        'git add -A && git commit -m "Added Codecov bundler plugin" && git push'
       )
       expect(gitCommit).toBeInTheDocument()
     })

--- a/src/pages/RepoPage/BundlesTab/BundleOnboarding/WebpackOnboarding/WebpackOnboarding.tsx
+++ b/src/pages/RepoPage/BundlesTab/BundleOnboarding/WebpackOnboarding/WebpackOnboarding.tsx
@@ -35,7 +35,7 @@ module.exports = {
   ],
 };`
 
-const commitString = `git add -A && git commit -m "Added Codecov bundler plugin"`
+const commitString = `git add -A && git commit -m "Added Codecov bundler plugin" && git push`
 
 const npmBuild = `npm run build`
 const yarnBuild = `yarn run build`
@@ -111,7 +111,7 @@ const StepTwo: React.FC<{ uploadToken: string }> = ({ uploadToken }) => {
         <pre className="flex basis-2/3 items-center justify-between gap-2 rounded-md border-2 border-ds-gray-secondary bg-ds-gray-primary px-4 py-2 font-mono">
           <div className="w-0 flex-1 overflow-hidden">{uploadToken}</div>
           <CopyClipboard
-            string={uploadToken ?? ''}
+            string={uploadToken}
             testIdExtension="-upload-token"
             onClick={() => {
               copiedTokenMetric('webpack')
@@ -171,8 +171,8 @@ const StepFour: React.FC = () => {
   return (
     <div>
       <h2 className="pb-2 text-base">
-        <span className="font-semibold">Step 4:</span> Commit your latest
-        changes
+        <span className="font-semibold">Step 4:</span> Commit and push your
+        latest changes
       </h2>
       <p className="pb-2 text-sm">
         The plugin requires at least one commit to be made to properly upload
@@ -249,10 +249,7 @@ const WebpackOnboarding: React.FC = () => {
   const { data: repoData } = useRepo({ provider, owner, repo })
   const { data: orgUploadToken } = useOrgUploadToken({ provider, owner })
 
-  let uploadToken = repoData?.repository?.uploadToken
-  if (orgUploadToken) {
-    uploadToken = orgUploadToken
-  }
+  const uploadToken = orgUploadToken ?? repoData?.repository?.uploadToken ?? ''
 
   useEffect(() => {
     visitedOnboardingMetric('webpack')
@@ -261,7 +258,7 @@ const WebpackOnboarding: React.FC = () => {
   return (
     <div className="flex flex-col gap-6">
       <StepOne />
-      <StepTwo uploadToken={uploadToken || ''} />
+      <StepTwo uploadToken={uploadToken} />
       <StepThree />
       <StepFour />
       <StepFive />


### PR DESCRIPTION
# Description

This PR adds in a `git push` command to the committing your changes step for bundle onboarding so that when we process the commit we're able to fill in the details for the given commit.

# Notable Changes

- Update Rollup, Vite, and Webpack onboarding with new command 
- Slight change as to how the `BundleOnboarding` component is structured and how it lazily loads components to have a more optimal end user experience.
- Update tests

# Screenshots

![Screenshot 2024-04-05 at 07 35 50](https://github.com/codecov/gazebo/assets/105234307/06e323cb-5f6b-4083-a7d8-49d726373738)