### PR TITLE
fix: Show enterprise plan card when usesInvoices true

### DIFF
--- a/gazebo
+++ b/gazebo
@@ -1,0 +1,1 @@
+/Users/ajaysingh/dev/codecov/gazebo

--- a/gazebo
+++ b/gazebo
@@ -1,1 +1,0 @@
-/Users/ajaysingh/dev/codecov/gazebo

--- a/src/pages/PlanPage/subRoutes/CurrentOrgPlan/CurrentPlanCard/CurrentPlanCard.spec.tsx
+++ b/src/pages/PlanPage/subRoutes/CurrentOrgPlan/CurrentPlanCard/CurrentPlanCard.spec.tsx
@@ -50,6 +50,21 @@ const enterprisePlan = {
   },
 }
 
+const usesInvoiceTeamPlan = {
+  plan: {
+    marketingName: 'blah',
+    value: 'users-teamm',
+    billingRate: null,
+    baseUnitPrice: 0,
+    benefits: [
+      'Unlimited users',
+      'Unlimited public repositories',
+      'Unlimited private repositories',
+    ],
+  },
+  usesInvoice: true,
+}
+
 const trialPlanDetails = {
   plan: {
     marketingName: 'Pro Trial Team',
@@ -140,6 +155,19 @@ describe('CurrentPlanCard', () => {
 
       const enterpriseCard = await screen.findByText(/Enterprise plan card/)
       expect(enterpriseCard).toBeInTheDocument()
+    })
+
+    it('renders enterprise plan card when usesInvoice True', async () => {
+      setup(usesInvoiceTeamPlan)
+
+      render(<CurrentPlanCard />, {
+        wrapper,
+      })
+
+      const usesInvoiceEnterprise = await screen.findByText(
+        /Enterprise plan card/
+      )
+      expect(usesInvoiceEnterprise).toBeInTheDocument()
     })
   })
 })

--- a/src/pages/PlanPage/subRoutes/CurrentOrgPlan/CurrentPlanCard/CurrentPlanCard.tsx
+++ b/src/pages/PlanPage/subRoutes/CurrentOrgPlan/CurrentPlanCard/CurrentPlanCard.tsx
@@ -30,7 +30,8 @@ function CurrentPlanCard() {
 
   if (
     isEnterprisePlan(plan?.value) ||
-    collectionMethod === CollectionMethods.INVOICED_CUSTOMER_METHOD
+    collectionMethod === CollectionMethods.INVOICED_CUSTOMER_METHOD ||
+    accountDetails?.usesInvoice
   ) {
     return <EnterprisePlanCard plan={plan} />
   }

--- a/src/services/user/useResyncUser.js
+++ b/src/services/user/useResyncUser.js
@@ -78,7 +78,6 @@ export function useResyncUser() {
         data?.length > 0 ? data[data.length - 1]?.pages?.repos?.length : 0
 
       if (numRepos < PAGE_SIZE) {
-        console.log(data, numRepos)
         queryClient.invalidateQueries({
           queryKey: ['repos', provider, owner],
         })


### PR DESCRIPTION
# Description

We want to show the enterprise plan card (maybe not the best name anymore?) when usesInvoices is true; usesInvoices being a property on the user model set in Django admin.

# Notable Changes

# Screenshots

![Screenshot 2024-04-16 at 3 01 07 PM](https://github.com/codecov/gazebo/assets/159853603/5eebfa0f-441f-4b89-9b52-f7b77b51ffcd)
![Screenshot 2024-04-16 at 3 01 15 PM](https://github.com/codecov/gazebo/assets/159853603/8743ac49-0ebd-48fc-aa34-50cd2bb69547)


# Link to Sample Entry

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.