### PR TITLE
Use bracket notation over array.at()

### DIFF
--- a/src/pages/AccountSettings/tabs/Admin/ManageAdminCard/AdminTable/AdminTable.tsx
+++ b/src/pages/AccountSettings/tabs/Admin/ManageAdminCard/AdminTable/AdminTable.tsx
@@ -60,7 +60,7 @@ const columns = [
 ]
 
 function getOrderingDirection(sorting: Array<{ id: string; desc: boolean }>) {
-  const state = sorting.at(0)
+  const state = sorting[0]
   return state ? (state.desc ? `-${state.id}` : state.id) : undefined
 }
 

--- a/src/pages/CommitDetailPage/CommitCoverage/routes/FilesChangedTab/FilesChangedTable/FilesChangedTable.tsx
+++ b/src/pages/CommitDetailPage/CommitCoverage/routes/FilesChangedTab/FilesChangedTable/FilesChangedTable.tsx
@@ -34,7 +34,7 @@ const isNumericValue = (value: string) =>
   value === 'patchPercentage' || value === 'head' || value === 'change'
 
 function getFilter(sorting: Array<{ id: string; desc: boolean }>) {
-  const state = sorting.at(0)
+  const state = sorting[0]
 
   if (state) {
     const direction = state?.desc

--- a/src/pages/CommitDetailPage/CommitCoverage/routes/FilesChangedTab/FilesChangedTableTeam/FilesChangedTableTeam.tsx
+++ b/src/pages/CommitDetailPage/CommitCoverage/routes/FilesChangedTab/FilesChangedTableTeam/FilesChangedTableTeam.tsx
@@ -34,7 +34,7 @@ const isNumericColumn = (cellId: string) =>
   cellId === 'missedLines' || cellId === 'patchPercentage'
 
 export function getFilter(sorting: Array<{ id: string; desc: boolean }>) {
-  const state = sorting.at(0)
+  const state = sorting[0]
 
   if (state) {
     const direction = state?.desc

--- a/src/pages/MembersPage/MembersList/MembersTable/MembersTable.tsx
+++ b/src/pages/MembersPage/MembersList/MembersTable/MembersTable.tsx
@@ -138,7 +138,7 @@ function LoadMoreTrigger({
 }
 
 function getOrderingDirection(sorting: Array<{ id: string; desc: boolean }>) {
-  const state = sorting.at(0)
+  const state = sorting[0]
   return state ? (state.desc ? `-${state.id}` : state.id) : undefined
 }
 

--- a/src/pages/PullRequestPage/PullCoverage/routes/FilesChangedTab/FilesChanged/FilesChangedTable/FilesChangedTable.tsx
+++ b/src/pages/PullRequestPage/PullCoverage/routes/FilesChangedTab/FilesChanged/FilesChangedTable/FilesChangedTable.tsx
@@ -14,7 +14,7 @@ import isEmpty from 'lodash/isEmpty'
 import isNumber from 'lodash/isNumber'
 import qs from 'qs'
 import { Fragment, lazy, Suspense, useEffect, useMemo, useState } from 'react'
-import { useLocation , useParams } from 'react-router-dom'
+import { useLocation, useParams } from 'react-router-dom'
 
 import {
   ImpactedFile,
@@ -40,7 +40,7 @@ const isNumericValue = (value: string) =>
   value === 'change'
 
 export function getFilter(sorting: Array<{ id: string; desc: boolean }>) {
-  const state = sorting.at(0)
+  const state = sorting[0]
 
   if (state) {
     const direction = state?.desc

--- a/src/pages/PullRequestPage/PullCoverage/routes/FilesChangedTab/FilesChanged/TableTeam/TableTeam.tsx
+++ b/src/pages/PullRequestPage/PullCoverage/routes/FilesChangedTab/FilesChanged/TableTeam/TableTeam.tsx
@@ -13,7 +13,7 @@ import cs from 'classnames'
 import isEmpty from 'lodash/isEmpty'
 import qs from 'qs'
 import { Fragment, lazy, Suspense, useEffect, useMemo, useState } from 'react'
-import { useLocation , useParams } from 'react-router-dom'
+import { useLocation, useParams } from 'react-router-dom'
 
 import {
   ImpactedFile,
@@ -35,7 +35,7 @@ const isNumericColumn = (cellId: string) =>
   cellId === 'missedLines' || cellId === 'patchPercentage'
 
 export function getFilter(sorting: Array<{ id: string; desc: boolean }>) {
-  const state = sorting.at(0)
+  const state = sorting[0]
 
   if (state) {
     const direction = state?.desc

--- a/src/pages/PullRequestPage/PullCoverage/routes/IndirectChangesTab/IndirectChangedFiles/hooks/useIndirectChangedFilesTable.ts
+++ b/src/pages/PullRequestPage/PullCoverage/routes/IndirectChangesTab/IndirectChangedFiles/hooks/useIndirectChangedFilesTable.ts
@@ -29,7 +29,7 @@ function getFilters({
   flags?: ParsedQs[] | string[]
   components?: ParsedQs[] | string[]
 }) {
-  const state = sorting.at(0)
+  const state = sorting[0]
   const direction = state?.desc ? orderingDirection.desc : orderingDirection.asc
 
   let parameter = undefined

--- a/src/pages/RepoPage/CoverageTab/subroute/FileExplorer/CodeTreeTable/CodeTreeTable.tsx
+++ b/src/pages/RepoPage/CoverageTab/subroute/FileExplorer/CodeTreeTable/CodeTreeTable.tsx
@@ -19,7 +19,7 @@ import 'ui/Table/Table.css'
 const columnHelper = createColumnHelper<Row>()
 
 function getOrderingDirection(sorting: Array<{ id: string; desc: boolean }>) {
-  const state = sorting.at(0)
+  const state = sorting[0]
 
   if (state) {
     const direction = state?.desc

--- a/src/pages/RepoPage/CoverageTab/subroute/FileExplorer/FileListTable/FileListTable.tsx
+++ b/src/pages/RepoPage/CoverageTab/subroute/FileExplorer/FileListTable/FileListTable.tsx
@@ -19,7 +19,7 @@ import 'ui/Table/Table.css'
 const columnHelper = createColumnHelper<Row>()
 
 function getOrderingDirection(sorting: Array<{ id: string; desc: boolean }>) {
-  const state = sorting.at(0)
+  const state = sorting[0]
 
   if (state) {
     const direction = state?.desc

--- a/src/shared/ListRepo/ReposTable/ReposTable.tsx
+++ b/src/shared/ListRepo/ReposTable/ReposTable.tsx
@@ -36,7 +36,7 @@ interface ReposTableProps {
 }
 
 function getOrderingDirection(sorting: Array<{ id: string; desc: boolean }>) {
-  const state = sorting.at(0)
+  const state = sorting[0]
 
   if (state) {
     const direction = state?.desc

--- a/src/shared/ListRepo/ReposTableTeam/ReposTableTeam.tsx
+++ b/src/shared/ListRepo/ReposTableTeam/ReposTableTeam.tsx
@@ -33,7 +33,7 @@ import 'ui/Table/Table.css'
 export function getSortingOption(
   sorting: Array<{ id: string; desc: boolean }>
 ) {
-  const state = sorting.at(0)
+  const state = sorting[0]
 
   if (state) {
     const direction = state.desc


### PR DESCRIPTION
The `.at()` method on arrays seems to still not be supported on some browsers.

Bracket notation functions the exact same at `.at()` for non-negative indexes.

Fixes all the `e.at is not a function` Sentry issues.
