### PR TITLE
feat: Make email field required when submitting feedback

### DIFF
--- a/src/sentry.ts
+++ b/src/sentry.ts
@@ -89,6 +89,7 @@ export const setupSentry = ({
       buttonLabel: 'Give Feedback',
       submitButtonLabel: 'Send Feedback',
       nameLabel: 'Username',
+      isEmailRequired: true,
     })
     integrations.push(feedback)
   }


### PR DESCRIPTION
# Description

This PR makes it so that users are required to submit an email before submitting feedback through Sentry's feedback utility.