### PR TITLE
A few UI tweaks for coverage over time for components

### DIFF
--- a/src/pages/RepoPage/ComponentsTab/Header/Header.tsx
+++ b/src/pages/RepoPage/ComponentsTab/Header/Header.tsx
@@ -58,7 +58,7 @@ const Header = ({
   )
 
   return (
-    <div className="flex flex-col justify-end divide-y divide-solid divide-ds-gray-secondary">
+    <div className="flex flex-col justify-end">
       <div className="grid w-2/3 divide-y divide-solid divide-ds-gray-secondary sm:w-full sm:grid-cols-2 sm:divide-x sm:divide-y-0 md:grid-cols-4">
         <BranchSelector isDisabled={controlsDisabled} />
         <div className="flex flex-col justify-between gap-2 p-4 sm:py-0">

--- a/src/pages/RepoPage/ComponentsTab/subroute/ComponentsTable/ComponentsTable.tsx
+++ b/src/pages/RepoPage/ComponentsTab/subroute/ComponentsTable/ComponentsTable.tsx
@@ -74,6 +74,9 @@ export const LoadingTable = () => {
             </tr>
           ))}
         </thead>
+        <tbody>
+          <br />
+        </tbody>
       </table>
     </div>
   )
@@ -266,7 +269,6 @@ const ComponentTable = memo(function Table({
             </tr>
           ))}
         </thead>
-
         <tbody data-testid="body-row">
           {isLoading ? (
             <tr>
@@ -285,6 +287,10 @@ const ComponentTable = memo(function Table({
               </tr>
             ))
           )}
+          {
+            /* Adds an extra line beneath the header row for the special case that the table is empty  */
+            !tableData.length ? <br /> : null
+          }
         </tbody>
       </table>
     </div>

--- a/src/shared/ComponentsNotConfigured/ComponentsNotConfigured.tsx
+++ b/src/shared/ComponentsNotConfigured/ComponentsNotConfigured.tsx
@@ -1,4 +1,5 @@
 import Button from 'ui/Button'
+import Icon from 'ui/Icon'
 
 function ComponentsNotConfigured() {
   return (
@@ -16,8 +17,10 @@ function ComponentsNotConfigured() {
           variant="primary"
           disabled={false}
           to={{ pageName: 'components' }}
+          showExternalIcon={false}
         >
           Get started with components
+          <Icon name="externalLink" variant="solid" size="sm" />
         </Button>
       </div>
     </div>


### PR DESCRIPTION
fixes: https://github.com/codecov/engineering-team/issues/1666

- Change the icon in the "Get started with Components" button to white.
- Have a bottom border for components table when no data state (needs configuration, activate, backfilling)
- Remove the bottom border line of the header section

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.