### PR TITLE
fix: Only show activation banner for non activated users

### DIFF
--- a/src/pages/RepoPage/CoverageOnboarding/NewRepoTab.tsx
+++ b/src/pages/RepoPage/CoverageOnboarding/NewRepoTab.tsx
@@ -1,4 +1,3 @@
-import PropTypes from 'prop-types'
 import { lazy, Suspense } from 'react'
 import { Switch, useParams } from 'react-router-dom'
 
@@ -24,7 +23,13 @@ const Loader = () => (
   </div>
 )
 
-function Content({ provider }: { provider: string }) {
+function Content({
+  provider,
+  isCurrentUserActivated,
+}: {
+  provider: string
+  isCurrentUserActivated: boolean
+}) {
   if (providerToName(provider) !== 'Github') {
     return (
       <div className="mt-6">
@@ -44,7 +49,7 @@ function Content({ provider }: { provider: string }) {
           { pageName: 'newOtherCI' },
         ]}
       />
-      <ActivationBanner />
+      {!isCurrentUserActivated ? <ActivationBanner /> : null}
       <div className="mt-6">
         <Switch>
           <SentryRoute path="/:provider/:owner/:repo/new" exact>
@@ -62,10 +67,6 @@ function Content({ provider }: { provider: string }) {
       </div>
     </>
   )
-}
-
-Content.propTypes = {
-  provider: PropTypes.string,
 }
 
 interface URLParams {
@@ -90,7 +91,10 @@ function NewRepoTab() {
     <div className="flex flex-col gap-6">
       <div className="flex flex-col gap-4 pt-4 lg:w-3/5">
         <IntroBlurb />
-        <Content provider={provider} />
+        <Content
+          provider={provider}
+          isCurrentUserActivated={data?.isCurrentUserActivated ?? false}
+        />
       </div>
     </div>
   )


### PR DESCRIPTION
# Description
We want to only show this banner if current user is not activated and will be seeing unauthorized error once repo is configured. 

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.