### PR TITLE
fix: Remove repository from GUT settings page header

### DIFF
--- a/src/pages/AccountSettings/tabs/OrgUploadToken/OrgUploadToken.jsx
+++ b/src/pages/AccountSettings/tabs/OrgUploadToken/OrgUploadToken.jsx
@@ -14,9 +14,7 @@ function OrgUploadToken() {
   return (
     <div className="flex flex-col gap-4 lg:w-3/4">
       <div className="flex gap-1">
-        <h1 className="text-lg font-semibold">
-          Global repository upload token
-        </h1>
+        <h1 className="text-lg font-semibold">Global upload token</h1>
         <div className="mt-2 text-xs">
           <A to={{ pageName: 'orgUploadTokenDoc' }}>learn more</A>
         </div>

--- a/src/pages/AccountSettings/tabs/OrgUploadToken/OrgUploadToken.spec.jsx
+++ b/src/pages/AccountSettings/tabs/OrgUploadToken/OrgUploadToken.spec.jsx
@@ -113,7 +113,7 @@ describe('OrgUploadToken', () => {
     it('renders title', async () => {
       render(<OrgUploadToken />, { wrapper })
 
-      const title = await screen.findByText(/Global repository upload token/)
+      const title = await screen.findByText(/Global upload token/)
       expect(title).toBeInTheDocument()
     })
 
@@ -237,7 +237,7 @@ describe('OrgUploadToken', () => {
       await waitFor(() =>
         expect(addNotification).toHaveBeenCalledWith({
           type: 'success',
-          text: 'Global repository upload token generated.',
+          text: 'Global upload token generated.',
         })
       )
     })

--- a/src/pages/AccountSettings/tabs/OrgUploadToken/useGenerateOrgUploadToken.js
+++ b/src/pages/AccountSettings/tabs/OrgUploadToken/useGenerateOrgUploadToken.js
@@ -19,7 +19,7 @@ export default function useGenerateOrgUploadToken() {
       } else {
         addToast({
           type: 'success',
-          text: 'Global repository upload token generated.',
+          text: 'Global upload token generated.',
         })
       }
     },


### PR DESCRIPTION
# Description

Super small change removing the word `repository` from GUT page header, and toast cleaning things up a little bit.

# Notable Changes

- Remove `repository` from header and toast
- Update tests