### PR TITLE
[v2] Allow onboarding for private repos to be viewed for inactive users

### DIFF
--- a/src/pages/RepoPage/RepoPage.spec.tsx
+++ b/src/pages/RepoPage/RepoPage.spec.tsx
@@ -763,14 +763,14 @@ describe('RepoPage', () => {
   })
 
   describe('user is not activated and repo is private', () => {
-    describe('user does not have product enabled', () => {
-      it('renders setup tabs', async () => {
+    describe('user does not have coverage enabled', () => {
+      it('renders coverage setup tabs', async () => {
         const { queryClient } = setup({
           hasRepoData: true,
           isCurrentUserActivated: false,
           isRepoPrivate: true,
           coverageEnabled: false,
-          bundleAnalysisEnabled: false,
+          bundleAnalysisEnabled: true,
           language: 'javascript',
         })
         render(<RepoPage />, { wrapper: wrapper({ queryClient }) })
@@ -778,12 +778,12 @@ describe('RepoPage', () => {
         expect(repoCrumb).toBeInTheDocument()
         const coverageOnboarding = await screen.findByText('CoverageOnboarding')
         expect(coverageOnboarding).toBeInTheDocument()
-        const bundlesTab = await screen.findByText('Bundles')
-        expect(bundlesTab).toBeInTheDocument()
+        const error = screen.queryByText(/Unauthorized/)
+        expect(error).not.toBeInTheDocument()
       })
     })
 
-    describe('user has product enabled', () => {
+    describe('user has coverage enabled', () => {
       it('renders unauthorized access error', async () => {
         const { queryClient } = setup({
           hasRepoData: true,
@@ -794,6 +794,47 @@ describe('RepoPage', () => {
         const repoCrumb = await screen.findByText('cool-repo')
         expect(repoCrumb).toBeInTheDocument()
 
+        const error = await screen.findByText('Unauthorized')
+        expect(error).toBeInTheDocument()
+      })
+    })
+
+    describe('user does not have bundles enabled', () => {
+      it('renders bundle setup tabs', async () => {
+        const { queryClient, user } = setup({
+          hasRepoData: true,
+          isCurrentUserActivated: false,
+          isRepoPrivate: true,
+          coverageEnabled: true,
+          bundleAnalysisEnabled: false,
+          language: 'javascript',
+        })
+        render(<RepoPage />, { wrapper: wrapper({ queryClient }) })
+        const repoCrumb = await screen.findByText('cool-repo')
+        expect(repoCrumb).toBeInTheDocument()
+        const bundlesTab = await screen.findByText('Bundles')
+        expect(bundlesTab).toBeInTheDocument()
+        await user.click(bundlesTab)
+        const error = screen.queryByText(/Unauthorized/)
+        expect(error).not.toBeInTheDocument()
+      })
+    })
+
+    describe('user has bundles enabled', () => {
+      it('renders unauthorized access error', async () => {
+        const { queryClient, user } = setup({
+          hasRepoData: true,
+          isCurrentUserActivated: false,
+          coverageEnabled: false,
+          bundleAnalysisEnabled: true,
+          isRepoPrivate: true,
+        })
+        render(<RepoPage />, { wrapper: wrapper({ queryClient }) })
+        const repoCrumb = await screen.findByText('cool-repo')
+        expect(repoCrumb).toBeInTheDocument()
+        const bundlesTab = await screen.findByText('Bundles')
+        expect(bundlesTab).toBeInTheDocument()
+        await user.click(bundlesTab)
         const error = await screen.findByText('Unauthorized')
         expect(error).toBeInTheDocument()
       })

--- a/src/pages/RepoPage/RepoPage.tsx
+++ b/src/pages/RepoPage/RepoPage.tsx
@@ -61,8 +61,11 @@ function Routes({
   })
 
   const productEnabled = coverageEnabled || bundleAnalysisEnabled
-  const showUnauthorizedMessage =
-    productEnabled && isRepoPrivate && !isCurrentUserActivated
+  const showUnauthorizedMessageCoverage =
+    coverageEnabled && isRepoPrivate && !isCurrentUserActivated
+  const showUnauthorizedMessageBundles =
+    bundleAnalysisEnabled && isRepoPrivate && !isCurrentUserActivated
+
   if (isRepoActive && isRepoActivated) {
     return (
       <Switch>
@@ -76,7 +79,7 @@ function Routes({
             ]}
             exact
           >
-            {showUnauthorizedMessage ? (
+            {showUnauthorizedMessageCoverage ? (
               <UnauthorizedRepoDisplay />
             ) : (
               <CoverageTab />
@@ -103,7 +106,7 @@ function Routes({
             ]}
             exact
           >
-            {showUnauthorizedMessage ? (
+            {showUnauthorizedMessageBundles ? (
               <UnauthorizedRepoDisplay />
             ) : (
               <BundlesTab />
@@ -230,8 +233,8 @@ function RepoPage() {
   const isCurrentUserActivated = repoData?.isCurrentUserActivated
   const isRepoActive = repoData?.repository?.active
   const isRepoActivated = repoData?.repository?.activated
-  const isRepoPrivate = !!repoData?.repository?.private
-
+  const isRepoPrivate =
+    !!repoData?.repository?.private ?? repoData?.isRepoPrivate
   if (!refetchEnabled && !isRepoActivated) {
     setRefetchEnabled(true)
   }

--- a/src/services/repo/useRepo.spec.tsx
+++ b/src/services/repo/useRepo.spec.tsx
@@ -175,7 +175,7 @@ describe('useRepo', () => {
         )
       )
     })
-    it('can return an owner not activated error', async () => {
+    it('returns a subset of data when owner not activated', async () => {
       setup({ isOwnerNotActivatedError: true })
       const { result } = renderHook(
         () =>
@@ -187,13 +187,12 @@ describe('useRepo', () => {
         { wrapper }
       )
 
-      await waitFor(() => expect(result.current.isError).toBeTruthy())
-
       await waitFor(() =>
-        expect(result.current.error).toEqual(
+        expect(result.current.data).toEqual(
           expect.objectContaining({
-            status: 403,
-            dev: 'useRepo - 403 OwnerNotActivatedError',
+            isCurrentUserActivated: null,
+            repository: null,
+            isRepoPrivate: true,
           })
         )
       )

--- a/src/services/repo/useRepo.tsx
+++ b/src/services/repo/useRepo.tsx
@@ -3,7 +3,6 @@ import { z } from 'zod'
 
 import Api from 'shared/api'
 import { NetworkErrorObject } from 'shared/api/helpers'
-import A from 'ui/A'
 
 import {
   RepoNotFoundErrorSchema,
@@ -109,20 +108,12 @@ export function useRepo({ provider, owner, repo, opts = {} }: UseRepoArgs) {
         }
 
         if (data?.owner?.repository?.__typename === 'OwnerNotActivatedError') {
-          return Promise.reject({
-            status: 403,
-            data: {
-              detail: (
-                <p>
-                  Activation is required to view this repo, please{' '}
-                  {/* @ts-expect-error */}
-                  <A to={{ pageName: 'membersTab' }}>click here </A> to activate
-                  your account.
-                </p>
-              ),
-            },
-            dev: 'useRepo - 403 OwnerNotActivatedError',
-          } satisfies NetworkErrorObject)
+          return {
+            isCurrentUserActivated: data?.owner?.isCurrentUserActivated,
+            repository: null,
+            // OwnerNotActivated can only be returned if a repo is private
+            isRepoPrivate: true,
+          }
         }
 
         return (


### PR DESCRIPTION
# Description

# Code Example

# Notable Changes

# Screenshots

# Link to Sample Entry

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.