### PR TITLE
fix: Not showing select bundle when there is no bundle selected

### DIFF
--- a/src/pages/RepoPage/BundlesTab/BundleContent/BundleContent.tsx
+++ b/src/pages/RepoPage/BundlesTab/BundleContent/BundleContent.tsx
@@ -56,6 +56,11 @@ const BundleContent: React.FC = () => {
               <AssetEmptyTable />
             </Route>
           </Switch>
+        ) : bundleType === undefined && !branch ? (
+          <>
+            <InfoBanner branch={branch} bundle={bundle} />
+            <AssetEmptyTable />
+          </>
         ) : (
           <>
             <ErrorBanner errorType={bundleType} />


### PR DESCRIPTION
# Description

Currently missing the case where there's no bundle selected and we get a bad response from the API, this PR solves that by adding in a new check for those cases.

# Notable Changes

- Update conditional rendering of the `BundleContent` component