### PR TITLE
Maintain filters on coverage tab when no data is present 

### DIFF
--- a/src/pages/RepoPage/CoverageTab/subroute/FileExplorer/CodeTreeTable/CodeTreeTable.tsx
+++ b/src/pages/RepoPage/CoverageTab/subroute/FileExplorer/CodeTreeTable/CodeTreeTable.tsx
@@ -2,6 +2,7 @@ import {
   createColumnHelper,
   flexRender,
   getCoreRowModel,
+  SortingState,
   useReactTable,
 } from '@tanstack/react-table'
 import cs from 'classnames'
@@ -88,7 +89,9 @@ const baseColumns = [
 ]
 
 function CodeTreeTable() {
-  const [sorting, setSorting] = useState([{ id: 'name', desc: false }])
+  const [sorting, setSorting] = useState<SortingState>([
+    { id: 'name', desc: false },
+  ])
   const ordering = getOrderingDirection(sorting)
   const {
     data,

--- a/src/pages/RepoPage/CoverageTab/subroute/FileExplorer/FileExplorer.jsx
+++ b/src/pages/RepoPage/CoverageTab/subroute/FileExplorer/FileExplorer.jsx
@@ -18,24 +18,8 @@ function FileExplorer() {
   const { params, updateParams } = useLocationParams(defaultQueryParams)
   const isFileListDisplay = params?.displayType === 'list'
 
-  const {
-    data: branchData,
-    isLoading: branchIsLoading,
-    pathContentsType,
-  } = useRepoBranchContentsTable()
-
-  if (pathContentsType === 'UnknownPath') {
-    return (
-      <p className="m-4">
-        Unknown filepath. Please ensure that files/directories exist and are not
-        empty.
-      </p>
-    )
-  }
-
-  if (pathContentsType === 'MissingCoverage') {
-    return <p className="m-4">No coverage data available.</p>
-  }
+  const { data: branchData, isLoading: branchIsLoading } =
+    useRepoBranchContentsTable()
 
   return (
     <>

--- a/src/pages/RepoPage/CoverageTab/subroute/FileExplorer/FileExplorer.spec.jsx
+++ b/src/pages/RepoPage/CoverageTab/subroute/FileExplorer/FileExplorer.spec.jsx
@@ -259,28 +259,6 @@ describe('FileExplorer', () => {
       })
     })
 
-    describe('branch contents returns unknown path', () => {
-      it('renders unknown path message', async () => {
-        setup(true, false)
-        render(<FileExplorer />, { wrapper: wrapper() })
-
-        const message = await screen.findByText('No coverage data available.')
-        expect(message).toBeInTheDocument()
-      })
-    })
-
-    describe('branch contents has missing coverage', () => {
-      it('renders the missing coverage message', async () => {
-        setup(false, true)
-        render(<FileExplorer />, { wrapper: wrapper() })
-
-        const message = await screen.findByText(
-          'Unknown filepath. Please ensure that files/directories exist and are not empty.'
-        )
-        expect(message).toBeInTheDocument()
-      })
-    })
-
     describe('display type is set to list', () => {
       it('renders file list table', async () => {
         setup()

--- a/src/pages/RepoPage/CoverageTab/subroute/FileExplorer/FileListTable/FileListTable.tsx
+++ b/src/pages/RepoPage/CoverageTab/subroute/FileExplorer/FileListTable/FileListTable.tsx
@@ -2,6 +2,7 @@ import {
   createColumnHelper,
   flexRender,
   getCoreRowModel,
+  SortingState,
   useReactTable,
 } from '@tanstack/react-table'
 import cs from 'classnames'
@@ -89,7 +90,9 @@ const baseColumns = [
 ]
 
 function FileListTable() {
-  const [sorting, setSorting] = useState([{ id: 'misses', desc: true }])
+  const [sorting, setSorting] = useState<SortingState>([
+    { id: 'misses', desc: true },
+  ])
   const ordering = getOrderingDirection(sorting)
   const {
     data,


### PR DESCRIPTION
This PR fixes https://github.com/codecov/engineering-team/issues/1455. Moves the `No Coverage Available` message to the table and keeps the select state instead of removing the filters altogether.

**BEFORE**

https://github.com/codecov/gazebo/assets/148245014/88994b8d-74ee-40c7-bea9-b10e9efffb05

**AFTER**


https://github.com/codecov/gazebo/assets/148245014/c7c1b957-83e1-472f-a8b6-0ba4da87ccb7






<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.