### PR TITLE
ref: Show repo tabs for public repos

### DIFF
--- a/src/pages/RepoPage/RepoPage.tsx
+++ b/src/pages/RepoPage/RepoPage.tsx
@@ -60,8 +60,9 @@ function Routes({
     bundleAnalysisPrAndCommitPages: false,
   })
 
-  const productEnabled =
-    (coverageEnabled || bundleAnalysisEnabled) && isCurrentUserActivated
+  const productEnabled = coverageEnabled || bundleAnalysisEnabled
+  const userAuthorizedtoViewRepo =
+    (isRepoPrivate && isCurrentUserActivated) || !isRepoPrivate
   const showUnauthorizedMessageCoverage =
     coverageEnabled && isRepoPrivate && !isCurrentUserActivated
   const showUnauthorizedMessageBundles =
@@ -125,27 +126,27 @@ function Routes({
             <BundlesTab />
           </SentryRoute>
         ) : null}
-        {coverageEnabled && isCurrentUserActivated ? (
+        {coverageEnabled && userAuthorizedtoViewRepo ? (
           <SentryRoute path={`${path}/flags`} exact>
             <FlagsTab />
           </SentryRoute>
         ) : null}
-        {coverageEnabled && componentTab && isCurrentUserActivated ? (
+        {coverageEnabled && componentTab && userAuthorizedtoViewRepo ? (
           <SentryRoute path={`${path}/components`} exact>
             <ComponentsTab />
           </SentryRoute>
         ) : null}
-        {productEnabled ? (
+        {productEnabled && userAuthorizedtoViewRepo ? (
           <SentryRoute path={`${path}/commits`} exact>
             <CommitsTab />
           </SentryRoute>
         ) : null}
-        {productEnabled ? (
+        {productEnabled && userAuthorizedtoViewRepo ? (
           <SentryRoute path={`${path}/pulls`} exact>
             <PullsTab />
           </SentryRoute>
         ) : null}
-        {productEnabled ? (
+        {productEnabled && userAuthorizedtoViewRepo ? (
           <Redirect from={`${path}/compare`} to={`${path}/pulls`} />
         ) : null}
         <SentryRoute path={`${path}/settings`}>

--- a/src/pages/RepoPage/RepoPageTabs.tsx
+++ b/src/pages/RepoPage/RepoPageTabs.tsx
@@ -84,10 +84,13 @@ export const useRepoTabs = ({ refetchEnabled }: UseRepoTabsArgs) => {
   }
 
   const hideFlagsTab = !!repoOverview?.private && tierData === TierNames.TEAM
+  const userAuthorizedtoViewRepo =
+    (repoData?.isCurrentUserActivated && repoOverview?.private) ||
+    !repoOverview?.private
   if (
     repoOverview?.coverageEnabled &&
     !hideFlagsTab &&
-    repoData?.isCurrentUserActivated
+    userAuthorizedtoViewRepo
   ) {
     tabs.push({ pageName: 'flagsTab' })
   }
@@ -98,14 +101,14 @@ export const useRepoTabs = ({ refetchEnabled }: UseRepoTabsArgs) => {
     repoOverview?.coverageEnabled &&
     componentTab &&
     !hideComponentsTab &&
-    repoData?.isCurrentUserActivated
+    userAuthorizedtoViewRepo
   ) {
     tabs.push({ pageName: 'componentsTab' })
   }
 
   if (
     (repoOverview?.bundleAnalysisEnabled || repoOverview?.coverageEnabled) &&
-    repoData?.isCurrentUserActivated
+    userAuthorizedtoViewRepo
   ) {
     tabs.push({ pageName: 'commits' }, { pageName: 'pulls' })
   }


### PR DESCRIPTION
# Description
We are hiding commits/pulls/flags/components for public repos when checking for isUserActivated, we should be accounting for activation only when repo is private. Same thing goes for routes.


<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.