### PR TITLE
Add a note to the README about the first `npm run start`

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ To run the project in development mode
 > npm run start
 ```
 
+Note: The first run of `npm run start` may take 5-10 minutes to finish building.
+
 The page will reload when you make edits. There is a local proxy to the staging API so you can develop against it. You can overwrite it by creating a `.env.local` file with it with the following:
 
 ```
@@ -166,5 +168,4 @@ Read more at the [official documentation.](https://mswjs.io/docs/getting-started
 
 ## Contributing
 
-This repository, like all of Codecov's repositories, strives to follow our general [Contributing guidlines](https://github.com/codecov/contributing). If you're considering making a contribution to this repository, we encourage review of our Contributing guidelines first. 
-
+This repository, like all of Codecov's repositories, strives to follow our general [Contributing guidelines](https://github.com/codecov/contributing). If you're considering making a contribution to this repository, we encourage review of our Contributing guidelines first.


### PR DESCRIPTION
# Description

The first build may take a while to start, so adding a note in the README in case other people run into the same problem.

The other change is a typo fix on line 169.

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.