### PR TITLE
feat: Swap to avg and add in data source label

### DIFF
--- a/src/pages/AnalyticsPage/Chart/Chart.jsx
+++ b/src/pages/AnalyticsPage/Chart/Chart.jsx
@@ -2,6 +2,7 @@ import { format } from 'date-fns'
 import PropTypes from 'prop-types'
 
 import CoverageAreaChart from 'ui/CoverageAreaChart'
+import Icon from 'ui/Icon'
 
 import { useCoverage } from './useCoverage'
 
@@ -36,15 +37,21 @@ function Chart({ params }) {
   })
 
   return (
-    <CoverageAreaChart
-      axisLabelFunc={data?.coverageAxisLabel}
-      data={data?.coverage}
-      title={`${repos?.join(', ')} coverage chart`}
-      desc={desc}
-      renderAreaChart={isPreviousData || isSuccess}
-      aproxWidth={260.5}
-      aproxHeight={47.5}
-    />
+    <>
+      <p className="flex items-center gap-1 self-end text-sm text-ds-gray-senary">
+        <Icon name="informationCircle" size="sm" />
+        Data is average of selected repos
+      </p>
+      <CoverageAreaChart
+        axisLabelFunc={data?.coverageAxisLabel}
+        data={data?.coverage}
+        title={`${repos?.join(', ')} coverage chart`}
+        desc={desc}
+        renderAreaChart={isPreviousData || isSuccess}
+        aproxWidth={260.5}
+        aproxHeight={47.5}
+      />
+    </>
   )
 }
 

--- a/src/pages/AnalyticsPage/Chart/Chart.spec.jsx
+++ b/src/pages/AnalyticsPage/Chart/Chart.spec.jsx
@@ -32,7 +32,7 @@ describe('Analytics coverage chart', () => {
       measurements: [
         {
           timestamp: '2020-01-01T00:00:00Z',
-          max: 91.11,
+          avg: 91.11,
         },
       ],
     },
@@ -43,11 +43,11 @@ describe('Analytics coverage chart', () => {
       measurements: [
         {
           timestamp: '2020-01-01T00:00:00Z',
-          max: 90.0,
+          avg: 90.0,
         },
         {
           timestamp: '2021-01-01T00:00:00Z',
-          max: 91.11,
+          avg: 91.11,
         },
       ],
     },
@@ -65,7 +65,10 @@ describe('Analytics coverage chart', () => {
         }
 
         return res(ctx.status(200), ctx.data(mockDataPoints))
-      })
+      }),
+      graphql.query('OwnerTier', (req, res, ctx) =>
+        res(ctx.status(200), ctx.data({ owner: { tier: 'pro' } }))
+      )
     )
   }
 
@@ -88,12 +91,29 @@ describe('Analytics coverage chart', () => {
       const message = await screen.findByTitle('coverage chart')
       expect(message).toBeInTheDocument()
     })
+
+    it('renders data label', async () => {
+      setup({ hasNoData: true })
+      render(
+        <Chart
+          params={{
+            startDate: '2020-01-15',
+            endDate: '2020-01-19',
+          }}
+        />,
+        {
+          wrapper,
+        }
+      )
+
+      const label = await screen.findByText(/Data is average of selected repos/)
+      expect(label).toBeInTheDocument()
+    })
   })
 
   describe('One data point', () => {
     it('Not enough data to render', async () => {
       setup({ hasSingleData: true })
-
       render(
         <Chart
           params={{
@@ -109,6 +129,25 @@ describe('Analytics coverage chart', () => {
 
       const message = await screen.findByText(/Not enough data to render/)
       expect(message).toBeInTheDocument()
+    })
+
+    it('renders data label', async () => {
+      setup({ hasSingleData: true })
+      render(
+        <Chart
+          params={{
+            startDate: '2020-01-15',
+            endDate: '2020-01-19',
+            repositories: [],
+          }}
+        />,
+        {
+          wrapper,
+        }
+      )
+
+      const label = await screen.findByText(/Data is average of selected repos/)
+      expect(label).toBeInTheDocument()
     })
   })
 
@@ -153,6 +192,25 @@ describe('Analytics coverage chart', () => {
         'api, frontend coverage chart from Jan 01, 2020 to Jan 01, 2021, coverage change is +90%'
       )
       expect(message).toBeInTheDocument()
+    })
+
+    it('renders data label', async () => {
+      setup({ hasNoData: false, hasSingleData: false })
+      render(
+        <Chart
+          params={{
+            startDate: '2020-01-15',
+            endDate: '2020-01-19',
+            repositories: ['api', 'frontend'],
+          }}
+        />,
+        {
+          wrapper,
+        }
+      )
+
+      const label = await screen.findByText(/Data is average of selected repos/)
+      expect(label).toBeInTheDocument()
     })
   })
 })

