### PR TITLE
fix: Fix a couple of quick stuff for components tab

### DIFF
--- a/src/pages/RepoPage/ComponentsTab/subroute/ComponentsTable/ComponentsTable.tsx
+++ b/src/pages/RepoPage/ComponentsTab/subroute/ComponentsTable/ComponentsTable.tsx
@@ -125,7 +125,7 @@ function createTableData({
         />
       ),
       lastUploaded: (
-        <span className="flex items-center">
+        <span className="flex justify-end">
           {lastUploaded ? formatTimeToNow(lastUploaded) : ''}
         </span>
       ),

--- a/src/pages/RepoPage/ComponentsTab/subroute/ComponentsTable/hooks/useRepoComponentsTable.js
+++ b/src/pages/RepoPage/ComponentsTab/subroute/ComponentsTable/hooks/useRepoComponentsTable.js
@@ -47,7 +47,9 @@ function useRepoComponentsTable(isDesc) {
   )
 
   const { data, isLoading } = useRepoComponents({
-    filters: { components: params?.components },
+    filters: Boolean(params?.components?.length)
+      ? { components: params?.components }
+      : {},
     orderingDirection: sortBy,
     before: format(new Date(), 'yyyy-MM-dd'),
     interval,

--- a/src/pages/RepoPage/ComponentsTab/subroute/ComponentsTable/hooks/useRepoComponentsTable.spec.js
+++ b/src/pages/RepoPage/ComponentsTab/subroute/ComponentsTable/hooks/useRepoComponentsTable.spec.js
@@ -214,7 +214,7 @@ describe('useRepoComponentsTable', () => {
           expect(requestFilters).toHaveBeenCalledWith({
             after: '2022-10-10',
             before: format(new Date(), 'yyyy-MM-dd'),
-            filters: { components: [] },
+            filters: {},
             interval: 'INTERVAL_30_DAY',
             orderingDirection: 'ASC',
             name: 'codecov',


### PR DESCRIPTION
# Description
This fixes:
- calling empty array of components as filters 
- padding for last uploaded 

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.