### PR TITLE
Update repo onboarding title position and page alignment

### DIFF
--- a/src/pages/RepoPage/CoverageOnboarding/CircleCI/CircleCI.spec.tsx
+++ b/src/pages/RepoPage/CoverageOnboarding/CircleCI/CircleCI.spec.tsx
@@ -91,17 +91,6 @@ describe('CircleCI', () => {
     )
   }
 
-  describe('intro blurb', () => {
-    beforeEach(() => setup({}))
-
-    it('renders intro blurb', async () => {
-      render(<CircleCI />, { wrapper })
-
-      const blurb = await screen.findByTestId('intro-blurb')
-      expect(blurb).toBeInTheDocument()
-    })
-  })
-
   describe('step one', () => {
     it('renders header', async () => {
       setup({})

--- a/src/pages/RepoPage/CoverageOnboarding/CircleCI/CircleCI.tsx
+++ b/src/pages/RepoPage/CoverageOnboarding/CircleCI/CircleCI.tsx
@@ -9,7 +9,6 @@ import A from 'ui/A'
 import CopyClipboard from 'ui/CopyClipboard'
 
 import ExampleBlurb from '../ExampleBlurb'
-import IntroBlurb from '../IntroBlurb/IntroBlurb'
 
 const orbsString = `orbs:
   codecov: codecov/codecov@4.0.1
@@ -44,7 +43,6 @@ function CircleCI() {
 
   return (
     <div className="flex flex-col gap-6">
-      <IntroBlurb />
       <div className="flex flex-col gap-3">
         <div>
           <h2 className="text-base font-semibold">

--- a/src/pages/RepoPage/CoverageOnboarding/GitHubActions/GitHubActions.spec.tsx
+++ b/src/pages/RepoPage/CoverageOnboarding/GitHubActions/GitHubActions.spec.tsx
@@ -92,17 +92,6 @@ describe('GitHubActions', () => {
     )
   }
 
-  describe('intro blurb', () => {
-    beforeEach(() => setup({}))
-
-    it('renders intro blurb', async () => {
-      render(<GitHubActions />, { wrapper })
-
-      const blurb = await screen.findByTestId('intro-blurb')
-      expect(blurb).toBeInTheDocument()
-    })
-  })
-
   describe('step one', () => {
     it('renders header', async () => {
       setup({})

--- a/src/pages/RepoPage/CoverageOnboarding/GitHubActions/GitHubActions.tsx
+++ b/src/pages/RepoPage/CoverageOnboarding/GitHubActions/GitHubActions.tsx
@@ -8,7 +8,6 @@ import A from 'ui/A'
 import CopyClipboard from 'ui/CopyClipboard'
 
 import ExampleBlurb from '../ExampleBlurb'
-import IntroBlurb from '../IntroBlurb/IntroBlurb'
 
 interface URLParams {
   provider: string
@@ -42,7 +41,6 @@ function GitHubActions() {
 
   return (
     <div className="flex flex-col gap-6">
-      <IntroBlurb />
       <div className="flex flex-col gap-4">
         <div>
           <h2 className="text-base font-semibold">

--- a/src/pages/RepoPage/CoverageOnboarding/IntroBlurb/IntroBlurb.spec.tsx
+++ b/src/pages/RepoPage/CoverageOnboarding/IntroBlurb/IntroBlurb.spec.tsx
@@ -25,18 +25,32 @@ const wrapper: React.FC<React.PropsWithChildren> = ({ children }) => (
 )
 
 describe('IntroBlurb', () => {
-  describe('prologue', () => {
-    it('renders quick start box', async () => {
-      render(<IntroBlurb />, { wrapper })
+  it('renders header', async () => {
+    render(<IntroBlurb />, { wrapper })
 
-      const docsLink = await screen.findByRole('link', {
-        name: /Read our documentation/,
-      })
-      expect(docsLink).toBeInTheDocument()
-      expect(docsLink).toHaveAttribute(
-        'href',
-        'https://docs.codecov.com/docs/quick-start'
-      )
+    const header = await screen.findByText("Let's get your repo covered")
+    expect(header).toBeInTheDocument()
+  })
+
+  it('renders paragraph', async () => {
+    render(<IntroBlurb />, { wrapper })
+
+    const paragraph = await screen.findByText(
+      /Before integrating with Codecov, ensure/
+    )
+    expect(paragraph).toBeInTheDocument()
+  })
+
+  it('renders docs bnox', async () => {
+    render(<IntroBlurb />, { wrapper })
+
+    const docsLink = await screen.findByRole('link', {
+      name: /Read our documentation/,
     })
+    expect(docsLink).toBeInTheDocument()
+    expect(docsLink).toHaveAttribute(
+      'href',
+      'https://docs.codecov.com/docs/quick-start'
+    )
   })
 })

--- a/src/pages/RepoPage/CoverageOnboarding/IntroBlurb/IntroBlurb.tsx
+++ b/src/pages/RepoPage/CoverageOnboarding/IntroBlurb/IntroBlurb.tsx
@@ -4,7 +4,7 @@ import Icon from 'ui/Icon'
 const IntroBlurb = () => {
   return (
     <div
-      className="mb-4 flex flex-col gap-2 overflow-auto border-l-4 border-ds-blue bg-ds-gray-primary p-4"
+      className="flex flex-col gap-2 overflow-auto border-l-4 border-ds-blue bg-ds-gray-primary p-4"
       data-testid="intro-blurb"
     >
       <h2 className="text-base font-semibold">

--- a/src/pages/RepoPage/CoverageOnboarding/IntroBlurb/IntroBlurb.tsx
+++ b/src/pages/RepoPage/CoverageOnboarding/IntroBlurb/IntroBlurb.tsx
@@ -7,9 +7,14 @@ const IntroBlurb = () => {
       className="flex flex-col gap-2 overflow-auto border-l-4 border-ds-blue bg-ds-gray-primary p-4"
       data-testid="intro-blurb"
     >
-      Before integrating with Codecov, ensure that your project already
-      generates coverage reports. Codecov relies on these reports to provide the
-      coverage analysis.
+      <h2 className="text-base font-semibold">
+        Let&apos;s get your repo covered
+      </h2>
+      <p>
+        Before integrating with Codecov, ensure that your project already
+        generates coverage reports. Codecov relies on these reports to provide
+        the coverage analysis.
+      </p>
       <A
         to={{ pageName: 'quickStart' }}
         isExternal

--- a/src/pages/RepoPage/CoverageOnboarding/IntroBlurb/IntroBlurb.tsx
+++ b/src/pages/RepoPage/CoverageOnboarding/IntroBlurb/IntroBlurb.tsx
@@ -4,7 +4,7 @@ import Icon from 'ui/Icon'
 const IntroBlurb = () => {
   return (
     <div
-      className="flex flex-col gap-2 overflow-auto border-l-4 border-ds-blue bg-ds-gray-primary p-4"
+      className="mb-4 flex flex-col gap-2 overflow-auto border-l-4 border-ds-blue bg-ds-gray-primary p-4"
       data-testid="intro-blurb"
     >
       <h2 className="text-base font-semibold">

--- a/src/pages/RepoPage/CoverageOnboarding/NewRepoTab.jsx
+++ b/src/pages/RepoPage/CoverageOnboarding/NewRepoTab.jsx
@@ -80,7 +80,7 @@ function NewRepoTab() {
 
   return (
     <div className="flex flex-col gap-6">
-      <div className="pt-4 lg:w-3/5">
+      <div className="flex flex-col gap-4 pt-4 lg:w-3/5">
         <IntroBlurb />
         <Content provider={provider} />
       </div>

--- a/src/pages/RepoPage/CoverageOnboarding/NewRepoTab.jsx
+++ b/src/pages/RepoPage/CoverageOnboarding/NewRepoTab.jsx
@@ -80,7 +80,7 @@ function NewRepoTab() {
 
   return (
     <div className="flex flex-col gap-6">
-      <div className="mx-auto w-4/5 pt-4 md:w-3/5 lg:w-3/6">
+      <div className="pt-4 lg:w-3/5">
         <IntroBlurb />
         <Content provider={provider} />
       </div>

--- a/src/pages/RepoPage/CoverageOnboarding/NewRepoTab.jsx
+++ b/src/pages/RepoPage/CoverageOnboarding/NewRepoTab.jsx
@@ -13,6 +13,7 @@ import TabNavigation from 'ui/TabNavigation'
 
 import CircleCI from './CircleCI'
 import GitHubActions from './GitHubActions'
+import IntroBlurb from './IntroBlurb'
 
 const OtherCI = lazy(() => import('./OtherCI'))
 
@@ -80,9 +81,7 @@ function NewRepoTab() {
   return (
     <div className="flex flex-col gap-6">
       <div className="mx-auto w-4/5 pt-4 md:w-3/5 lg:w-3/6">
-        <h1 className="pb-4 text-3xl font-semibold">
-          Let&apos;s get your repo covered
-        </h1>
+        <IntroBlurb />
         <Content provider={provider} />
       </div>
     </div>

--- a/src/pages/RepoPage/CoverageOnboarding/NewRepoTab.spec.jsx
+++ b/src/pages/RepoPage/CoverageOnboarding/NewRepoTab.spec.jsx
@@ -111,6 +111,16 @@ describe('NewRepoTab', () => {
     return { hardRedirect, user }
   }
 
+  describe('intro blurb', () => {
+    it('renders', async () => {
+      setup()
+      render(<NewRepoTab />, { wrapper: wrapper() })
+
+      const intro = await screen.findByTestId('intro-blurb')
+      expect(intro).toBeInTheDocument()
+    })
+  })
+
   describe('rendering component', () => {
     beforeEach(() => setup())
 

--- a/src/pages/RepoPage/CoverageOnboarding/OtherCI/OtherCI.spec.tsx
+++ b/src/pages/RepoPage/CoverageOnboarding/OtherCI/OtherCI.spec.tsx
@@ -96,17 +96,6 @@ describe('OtherCI', () => {
     return { user }
   }
 
-  describe('intro blurb', () => {
-    beforeEach(() => setup({}))
-
-    it('renders intro blurb', async () => {
-      render(<OtherCI />, { wrapper })
-
-      const blurb = await screen.findByTestId('intro-blurb')
-      expect(blurb).toBeInTheDocument()
-    })
-  })
-
   describe('step one', () => {
     it('renders header', async () => {
       setup({})

--- a/src/pages/RepoPage/CoverageOnboarding/OtherCI/OtherCI.tsx
+++ b/src/pages/RepoPage/CoverageOnboarding/OtherCI/OtherCI.tsx
@@ -9,7 +9,6 @@ import CopyClipboard from 'ui/CopyClipboard'
 import { InstructionBox } from './TerminalInstructions'
 
 import ExampleBlurb from '../ExampleBlurb'
-import IntroBlurb from '../IntroBlurb/IntroBlurb'
 
 interface URLParams {
   provider: string
@@ -34,7 +33,6 @@ function OtherCI() {
 
   return (
     <div className="flex flex-col gap-6">
-      <IntroBlurb />
       <div className="flex flex-col gap-3">
         <h2 className="text-base font-semibold">
           Step 1: add {tokenCopy} token as a secret to your CI Provider


### PR DESCRIPTION
# Description

First increment of onboarding changes. Adjusts title, banner, and page layout. Next PR to include new Card component.

[Design](https://www.figma.com/file/ICgJ2z5wJSxs0kzrtOp073/GH-1439?type=design&node-id=1-238&mode=design&t=sSmo8OEMnLvhAOzt-0)

# Notable Changes

- Move title into banner
- Move banner to above CI provider tabs
- Left align onboarding page

# Screenshots

Before:

![Screenshot 2024-04-30 at 11 24 06](https://github.com/codecov/gazebo/assets/159931558/d6509684-5b17-46d2-9ebd-935fe139c055)

After:

![Screenshot 2024-04-30 at 11 23 45](https://github.com/codecov/gazebo/assets/159931558/db8ab96e-bd57-4ad4-a913-c554e6c4c1d6)
