### PR TITLE
Fix MembersTable duplicate users

### DIFF
--- a/src/pages/MembersPage/MembersList/MembersList.jsx
+++ b/src/pages/MembersPage/MembersList/MembersList.jsx
@@ -59,7 +59,6 @@ function MembersList() {
     isAdmin: ApiFilterEnum.none, // Default to no filter on isAdmin
     ordering: '-name', // Default sort is A-Z Name
     search: '', // Default to no search on initial load
-    page: 1, // Default to first page
     pageSize: 50, // Default page size
   })
 

--- a/src/pages/MembersPage/MembersList/MembersTable/MembersTable.tsx
+++ b/src/pages/MembersPage/MembersList/MembersTable/MembersTable.tsx
@@ -149,7 +149,6 @@ interface MembersTableProps {
     isAdmin?: boolean
     ordering?: string[]
     search?: string
-    page: number
     pageSize: number
   }
 }

--- a/src/services/users/useInfiniteUser.tsx
+++ b/src/services/users/useInfiniteUser.tsx
@@ -36,7 +36,6 @@ export interface InfiniteUsersQuery {
     isAdmin?: boolean
     ordering?: string
     search?: string
-    page?: number
     pageSize?: number
   }
 }
@@ -57,8 +56,8 @@ export const useInfiniteUsers = (
         signal,
         query: {
           pageSize: 25,
-          page: pageParam,
           ...query,
+          page: pageParam,
         },
       }).then((res) => {
         const parsedRes = MemberListSchema.safeParse(res)


### PR DESCRIPTION
Issue was that the page number was being manually set in the parent component, overriding the infinite query's automatic page handling.

Closes https://github.com/codecov/engineering-team/issues/1637