### PR TITLE
fix: Footer Codecov icon displaying incorrect color 

### DIFF
--- a/src/layouts/Footer/Footer.jsx
+++ b/src/layouts/Footer/Footer.jsx
@@ -40,7 +40,10 @@ function Footer() {
           ))}
         </ul>
         <A to={{ pageName: 'owner' }}>
-          <CodecovIcon className="mr-2 cursor-pointer text-ds-gray-quinary" />
+          <CodecovIcon
+            className="mr-2 cursor-pointer text-ds-gray-quinary"
+            fillColor="#808080"
+          />
         </A>
         <ul className="flex flex-1 items-center justify-center gap-4 lg:justify-end">
           {rightMenu.map((props, i) => (

--- a/src/layouts/Footer/Footer.jsx
+++ b/src/layouts/Footer/Footer.jsx
@@ -42,7 +42,7 @@ function Footer() {
         <A to={{ pageName: 'owner' }}>
           <CodecovIcon
             className="mr-2 cursor-pointer text-ds-gray-quinary"
-            fillColor="#808080"
+            fillColor="#68737e"
           />
         </A>
         <ul className="flex flex-1 items-center justify-center gap-4 lg:justify-end">


### PR DESCRIPTION
# Description

Bug introduced in https://github.com/codecov/gazebo/pull/2836, codecov Icon turned blue for some reason. This PR updates the color of the icon back to what it was previously.

# Screenshots

**BUG**
![Screenshot 2024-05-07 at 4 19 19 PM](https://github.com/codecov/gazebo/assets/159853603/c2721f66-94c5-4d09-b2a8-1469d1d93d5f)

**NO BUG**
![Screenshot 2024-05-07 at 4 36 54 PM](https://github.com/codecov/gazebo/assets/159853603/058a90e6-ac2a-4ba9-b428-8bb18acd3bc4)



# Link to Sample Entry

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.