### PR TITLE
fix: Move the banner above summary, and fix the use of team hook 

### DIFF
--- a/src/pages/RepoPage/BundlesTab/BundleOnboarding/BundleOnboarding.spec.tsx
+++ b/src/pages/RepoPage/BundlesTab/BundleOnboarding/BundleOnboarding.spec.tsx
@@ -32,6 +32,7 @@ const mockGetRepo = (hasUploadToken: boolean, isActive: boolean) => ({
       activated: false,
       oldestCommitAt: '',
       active: isActive,
+      isFirstPullRequest: false,
     },
   },
 })

--- a/src/pages/RepoPage/BundlesTab/BundleOnboarding/RollupOnboarding/RollupOnboarding.spec.tsx
+++ b/src/pages/RepoPage/BundlesTab/BundleOnboarding/RollupOnboarding/RollupOnboarding.spec.tsx
@@ -23,6 +23,7 @@ const mockGetRepo = {
       activated: false,
       oldestCommitAt: '',
       active: true,
+      isFirstPullRequest: false,
     },
   },
 }

--- a/src/pages/RepoPage/BundlesTab/BundleOnboarding/ViteOnboarding/ViteOnboarding.spec.tsx
+++ b/src/pages/RepoPage/BundlesTab/BundleOnboarding/ViteOnboarding/ViteOnboarding.spec.tsx
@@ -23,6 +23,7 @@ const mockGetRepo = {
       activated: false,
       oldestCommitAt: '',
       active: true,
+      isFirstPullRequest: false,
     },
   },
 }

--- a/src/pages/RepoPage/BundlesTab/BundleOnboarding/WebpackOnboarding/WebpackOnboarding.spec.tsx
+++ b/src/pages/RepoPage/BundlesTab/BundleOnboarding/WebpackOnboarding/WebpackOnboarding.spec.tsx
@@ -23,6 +23,7 @@ const mockGetRepo = {
       activated: false,
       oldestCommitAt: '',
       active: true,
+      isFirstPullRequest: false,
     },
   },
 }

--- a/src/pages/RepoPage/ComponentsTab/subroute/ComponentsTable/ComponentsTable.spec.tsx
+++ b/src/pages/RepoPage/ComponentsTab/subroute/ComponentsTable/ComponentsTable.spec.tsx
@@ -34,6 +34,7 @@ const mockGetRepo = {
       activated: true,
       oldestCommitAt: '2020-01-01T12:00:00',
       active: true,
+      isFirstPullRequest: false,
     },
   },
 }

--- a/src/pages/RepoPage/ComponentsTab/subroute/ComponentsTable/hooks/useRepoComponentsTable.spec.tsx
+++ b/src/pages/RepoPage/ComponentsTab/subroute/ComponentsTable/hooks/useRepoComponentsTable.spec.tsx
@@ -71,6 +71,7 @@ const mockGetRepo = ({
       activated: isRepoActivated,
       oldestCommitAt: '2022-10-10T11:59:59',
       active: isRepoActive,
+      isFirstPullRequest: false,
     },
   },
 })

--- a/src/pages/RepoPage/CoverageOnboarding/CircleCI/CircleCI.spec.tsx
+++ b/src/pages/RepoPage/CoverageOnboarding/CircleCI/CircleCI.spec.tsx
@@ -28,6 +28,7 @@ const mockGetRepo = {
       activated: false,
       oldestCommitAt: '',
       active: true,
+      isFirstPullRequest: false,
     },
   },
 }

--- a/src/pages/RepoPage/CoverageOnboarding/GitHubActions/GitHubActions.spec.tsx
+++ b/src/pages/RepoPage/CoverageOnboarding/GitHubActions/GitHubActions.spec.tsx
@@ -28,6 +28,7 @@ const mockGetRepo = {
       activated: false,
       oldestCommitAt: '',
       active: true,
+      isFirstPullRequest: false,
     },
   },
 }

--- a/src/pages/RepoPage/CoverageOnboarding/NewRepoTab.spec.tsx
+++ b/src/pages/RepoPage/CoverageOnboarding/NewRepoTab.spec.tsx
@@ -46,6 +46,7 @@ const mockGetRepo = (
       activated: false,
       oldestCommitAt: '',
       active: hasCommits,
+      isFirstPullRequest: false,
     },
   },
 })

