### PR TITLE
fix: Unlink PR author on pulls table

### DIFF
--- a/src/pages/RepoPage/PullsTab/shared/Title/Title.tsx
+++ b/src/pages/RepoPage/PullsTab/shared/Title/Title.tsx
@@ -47,10 +47,7 @@ const Title: React.FC<TitleProps> = ({
           <h2 className="text-sm font-semibold text-black">{title}</h2>
         </A>
         <p className="text-xs">
-          {/* @ts-expect-error - disable because of non-ts component and type mismatch */}
-          <A to={{ pageName: 'owner' }}>
-            <span className="text-black">{author?.username}</span>
-          </A>
+          <span className="text-black">{author?.username}</span>
           {updatestamp && (
             <span className="text-ds-gray-quinary">
               {' '}


### PR DESCRIPTION
Unlinks the PR author name on the pulls table. Currently the link just goes to the home page. Causes no visual changes.

Closes https://github.com/codecov/engineering-team/issues/1568
