### PR TITLE
feat: Add radio button navigation to repo onboarding

### DIFF
--- a/src/pages/RepoPage/CoverageOnboarding/NewRepoTab.spec.tsx
+++ b/src/pages/RepoPage/CoverageOnboarding/NewRepoTab.spec.tsx
@@ -350,8 +350,8 @@ describe('NewRepoTab', () => {
         })
         render(<NewRepoTab />, { wrapper: wrapper() })
 
-        await waitFor(() => queryClient.isFetching)
-        await waitFor(() => !queryClient.isFetching)
+        // Wait for full render
+        expect(await screen.findByText(/GitHubActions/)).toBeInTheDocument()
 
         const banner = screen.queryByText(/ActivationBanner/)
         expect(banner).not.toBeInTheDocument()
@@ -366,12 +366,13 @@ describe('NewRepoTab', () => {
         })
         render(<NewRepoTab />, { wrapper: wrapper() })
 
-        await waitFor(() => queryClient.isFetching)
-        await waitFor(() => !queryClient.isFetching)
+        // Wait for full render
+        expect(await screen.findByText(/GitHubActions/)).toBeInTheDocument()
 
         const banner = screen.queryByText(/ActivationBanner/)
         expect(banner).not.toBeInTheDocument()
       })
+    })
 
     describe('when user is not activated and is private repo', () => {
       it('renders ActivationBanner', async () => {
@@ -381,13 +382,9 @@ describe('NewRepoTab', () => {
         })
         render(<NewRepoTab />, { wrapper: wrapper() })
 
-        await waitFor(() => queryClient.isFetching)
-        await waitFor(() => !queryClient.isFetching)
-
-        const banner = screen.queryByText(/ActivationBanner/)
+        const banner = await screen.findByText(/ActivationBanner/)
         expect(banner).toBeInTheDocument()
       })
-    })
     })
   })
 })

--- a/src/pages/RepoPage/CoverageOnboarding/NewRepoTab.spec.tsx
+++ b/src/pages/RepoPage/CoverageOnboarding/NewRepoTab.spec.tsx
@@ -13,6 +13,7 @@ import NewRepoTab from './NewRepoTab'
 jest.mock('shared/useRedirect')
 const mockedUseRedirect = useRedirect as jest.Mock
 jest.mock('./GitHubActions', () => () => 'GitHubActions')
+jest.mock('./CircleCI', () => () => 'CircleCI')
 jest.mock('./OtherCI', () => () => 'OtherCI')
 jest.mock('./ActivationBanner', () => () => 'ActivationBanner')
 
@@ -69,12 +70,12 @@ const wrapper: (initialEntries?: string) => React.FC<PropsWithChildren> =
           <Route
             path={[
               '/:provider/:owner/:repo/new',
+              '/:provider/:owner/:repo/new/circle-ci',
               '/:provider/:owner/:repo/new/other-ci',
             ]}
           >
             <Suspense fallback={null}>{children}</Suspense>
           </Route>