--- a/src/pages/RepoPage/CoverageOnboarding/OtherCI/OtherCI.spec.tsx
+++ b/src/pages/RepoPage/CoverageOnboarding/OtherCI/OtherCI.spec.tsx
@@ -28,6 +28,7 @@ const mockGetRepo = {
       activated: false,
       oldestCommitAt: '',
       active: true,
+      isFirstPullRequest: false,
     },
   },
 }

--- a/src/pages/RepoPage/CoverageTab/CoverageTab.jsx
+++ b/src/pages/RepoPage/CoverageTab/CoverageTab.jsx
@@ -4,11 +4,12 @@ import { Switch, useParams } from 'react-router-dom'
 import { SentryRoute } from 'sentry'
 
 import SilentNetworkErrorWrapper from 'layouts/shared/SilentNetworkErrorWrapper'
-import { useRepoSettingsTeam } from 'services/repo'
+import { useRepo } from 'services/repo'
 import { TierNames, useTier } from 'services/tier'
 import { useFlags } from 'shared/featureFlags'
 import Spinner from 'ui/Spinner'
 
+import FirstPullRequestBanner from './FirstPullRequestBanner'
 import Summary from './Summary'
 import SummaryTeamPlan from './SummaryTeamPlan'
 import ToggleElement from './ToggleElement'
