### PR TITLE
feat: Implement RadioTileGroup component

### DIFF
--- a/src/ui/Card/Card.tsx
+++ b/src/ui/Card/Card.tsx
@@ -1,6 +1,8 @@
 import { cva, VariantProps } from 'cva'
 import React from 'react'
 
+import { cn } from 'shared/utils/cn'
+
 const card = cva(['border border-ds-gray-secondary'])
 interface CardProps
   extends React.HTMLAttributes<HTMLDivElement>,
@@ -8,7 +10,7 @@ interface CardProps
 
 const CardRoot = React.forwardRef<HTMLDivElement, CardProps>(
   ({ className, ...props }, ref) => (
-    <div ref={ref} className={card({ className })} {...props} />
+    <div ref={ref} className={cn(card({ className }))} {...props} />
   )
 )
 CardRoot.displayName = 'Card'
@@ -20,7 +22,7 @@ interface HeaderProps
 
 const Header = React.forwardRef<HTMLDivElement, HeaderProps>(
   ({ className, ...props }, ref) => (
-    <div ref={ref} className={header({ className })} {...props} />
+    <div ref={ref} className={cn(header({ className }))} {...props} />
   )
 )
 Header.displayName = 'Card.Header'
@@ -42,7 +44,7 @@ interface TitleProps
 
 const Title = React.forwardRef<HTMLParagraphElement, TitleProps>(
   ({ className, size, children, ...props }, ref) => (
-    <h3 ref={ref} className={title({ className, size })} {...props}>
+    <h3 ref={ref} className={cn(title({ className, size }))} {...props}>
       {children}
     </h3>
   )
@@ -56,7 +58,7 @@ interface DescriptionProps
 
 const Description = React.forwardRef<HTMLParagraphElement, DescriptionProps>(
   ({ className, ...props }, ref) => (
-    <p ref={ref} className={description({ className })} {...props} />
+    <p ref={ref} className={cn(description({ className }))} {...props} />
   )
 )
 Description.displayName = 'Card.Description'
@@ -68,7 +70,7 @@ interface ContentProps
 
 const Content = React.forwardRef<HTMLDivElement, ContentProps>(
   ({ className, ...props }, ref) => (
-    <div ref={ref} className={content({ className })} {...props} />
+    <div ref={ref} className={cn(content({ className }))} {...props} />
   )
 )
 Content.displayName = 'Card.Content'
@@ -80,7 +82,7 @@ interface FooterProps
 
 const Footer = React.forwardRef<HTMLDivElement, FooterProps>(
   ({ className, ...props }, ref) => (
-    <div ref={ref} className={footer({ className })} {...props} />
+    <div ref={ref} className={cn(footer({ className }))} {...props} />
   )
 )
 Footer.displayName = 'Card.Footer'

--- a/src/ui/RadioTileGroup/RadioTileGroup.spec.tsx
+++ b/src/ui/RadioTileGroup/RadioTileGroup.spec.tsx
@@ -64,12 +64,12 @@ describe('RadioTileGroup', () => {
       const tile = await screen.findByText('Asdf')
       const tile2 = await screen.findByText('Jkl;')
 
-      user.click(tile)
+      await user.click(tile)
 
       const selected = await screen.findByTestId('radio-button-circle-selected')
       expect(selected).toBeInTheDocument()
 
-      user.click(tile2)
+      await user.click(tile2)
 
       await waitForElementToBeRemoved(selected)
 

--- a/src/ui/RadioTileGroup/RadioTileGroup.spec.tsx
+++ b/src/ui/RadioTileGroup/RadioTileGroup.spec.tsx
@@ -7,7 +7,7 @@ import { userEvent } from '@testing-library/user-event'
 
 import { RadioTileGroup } from './RadioTileGroup'
 
-describe('Card', () => {
+describe('RadioTileGroup', () => {
   function setup() {
     return {
       user: userEvent.setup(),
@@ -17,8 +17,12 @@ describe('Card', () => {
   it('renders', async () => {
     render(
       <RadioTileGroup>
-        <RadioTileGroup.Item value="asdf" label="Asdf" />
-        <RadioTileGroup.Item value="jkl;" label="Jkl;" />
+        <RadioTileGroup.Item value="asdf">
+          <RadioTileGroup.Label>Asdf</RadioTileGroup.Label>
+        </RadioTileGroup.Item>
+        <RadioTileGroup.Item value="jkl;">
+          <RadioTileGroup.Label>Jkl;</RadioTileGroup.Label>
+        </RadioTileGroup.Item>
       </RadioTileGroup>
     )
     const item1 = await screen.findByText('Asdf')
@@ -27,15 +31,16 @@ describe('Card', () => {
     expect(item2).toBeInTheDocument()
   })
 
-  describe('Item description', () => {
+  describe('with item description', () => {
     it('renders', async () => {
       render(
         <RadioTileGroup>
-          <RadioTileGroup.Item
-            value="asdf"
-            label="Asdf"
-            description="This is a description."
-          />
+          <RadioTileGroup.Item value="asdf">
+            <RadioTileGroup.Label>Asdf</RadioTileGroup.Label>
+            <RadioTileGroup.Description>
+              This is a description.
+            </RadioTileGroup.Description>
+          </RadioTileGroup.Item>
         </RadioTileGroup>
       )
       const description = await screen.findByText('This is a description.')
@@ -48,8 +53,12 @@ describe('Card', () => {
       const { user } = setup()
       render(
         <RadioTileGroup>
-          <RadioTileGroup.Item value="asdf" label="Asdf" />
-          <RadioTileGroup.Item value="jkl;" label="Jkl;" />
+          <RadioTileGroup.Item value="asdf">
+            <RadioTileGroup.Label>Asdf</RadioTileGroup.Label>
+          </RadioTileGroup.Item>
+          <RadioTileGroup.Item value="jkl;">
+            <RadioTileGroup.Label>Jkl;</RadioTileGroup.Label>
+          </RadioTileGroup.Item>
         </RadioTileGroup>
       )
       const tile = await screen.findByText('Asdf')

--- a/src/ui/RadioTileGroup/RadioTileGroup.spec.tsx
+++ b/src/ui/RadioTileGroup/RadioTileGroup.spec.tsx
@@ -1,8 +1,19 @@
-import { render, screen } from '@testing-library/react'
+import {
+  render,
+  screen,
+  waitForElementToBeRemoved,
+} from '@testing-library/react'
+import { userEvent } from '@testing-library/user-event'
 
 import { RadioTileGroup } from './RadioTileGroup'
 
 describe('Card', () => {
+  function setup() {
+    return {
+      user: userEvent.setup(),
+    }
+  }
+
   it('renders', async () => {
     render(
       <RadioTileGroup>
@@ -29,6 +40,36 @@ describe('Card', () => {
       )
       const description = await screen.findByText('This is a description.')
       expect(description).toBeInTheDocument()
+    })
+  })
+
+  describe('when an item is clicked', () => {
+    it('toggles selected circle', async () => {
+      const { user } = setup()
+      render(
+        <RadioTileGroup>
+          <RadioTileGroup.Item value="asdf" label="Asdf" />
+          <RadioTileGroup.Item value="jkl;" label="Jkl;" />
+        </RadioTileGroup>
+      )
+      const tile = await screen.findByText('Asdf')
+      const tile2 = await screen.findByText('Jkl;')
+
+      user.click(tile)
+
+      const selected = await screen.findByTestId('radio-button-circle-selected')
+      expect(selected).toBeInTheDocument()
+
+      user.click(tile2)
+
+      await waitForElementToBeRemoved(selected)
+
+      expect(selected).not.toBeInTheDocument()
+
+      const otherSelected = await screen.findByTestId(
+        'radio-button-circle-selected'
+      )
+      expect(otherSelected).toBeInTheDocument()
     })
   })
 })

--- a/src/ui/RadioTileGroup/RadioTileGroup.spec.tsx
+++ b/src/ui/RadioTileGroup/RadioTileGroup.spec.tsx
@@ -27,7 +27,29 @@ describe('RadioTileGroup', () => {
     expect(item2).toBeInTheDocument()
   })
 
-  describe('with item description', () => {
+  describe('item title', () => {
+    it('has htmlFor attribute when used inside Item', async () => {
+      render(
+        <RadioTileGroup>
+          <RadioTileGroup.Item value="test">
+            <RadioTileGroup.Label>Label</RadioTileGroup.Label>
+          </RadioTileGroup.Item>
+        </RadioTileGroup>
+      )
+      const label = await screen.findByText('Label')
+      expect(label).toBeInTheDocument()
+      expect(label.hasAttribute('for')).toBeTruthy()
+    })
+
+    it('does not have htmlFor attribute when used outside of Item', async () => {
+      render(<RadioTileGroup.Label>Label</RadioTileGroup.Label>)
+      const label = await screen.findByText('Label')
+      expect(label).toBeInTheDocument()
+      expect(label.hasAttribute('for')).toBeFalsy()
+    })
+  })
+
+  describe('item description', () => {
     it('renders', async () => {
       render(
         <RadioTileGroup>
@@ -65,7 +87,7 @@ describe('RadioTileGroup', () => {
       const selected = await screen.findByTestId('radio-button-circle-selected')
       expect(selected).toBeInTheDocument()
 
-      await user.click(tile2) //asdf
+      await user.click(tile2)
 
       expect(selected).not.toBeInTheDocument()
 

--- a/src/ui/RadioTileGroup/RadioTileGroup.spec.tsx
+++ b/src/ui/RadioTileGroup/RadioTileGroup.spec.tsx
@@ -1,0 +1,34 @@
+import { render, screen } from '@testing-library/react'
+
+import { RadioTileGroup } from './RadioTileGroup'
+
+describe('Card', () => {
+  it('renders', async () => {
+    render(
+      <RadioTileGroup>
+        <RadioTileGroup.Item value="asdf" label="Asdf" />
+        <RadioTileGroup.Item value="jkl;" label="Jkl;" />
+      </RadioTileGroup>
+    )
+    const item1 = await screen.findByText('Asdf')
+    expect(item1).toBeInTheDocument()
+    const item2 = await screen.findByText('Jkl;')
+    expect(item2).toBeInTheDocument()
+  })
+
+  describe('Item description', () => {
+    it('renders', async () => {
+      render(
+        <RadioTileGroup>
+          <RadioTileGroup.Item
+            value="asdf"
+            label="Asdf"
+            description="This is a description."
+          />
+        </RadioTileGroup>
+      )
+      const description = await screen.findByText('This is a description.')
+      expect(description).toBeInTheDocument()
+    })
+  })
+})

--- a/src/ui/RadioTileGroup/RadioTileGroup.spec.tsx
+++ b/src/ui/RadioTileGroup/RadioTileGroup.spec.tsx
@@ -1,8 +1,4 @@
-import {
-  render,
-  screen,
-  waitForElementToBeRemoved,
-} from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 import { userEvent } from '@testing-library/user-event'
 
 import { RadioTileGroup } from './RadioTileGroup'
@@ -69,9 +65,7 @@ describe('RadioTileGroup', () => {
       const selected = await screen.findByTestId('radio-button-circle-selected')
       expect(selected).toBeInTheDocument()
 
-      await user.click(tile2)
-
-      await waitForElementToBeRemoved(selected)
+      await user.click(tile2) //asdf
 
       expect(selected).not.toBeInTheDocument()
 

--- a/src/ui/RadioTileGroup/RadioTileGroup.stories.tsx
+++ b/src/ui/RadioTileGroup/RadioTileGroup.stories.tsx
@@ -1,4 +1,5 @@
 import { Meta, StoryObj } from '@storybook/react'
+import { useState } from 'react'
 
 import { RadioTileGroup } from './RadioTileGroup'
 
@@ -64,4 +65,37 @@ export const WithDescription: Story = {
       </RadioTileGroup.Item>
     </RadioTileGroup>
   ),
+}
+
+export const WithControlledInput: Story = {
+  args: {
+    direction: 'row',
+    flex: 1,
+  },
+  render: (args) => {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const [value, setValue] = useState<string | undefined>(undefined)
+
+    return (
+      <RadioTileGroup
+        className="w-full"
+        direction={args.direction}
+        value={value}
+        onValueChange={(value) => {
+          setValue(value)
+          // controlled input state isn't always required, you can also do things here ... like navigation etc.
+        }}
+      >
+        <RadioTileGroup.Item value="radio" flex={args.flex}>
+          <RadioTileGroup.Label>Radio</RadioTileGroup.Label>
+        </RadioTileGroup.Item>
+        <RadioTileGroup.Item value="tile" flex={args.flex}>
+          <RadioTileGroup.Label>Tile</RadioTileGroup.Label>
+        </RadioTileGroup.Item>
+        <RadioTileGroup.Item value="group" flex={args.flex}>
+          <RadioTileGroup.Label>Group</RadioTileGroup.Label>
+        </RadioTileGroup.Item>
+      </RadioTileGroup>
+    )
+  },
 }

--- a/src/ui/RadioTileGroup/RadioTileGroup.stories.tsx
+++ b/src/ui/RadioTileGroup/RadioTileGroup.stories.tsx
@@ -1,0 +1,58 @@
+import { Meta, StoryObj } from '@storybook/react'
+
+import { RadioTileGroup } from './RadioTileGroup'
+
+type RadioTileGroupStory = React.ComponentProps<typeof RadioTileGroup> & {
+  flex: 1 | 'none'
+}
+
+const meta: Meta<RadioTileGroupStory> = {
+  title: 'Components/RadioTileGroup',
+  component: RadioTileGroup,
+  argTypes: {
+    direction: {
+      description: 'Controls the flex direction of the RadioTileGroup',
+      control: 'radio',
+      options: ['row', 'col'],
+    },
+    flex: {
+      description: 'Toggles between the item flexing and not',
+      control: 'radio',
+      options: [1, 'none'],
+    },
+  },
+}
+export default meta
+
+type Story = StoryObj<RadioTileGroupStory>
+
+export const Default: Story = {
+  args: {
+    direction: 'row',
+    flex: 1,
+  },
+  render: (args) => (
+    <RadioTileGroup className="w-full" direction={args.direction}>
+      <RadioTileGroup.Item value="radio" label="Radio" flex={args.flex} />
+      <RadioTileGroup.Item value="tile" label="Tile" flex={args.flex} />
+      <RadioTileGroup.Item value="group" label="Group" flex={args.flex} />
+    </RadioTileGroup>
+  ),
+}
+
+export const WithDescription: Story = {
+  args: {
+    direction: 'row',
+    flex: 1,
+  },
+  render: (args) => (
+    <RadioTileGroup className="w-full" direction={args.direction}>
+      <RadioTileGroup.Item
+        value="description"
+        label="Description"
+        description="A RadioTileGroup Item can optionally have a description"
+      />
+      <RadioTileGroup.Item value="noDescription" label="No Description" />
+    </RadioTileGroup>
+  ),
+}

--- a/src/ui/RadioTileGroup/RadioTileGroup.stories.tsx
+++ b/src/ui/RadioTileGroup/RadioTileGroup.stories.tsx
@@ -33,9 +33,15 @@ export const Default: Story = {
   },
   render: (args) => (
     <RadioTileGroup className="w-full" direction={args.direction}>
-      <RadioTileGroup.Item value="radio" label="Radio" flex={args.flex} />
-      <RadioTileGroup.Item value="tile" label="Tile" flex={args.flex} />
-      <RadioTileGroup.Item value="group" label="Group" flex={args.flex} />
+      <RadioTileGroup.Item value="radio" flex={args.flex}>
+        <RadioTileGroup.Label>Radio</RadioTileGroup.Label>
+      </RadioTileGroup.Item>
+      <RadioTileGroup.Item value="tile" flex={args.flex}>
+        <RadioTileGroup.Label>Tile</RadioTileGroup.Label>
+      </RadioTileGroup.Item>
+      <RadioTileGroup.Item value="group" flex={args.flex}>
+        <RadioTileGroup.Label>Group</RadioTileGroup.Label>
+      </RadioTileGroup.Item>
     </RadioTileGroup>
   ),
 }
@@ -47,12 +53,15 @@ export const WithDescription: Story = {
   },
   render: (args) => (
     <RadioTileGroup className="w-full" direction={args.direction}>
-      <RadioTileGroup.Item
-        value="description"
-        label="Description"
-        description="A RadioTileGroup Item can optionally have a description"
-      />
-      <RadioTileGroup.Item value="noDescription" label="No Description" />
+      <RadioTileGroup.Item value="description" flex={args.flex}>
+        <RadioTileGroup.Label>Description</RadioTileGroup.Label>
+        <RadioTileGroup.Description>
+          A RadioTileGroup Item can optionally have a description
+        </RadioTileGroup.Description>
+      </RadioTileGroup.Item>
+      <RadioTileGroup.Item value="noDescription" flex={args.flex}>
+        <RadioTileGroup.Label>No Description</RadioTileGroup.Label>
+      </RadioTileGroup.Item>
     </RadioTileGroup>
   ),
 }

--- a/src/ui/RadioTileGroup/RadioTileGroup.tsx
+++ b/src/ui/RadioTileGroup/RadioTileGroup.tsx
@@ -1,6 +1,7 @@
+import * as LabelPrimitive from '@radix-ui/react-label'
 import * as RadioGroupPrimitive from '@radix-ui/react-radio-group'
 import { cva, VariantProps } from 'cva'
-import React from 'react'
+import React, { createContext, useContext, useId } from 'react'
 
 const group = cva(['flex', 'gap-4'], {
   variants: {
@@ -31,23 +32,74 @@ const Group = React.forwardRef<
 })
 Group.displayName = 'RadioTileGroup'
 
+const item = cva(['relative'], {
+  variants: {
+    flex: {
+      1: 'flex-1',
+      none: 'flex-none',
+    },
+  },
+  defaultVariants: {
+    flex: 1,
+  },
+})
+interface ItemProps
+  extends React.ComponentPropsWithoutRef<typeof RadioGroupPrimitive.Item>,
+    VariantProps<typeof item> {}
+const ItemContext = createContext<string | null>(null)
+
+const Item = React.forwardRef<
+  React.ElementRef<typeof RadioGroupPrimitive.Item>,
+  ItemProps
+>(({ children, className, flex, ...props }, ref) => {
+  const itemId = useId()
+  return (
+    <RadioGroupPrimitive.Item
+      id={itemId}
+      ref={ref}
+      className={item({ className, flex })}
+      {...props}
+    >
+      <ItemContext.Provider value={itemId}>
+        <div className="flex h-full flex-col gap-2 rounded-md border border-ds-gray-quaternary p-4">
+          {children}
+        </div>
+        <RadioGroupPrimitive.Indicator className="absolute right-0 top-0 h-full w-full">
+          <div className="absolute h-full w-full rounded-md border-2 border-ds-blue-darker" />
+          <div className="h-full w-full rounded-md border border-ds-blue-darker p-4">
+            <div className="flex h-5 w-full items-center justify-end">
+              <RadioButtonCircle selected />
+            </div>
+          </div>
+        </RadioGroupPrimitive.Indicator>
+      </ItemContext.Provider>
+    </RadioGroupPrimitive.Item>
+  )
+})
+Item.displayName = 'RadioTileGroup.Item'
+
 const label = cva(['font-medium'])
 interface LabelProps
-  extends React.HTMLAttributes<HTMLParagraphElement>,
+  extends React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root>,
     VariantProps<typeof label> {}
 
-const Label = React.forwardRef<HTMLParagraphElement, LabelProps>(
-  ({ children, className, ...props }, ref) => {
-    return (
-      <div className="flex items-center justify-between gap-4">
-        <p ref={ref} className={label({ className })} {...props}>
-          {children}
-        </p>
-        <RadioButtonCircle />
-      </div>
-    )
-  }
-)
+const Label = React.forwardRef<
+  React.ElementRef<typeof LabelPrimitive.Root>,
+  LabelProps
+>(({ className, ...props }, ref) => {
+  const itemId = useContext(ItemContext)
+  return (
+    <div className="flex items-center justify-between gap-4">
+      <LabelPrimitive.Root
+        {...{ htmlFor: itemId ?? undefined }}
+        ref={ref}
+        className={label({ className })}
+        {...props}
+      />
+      <RadioButtonCircle />
+    </div>
+  )
+})
 Label.displayName = 'RadioTileGroup.Label'
 
 const description = cva(['text-left text-ds-gray-quinary'])
@@ -65,47 +117,6 @@ const Description = React.forwardRef<HTMLParagraphElement, DescriptionProps>(
   }
 )
 Description.displayName = 'RadioTileGroup.Description'
-
-const item = cva(['relative'], {
-  variants: {
-    flex: {
-      1: 'flex-1',
-      none: 'flex-none',
-    },
-  },
-  defaultVariants: {
-    flex: 1,
-  },
-})
-interface ItemProps
-  extends React.ComponentPropsWithoutRef<typeof RadioGroupPrimitive.Item>,
-    VariantProps<typeof item> {}
-
-const Item = React.forwardRef<
-  React.ElementRef<typeof RadioGroupPrimitive.Item>,
-  ItemProps
->(({ children, className, flex, ...props }, ref) => {
-  return (
-    <RadioGroupPrimitive.Item
-      ref={ref}
-      className={item({ className, flex })}
-      {...props}
-    >
-      <div className="flex h-full flex-col gap-2 rounded-md border border-ds-gray-quaternary p-4">
-        {children}
-      </div>
-      <RadioGroupPrimitive.Indicator className="absolute right-0 top-0 h-full w-full">
-        <div className="absolute h-full w-full rounded-md border-2 border-ds-blue-darker" />
-        <div className="h-full w-full rounded-md border border-ds-blue-darker p-4">
-          <div className="flex h-5 w-full items-center justify-end">
-            <RadioButtonCircle selected />
-          </div>
-        </div>
-      </RadioGroupPrimitive.Indicator>
-    </RadioGroupPrimitive.Item>
-  )
-})
-Item.displayName = 'RadioTileGroup.Item'
 
 function RadioButtonCircle({ selected = false }: { selected?: boolean }) {
   return selected ? (

--- a/src/ui/RadioTileGroup/RadioTileGroup.tsx
+++ b/src/ui/RadioTileGroup/RadioTileGroup.tsx
@@ -3,6 +3,8 @@ import * as RadioGroupPrimitive from '@radix-ui/react-radio-group'
 import { cva, VariantProps } from 'cva'
 import React, { createContext, useContext, useId } from 'react'
 
+import { cn } from 'shared/utils/cn'
+
 const group = cva(['flex', 'gap-4'], {
   variants: {
     direction: {
@@ -24,7 +26,7 @@ const Group = React.forwardRef<
 >(({ className, direction, ...props }, ref) => {
   return (
     <RadioGroupPrimitive.Root
-      className={group({ className, direction })}
+      className={cn(group({ className, direction }))}
       {...props}
       ref={ref}
     />
@@ -57,7 +59,7 @@ const Item = React.forwardRef<
     <RadioGroupPrimitive.Item
       id={itemId}
       ref={ref}
-      className={item({ className, flex })}
+      className={cn(item({ className, flex }))}
       {...props}
     >
       <ItemContext.Provider value={itemId}>
@@ -93,7 +95,7 @@ const Label = React.forwardRef<
       <LabelPrimitive.Root
         {...{ htmlFor: itemId ?? undefined }}
         ref={ref}
-        className={label({ className })}
+        className={cn(label({ className }))}
         {...props}
       />
       <RadioButtonCircle />
@@ -110,7 +112,7 @@ interface DescriptionProps
 const Description = React.forwardRef<HTMLParagraphElement, DescriptionProps>(
   ({ children, className, ...props }, ref) => {
     return (
-      <p ref={ref} className={description({ className })} {...props}>
+      <p ref={ref} className={cn(description({ className }))} {...props}>
         {children}
       </p>
     )

--- a/src/ui/RadioTileGroup/RadioTileGroup.tsx
+++ b/src/ui/RadioTileGroup/RadioTileGroup.tsx
@@ -1,0 +1,96 @@
+import * as RadioGroupPrimitive from '@radix-ui/react-radio-group'
+import { cva, VariantProps } from 'cva'
+import React from 'react'
+
+const group = cva(['flex', 'gap-4'], {
+  variants: {
+    direction: {
+      row: 'flex-row',
+      col: 'flex-col',
+    },
+  },
+  defaultVariants: {
+    direction: 'row',
+  },
+})
+interface GroupProps
+  extends React.ComponentPropsWithoutRef<typeof RadioGroupPrimitive.Root>,
+    VariantProps<typeof group> {}
+
+const Group = React.forwardRef<
+  React.ElementRef<typeof RadioGroupPrimitive.Root>,
+  GroupProps
+>(({ className, direction, ...props }, ref) => {
+  return (
+    <RadioGroupPrimitive.Root
+      className={group({ className, direction })}
+      {...props}
+      ref={ref}
+    />
+  )
+})
+Group.displayName = RadioGroupPrimitive.Root.displayName
+
+const item = cva(['relative'], {
+  variants: {
+    flex: {
+      1: 'flex-1',
+      none: 'flex-none',
+    },
+  },
+  defaultVariants: {
+    flex: 1,
+  },
+})
+interface ItemProps
+  extends React.ComponentPropsWithoutRef<typeof RadioGroupPrimitive.Item>,
+    VariantProps<typeof item> {
+  label: string
+  description?: string
+}
+
+const Item = React.forwardRef<
+  React.ElementRef<typeof RadioGroupPrimitive.Item>,
+  ItemProps
+>(({ className, label, description, flex, ...props }, ref) => {
+  return (
+    <RadioGroupPrimitive.Item
+      ref={ref}
+      className={item({ className, flex })}
+      {...props}
+    >
+      <div className="flex h-full flex-col gap-2 rounded-md border border-ds-gray-quaternary p-4">
+        <div className="flex items-center justify-between gap-4">
+          <p className="font-medium">{label}</p>
+          <RadioButtonCircle />
+        </div>
+        {description ? (
+          <p className="text-left text-ds-gray-quinary">{description}</p>
+        ) : null}
+      </div>
+      <RadioGroupPrimitive.Indicator className="absolute right-0 top-0 flex h-full w-full justify-end">
+        <div className="absolute h-full w-full rounded-md border-2 border-ds-blue" />
+        <div className="h-full w-full rounded-md border border-ds-blue p-4">
+          <div className="flex h-5 w-full items-center justify-end">
+            <RadioButtonCircle selected />
+          </div>
+        </div>
+      </RadioGroupPrimitive.Indicator>
+    </RadioGroupPrimitive.Item>
+  )
+})
+Item.displayName = RadioGroupPrimitive.Item.displayName
+
+export const RadioTileGroup = Object.assign(Group, {
+  Item,
+})
+
+function RadioButtonCircle({ selected = false }: { selected?: boolean }) {
+  return selected ? (
+    <div className="flex h-4 w-4 items-center justify-center rounded-full bg-ds-blue">
+      <div className="h-1 w-1 rounded-full bg-white " />
+    </div>
+  ) : (
+    <div className="h-4 w-4 rounded-full border border-ds-gray-quaternary" />
+  )
+}

--- a/src/ui/RadioTileGroup/RadioTileGroup.tsx
+++ b/src/ui/RadioTileGroup/RadioTileGroup.tsx
@@ -68,7 +68,7 @@ const Item = React.forwardRef<
           <p className="text-left text-ds-gray-quinary">{description}</p>
         ) : null}
       </div>
-      <RadioGroupPrimitive.Indicator className="absolute right-0 top-0 flex h-full w-full justify-end">
+      <RadioGroupPrimitive.Indicator className="absolute right-0 top-0 h-full w-full">
         <div className="absolute h-full w-full rounded-md border-2 border-ds-blue-darker" />
         <div className="h-full w-full rounded-md border border-ds-blue-darker p-4">
           <div className="flex h-5 w-full items-center justify-end">

--- a/src/ui/RadioTileGroup/RadioTileGroup.tsx
+++ b/src/ui/RadioTileGroup/RadioTileGroup.tsx
@@ -29,7 +29,42 @@ const Group = React.forwardRef<
     />
   )
 })
-Group.displayName = RadioGroupPrimitive.Root.displayName
+Group.displayName = 'RadioTileGroup'
+
+const label = cva(['font-medium'])
+interface LabelProps
+  extends React.HTMLAttributes<HTMLParagraphElement>,
+    VariantProps<typeof label> {}
+
+const Label = React.forwardRef<HTMLParagraphElement, LabelProps>(
+  ({ children, className, ...props }, ref) => {
+    return (
+      <div className="flex items-center justify-between gap-4">
+        <p ref={ref} className={label({ className })} {...props}>
+          {children}
+        </p>
+        <RadioButtonCircle />
+      </div>
+    )
+  }
+)
+Label.displayName = 'RadioTileGroup.Label'
+
+const description = cva(['text-left text-ds-gray-quinary'])
+interface DescriptionProps
+  extends React.HTMLAttributes<HTMLParagraphElement>,
+    VariantProps<typeof description> {}
+
+const Description = React.forwardRef<HTMLParagraphElement, DescriptionProps>(
+  ({ children, className, ...props }, ref) => {
+    return (
+      <p ref={ref} className={description({ className })} {...props}>
+        {children}
+      </p>
+    )
+  }
+)
+Description.displayName = 'RadioTileGroup.Description'
 
 const item = cva(['relative'], {
   variants: {
@@ -44,15 +79,12 @@ const item = cva(['relative'], {
 })
 interface ItemProps
   extends React.ComponentPropsWithoutRef<typeof RadioGroupPrimitive.Item>,
-    VariantProps<typeof item> {
-  label: string
-  description?: string
-}
+    VariantProps<typeof item> {}
 
 const Item = React.forwardRef<
   React.ElementRef<typeof RadioGroupPrimitive.Item>,
   ItemProps
->(({ className, label, description, flex, ...props }, ref) => {
+>(({ children, className, flex, ...props }, ref) => {
   return (
     <RadioGroupPrimitive.Item
       ref={ref}
@@ -60,13 +92,7 @@ const Item = React.forwardRef<
       {...props}
     >
       <div className="flex h-full flex-col gap-2 rounded-md border border-ds-gray-quaternary p-4">
-        <div className="flex items-center justify-between gap-4">
-          <p className="font-medium">{label}</p>
-          <RadioButtonCircle />
-        </div>
-        {description ? (
-          <p className="text-left text-ds-gray-quinary">{description}</p>
-        ) : null}
+        {children}
       </div>
       <RadioGroupPrimitive.Indicator className="absolute right-0 top-0 h-full w-full">
         <div className="absolute h-full w-full rounded-md border-2 border-ds-blue-darker" />
@@ -79,11 +105,7 @@ const Item = React.forwardRef<
     </RadioGroupPrimitive.Item>
   )
 })
-Item.displayName = RadioGroupPrimitive.Item.displayName
-
-export const RadioTileGroup = Object.assign(Group, {
-  Item,
-})
+Item.displayName = 'RadioTileGroup.Item'
 
 function RadioButtonCircle({ selected = false }: { selected?: boolean }) {
   return selected ? (
@@ -100,3 +122,9 @@ function RadioButtonCircle({ selected = false }: { selected?: boolean }) {
     />
   )
 }
+
+export const RadioTileGroup = Object.assign(Group, {
+  Item,
+  Label,
+  Description,
+})

--- a/src/ui/RadioTileGroup/RadioTileGroup.tsx
+++ b/src/ui/RadioTileGroup/RadioTileGroup.tsx
@@ -69,8 +69,8 @@ const Item = React.forwardRef<
         ) : null}
       </div>
       <RadioGroupPrimitive.Indicator className="absolute right-0 top-0 flex h-full w-full justify-end">
-        <div className="absolute h-full w-full rounded-md border-2 border-ds-blue" />
-        <div className="h-full w-full rounded-md border border-ds-blue p-4">
+        <div className="absolute h-full w-full rounded-md border-2 border-ds-blue-darker" />
+        <div className="h-full w-full rounded-md border border-ds-blue-darker p-4">
           <div className="flex h-5 w-full items-center justify-end">
             <RadioButtonCircle selected />
           </div>
@@ -87,7 +87,7 @@ export const RadioTileGroup = Object.assign(Group, {
 
 function RadioButtonCircle({ selected = false }: { selected?: boolean }) {
   return selected ? (
-    <div className="flex h-4 w-4 items-center justify-center rounded-full bg-ds-blue">
+    <div className="flex h-4 w-4 items-center justify-center rounded-full bg-ds-blue-darker">
       <div
         className="h-1 w-1 rounded-full bg-white "
         data-testid="radio-button-circle-selected"

--- a/src/ui/RadioTileGroup/RadioTileGroup.tsx
+++ b/src/ui/RadioTileGroup/RadioTileGroup.tsx
@@ -88,9 +88,15 @@ export const RadioTileGroup = Object.assign(Group, {
 function RadioButtonCircle({ selected = false }: { selected?: boolean }) {
   return selected ? (
     <div className="flex h-4 w-4 items-center justify-center rounded-full bg-ds-blue">
-      <div className="h-1 w-1 rounded-full bg-white " />
+      <div
+        className="h-1 w-1 rounded-full bg-white "
+        data-testid="radio-button-circle-selected"
+      />
     </div>
   ) : (
-    <div className="h-4 w-4 rounded-full border border-ds-gray-quaternary" />
+    <div
+      className="h-4 w-4 rounded-full border border-ds-gray-quaternary"
+      data-testid="radio-button-circle-unselected"
+    />
   )
 }

--- a/src/ui/RadioTileGroup/RadioTileGroup.tsx
+++ b/src/ui/RadioTileGroup/RadioTileGroup.tsx
@@ -89,7 +89,7 @@ function RadioButtonCircle({ selected = false }: { selected?: boolean }) {
   return selected ? (
     <div className="flex h-4 w-4 items-center justify-center rounded-full bg-ds-blue-darker">
       <div
-        className="h-1 w-1 rounded-full bg-white "
+        className="h-1 w-1 rounded-full bg-white"
         data-testid="radio-button-circle-selected"
       />
     </div>

--- a/src/ui/RadioTileGroup/index.ts
+++ b/src/ui/RadioTileGroup/index.ts
@@ -1,0 +1,1 @@
+export { RadioTileGroup } from './RadioTileGroup'


### PR DESCRIPTION
# Description

Adds a new RadioTileGroup component to be used in repo and bundle onboarding. Description added preemptively to work with Failed test onboarding designs, which is coming soon.

Uses radixui react radio group and react label as base for accessibility.

[Repo and bundle onboarding designs](https://www.figma.com/file/ICgJ2z5wJSxs0kzrtOp073/GH-1439?type=design&node-id=1-238&mode=design&t=AJwVUnmg0UpBAybr-0)
[Failed test onboarding designs](https://www.figma.com/file/MbfQ7BE0ENmUOPRIe6GMvV/GH-1494?type=design&node-id=1-2&mode=design&t=GQQKAWFEEFJNIV55-0)

# Screenshots

Storybook:

![Screenshot 2024-05-01 at 16 23 05](https://github.com/codecov/gazebo/assets/159931558/bd842700-1352-47c8-bfef-dc6512268795)