-
           <Route
             path="*"
             render={({ location }) => {
@@ -87,7 +88,7 @@ const wrapper: (initialEntries?: string) => React.FC<PropsWithChildren> =
     )
 
 beforeAll(() => {
-  // console.error = () => {}
+  console.error = () => {}
   server.listen()
 })
 afterEach(() => {
@@ -138,13 +139,156 @@ describe('NewRepoTab', () => {
     return { hardRedirect, user }
   }
 
-  describe('intro blurb', () => {
+  it('renders intro blurb', async () => {
+    setup({})
+    render(<NewRepoTab />, { wrapper: wrapper() })
+
+    const intro = await screen.findByTestId('intro-blurb')
+    expect(intro).toBeInTheDocument()
+  })
+
+  describe('CISelector', () => {
     it('renders', async () => {
       setup({})
       render(<NewRepoTab />, { wrapper: wrapper() })
 
-      const intro = await screen.findByTestId('intro-blurb')
-      expect(intro).toBeInTheDocument()
+      const selectorHeader = await screen.findByText('Select your CI')
+      expect(selectorHeader).toBeInTheDocument()
+
+      const githubActions = await screen.findByText('Using GitHub Actions')
+      const circleCI = await screen.findByText('Using Circle CI')
+      const otherCI = await screen.findByText('Other')
+      expect(githubActions).toBeInTheDocument()
+      expect(circleCI).toBeInTheDocument()
+      expect(otherCI).toBeInTheDocument()
+    })
+
+    describe('initial selection', () => {
+      describe('when on GH provider and /new path', () => {
+        it('selects GitHub Actions as default', async () => {
+          setup({})
+          render(<NewRepoTab />, { wrapper: wrapper() })
+
+          const githubActions = await screen.findByTestId(
+            'github-actions-radio'
+          )
+          expect(githubActions).toBeInTheDocument()
+          expect(githubActions.hasAttribute('data-state')).toBeTruthy()
+          expect(githubActions.getAttribute('data-state')).toBe('checked')
+        })
+      })
+
+      describe('when on non GH provider and /new path', () => {
+        it('selects Other CI as default', async () => {
+          setup({})
+          render(<NewRepoTab />, {
+            wrapper: wrapper('/gl/codecov/cool-repo/new'),
+          })
+
+          const otherCI = await screen.findByTestId('other-ci-radio')
+          expect(otherCI).toBeInTheDocument()
+          expect(otherCI.hasAttribute('data-state')).toBeTruthy()
+          expect(otherCI.getAttribute('data-state')).toBe('checked')
+        })
+      })
+
+      describe('when on /new/circle-ci', () => {
+        it('selects Circle CI as default', async () => {
+          setup({})
+          render(<NewRepoTab />, {
+            wrapper: wrapper('/gl/codecov/cool-repo/new/circle-ci'),
+          })
+
+          const circleCI = await screen.findByTestId('circle-ci-radio')
+          expect(circleCI).toBeInTheDocument()
+          expect(circleCI.hasAttribute('data-state')).toBeTruthy()
+          expect(circleCI.getAttribute('data-state')).toBe('checked')
+        })
+      })
+
+      describe('when on /new/other-ci', () => {
+        it('selects Other CI as default', async () => {
+          setup({})
+          render(<NewRepoTab />, {
+            wrapper: wrapper('/gl/codecov/cool-repo/new/other-ci'),
+          })
+
+          const otherCI = await screen.findByTestId('other-ci-radio')
+          expect(otherCI).toBeInTheDocument()
+          expect(otherCI.hasAttribute('data-state')).toBeTruthy()
+          expect(otherCI.getAttribute('data-state')).toBe('checked')
+        })
+      })
+    })
+
+    describe('navigation', () => {
+      describe('when GitHub Actions is selected', () => {
+        it('should navigate to /new', async () => {
+          const { user } = setup({})
+          render(<NewRepoTab />, {
+            wrapper: wrapper('/gh/codecov/cool-repo/new/other-ci'),
+          })
+
+          const githubActions = await screen.findByTestId(
+            'github-actions-radio'
+          )
+          expect(githubActions).toBeInTheDocument()
+          expect(githubActions.hasAttribute('data-state')).toBeTruthy()
+          expect(githubActions.getAttribute('data-state')).toBe('unchecked')
+
+          await user.click(githubActions)
+
+          expect(githubActions).toBeInTheDocument()
+          expect(githubActions.hasAttribute('data-state')).toBeTruthy()
+          expect(githubActions.getAttribute('data-state')).toBe('checked')
+
+          expect(testLocation.pathname).toBe('/gh/codecov/cool-repo/new')
+        })
+      })
+
+      describe('when Circle CI is selected', () => {
+        it('should navigate to /new/circle-ci', async () => {
+          const { user } = setup({})
+          render(<NewRepoTab />, { wrapper: wrapper() })
+
+          const circleCI = await screen.findByTestId('circle-ci-radio')
+          expect(circleCI).toBeInTheDocument()
+          expect(circleCI.hasAttribute('data-state')).toBeTruthy()
+          expect(circleCI.getAttribute('data-state')).toBe('unchecked')
+
+          await user.click(circleCI)
+
+          expect(circleCI).toBeInTheDocument()
+          expect(circleCI.hasAttribute('data-state')).toBeTruthy()
+          expect(circleCI.getAttribute('data-state')).toBe('checked')
+
+          expect(testLocation.pathname).toBe(
+            '/gh/codecov/cool-repo/new/circle-ci'
+          )
+        })
+      })
+
+      describe('when Other CI is selected', () => {
+        it('should navigate to /new/other-ci', async () => {
+          const { user } = setup({})
+          render(<NewRepoTab />, { wrapper: wrapper() })
+
+          const otherCI = await screen.findByTestId('other-ci-radio')
+          expect(otherCI).toBeInTheDocument()
+          expect(otherCI.hasAttribute('data-state')).toBeTruthy()
+          expect(otherCI.getAttribute('data-state')).toBe('unchecked')
+
+          await user.click(otherCI)
+
+          expect(otherCI).toBeInTheDocument()
+          expect(otherCI.hasAttribute('data-state')).toBeTruthy()
+          expect(otherCI.getAttribute('data-state')).toBe('checked')
+
+          expect(testLocation.pathname).toBe(
+            '/gh/codecov/cool-repo/new/other-ci'
+          )
+        })
+      })
     })
   })
 
@@ -155,73 +299,26 @@ describe('NewRepoTab', () => {
       })
     )
 
-    it('renders header', async () => {
+    it('renders github actions', async () => {
       render(<NewRepoTab />, { wrapper: wrapper() })
-
-      const header = await screen.findByRole('heading', {
-        name: /Let's get your repo covered/,
-      })
-      expect(header).toBeInTheDocument()
+      const content = await screen.findByText(/GitHubActions/)
+      expect(content).toBeInTheDocument()
     })
 
-    it('renders ActivationBanner', async () => {
-      render(<NewRepoTab />, { wrapper: wrapper() })
-
-      const banner = await screen.findByText('ActivationBanner')
-      expect(banner).toBeInTheDocument()
+    it('renders circle ci', async () => {
+      render(<NewRepoTab />, {
+        wrapper: wrapper('/gh/codecov/cool-repo/new/circle-ci'),
+      })
+      const content = await screen.findByText(/CircleCI/)
+      expect(content).toBeInTheDocument()
     })
 
-    describe('users provider is github', () => {
-      it('renders github actions tab', async () => {
-        render(<NewRepoTab />, { wrapper: wrapper() })
-
-        const content = await screen.findByText('GitHubActions')
-        expect(content).toBeInTheDocument()
-
-        const tab = await screen.findByRole('link', { name: 'GitHub Actions' })
-        expect(tab).toBeInTheDocument()
-        expect(tab).toHaveAttribute('href', '/gh/codecov/cool-repo/new')
+    it('renders other ci', async () => {
+      render(<NewRepoTab />, {
+        wrapper: wrapper('/gh/codecov/cool-repo/new/other-ci'),
       })
-
-      it('renders other ci tab', async () => {
-        render(<NewRepoTab />, { wrapper: wrapper() })
-
-        const content = await screen.findByText('GitHubActions')
-        expect(content).toBeInTheDocument()
-
-        const tab = await screen.findByRole('link', { name: 'Other CI' })
-        expect(tab).toBeInTheDocument()
-        expect(tab).toHaveAttribute(
-          'href',
-          '/gh/codecov/cool-repo/new/other-ci'
-        )
-      })
-    })
-
-    describe('users provider is not github', () => {
-      it('does not render github actions tab', async () => {
-        render(<NewRepoTab />, {
-          wrapper: wrapper('/gl/codecov/cool-repo/new'),
-        })
-
-        const content = await screen.findByText('OtherCI')
-        expect(content).toBeInTheDocument()
-
-        const tab = screen.queryByRole('link', { name: 'GitHub Actions' })
-        expect(tab).not.toBeInTheDocument()
-      })
-
-      it('does not render other ci tab', async () => {
-        render(<NewRepoTab />, {
-          wrapper: wrapper('/gl/codecov/cool-repo/new'),
-        })
-
-        const content = await screen.findByText('OtherCI')
-        expect(content).toBeInTheDocument()
-
-        const tab = screen.queryByRole('link', { name: 'Other CI' })
-        expect(tab).not.toBeInTheDocument()
-      })
+      const content = await screen.findByText(/OtherCI/)
+      expect(content).toBeInTheDocument()
     })
   })
 
@@ -244,69 +341,53 @@ describe('NewRepoTab', () => {
     })
   })
 
-  describe('users provider is github', () => {
-    describe('testing tab navigation', () => {
-      describe('clicking on other ci', () => {
-        it('navigates to /other-ci', async () => {
-          const { user } = setup({
-            isPrivate: true,
-          })
-          render(<NewRepoTab />, { wrapper: wrapper() })
-
-          const tab = await screen.findByRole('link', { name: 'Other CI' })
-          expect(tab).toBeInTheDocument()
-          expect(tab).toHaveAttribute(
-            'href',
-            '/gh/codecov/cool-repo/new/other-ci'
-          )
-
-          await user.click(tab)
-
-          expect(testLocation.pathname).toBe(
-            '/gh/codecov/cool-repo/new/other-ci'
-          )
-
-          const content = await screen.findByText('OtherCI')
-          expect(content).toBeInTheDocument()
+  describe('ActivationBanner', () => {
+    describe('when user is activated', () => {
+      it('does not render ActivationBanner', async () => {
+        setup({
+          isCurrentUserActivated: true,
+          isPrivate: true,
         })
-      })
+        render(<NewRepoTab />, { wrapper: wrapper() })
 
-      describe('clicking on github actions', () => {
-        it('navigates to /new', async () => {
-          const { user } = setup({})
-          render(<NewRepoTab />, {
-            wrapper: wrapper('/gh/codecov/cool-repo/new/other-ci'),
-          })
+        await waitFor(() => queryClient.isFetching)
+        await waitFor(() => !queryClient.isFetching)
 
-          const tab = await screen.findByRole('link', {
-            name: 'GitHub Actions',
-          })
-          expect(tab).toBeInTheDocument()
-          expect(tab).toHaveAttribute('href', '/gh/codecov/cool-repo/new')
-
-          await user.click(tab)
-
-          expect(testLocation.pathname).toBe('/gh/codecov/cool-repo/new')
-
-          const content = await screen.findByText('GitHubActions')
-          expect(content).toBeInTheDocument()
-        })
+        const banner = screen.queryByText(/ActivationBanner/)
+        expect(banner).not.toBeInTheDocument()
       })
     })
-  })
 
-  describe('user is activated', () => {
-    it('does not render ActivationBanner', async () => {
-      setup({
-        isCurrentUserActivated: true,
+    describe('when user is not activated but public repo', () => {
+      it('does not render ActivationBanner', async () => {
+        setup({
+          isCurrentUserActivated: false,
+          isPrivate: false,
+        })
+        render(<NewRepoTab />, { wrapper: wrapper() })
+
+        await waitFor(() => queryClient.isFetching)
+        await waitFor(() => !queryClient.isFetching)
+
+        const banner = screen.queryByText(/ActivationBanner/)
+        expect(banner).not.toBeInTheDocument()
       })
-      render(<NewRepoTab />, { wrapper: wrapper() })
 
-      await waitFor(() => queryClient.isFetching)
-      await waitFor(() => !queryClient.isFetching)
+    describe('when user is not activated and is private repo', () => {
+      it('renders ActivationBanner', async () => {
+        setup({
+          isCurrentUserActivated: false,
+          isPrivate: true,
+        })
+        render(<NewRepoTab />, { wrapper: wrapper() })
 
-      const banner = screen.queryByText('ActivationBanner')
-      expect(banner).not.toBeInTheDocument()
+        await waitFor(() => queryClient.isFetching)
+        await waitFor(() => !queryClient.isFetching)
+
+        const banner = screen.queryByText(/ActivationBanner/)
+        expect(banner).toBeInTheDocument()
+      })
+    })
     })
   })
 })

--- a/src/pages/RepoPage/CoverageOnboarding/NewRepoTab.tsx
+++ b/src/pages/RepoPage/CoverageOnboarding/NewRepoTab.tsx
@@ -138,16 +138,15 @@ function NewRepoTab() {
     return <NotFound />
   }
 
-  const renderActivationBanner = !data?.isCurrentUserActivated && data?.repository.private
+  const renderActivationBanner =
+    !data?.isCurrentUserActivated && data?.repository.private
 
   return (
-    <div className="flex flex-col gap-6">
-      <div className="flex flex-col gap-6 pt-4 lg:w-3/5">
-        <IntroBlurb />
-        {renderActivationBanner ? <ActivationBanner /> : null}
-        <CISelector provider={provider} owner={owner} repo={repo} />
-        <Content />
-      </div>
+    <div className="flex flex-col gap-6 pt-4 lg:w-3/5">
+      <IntroBlurb />
+      {renderActivationBanner ? <ActivationBanner /> : null}
+      <CISelector provider={provider} owner={owner} repo={repo} />
+      <Content />
     </div>
   )
 }

--- a/src/pages/RepoPage/CoverageOnboarding/NewRepoTab.tsx
+++ b/src/pages/RepoPage/CoverageOnboarding/NewRepoTab.tsx
@@ -1,14 +1,16 @@
-import { lazy, Suspense } from 'react'
-import { Switch, useParams } from 'react-router-dom'
+import { lazy, Suspense, useCallback, useMemo } from 'react'
+import { Switch, useHistory, useLocation, useParams } from 'react-router-dom'
 
 import { SentryRoute } from 'sentry'
 
 import NotFound from 'pages/NotFound'
+import { useNavLinks } from 'services/navigation'
 import { useRepo } from 'services/repo'
 import { useRedirect } from 'shared/useRedirect'
 import { providerToName } from 'shared/utils'
+import { Card } from 'ui/Card'
+import { RadioTileGroup } from 'ui/RadioTileGroup'
 import Spinner from 'ui/Spinner'
-import TabNavigation from 'ui/TabNavigation'
 
 import ActivationBanner from './ActivationBanner'
 import CircleCI from './CircleCI'
@@ -23,53 +25,97 @@ const Loader = () => (
   </div>
 )
 
-function Content({
-  provider,
-  isCurrentUserActivated,
-  isRepoPrivate,
-}: {
-  provider: string
-  isCurrentUserActivated: boolean
-  isRepoPrivate?: boolean
-}) {
-  const renderActivationBanner = !isCurrentUserActivated && isRepoPrivate
+const CI_PROVIDERS = {
+  GitHubActions: 'GitHubActions',
+  CircleCI: 'CircleCI',
+  OtherCI: 'OtherCI',
+} as const
+type CIProviderValue = (typeof CI_PROVIDERS)[keyof typeof CI_PROVIDERS]
 
-  if (providerToName(provider) !== 'Github') {
-    return (
-      <div className="mt-6">
+interface CISelectorProps {
+  provider: string
+  owner: string
+  repo: string
+}
+
+function CISelector({ provider, owner, repo }: CISelectorProps) {
+  const location = useLocation()
+  const history = useHistory()
+  const { new: githubActions, circleCI, newOtherCI } = useNavLinks()
+  const urls = useMemo(
+    () => ({
+      GitHubActions: githubActions.path({ provider, owner, repo }),
+      CircleCI: circleCI.path({ provider, owner, repo }),
+      OtherCI: newOtherCI.path({ provider, owner, repo }),
+    }),
+    [githubActions, circleCI, newOtherCI, provider, owner, repo]
+  )
+
+  const getInitialProvider = useCallback(() => {
+    const defaultProvider =
+      providerToName(provider) !== 'Github'
+        ? CI_PROVIDERS.OtherCI
+        : CI_PROVIDERS.GitHubActions
+    if (location.pathname === urls.CircleCI) {
+      return CI_PROVIDERS.CircleCI
+    }
+    if (location.pathname === urls.OtherCI) {
+      return CI_PROVIDERS.OtherCI
+    }
+    return defaultProvider
+  }, [location, urls, provider])
+
+  return (
+    <Card>
+      <Card.Header>
+        <Card.Title size="base">Select your CI</Card.Title>
+      </Card.Header>
+      <Card.Content>
+        <RadioTileGroup
+          defaultValue={getInitialProvider()}
+          onValueChange={(value: CIProviderValue) => {
+            history.replace(urls[value])
+          }}
+        >
+          <RadioTileGroup.Item
+            value={CI_PROVIDERS.GitHubActions}
+            data-testid="github-actions-radio"
+          >
+            <RadioTileGroup.Label>Using GitHub Actions</RadioTileGroup.Label>
+          </RadioTileGroup.Item>
+          <RadioTileGroup.Item
+            value={CI_PROVIDERS.CircleCI}
+            data-testid="circle-ci-radio"
+          >
+            <RadioTileGroup.Label>Using Circle CI</RadioTileGroup.Label>
+          </RadioTileGroup.Item>
+          <RadioTileGroup.Item
+            value={CI_PROVIDERS.OtherCI}
+            data-testid="other-ci-radio"
+          >
+            <RadioTileGroup.Label>Other</RadioTileGroup.Label>
+          </RadioTileGroup.Item>
+        </RadioTileGroup>
+      </Card.Content>
+    </Card>
+  )
+}
+
+function Content() {
+  return (
+    <Switch>
+      <SentryRoute path="/:provider/:owner/:repo/new" exact>
+        <GitHubActions />
+      </SentryRoute>
+      <SentryRoute path="/:provider/:owner/:repo/new/circle-ci" exact>
+        <CircleCI />
+      </SentryRoute>
+      <SentryRoute path="/:provider/:owner/:repo/new/other-ci" exact>
         <Suspense fallback={<Loader />}>
           <OtherCI />
         </Suspense>
-      </div>
-    )
-  }
-
-  return (
-    <>
-      <TabNavigation
-        tabs={[
-          { pageName: 'new', children: 'GitHub Actions', exact: true },
-          { pageName: 'circleCI' },
-          { pageName: 'newOtherCI' },
-        ]}
-      />
-      {renderActivationBanner ? <ActivationBanner /> : null}
-      <div className="mt-6">
-        <Switch>
-          <SentryRoute path="/:provider/:owner/:repo/new" exact>
-            <GitHubActions />
-          </SentryRoute>
-          <SentryRoute path="/:provider/:owner/:repo/new/circle-ci" exact>
-            <CircleCI />
-          </SentryRoute>
-          <SentryRoute path="/:provider/:owner/:repo/new/other-ci" exact>
-            <Suspense fallback={<Loader />}>
-              <OtherCI />
-            </Suspense>
-          </SentryRoute>
-        </Switch>
-      </div>
-    </>
+      </SentryRoute>
+    </Switch>
   )
 }
 
@@ -91,15 +137,15 @@ function NewRepoTab() {
     return <NotFound />
   }
 
+  const renderActivationBanner = !data?.isCurrentUserActivated && data?.repository.private
+
   return (
     <div className="flex flex-col gap-6">
-      <div className="flex flex-col gap-4 pt-4 lg:w-3/5">
+      <div className="flex flex-col gap-6 pt-4 lg:w-3/5">
         <IntroBlurb />
-        <Content
-          provider={provider}
-          isCurrentUserActivated={data?.isCurrentUserActivated ?? false}
-          isRepoPrivate={data?.repository.private ?? false}
-        />
+        {renderActivationBanner ? <ActivationBanner /> : null}
+        <CISelector provider={provider} owner={owner} repo={repo} />
+        <Content />
       </div>
     </div>
   )


### PR DESCRIPTION
# Description

Updates the CI provider navigation in new repo onboarding to use the new RadioTileGroup component.

[Design](https://www.figma.com/file/ICgJ2z5wJSxs0kzrtOp073/GH-1439?type=design&node-id=1-238&mode=design&t=DWNl8qjORVenKYbd-0)

# Notable Changes

- Add new navigator on NewReopTab.tsx using RadioTileGroup component
- Rewrite NewRepoTab.tsx for better organization
- Add better testing for NewRepoTab.tsx

# Screenshots

Before:

![Screenshot 2024-05-03 at 18 24 04](https://github.com/codecov/gazebo/assets/159931558/536920db-65b2-463b-8925-9987f1be4dd3)

After:

![Screenshot 2024-05-03 at 18 24 42](https://github.com/codecov/gazebo/assets/159931558/e4c275f9-fc34-4c95-91d9-c630ed4c646d)