@@ -25,11 +26,16 @@ const Loader = () => (
 )
 
 function CoverageTab() {
-  const { data: repoData } = useRepoSettingsTeam()
+  const { provider, owner, repo } = useParams()
+  const { data: repoData } = useRepo({
+    provider,
+    owner,
+    repo,
+  })
+
   const { multipleTiers } = useFlags({
     multipleTiers: false,
   })
-  const { provider, owner } = useParams()
   const { data: tierName } = useTier({ provider, owner })
 
   const showTeamSummary =
@@ -39,6 +45,9 @@ function CoverageTab() {
 
   return (
     <div className="mx-4 flex flex-col gap-2 divide-y border-solid border-ds-gray-secondary sm:mx-0">
+      {repoData?.repository?.isFirstPullRequest ? (
+        <FirstPullRequestBanner />
+      ) : null}
       {showTeamSummary ? <SummaryTeamPlan /> : <Summary />}
       {!showTeamSummary && (
         <SentryRoute

--- a/src/pages/RepoPage/CoverageTab/CoverageTab.spec.jsx
+++ b/src/pages/RepoPage/CoverageTab/CoverageTab.spec.jsx
@@ -23,23 +23,6 @@ const queryClient = new QueryClient({
 
 const server = setupServer()
 
-const mockRepoSettings = (isPrivate = false) => ({
-  owner: {
-    repository: {
-      __typename: 'Repository',
-      activated: true,
-      defaultBranch: 'master',
-      private: isPrivate,
-      uploadToken: 'token',
-      graphToken: 'token',
-      yaml: 'yaml',
-      bot: {
-        username: 'test',
-      },
-    },
-  },
-})
-
 const wrapper =
   (initialEntries = ['/gh/codecov/cool-repo/tree/main']) =>
   ({ children }) =>
@@ -53,13 +36,24 @@ const wrapper =
       </QueryClientProvider>
     )
 
-const mockRepo = {
+const mockRepo = (isPrivate = false) => ({
   owner: {
+    isCurrentUserPartOfOrg: true,
+    isAdmin: null,
+    isCurrentUserActivated: null,
     repository: {
+      __typename: 'Repository',
+      private: isPrivate,
+      uploadToken: '9e6a6189-20f1-482d-ab62-ecfaa2629295',
       defaultBranch: 'main',
+      yaml: '',
+      activated: false,
+      oldestCommitAt: '',
+      active: true,
+      isFirstPullRequest: false,
     },
   },
-}
+})
 
 const repoConfigMock = {
   owner: {
@@ -208,8 +202,7 @@ afterAll(() => {
 
 describe('Coverage Tab', () => {
   function setup(
-    { repoData = mockRepo, isPrivate = false, tierValue = TierNames.PRO } = {
-      repoData: mockRepo,
+    { isPrivate = false, tierValue = TierNames.PRO } = {
       isPrivate: false,
       tierValue: TierNames.PRO,
     }
@@ -220,7 +213,7 @@ describe('Coverage Tab', () => {
 
     server.use(
       graphql.query('GetRepo', (req, res, ctx) =>
-        res(ctx.status(200), ctx.data(repoData))
+        res(ctx.status(200), ctx.data(mockRepo(isPrivate)))
       ),
       graphql.query('GetBranches', (req, res, ctx) =>
         res(ctx.status(200), ctx.data(branchesMock))
@@ -268,10 +261,7 @@ describe('Coverage Tab', () => {
         (req, res, ctx) => {
           return res(ctx.status(200), ctx.json({ data: {} }))
         }
-      ),
-      graphql.query('GetRepoSettingsTeam', (req, res, ctx) => {
-        return res(ctx.status(200), ctx.data(mockRepoSettings(isPrivate)))
-      })
+      )
     )
   }
 

--- a/src/pages/RepoPage/CoverageTab/FirstPullRequestBanner/FirstPullRequestBanner.spec.tsx
+++ b/src/pages/RepoPage/CoverageTab/FirstPullRequestBanner/FirstPullRequestBanner.spec.tsx
@@ -1,0 +1,26 @@
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter, Route } from 'react-router-dom'
+
+import FirstPullRequestBanner from './FirstPullRequestBanner'
+
+const wrapper: React.FC<React.PropsWithChildren> = ({ children }) => (
+  <MemoryRouter initialEntries={['/gh/codecov/gazebo']}>
+    <Route path="/:provider/:owner/:repo">{children}</Route>
+  </MemoryRouter>
+)
+
+describe('FirstPullRequestBanner', () => {
+  it('renders content', () => {
+    render(<FirstPullRequestBanner />, { wrapper })
+    const content = screen.getByText(
+      'Once merged to your default branch, Codecov will show your report results on this dashboard.'
+    )
+    expect(content).toBeInTheDocument()
+  })
+
+  it('renders the correct link', () => {
+    render(<FirstPullRequestBanner />, { wrapper })
+    const link = screen.getByRole('link', { name: 'edit default branch' })
+    expect(link).toHaveAttribute('href', '/gh/codecov/gazebo/settings')
+  })
+})

--- a/src/pages/RepoPage/CoverageTab/FirstPullRequestBanner/FirstPullRequestBanner.tsx
+++ b/src/pages/RepoPage/CoverageTab/FirstPullRequestBanner/FirstPullRequestBanner.tsx
@@ -1,0 +1,27 @@
+import A from 'ui/A'
+import Banner from 'ui/Banner'
+import BannerContent from 'ui/Banner/BannerContent'
+
+const FirstPullRequestBanner = () => {
+  return (
+    <Banner>
+      <BannerContent>
+        <p>
+          Once merged to your default branch, Codecov will show your report
+          results on this dashboard.{' '}
+          <A
+            to={{ pageName: 'settings' }}
+            hook={'repo-to-edit-branch'}
+            variant="semibold"
+            isExternal={false}
+            data-testid="settings-page"
+          >
+            edit default branch
+          </A>
+        </p>
+      </BannerContent>
+    </Banner>
+  )
+}
+
+export default FirstPullRequestBanner

--- a/src/pages/RepoPage/CoverageTab/FirstPullRequestBanner/index.ts
+++ b/src/pages/RepoPage/CoverageTab/FirstPullRequestBanner/index.ts
@@ -1,0 +1,1 @@
+export { default } from './FirstPullRequestBanner'

--- a/src/pages/RepoPage/CoverageTab/subroute/FileExplorer/CodeTreeTable/CodeTreeTable.spec.tsx
+++ b/src/pages/RepoPage/CoverageTab/subroute/FileExplorer/CodeTreeTable/CodeTreeTable.spec.tsx
@@ -356,22 +356,6 @@ describe('CodeTreeTable', () => {
       })
     })
 
-    describe('there is no results found', () => {
-      it('displays error fetching data message', async () => {
-        setup({ noFiles: true })
-        render(<CodeTreeTable />, { wrapper: wrapper() })
-
-        const message = await screen.findByText(
-          'Once merged to your default branch, Codecov will show your report results on this dashboard.'
-        )
-        expect(message).toBeInTheDocument()
-
-        const link = await screen.findByTestId('settings-page')
-        expect(link).toBeInTheDocument()
-        expect(link).toHaveAttribute('href', '/gh/codecov/cool-repo/settings')
-      })
-    })
-
     describe('when head commit has no reports', () => {
       it('renders no report uploaded message', async () => {
         setup({ noHeadReport: true })

--- a/src/pages/RepoPage/CoverageTab/subroute/FileExplorer/FileListTable/FileListTable.spec.tsx
+++ b/src/pages/RepoPage/CoverageTab/subroute/FileExplorer/FileListTable/FileListTable.spec.tsx
@@ -290,24 +290,6 @@ describe('FileListTable', () => {
       })
     })
 
-    describe('there is no results found', () => {
-      it('displays error fetching data message', async () => {
-        setup({ noFiles: true })
-        render(<FileListTable />, {
-          wrapper: wrapper('/gh/codecov/cool-repo/tree/main/'),
-        })
-
-        const message = await screen.findByText(
-          'Once merged to your default branch, Codecov will show your report results on this dashboard.'
-        )
-        expect(message).toBeInTheDocument()
-
-        const link = await screen.findByTestId('settings-page')
-        expect(link).toBeInTheDocument()
-        expect(link).toHaveAttribute('href', '/gh/codecov/cool-repo/settings')
-      })
-    })
-
     describe('when head commit has no reports', () => {
       it('renders no report uploaded message', async () => {
         setup({ noHeadReport: true })

--- a/src/pages/RepoPage/CoverageTab/subroute/FileExplorer/shared/RepoContentsResult.spec.tsx
+++ b/src/pages/RepoPage/CoverageTab/subroute/FileExplorer/shared/RepoContentsResult.spec.tsx
@@ -1,6 +1,4 @@
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { render, screen } from '@testing-library/react'
-import { MemoryRouter, Route, useParams } from 'react-router-dom'
 
 import RepoContentsResult from './RepoContentsResult'
 
@@ -56,51 +54,6 @@ describe('RepoContentsResult', () => {
       /No coverage report uploaded for the selected flags in this branch's head commit/
     )
     expect(noCoverageForFlags).toBeInTheDocument()
-  })
-
-  it('renders no coverage for default if there is no coverage on the branch', async () => {
-    const props = {
-      isSearching: false,
-      isMissingHeadReport: false,
-      hasFlagsSelected: false,
-      hasComponentsSelected: false,
-    }
-
-    const queryClient = new QueryClient({
-      defaultOptions: {
-        queries: {
-          retry: false,
-        },
-      },
-    })
-
-    const mockedUseParams = useParams as jest.Mock
-    mockedUseParams.mockReturnValue({
-      owner: 'codecov',
-      provider: 'gh',
-      repo: 'cool-repo',
-    })
-
-    render(
-      <QueryClientProvider client={queryClient}>
-        <MemoryRouter
-          initialEntries={['/gh/codecov/cool-repo/tree/main/a/b/c']}
-        >
-          <Route path="/:provider/:owner/:repo/tree/:branch/:path+">
-            <RepoContentsResult {...props} />
-          </Route>
-        </MemoryRouter>
-      </QueryClientProvider>
-    )
-
-    const noCoverageForFlags = await screen.findByText(
-      /Once merged to your default branch, Codecov will show your report results on this dashboard./
-    )
-    expect(noCoverageForFlags).toBeInTheDocument()
-
-    const link = await screen.findByTestId('settings-page')
-    expect(link).toBeInTheDocument()
-    expect(link).toHaveAttribute('href', '/gh/codecov/cool-repo/settings')
   })
 
   it('renders no coverage for components if user has components selected', async () => {

--- a/src/pages/RepoPage/CoverageTab/subroute/FileExplorer/shared/RepoContentsResult.spec.tsx
+++ b/src/pages/RepoPage/CoverageTab/subroute/FileExplorer/shared/RepoContentsResult.spec.tsx
@@ -1,4 +1,6 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { render, screen } from '@testing-library/react'
+import { MemoryRouter, Route, useParams } from 'react-router-dom'
 
 import RepoContentsResult from './RepoContentsResult'
 
@@ -54,6 +56,51 @@ describe('RepoContentsResult', () => {
       /No coverage report uploaded for the selected flags in this branch's head commit/
     )
     expect(noCoverageForFlags).toBeInTheDocument()
+  })
+
+  it('renders no coverage for default if there is no coverage on the branch', async () => {
+    const props = {
+      isSearching: false,
+      isMissingHeadReport: false,
+      hasFlagsSelected: false,
+      hasComponentsSelected: false,
+    }
+
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: {
+          retry: false,
+        },
+      },
+    })
+
+    const mockedUseParams = useParams as jest.Mock
+    mockedUseParams.mockReturnValue({
+      owner: 'codecov',
+      provider: 'gh',
+      repo: 'cool-repo',
+    })
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter
+          initialEntries={['/gh/codecov/cool-repo/tree/main/a/b/c']}
+        >
+          <Route path="/:provider/:owner/:repo/tree/:branch/:path+">
+            <RepoContentsResult {...props} />
+          </Route>
+        </MemoryRouter>
+      </QueryClientProvider>
+    )
+
+    const noCoverageForFlags = await screen.findByText(
+      /Once merged to your default branch, Codecov will show your report results on this dashboard./
+    )
+    expect(noCoverageForFlags).toBeInTheDocument()
+
+    const link = await screen.findByTestId('settings-page')
+    expect(link).toBeInTheDocument()
+    expect(link).toHaveAttribute('href', '/gh/codecov/cool-repo/settings')
   })
 
   it('renders no coverage for components if user has components selected', async () => {

--- a/src/pages/RepoPage/CoverageTab/subroute/FileExplorer/shared/RepoContentsResult.tsx
+++ b/src/pages/RepoPage/CoverageTab/subroute/FileExplorer/shared/RepoContentsResult.tsx
@@ -1,4 +1,3 @@
-import A from 'ui/A'
 import Banner from 'ui/Banner'
 import BannerContent from 'ui/Banner/BannerContent'
 
@@ -16,6 +15,15 @@ const RepoContentsResult: React.FC<RepoContentsProps> = ({
   hasComponentsSelected,
 }) => {
   let copy: JSX.Element | string = ''
+
+  if (
+    !isSearching &&
+    !isMissingHeadReport &&
+    !hasFlagsSelected &&
+    !hasComponentsSelected
+  ) {
+    return null
+  }
 
   if (isSearching) {
     copy = 'No results found'
@@ -36,22 +44,6 @@ const RepoContentsResult: React.FC<RepoContentsProps> = ({
         No coverage report uploaded for the selected flags in this branch's
         head commit
       `
-  } else {
-    copy = (
-      <p>
-        Once merged to your default branch, Codecov will show your report
-        results on this dashboard.{' '}
-        <A
-          to={{ pageName: 'settings' }}
-          hook={'repo-to-edit-branch'}
-          variant="semibold"
-          isExternal={false}
-          data-testid="settings-page"
-        >
-          edit default branch
-        </A>
-      </p>
-    )
   }
 
   return (

--- a/src/pages/RepoPage/CoverageTab/subroute/FileExplorer/shared/RepoContentsResult.tsx
+++ b/src/pages/RepoPage/CoverageTab/subroute/FileExplorer/shared/RepoContentsResult.tsx
@@ -1,3 +1,4 @@
+import A from 'ui/A'
 import Banner from 'ui/Banner'
 import BannerContent from 'ui/Banner/BannerContent'
 
@@ -15,15 +16,6 @@ const RepoContentsResult: React.FC<RepoContentsProps> = ({
   hasComponentsSelected,
 }) => {
   let copy: JSX.Element | string = ''
-
-  if (
-    !isSearching &&
-    !isMissingHeadReport &&
-    !hasFlagsSelected &&
-    !hasComponentsSelected
-  ) {
-    return null
-  }
 
   if (isSearching) {
     copy = 'No results found'
@@ -44,6 +36,22 @@ const RepoContentsResult: React.FC<RepoContentsProps> = ({
         No coverage report uploaded for the selected flags in this branch's
         head commit
       `
+  } else {
+    return (
+      <p className="mt-4">
+        Once merged to your default branch, Codecov will show your report
+        results on this dashboard.{' '}
+        <A
+          to={{ pageName: 'settings' }}
+          hook={'repo-to-edit-branch'}
+          variant="semibold"
+          isExternal={false}
+          data-testid="settings-page"
+        >
+          edit default branch
+        </A>
+      </p>
+    )
   }
 
   return (

--- a/src/pages/RepoPage/DeactivatedRepo/DeactivatedRepo.spec.jsx
+++ b/src/pages/RepoPage/DeactivatedRepo/DeactivatedRepo.spec.jsx
@@ -52,6 +52,7 @@ describe('DeactivatedRepo', () => {
                 activated: false,
                 oldestCommitAt: '',
                 active: false,
+                isFirstPullRequest: false,
               },
             },
           })

--- a/src/pages/RepoPage/FlagsTab/subroute/FlagsTable/FlagsTable.spec.tsx
+++ b/src/pages/RepoPage/FlagsTab/subroute/FlagsTable/FlagsTable.spec.tsx
@@ -41,6 +41,7 @@ const mockGetRepo = ({ isAdmin = true }) => ({
       activated: true,
       oldestCommitAt: '2020-01-01T12:00:00',
       active: true,
+      isFirstPullRequest: false,
     },
   },
 })

--- a/src/pages/RepoPage/RepoPage.spec.tsx
+++ b/src/pages/RepoPage/RepoPage.spec.tsx
@@ -52,6 +52,7 @@ const mockGetRepo = ({
       activated: isRepoActivated,
       oldestCommitAt: '',
       active: isRepoActive,
+      isFirstPullRequest: false,
     },
   },
 })

--- a/src/pages/RepoPage/RepoPageTabs.spec.tsx
+++ b/src/pages/RepoPage/RepoPageTabs.spec.tsx
@@ -61,6 +61,7 @@ const mockRepo = ({ isCurrentUserPartOfOrg = true }) => ({
       activated: true,
       oldestCommitAt: '2022-10-10T11:59:59',
       active: true,
+      isFirstPullRequest: false,
     },
   },
 })
@@ -839,7 +840,7 @@ describe('useRepoTabs', () => {
         )
       })
     })
-        
+
     describe('repo is private and tier is team', () => {
       it('does not add the components link to the array', async () => {
         setup({ isRepoPrivate: true, tierName: TierNames.TEAM })
@@ -865,7 +866,7 @@ describe('useRepoTabs', () => {
         )
       })
     })
-        
+
     describe('feature flag is off', () => {
       it('does not add the components link to the array', async () => {
         mockedUseFlags.mockReturnValueOnce({
@@ -896,7 +897,6 @@ describe('useRepoTabs', () => {
       })
     })
   })
-          
 
   describe('commits and pulls tab', () => {
     describe('bundle analysis is enabled', () => {

--- a/src/pages/RepoPage/context.spec.js
+++ b/src/pages/RepoPage/context.spec.js
@@ -76,6 +76,7 @@ describe('Repo breadcrumb context', () => {
             owner: {
               repository: {
                 private: false,
+                isFirstPullRequest: false,
               },
             },
           })

--- a/src/services/repo/hooks.spec.tsx
+++ b/src/services/repo/hooks.spec.tsx
@@ -99,6 +99,7 @@ describe('useRepo', () => {
           active: true,
           activated: true,
           oldestCommitAt: '',
+          isFirstPullRequest: false,
         },
       },
     }
@@ -129,6 +130,7 @@ describe('useRepo', () => {
             active: true,
             activated: true,
             oldestCommitAt: '',
+            isFirstPullRequest: false,
           },
         }
 

--- a/src/services/repo/useRepo.spec.tsx
+++ b/src/services/repo/useRepo.spec.tsx
@@ -20,6 +20,7 @@ const mockRepo = {
       activated: false,
       oldestCommitAt: '',
       active: true,
+      isFirstPullRequest: false,
     },
   },
 }
@@ -124,6 +125,7 @@ describe('useRepo', () => {
             activated: false,
             oldestCommitAt: '',
             active: true,
+            isFirstPullRequest: false,
           },
         })
       )

--- a/src/services/repo/useRepo.tsx
+++ b/src/services/repo/useRepo.tsx
@@ -18,6 +18,7 @@ const RepositorySchema = z.object({
   activated: z.boolean(),
   oldestCommitAt: z.string().nullable(),
   active: z.boolean(),
+  isFirstPullRequest: z.boolean(),
 })
 
 export const RepoSchema = z.object({
@@ -53,6 +54,7 @@ const query = `
             activated
             oldestCommitAt
             active
+            isFirstPullRequest
           }
           ... on NotFoundError {
             message


### PR DESCRIPTION
# Description
The purpose of this PR is to left the onboarding banner up the summary. The banner should be visible for the user under the coverage tab 

# Notable Changes

- [x] https://github.com/codecov/codecov-api/pull/551
- Added `isFirstPR` field under repo. We needed a quick way to know whether this repo has an unmerged first PR in Codecov 
- Call repo hook in coverage tab. No need to call team settings in coverage tab not sure why we ever did that 
- Create the onboarding banner under coverage tab 

# Screenshots
<img width="1378" alt="Screenshot 2024-05-07 at 1 54 28 PM" src="https://github.com/codecov/gazebo/assets/91732700/306900dd-2095-45fe-8456-760cff1b267a">

closes: https://github.com/codecov/engineering-team/issues/1541

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.