### PR TITLE
fix: Show banner for private repos only

### DIFF
--- a/src/pages/RepoPage/CoverageOnboarding/NewRepoTab.spec.tsx
+++ b/src/pages/RepoPage/CoverageOnboarding/NewRepoTab.spec.tsx
@@ -27,7 +27,8 @@ const mockCurrentUser = {
 const mockGetRepo = (
   noUploadToken = false,
   hasCommits = false,
-  isCurrentUserActivated = false
+  isCurrentUserActivated = false,
+  isPrivate = false
 ) => ({
   owner: {
     isCurrentUserPartOfOrg: true,
@@ -35,7 +36,7 @@ const mockGetRepo = (
     isCurrentUserActivated,
     repository: {
       __typename: 'Repository',
-      private: false,
+      private: isPrivate,
       uploadToken: noUploadToken
         ? null
         : '9e6a6189-20f1-482d-ab62-ecfaa2629295',
@@ -99,6 +100,7 @@ interface SetupArgs {
   hasCommits?: boolean
   noUploadToken?: boolean
   isCurrentUserActivated?: boolean
+  isPrivate?: boolean
 }
 
 describe('NewRepoTab', () => {
@@ -106,6 +108,7 @@ describe('NewRepoTab', () => {
     hasCommits = false,
     noUploadToken = false,
     isCurrentUserActivated = false,
+    isPrivate = false,
   }: SetupArgs) {
     const user = userEvent.setup()
     const hardRedirect = jest.fn()
@@ -118,7 +121,12 @@ describe('NewRepoTab', () => {
         res(
           ctx.status(200),
           ctx.data(
-            mockGetRepo(noUploadToken, hasCommits, isCurrentUserActivated)
+            mockGetRepo(
+              noUploadToken,
+              hasCommits,
+              isCurrentUserActivated,
+              isPrivate
+            )
           )
         )
       ),
@@ -141,7 +149,11 @@ describe('NewRepoTab', () => {
   })
 
   describe('rendering component', () => {
-    beforeEach(() => setup({}))
+    beforeEach(() =>
+      setup({
+        isPrivate: true,
+      })
+    )
 
     it('renders header', async () => {
       render(<NewRepoTab />, { wrapper: wrapper() })
@@ -236,7 +248,9 @@ describe('NewRepoTab', () => {
     describe('testing tab navigation', () => {
       describe('clicking on other ci', () => {
         it('navigates to /other-ci', async () => {
-          const { user } = setup({})
+          const { user } = setup({
+            isPrivate: true,
+          })
           render(<NewRepoTab />, { wrapper: wrapper() })
 
           const tab = await screen.findByRole('link', { name: 'Other CI' })

--- a/src/pages/RepoPage/CoverageOnboarding/NewRepoTab.tsx
+++ b/src/pages/RepoPage/CoverageOnboarding/NewRepoTab.tsx
@@ -26,10 +26,14 @@ const Loader = () => (
 function Content({
   provider,
   isCurrentUserActivated,
+  isRepoPrivate,
 }: {
   provider: string
   isCurrentUserActivated: boolean
+  isRepoPrivate?: boolean
 }) {
+  const renderActivationBanner = !isCurrentUserActivated && isRepoPrivate
+
   if (providerToName(provider) !== 'Github') {
     return (
       <div className="mt-6">
@@ -49,7 +53,7 @@ function Content({
           { pageName: 'newOtherCI' },
         ]}
       />
-      {!isCurrentUserActivated ? <ActivationBanner /> : null}
+      {renderActivationBanner ? <ActivationBanner /> : null}
       <div className="mt-6">
         <Switch>
           <SentryRoute path="/:provider/:owner/:repo/new" exact>
@@ -94,6 +98,7 @@ function NewRepoTab() {
         <Content
           provider={provider}
           isCurrentUserActivated={data?.isCurrentUserActivated ?? false}
+          isRepoPrivate={data?.repository.private ?? false}
         />
       </div>
     </div>


### PR DESCRIPTION
# Description
Show the banner if the repo is private, public repos can be viewed by all users anyway. 


<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.