### PR TITLE
feat: Implement cn utility to wrap classnames and tailwind-merge

### DIFF
--- a/src/shared/utils/cn.spec.ts
+++ b/src/shared/utils/cn.spec.ts
@@ -25,6 +25,13 @@ describe('cn utility', () => {
 
       expect(className).toEqual('text-white text-base bg-ds-pink-tertiary asdf')
     })
+
+    it('should flatten arrays', () => {
+      const arr = ['b', { c: true, d: false }]
+      const className = cn('a', arr)
+
+      expect(className).toEqual('a b c')
+    })
   })
 
   describe('tailwind-merge functionality', () => {

--- a/src/shared/utils/cn.spec.ts
+++ b/src/shared/utils/cn.spec.ts
@@ -1,0 +1,40 @@
+import { cn } from './cn'
+
+describe('cn utility', () => {
+  describe('classnames functionality', () => {
+    it('should render styles conditionally', () => {
+      const className = cn('text-white', {
+        'bg-ds-primary-base': false,
+        'bg-ds-pink-tertiary': true,
+      })
+
+      expect(className).toEqual('text-white bg-ds-pink-tertiary')
+    })
+
+    it('should handle many arguments', () => {
+      const className = cn(
+        'text-white text-base',
+        {
+          'bg-ds-primary-base': false,
+          'bg-ds-pink-tertiary': true,
+        },
+        'asdf',
+        { asdf: null },
+        null
+      )
+
+      expect(className).toEqual('text-white text-base bg-ds-pink-tertiary asdf')
+    })
+  })
+
+  describe('tailwind-merge functionality', () => {
+    it('should merge tailwind classes', () => {
+      const className = cn(
+        'px-2 py-1 bg-red hover:bg-dark-red',
+        'p-3 bg-[#B91C1C]'
+      )
+
+      expect(className).toEqual('hover:bg-dark-red p-3 bg-[#B91C1C]')
+    })
+  })
+})

--- a/src/shared/utils/cn.ts
+++ b/src/shared/utils/cn.ts
@@ -1,0 +1,8 @@
+import classNames from 'classnames'
+import { twMerge } from 'tailwind-merge'
+
+// Combines the features of classnames and tailwind-merge into one, easy-to-use
+// utility. Drop in replacement for both classnames and tailwind-merge.
+export function cn(...inputs: classNames.ArgumentArray) {
+  return twMerge(classNames(inputs))
+}


### PR DESCRIPTION
Adds `cn` function as a wrapper around both classnames and tailwind-merge. This is to be used in our new reusable components right out of the gate, but a longer term migration plan for old classnames instances may be in order.
