### PR TITLE
fix: Move branch out of components filters

### DIFF
--- a/src/services/repo/useRepoComponents.tsx
+++ b/src/services/repo/useRepoComponents.tsx
@@ -101,8 +101,8 @@ interface FetchRepoComponentsArgs {
   repo: string
   filters?: {
     components?: string[]
-    branch?: string
   }
+  branch?: string
   orderingDirection: 'ASC' | 'DESC'
   interval: 'INTERVAL_30_DAY' | 'INTERVAL_7_DAY' | 'INTERVAL_1_DAY'
   afterDate: string
@@ -120,6 +120,7 @@ function fetchRepoComponents({
   interval,
   afterDate,
   beforeDate,
+  branch,
   after,
   signal,
 }: FetchRepoComponentsArgs) {
@@ -136,6 +137,7 @@ function fetchRepoComponents({
       afterDate,
       beforeDate,
       after,
+      branch,
     },
   }).then((res) => {
     const parsedRes = RequestSchema.safeParse(res?.data)


### PR DESCRIPTION
# Description
Migrate to the new schema 


<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.