--- a/src/pages/AnalyticsPage/Chart/useCoverage.js
+++ b/src/pages/AnalyticsPage/Chart/useCoverage.js
@@ -28,14 +28,14 @@ export const useCoverage = ({ params, options = {} }) => {
     isPublic: shouldDisplayPublicReposOnly,
     opts: {
       select: (data) => {
-        if (data?.measurements?.[0]?.max === null) {
-          data.measurements[0].max = 0
+        if (data?.measurements?.[0]?.avg === null) {
+          data.measurements[0].avg = 0
         }
 
         // set prevPercent so we can reuse value if next value is null
         let prevPercent = data?.measurements?.[0]
         const coverage = data?.measurements?.map((measurement) => {
-          let coverage = measurement?.max ?? prevPercent
+          let coverage = measurement?.avg ?? prevPercent
 
           // can save on a few reassignments
           if (prevPercent !== coverage) {

--- a/src/pages/AnalyticsPage/Chart/useCoverage.spec.js
+++ b/src/pages/AnalyticsPage/Chart/useCoverage.spec.js
@@ -15,23 +15,23 @@ const mockRepoMeasurements = {
     measurements: [
       {
         timestamp: '2023-01-01T00:00:00+00:00',
-        max: 85,
+        avg: 85,
       },
       {
         timestamp: '2023-01-02T00:00:00+00:00',
-        max: 80,
+        avg: 80,
       },
       {
         timestamp: '2023-01-02T00:00:00+00:00',
-        max: null,
+        avg: null,
       },
       {
         timestamp: '2023-01-03T00:00:00+00:00',
-        max: 80,
+        avg: 80,
       },
       {
         timestamp: '2023-01-04T00:00:00+00:00',
-        max: 95,
+        avg: 95,
       },
     ],
   },
@@ -42,11 +42,11 @@ const mockNullFirstValRepoMeasurements = {
     measurements: [
       {
         timestamp: '2023-01-01T00:00:00+00:00',
-        max: null,
+        avg: null,
       },
       {
         timestamp: '2023-01-02T00:00:00+00:00',
-        max: 80,
+        avg: 80,
       },
     ],
   },
@@ -57,7 +57,7 @@ const mockPublicRepoMeasurements = {
     measurements: [
       {
         timestamp: '2023-01-02T00:00:00+00:00',
-        max: 80,
+        avg: 80,
       },
     ],
   },

--- a/src/services/charts/useReposCoverageMeasurements.spec.tsx
+++ b/src/services/charts/useReposCoverageMeasurements.spec.tsx
@@ -10,19 +10,19 @@ const mockReposMeasurements = {
     measurements: [
       {
         timestamp: '2023-01-01T00:00:00+00:00',
-        max: 85,
+        avg: 85,
       },
       {
         timestamp: '2023-01-02T00:00:00+00:00',
-        max: 80,
+        avg: 80,
       },
       {
         timestamp: '2023-01-03T00:00:00+00:00',
-        max: 90,
+        avg: 90,
       },
       {
         timestamp: '2023-01-04T00:00:00+00:00',
-        max: 100,
+        avg: 100,
       },
     ],
   },
@@ -78,19 +78,19 @@ describe('useReposCoverageMeasurements', () => {
         measurements: [
           {
             timestamp: '2023-01-01T00:00:00+00:00',
-            max: 85,
+            avg: 85,
           },
           {
             timestamp: '2023-01-02T00:00:00+00:00',
-            max: 80,
+            avg: 80,
           },
           {
             timestamp: '2023-01-03T00:00:00+00:00',
-            max: 90,
+            avg: 90,
           },
           {
             timestamp: '2023-01-04T00:00:00+00:00',
-            max: 100,
+            avg: 100,
           },
         ],
       }

--- a/src/services/charts/useReposCoverageMeasurements.ts
+++ b/src/services/charts/useReposCoverageMeasurements.ts
@@ -9,7 +9,7 @@ export const ReposCoverageMeasurementsConfig = z
     measurements: z.array(
       z.object({
         timestamp: z.string(),
-        max: z.number().nullish(),
+        avg: z.number().nullish(),
       })
     ),
   })
@@ -48,7 +48,7 @@ const query = `
         isPublic: $isPublic
       ) {
         timestamp
-        max
+        avg
       }
     }
   }


### PR DESCRIPTION
# Description

This PR swaps the data source on the analytics page from `max` to `avg` and adds in label informing users that the chart displays the average of all selected repos.

Closes codecov/engineering-team#1066

# Notable Changes

- Swap to fetching `avg` data
- Add in chat label

# Screenshots

![Screenshot 2024-04-26 at 10 30 32](https://github.com/codecov/gazebo/assets/105234307/420b4ee5-dd05-4608-a0b9-e1a8f98facb5)