### PR TITLE
fix: Hide sunburst on very large repos

### DIFF
--- a/src/pages/RepoPage/CoverageTab/CoverageTab.jsx
+++ b/src/pages/RepoPage/CoverageTab/CoverageTab.jsx
@@ -49,7 +49,7 @@ function CoverageTab() {
 
   let displaySunburst = false
   const fileCount = data?.branch?.head?.totals?.fileCount
-  if (typeof fileCount === 'number' && fileCount <= 10_000) {
+  if (typeof fileCount === 'number' && fileCount <= 100_000) {
     displaySunburst = true
   }
 

--- a/src/pages/RepoPage/CoverageTab/CoverageTab.jsx
+++ b/src/pages/RepoPage/CoverageTab/CoverageTab.jsx
@@ -49,7 +49,7 @@ function CoverageTab() {
 
   let displaySunburst = false
   const fileCount = data?.branch?.head?.totals?.fileCount
-  if (typeof fileCount === 'number' && fileCount <= 100_000) {
+  if (typeof fileCount === 'number' && fileCount <= 200_000) {
     displaySunburst = true
   }
 

--- a/src/pages/RepoPage/CoverageTab/CoverageTab.jsx
+++ b/src/pages/RepoPage/CoverageTab/CoverageTab.jsx
@@ -64,7 +64,7 @@ function CoverageTab() {
         <FirstPullRequestBanner />
       ) : null}
       {showTeamSummary ? <SummaryTeamPlan /> : <Summary />}
-      {!showTeamSummary && (
+      {!showTeamSummary ? (
         <SentryRoute
           path={[
             '/:provider/:owner/:repo/tree/:branch/:path+',
@@ -97,7 +97,7 @@ function CoverageTab() {
             </ToggleElement>
           </Suspense>
         </SentryRoute>
-      )}
+      ) : null}
       <Switch>
         <SentryRoute path="/:provider/:owner/:repo/blob/:ref/:path+" exact>
           <Suspense fallback={<Loader />}>

--- a/src/pages/RepoPage/CoverageTab/CoverageTab.spec.jsx
+++ b/src/pages/RepoPage/CoverageTab/CoverageTab.spec.jsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { render, screen } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
 import { graphql, rest } from 'msw'
 import { setupServer } from 'msw/node'
 import { MemoryRouter, Route } from 'react-router-dom'
@@ -261,6 +261,7 @@ const mockBranchComponents = {
 const mockFlagSelect = {
   owner: {
     repository: {
+      __typename: 'Repository',
       flags: {
         edges: [
           {
@@ -416,6 +417,9 @@ describe('Coverage Tab', () => {
       setup({ fileCount: 100 })
       render(<CoverageTab />, { wrapper: wrapper(['/gh/test-org/repoName']) })
 
+      await waitFor(() => queryClient.isFetching)
+      await waitFor(() => !queryClient.isFetching)
+
       const hideChart = await screen.findByText(/Hide Chart/)
       expect(hideChart).toBeInTheDocument()
 
@@ -439,7 +443,6 @@ describe('Coverage Tab', () => {
 
   it('renders default summary', async () => {
     setup()
-
     render(<CoverageTab />, { wrapper: wrapper(['/gh/test-org/repoName']) })
 
     const summary = screen.getByText(/Summary/)

--- a/src/pages/RepoPage/CoverageTab/CoverageTab.spec.jsx
+++ b/src/pages/RepoPage/CoverageTab/CoverageTab.spec.jsx
@@ -58,7 +58,28 @@ const repoConfigMock = {
   },
 }
 
-const treeMock = [{ name: 'repoName', children: [] }]
+const treeMock = [
+  {
+    name: 'src',
+    full_path: 'src',
+    coverage: 98.0,
+    lines: 13026,
+    hits: 12828,
+    partials: 4,
+    misses: 194,
+    children: [
+      {
+        name: 'App.tsx',
+        full_path: 'src/App.tsx',
+        coverage: 100.0,
+        lines: 47,
+        hits: 47,
+        partials: 0,
+        misses: 0,
+      },
+    ],
+  },
+]
 
 const overviewMock = {
   owner: {

--- a/src/pages/RepoPage/CoverageTab/CoverageTab.spec.jsx
+++ b/src/pages/RepoPage/CoverageTab/CoverageTab.spec.jsx
@@ -384,7 +384,7 @@ describe('Coverage Tab', () => {
     jest.resetAllMocks()
   })
 
-  describe('file count is under 100_000', () => {
+  describe('file count is under 200_000', () => {
     it('renders the sunburst chart', async () => {
       setup({ fileCount: 100 })
       render(<CoverageTab />, { wrapper: wrapper(['/gh/test-org/repoName']) })
@@ -397,9 +397,9 @@ describe('Coverage Tab', () => {
     }, 60000)
   })
 
-  describe('file count is above 100_000', () => {
+  describe('file count is above 200_000', () => {
     it('does not render the sunburst chart', async () => {
-      setup({ fileCount: 100_000 })
+      setup({ fileCount: 200_000 })
       render(<CoverageTab />, { wrapper: wrapper(['/gh/test-org/repoName']) })
 
       const hideChart = await screen.findByText(/Hide Chart/)

--- a/src/pages/RepoPage/CoverageTab/CoverageTab.spec.jsx
+++ b/src/pages/RepoPage/CoverageTab/CoverageTab.spec.jsx
@@ -384,26 +384,20 @@ describe('Coverage Tab', () => {
     jest.resetAllMocks()
   })
 
-  describe('file count is under 10_000', () => {
+  describe('file count is under 100_000', () => {
     it('renders the sunburst chart', async () => {
       setup({ fileCount: 100 })
       render(<CoverageTab />, { wrapper: wrapper(['/gh/test-org/repoName']) })
 
-      expect(await screen.findByText(/Hide Chart/)).toBeTruthy()
-      const hideChart = screen.getByText(/Hide Chart/)
+      const hideChart = await screen.findByText(/Hide Chart/)
       expect(hideChart).toBeInTheDocument()
 
-      expect(await screen.findByTestId('sunburst')).toBeTruthy()
-      const sunburst = screen.getByTestId('sunburst')
+      const sunburst = await screen.findByTestId('sunburst')
       expect(sunburst).toBeInTheDocument()
-
-      expect(await screen.findByTestId('coverage-area-chart')).toBeTruthy()
-      const coverageAreaChart = screen.getByTestId('coverage-area-chart')
-      expect(coverageAreaChart).toBeInTheDocument()
     }, 60000)
   })
 
-  describe('file count is above 10_000', () => {
+  describe('file count is above 100_000', () => {
     it('does not render the sunburst chart', async () => {
       setup({ fileCount: 100_000 })
       render(<CoverageTab />, { wrapper: wrapper(['/gh/test-org/repoName']) })
@@ -413,9 +407,6 @@ describe('Coverage Tab', () => {
 
       const sunburst = screen.queryByTestId('sunburst')
       expect(sunburst).not.toBeInTheDocument()
-
-      const coverageAreaChart = await screen.findByTestId('coverage-area-chart')
-      expect(coverageAreaChart).toBeInTheDocument()
     })
   })
 
@@ -426,6 +417,14 @@ describe('Coverage Tab', () => {
 
     const summary = screen.getByText(/Summary/)
     expect(summary).toBeInTheDocument()
+  })
+
+  it('renders the coverage area chart', async () => {
+    setup({ fileCount: 100 })
+    render(<CoverageTab />, { wrapper: wrapper(['/gh/test-org/repoName']) })
+
+    const coverageAreaChart = await screen.findByTestId('coverage-area-chart')
+    expect(coverageAreaChart).toBeInTheDocument()
   })
 
   describe('when the repo is private and org is on team plan', () => {

--- a/src/pages/RepoPage/CoverageTab/CoverageTab.spec.jsx
+++ b/src/pages/RepoPage/CoverageTab/CoverageTab.spec.jsx
@@ -138,12 +138,17 @@ const branchesContentsMock = {
       branch: {
         head: {
           pathContents: {
+            __typename: 'PathContents',
             results: [
               {
+                __typename: 'PathContentDir',
+                hits: 9,
+                misses: 0,
+                partials: 0,
+                lines: 10,
                 name: 'src',
                 path: 'src',
                 percentCovered: 100.0,
-                __typename: 'PathContentDir',
               },
             ],
           },
@@ -255,6 +260,7 @@ const mockFlagSelect = {
 const mockBackfillFlag = {
   owner: {
     repository: {
+      __typename: 'Repository',
       flagsMeasurementsActive: true,
       flagsMeasurementsBackfilled: true,
     },
@@ -336,7 +342,7 @@ describe('Coverage Tab', () => {
         res(ctx.status(200), ctx.data(overviewMock))
       ),
       graphql.query('GetRepoCoverage', (req, res, ctx) =>
-        res(ctx.status(200), ctx.data({}))
+        res(ctx.status(200), ctx.data({ owner: null }))
       ),
       graphql.query('GetBranchCoverageMeasurements', (req, res, ctx) =>
         res(ctx.status(200), ctx.data(mockBranchMeasurements))

--- a/src/pages/RepoPage/CoverageTab/CoverageTab.spec.jsx
+++ b/src/pages/RepoPage/CoverageTab/CoverageTab.spec.jsx
@@ -400,7 +400,7 @@ describe('Coverage Tab', () => {
 
       const sunburst = await screen.findByTestId('sunburst')
       expect(sunburst).toBeInTheDocument()
-    }, 60000)
+    }, 100_000)
   })
 
   describe('file count is above 200_000', () => {

--- a/src/pages/RepoPage/CoverageTab/hooks/useCoverageTabData.spec.tsx
+++ b/src/pages/RepoPage/CoverageTab/hooks/useCoverageTabData.spec.tsx
@@ -1,0 +1,302 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { renderHook, waitFor } from '@testing-library/react'
+import { graphql } from 'msw'
+import { setupServer } from 'msw/node'
+import { MemoryRouter, Route } from 'react-router-dom'
+
+import { useCoverageTabData } from './useCoverageTabData'
+
+const mockOverview = {
+  owner: {
+    repository: {
+      __typename: 'Repository',
+      private: false,
+      defaultBranch: 'main',
+      oldestCommitAt: '2022-10-10T11:59:59',
+      coverageEnabled: true,
+      bundleAnalysisEnabled: true,
+      languages: ['JavaScript'],
+    },
+  },
+}
+
+const mockCoverageTabData = {
+  owner: {
+    repository: {
+      __typename: 'Repository',
+      branch: {
+        head: {
+          totals: {
+            fileCount: 10,
+          },
+        },
+      },
+    },
+  },
+}
+
+const mockNotFoundError = {
+  owner: {
+    isCurrentUserPartOfOrg: true,
+    repository: {
+      __typename: 'NotFoundError',
+      message: 'commit not found',
+    },
+  },
+}
+
+const mockOwnerNotActivatedError = {
+  owner: {
+    isCurrentUserPartOfOrg: true,
+    repository: {
+      __typename: 'OwnerNotActivatedError',
+      message: 'owner not activated',
+    },
+  },
+}
+
+const mockNullOwner = {
+  owner: null,
+}
+
+const mockUnsuccessfulParseError = {}
+
+const server = setupServer()
+const queryClient = new QueryClient({
+  defaultOptions: { queries: { retry: false } },
+})
+
+const wrapper =
+  (
+    initialEntries = '/gh/codecov/cool-repo'
+  ): React.FC<React.PropsWithChildren> =>
+  ({ children }) =>
+    (
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter initialEntries={[initialEntries]}>
+          <Route
+            path={[
+              '/:provider/:owner/:repo/tree/:branch',
+              '/:provider/:owner/:repo',
+            ]}
+          >
+            {children}
+          </Route>
+        </MemoryRouter>
+      </QueryClientProvider>
+    )
+
+beforeAll(() => {
+  server.listen()
+})
+
+afterEach(() => {
+  queryClient.clear()
+  server.resetHandlers()
+})
+
+afterAll(() => {
+  server.close()
+})
+
+interface SetupArgs {
+  isNotFoundError?: boolean
+  isOwnerNotActivatedError?: boolean
+  isUnsuccessfulParseError?: boolean
+  isNullOwner?: boolean
+}
+
+describe('useCoverageTabData', () => {
+  function setup({
+    isNotFoundError = false,
+    isOwnerNotActivatedError = false,
+    isUnsuccessfulParseError = false,
+    isNullOwner = false,
+  }: SetupArgs) {
+    server.use(
+      graphql.query('CoverageTabData', (req, res, ctx) => {
+        if (isNotFoundError) {
+          return res(ctx.status(200), ctx.data(mockNotFoundError))
+        } else if (isOwnerNotActivatedError) {
+          return res(ctx.status(200), ctx.data(mockOwnerNotActivatedError))
+        } else if (isUnsuccessfulParseError) {
+          return res(ctx.status(200), ctx.data(mockUnsuccessfulParseError))
+        } else if (isNullOwner) {
+          return res(ctx.status(200), ctx.data(mockNullOwner))
+        } else {
+          return res(ctx.status(200), ctx.data(mockCoverageTabData))
+        }
+      }),
+      graphql.query('GetRepoOverview', (req, res, ctx) => {
+        return res(ctx.status(200), ctx.data(mockOverview))
+      })
+    )
+  }
+
+  describe('valid data response', () => {
+    describe('branch is passed', () => {
+      it('returns the data for the passed branch', async () => {
+        setup({})
+        const { result } = renderHook(
+          () =>
+            useCoverageTabData({
+              provider: 'gh',
+              owner: 'codecov',
+              repo: 'cool-repo',
+              branch: 'main',
+            }),
+          { wrapper: wrapper() }
+        )
+
+        await waitFor(() => expect(result.current.isSuccess).toBeTruthy())
+        await waitFor(() =>
+          expect(result.current.data).toEqual({
+            branch: {
+              head: {
+                totals: {
+                  fileCount: 10,
+                },
+              },
+            },
+          })
+        )
+      })
+    })
+
+    describe('branch is not passed', () => {
+      it('returns the data for the default branch', async () => {
+        setup({})
+        const { result } = renderHook(
+          () =>
+            useCoverageTabData({
+              provider: 'gh',
+              owner: 'codecov',
+              repo: 'cool-repo',
+            }),
+          { wrapper: wrapper() }
+        )
+
+        await waitFor(() => expect(result.current.isSuccess).toBeTruthy())
+        await waitFor(() =>
+          expect(result.current.data).toEqual({
+            branch: {
+              head: {
+                totals: {
+                  fileCount: 10,
+                },
+              },
+            },
+          })
+        )
+      })
+    })
+  })
+
+  describe('returns NotFoundError __typename', () => {
+    let oldConsoleError = console.error
+
+    beforeEach(() => {
+      console.error = () => null
+    })
+
+    afterEach(() => {
+      console.error = oldConsoleError
+    })
+
+    it('throws a 404', async () => {
+      setup({ isNotFoundError: true })
+      const { result } = renderHook(
+        () =>
+          useCoverageTabData({
+            provider: 'gh',
+            owner: 'codecov',
+            repo: 'cool-repo',
+            branch: 'main',
+          }),
+        { wrapper: wrapper() }
+      )
+
+      await waitFor(() => expect(result.current.isError).toBeTruthy())
+      await waitFor(() =>
+        expect(result.current.error).toEqual(
+          expect.objectContaining({
+            status: 404,
+            dev: 'useCoverageTabData - 404 NotFoundError',
+          })
+        )
+      )
+    })
+  })
+
+  describe('returns OwnerNotActivatedError __typename', () => {
+    let oldConsoleError = console.error
+
+    beforeEach(() => {
+      console.error = () => null
+    })
+
+    afterEach(() => {
+      console.error = oldConsoleError
+    })
+
+    it('throws a 403', async () => {
+      setup({ isOwnerNotActivatedError: true })
+      const { result } = renderHook(
+        () =>
+          useCoverageTabData({
+            provider: 'gh',
+            owner: 'codecov',
+            repo: 'cool-repo',
+            branch: 'main',
+          }),
+        { wrapper: wrapper() }
+      )
+
+      await waitFor(() => expect(result.current.isError).toBeTruthy())
+      await waitFor(() =>
+        expect(result.current.error).toEqual(
+          expect.objectContaining({
+            status: 403,
+            dev: 'useCoverageTabData - 403 OwnerNotActivatedError',
+          })
+        )
+      )
+    })
+  })
+
+  describe('unsuccessful parse of zod schema', () => {
+    let oldConsoleError = console.error
+
+    beforeEach(() => {
+      console.error = () => null
+    })
+
+    afterEach(() => {
+      console.error = oldConsoleError
+    })
+
+    it('throws a 404', async () => {
+      setup({ isUnsuccessfulParseError: true })
+      const { result } = renderHook(
+        () =>
+          useCoverageTabData({
+            provider: 'gh',
+            owner: 'codecov',
+            repo: 'cool-repo',
+            branch: 'main',
+          }),
+        { wrapper: wrapper() }
+      )
+
+      await waitFor(() => expect(result.current.isError).toBeTruthy())
+      await waitFor(() =>
+        expect(result.current.error).toEqual(
+          expect.objectContaining({
+            status: 404,
+            dev: 'useCoverageTabData - 404 schema parsing failed',
+          })
+        )
+      )
+    })
+  })
+})

--- a/src/pages/RepoPage/CoverageTab/hooks/useCoverageTabData.tsx
+++ b/src/pages/RepoPage/CoverageTab/hooks/useCoverageTabData.tsx
@@ -1,0 +1,148 @@
+import { useQuery } from '@tanstack/react-query'
+import { z } from 'zod'
+
+import {
+  RepoNotFoundErrorSchema,
+  RepoOwnerNotActivatedErrorSchema,
+  useRepoOverview,
+} from 'services/repo'
+import Api from 'shared/api'
+import { type NetworkErrorObject } from 'shared/api/helpers'
+import A from 'ui/A'
+
+const BranchSchema = z
+  .object({
+    head: z
+      .object({
+        totals: z
+          .object({
+            fileCount: z.number().nullable(),
+          })
+          .nullable(),
+      })
+      .nullable(),
+  })
+  .nullable()
+
+const GetBranchSchema = z.object({
+  owner: z
+    .object({
+      repository: z
+        .discriminatedUnion('__typename', [
+          z.object({
+            __typename: z.literal('Repository'),
+            branch: BranchSchema,
+          }),
+          RepoNotFoundErrorSchema,
+          RepoOwnerNotActivatedErrorSchema,
+        ])
+        .nullable(),
+    })
+    .nullable(),
+})
+
+const query = `
+query CoverageTabData($owner: String!, $repo: String!, $branch: String!) {
+  owner(username: $owner) {
+    repository(name: $repo) {
+      __typename
+      ... on Repository {
+        branch(name: $branch) {
+          head {
+            totals {
+              fileCount
+            }
+          }
+        }
+      }
+      ... on NotFoundError {
+        message
+      }
+      ... on OwnerNotActivatedError {
+        message
+      }
+    }
+  }
+}`
+
+interface UseCoverageTabDataArgs {
+  provider: string
+  owner: string
+  repo: string
+  branch?: string
+}
+
+export const useCoverageTabData = ({
+  provider,
+  owner,
+  repo,
+  branch,
+}: UseCoverageTabDataArgs) => {
+  const { data: repoOverview } = useRepoOverview({
+    provider,
+    repo,
+    owner,
+    opts: {
+      enabled: !branch,
+    },
+  })
+
+  const passedBranch = branch ?? repoOverview?.defaultBranch
+
+  return useQuery({
+    queryKey: ['CoverageTabData', provider, owner, repo, passedBranch, query],
+    queryFn: ({ signal }) =>
+      Api.graphql({
+        provider,
+        query,
+        signal,
+        variables: {
+          owner,
+          repo,
+          branch: passedBranch,
+        },
+      }).then((res) => {
+        const parsedData = GetBranchSchema.safeParse(res?.data)
+
+        if (!parsedData.success) {
+          return Promise.reject({
+            status: 404,
+            data: {},
+            dev: 'useCoverageTabData - 404 schema parsing failed',
+          } satisfies NetworkErrorObject)
+        }
+
+        const data = parsedData.data
+
+        if (data?.owner?.repository?.__typename === 'NotFoundError') {
+          return Promise.reject({
+            status: 404,
+            data: {},
+            dev: 'useCoverageTabData - 404 NotFoundError',
+          } satisfies NetworkErrorObject)
+        }
+
+        if (data?.owner?.repository?.__typename === 'OwnerNotActivatedError') {
+          return Promise.reject({
+            status: 403,
+            data: {
+              detail: (
+                <p>
+                  Activation is required to view this repo, please{' '}
+                  {/* @ts-expect-error */}
+                  <A to={{ pageName: 'membersTab' }}>click here </A> to activate
+                  your account.
+                </p>
+              ),
+            },
+            dev: 'useCoverageTabData - 403 OwnerNotActivatedError',
+          } satisfies NetworkErrorObject)
+        }
+
+        return {
+          branch: data?.owner?.repository?.branch ?? null,
+        }
+      }),
+    enabled: !!passedBranch,
+  })
+}

--- a/src/pages/RepoPage/CoverageTab/subroute/CoverageChart/CoverageChart.jsx
+++ b/src/pages/RepoPage/CoverageTab/subroute/CoverageChart/CoverageChart.jsx
@@ -1,4 +1,5 @@
 import { format } from 'date-fns'
+import PropTypes from 'prop-types'
 import { useParams } from 'react-router-dom'
 
 import { useBranches } from 'services/branches'
@@ -46,7 +47,7 @@ const useCoverageChart = () => {
   )
 }
 
-function CoverageChart() {
+function CoverageChart({ extendedChart }) {
   const { repo } = useParams()
   const { data, isPreviousData, isSuccess, isError } = useCoverageChart()
 
@@ -65,6 +66,13 @@ function CoverageChart() {
     return <Placeholder />
   }
 
+  let appoxHeight = 91
+  let approxhWidth = 282.1
+  if (extendedChart) {
+    appoxHeight = 80
+    approxhWidth = 340
+  }
+
   return (
     <CoverageAreaChart
       axisLabelFunc={data?.coverageAxisLabel}
@@ -75,10 +83,14 @@ function CoverageChart() {
       // These aprox heights let us adjust the ratio and size of the chart.
       // I get these numbers by using the root container space and reducing
       // w/h to something that renders close to the DOM text sizes.
-      aproxHeight={91}
-      aproxWidth={282.1}
+      aproxHeight={appoxHeight}
+      aproxWidth={approxhWidth}
     />
   )
+}
+
+CoverageChart.propTypes = {
+  extendedChart: PropTypes.bool,
 }
 
 export default CoverageChart

--- a/src/services/repo/useRepoCoverage.tsx
+++ b/src/services/repo/useRepoCoverage.tsx
@@ -139,7 +139,7 @@ export function useRepoCoverage({
           } satisfies NetworkErrorObject)
         }
 
-        return data?.owner?.repository?.branch
+        return data?.owner?.repository?.branch ?? null
       }),
     ...options,
   })


### PR DESCRIPTION
# Description

This PR contains a temp fix that hides the sunburst chart if there are more than 200,000 files in a given repo, until we have some more time to further investigate and come up with a solution for this.

# Notable Changes

- Grab file count in new `useCoverageTabData` hook
- Hide Sunburst currently if file count is less than or equal to `200_000`
- Update/add in tests