### PR TITLE
fix: create new gazebo preview trigger

### DIFF
--- a/.github/workflows/run-preview.yml
+++ b/.github/workflows/run-preview.yml
@@ -1,0 +1,10 @@
+name: Trigger gazebo preview deploy
+
+on: [pull_request, push]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Succeed
+        run: exit 0

--- a/.github/workflows/trigger-gazebo-preview.yml
+++ b/.github/workflows/trigger-gazebo-preview.yml
@@ -1,6 +1,6 @@
 name: Trigger gazebo preview deploy
 
-on: [pull_request, push]
+on: pull_request
 
 jobs:
   run:


### PR DESCRIPTION
# Description

This is an empty workflow that will prevent forks from running the gazebo preview deploy until the code is approved. We will then trigger from this workflow succeeding

# Code Example

# Notable Changes

# Screenshots

# Link to Sample Entry

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.