### PR TITLE
style: Use Card component in bundle onboarding

### DIFF
--- a/src/pages/RepoPage/BundlesTab/BundleOnboarding/BundleOnboarding.tsx
+++ b/src/pages/RepoPage/BundlesTab/BundleOnboarding/BundleOnboarding.tsx
@@ -35,19 +35,21 @@ const Content: React.FC = () => {
           { pageName: 'bundleWebpackOnboarding' },
         ]}
       />
-      <Suspense fallback={<Loader />}>
-        <Switch>
-          <SentryRoute path="/:provider/:owner/:repo/bundles/new" exact>
-            <ViteOnboarding />
-          </SentryRoute>
-          <SentryRoute path="/:provider/:owner/:repo/bundles/new/rollup">
-            <RollupOnboarding />
-          </SentryRoute>
-          <SentryRoute path="/:provider/:owner/:repo/bundles/new/webpack">
-            <WebpackOnboarding />
-          </SentryRoute>
-        </Switch>
-      </Suspense>
+      <div className="pt-6">
+        <Suspense fallback={<Loader />}>
+          <Switch>
+            <SentryRoute path="/:provider/:owner/:repo/bundles/new" exact>
+              <ViteOnboarding />
+            </SentryRoute>
+            <SentryRoute path="/:provider/:owner/:repo/bundles/new/rollup">
+              <RollupOnboarding />
+            </SentryRoute>
+            <SentryRoute path="/:provider/:owner/:repo/bundles/new/webpack">
+              <WebpackOnboarding />
+            </SentryRoute>
+          </Switch>
+        </Suspense>
+      </div>
     </>
   )
 }
@@ -65,7 +67,7 @@ const BundleOnboarding: React.FC = () => {
 
   return (
     <div className="flex flex-col gap-6">
-      <div className="mx-auto w-4/5 pt-6 md:w-3/5 lg:w-3/6">
+      <div className="mx-auto pt-6 lg:w-3/5">
         <h1 className="mb-2 text-3xl font-semibold">
           Configure bundle analysis
         </h1>

--- a/src/pages/RepoPage/BundlesTab/BundleOnboarding/RollupOnboarding/RollupOnboarding.spec.tsx
+++ b/src/pages/RepoPage/BundlesTab/BundleOnboarding/RollupOnboarding/RollupOnboarding.spec.tsx
@@ -107,11 +107,11 @@ describe('RollupOnboarding', () => {
       setup(null)
       render(<RollupOnboarding />, { wrapper })
 
-      const stepText = await screen.findByText('Step 1:')
+      const stepText = await screen.findByText(/Step 1:/)
       expect(stepText).toBeInTheDocument()
 
       const headerText = await screen.findByText(
-        'Install the Codecov Rollup Plugin'
+        /Install the Codecov Rollup Plugin/
       )
       expect(headerText).toBeInTheDocument()
     })
@@ -231,10 +231,10 @@ describe('RollupOnboarding', () => {
       setup(null)
       render(<RollupOnboarding />, { wrapper })
 
-      const stepText = await screen.findByText('Step 2:')
+      const stepText = await screen.findByText(/Step 2:/)
       expect(stepText).toBeInTheDocument()
 
-      const headerText = await screen.findByText('Copy Codecov token')
+      const headerText = await screen.findByText(/Copy Codecov token/)
       expect(headerText).toBeInTheDocument()
     })
 
@@ -298,10 +298,10 @@ describe('RollupOnboarding', () => {
       setup(null)
       render(<RollupOnboarding />, { wrapper })
 
-      const stepText = await screen.findByText('Step 3:')
+      const stepText = await screen.findByText(/Step 3:/)
       expect(stepText).toBeInTheDocument()
 
-      const headerText = await screen.findByText('Configure the bundler plugin')
+      const headerText = await screen.findByText(/Configure the bundler plugin/)
       expect(headerText).toBeInTheDocument()
     })
 
@@ -352,11 +352,11 @@ describe('RollupOnboarding', () => {
       setup(null)
       render(<RollupOnboarding />, { wrapper })
 
-      const stepText = await screen.findByText('Step 4:')
+      const stepText = await screen.findByText(/Step 4:/)
       expect(stepText).toBeInTheDocument()
 
       const headerText = await screen.findByText(
-        'Commit and push your latest changes'
+        /Commit and push your latest changes/
       )
       expect(headerText).toBeInTheDocument()
     })
@@ -407,10 +407,10 @@ describe('RollupOnboarding', () => {
       setup(null)
       render(<RollupOnboarding />, { wrapper })
 
-      const stepText = await screen.findByText('Step 5:')
+      const stepText = await screen.findByText(/Step 5:/)
       expect(stepText).toBeInTheDocument()
 
-      const headerText = await screen.findByText('Build the application')
+      const headerText = await screen.findByText(/Build the application/)
       expect(headerText).toBeInTheDocument()
     })
 

--- a/src/pages/RepoPage/BundlesTab/BundleOnboarding/RollupOnboarding/RollupOnboarding.tsx
+++ b/src/pages/RepoPage/BundlesTab/BundleOnboarding/RollupOnboarding/RollupOnboarding.tsx
@@ -55,7 +55,7 @@ const StepOne: React.FC = () => {
         to your project, use one of the following commands.
       </p>
       <div className="flex flex-col gap-4">
-        <pre className="flex w-full items-center justify-between gap-2 overflow-auto whitespace-pre-wrap rounded-md border-2 border-ds-gray-secondary bg-ds-gray-primary px-4 py-2 font-mono">
+        <pre className="flex w-full items-center justify-between gap-2 overflow-auto whitespace-pre-wrap rounded-md border border-ds-gray-secondary bg-ds-gray-primary p-4 font-mono">
           {npmInstall}{' '}
           <CopyClipboard
             string={npmInstall}
@@ -65,7 +65,7 @@ const StepOne: React.FC = () => {
             }}
           />
         </pre>
-        <pre className="flex w-full items-center justify-between gap-2 overflow-auto whitespace-pre-wrap rounded-md border-2 border-ds-gray-secondary bg-ds-gray-primary px-4 py-2 font-mono">
+        <pre className="flex w-full items-center justify-between gap-2 overflow-auto whitespace-pre-wrap rounded-md border border-ds-gray-secondary bg-ds-gray-primary p-4 font-mono">
           {yarnInstall}{' '}
           <CopyClipboard
             string={yarnInstall}
@@ -75,7 +75,7 @@ const StepOne: React.FC = () => {
             }}
           />
         </pre>
-        <pre className="flex w-full items-center justify-between gap-2 overflow-auto whitespace-pre-wrap rounded-md border-2 border-ds-gray-secondary bg-ds-gray-primary px-4 py-2 font-mono">
+        <pre className="flex w-full items-center justify-between gap-2 overflow-auto whitespace-pre-wrap rounded-md border border-ds-gray-secondary bg-ds-gray-primary p-4 font-mono">
           {pnpmInstall}{' '}
           <CopyClipboard
             string={pnpmInstall}
@@ -101,13 +101,13 @@ const StepTwo: React.FC<{ uploadToken: string }> = ({ uploadToken }) => {
         upload token.
       </p>
       <div className="flex gap-4">
-        <pre className="flex basis-1/3 items-center justify-between gap-2 rounded-md border-2 border-ds-gray-secondary bg-ds-gray-primary px-4 py-2 font-mono">
+        <pre className="flex basis-1/3 items-center justify-between gap-2 rounded-md border border-ds-gray-secondary bg-ds-gray-primary p-4 font-mono">
           <div className="w-0 flex-1 overflow-hidden" data-testid="token-key">
             CODECOV_TOKEN
           </div>
           <CopyClipboard string="CODECOV_TOKEN" />
         </pre>
-        <pre className="flex basis-2/3 items-center justify-between gap-2 rounded-md border-2 border-ds-gray-secondary bg-ds-gray-primary px-4 py-2 font-mono">
+        <pre className="flex basis-2/3 items-center justify-between gap-2 rounded-md border border-ds-gray-secondary bg-ds-gray-primary p-4 font-mono">
           <div className="w-0 flex-1 overflow-hidden">{uploadToken}</div>
           <CopyClipboard
             string={uploadToken}
@@ -137,7 +137,7 @@ const StepThree: React.FC = () => {
         </span>{' '}
         file.
       </p>
-      <pre className="flex items-start justify-between overflow-auto whitespace-pre rounded-md border-2 border-ds-gray-secondary bg-ds-gray-primary px-4 py-2 font-mono">
+      <pre className="flex items-start justify-between overflow-auto whitespace-pre rounded-md border border-ds-gray-secondary bg-ds-gray-primary p-4 font-mono">
         {pluginConfig}
         <CopyClipboard
           string={pluginConfig}
@@ -162,7 +162,7 @@ const StepFour: React.FC = () => {
         The plugin requires at least one commit to be made to properly upload
         bundle analysis information up to Codecov.
       </p>
-      <pre className="flex w-full items-center justify-between gap-2 overflow-auto whitespace-pre-wrap rounded-md border-2 border-ds-gray-secondary bg-ds-gray-primary px-4 py-2 font-mono">
+      <pre className="flex w-full items-center justify-between gap-2 overflow-auto whitespace-pre-wrap rounded-md border border-ds-gray-secondary bg-ds-gray-primary p-4 font-mono">
         {commitString}{' '}
         <CopyClipboard
           string={commitString}
@@ -187,7 +187,7 @@ const StepFive: React.FC = () => {
         stats information to Codecov.
       </p>
       <div className="flex flex-col gap-4">
-        <pre className="flex w-full items-center justify-between gap-2 overflow-auto whitespace-pre-wrap rounded-md border-2 border-ds-gray-secondary bg-ds-gray-primary px-4 py-2 font-mono">
+        <pre className="flex w-full items-center justify-between gap-2 overflow-auto whitespace-pre-wrap rounded-md border border-ds-gray-secondary bg-ds-gray-primary p-4 font-mono">
           {npmBuild}{' '}
           <CopyClipboard
             string={npmBuild}
@@ -197,7 +197,7 @@ const StepFive: React.FC = () => {
             }}
           />
         </pre>
-        <pre className="flex w-full items-center justify-between gap-2 overflow-auto whitespace-pre-wrap rounded-md border-2 border-ds-gray-secondary bg-ds-gray-primary px-4 py-2 font-mono">
+        <pre className="flex w-full items-center justify-between gap-2 overflow-auto whitespace-pre-wrap rounded-md border border-ds-gray-secondary bg-ds-gray-primary p-4 font-mono">
           {yarnBuild}{' '}
           <CopyClipboard
             string={yarnBuild}
@@ -207,7 +207,7 @@ const StepFive: React.FC = () => {
             }}
           />
         </pre>
-        <pre className="flex w-full items-center justify-between gap-2 overflow-auto whitespace-pre-wrap rounded-md border-2 border-ds-gray-secondary bg-ds-gray-primary px-4 py-2 font-mono">
+        <pre className="flex w-full items-center justify-between gap-2 overflow-auto whitespace-pre-wrap rounded-md border border-ds-gray-secondary bg-ds-gray-primary p-4 font-mono">
           {pnpmBuild}{' '}
           <CopyClipboard
             string={pnpmBuild}

--- a/src/pages/RepoPage/BundlesTab/BundleOnboarding/RollupOnboarding/RollupOnboarding.tsx
+++ b/src/pages/RepoPage/BundlesTab/BundleOnboarding/RollupOnboarding/RollupOnboarding.tsx
@@ -4,6 +4,7 @@ import { useParams } from 'react-router-dom'
 import { useOrgUploadToken } from 'services/orgUploadToken'
 import { useRepo } from 'services/repo'
 import A from 'ui/A'
+import { Card } from 'ui/Card'
 import CopyClipboard from 'ui/CopyClipboard'
 
 import {
@@ -42,19 +43,20 @@ const pnpmBuild = `pnpm run build`
 
 const StepOne: React.FC = () => {
   return (
-    <div className="pt-4">
-      <h2 className="pb-2 text-base">
-        <span className="font-semibold">Step 1:</span> Install the Codecov
-        Rollup Plugin
-      </h2>
-      <p className="pb-2 text-sm">
-        To install the{' '}
-        <span className="bg-ds-gray-primary px-1 font-mono">
-          @codecov/rollup-plugin
-        </span>{' '}
-        to your project, use one of the following commands.
-      </p>
-      <div className="flex flex-col gap-4">
+    <Card>
+      <Card.Header>
+        <Card.Title size="base">
+          Step 1: Install the Codecov Rollup Plugin
+        </Card.Title>
+      </Card.Header>
+      <Card.Content className="flex flex-col gap-4">
+        <p>
+          To install the{' '}
+          <span className="bg-ds-gray-primary px-1 font-mono">
+            @codecov/rollup-plugin
+          </span>{' '}
+          to your project, use one of the following commands.
+        </p>
         <pre className="flex w-full items-center justify-between gap-2 overflow-auto whitespace-pre-wrap rounded-md border border-ds-gray-secondary bg-ds-gray-primary p-4 font-mono">
           {npmInstall}{' '}
           <CopyClipboard
@@ -85,108 +87,116 @@ const StepOne: React.FC = () => {
             }}
           />
         </pre>
-      </div>
-    </div>
+      </Card.Content>
+    </Card>
   )
 }
 
 const StepTwo: React.FC<{ uploadToken: string }> = ({ uploadToken }) => {
   return (
-    <div className="pt-4">
-      <h2 className="pb-2 text-base">
-        <span className="font-semibold">Step 2:</span> Copy Codecov token
-      </h2>
-      <p className="pb-2 text-sm">
-        Set an environment variable in your build environment with the following
-        upload token.
-      </p>
-      <div className="flex gap-4">
-        <pre className="flex basis-1/3 items-center justify-between gap-2 rounded-md border border-ds-gray-secondary bg-ds-gray-primary p-4 font-mono">
-          <div className="w-0 flex-1 overflow-hidden" data-testid="token-key">
-            CODECOV_TOKEN
-          </div>
-          <CopyClipboard string="CODECOV_TOKEN" />
-        </pre>
-        <pre className="flex basis-2/3 items-center justify-between gap-2 rounded-md border border-ds-gray-secondary bg-ds-gray-primary p-4 font-mono">
-          <div className="w-0 flex-1 overflow-hidden">{uploadToken}</div>
-          <CopyClipboard
-            string={uploadToken}
-            testIdExtension="-upload-token"
-            onClick={() => {
-              copiedTokenMetric('rollup')
-            }}
-          />
-        </pre>
-      </div>
-    </div>
+    <Card>
+      <Card.Header>
+        <Card.Title size="base">Step 2: Copy Codecov token</Card.Title>
+      </Card.Header>
+      <Card.Content className="flex flex-col gap-4">
+        <p>
+          Set an environment variable in your build environment with the
+          following upload token.
+        </p>
+        <div className="flex gap-4">
+          <pre className="flex basis-1/3 items-center justify-between gap-2 rounded-md border border-ds-gray-secondary bg-ds-gray-primary p-4 font-mono">
+            <div className="w-0 flex-1 overflow-hidden" data-testid="token-key">
+              CODECOV_TOKEN
+            </div>
+            <CopyClipboard string="CODECOV_TOKEN" />
+          </pre>
+          <pre className="flex basis-2/3 items-center justify-between gap-2 rounded-md border border-ds-gray-secondary bg-ds-gray-primary p-4 font-mono">
+            <div className="w-0 flex-1 overflow-hidden">{uploadToken}</div>
+            <CopyClipboard
+              string={uploadToken}
+              testIdExtension="-upload-token"
+              onClick={() => {
+                copiedTokenMetric('rollup')
+              }}
+            />
+          </pre>
+        </div>
+      </Card.Content>
+    </Card>
   )
 }
 
 const StepThree: React.FC = () => {
   return (
-    <div>
-      <h2 className="pb-2 text-base">
-        <span className="font-semibold">Step 3:</span> Configure the bundler
-        plugin
-      </h2>
-      <p className="pb-2 text-sm">
-        Import the bundler plugin, and add it to the end of your plugin array
-        found inside your{' '}
-        <span className="bg-ds-gray-primary px-1 font-mono">
-          rollup.config.js
-        </span>{' '}
-        file.
-      </p>
-      <pre className="flex items-start justify-between overflow-auto whitespace-pre rounded-md border border-ds-gray-secondary bg-ds-gray-primary p-4 font-mono">
-        {pluginConfig}
-        <CopyClipboard
-          string={pluginConfig}
-          testIdExtension="-plugin-config"
-          onClick={() => {
-            copiedConfigMetric('rollup')
-          }}
-        />
-      </pre>
-    </div>
+    <Card>
+      <Card.Header>
+        <Card.Title size="base">
+          Step 3: Configure the bundler plugin
+        </Card.Title>
+      </Card.Header>
+      <Card.Content className="flex flex-col gap-4">
+        <p>
+          Import the bundler plugin, and add it to the end of your plugin array
+          found inside your{' '}
+          <span className="bg-ds-gray-primary px-1 font-mono">
+            rollup.config.js
+          </span>{' '}
+          file.
+        </p>
+        <pre className="flex items-start justify-between overflow-auto whitespace-pre rounded-md border border-ds-gray-secondary bg-ds-gray-primary p-4 font-mono">
+          {pluginConfig}
+          <CopyClipboard
+            string={pluginConfig}
+            testIdExtension="-plugin-config"
+            onClick={() => {
+              copiedConfigMetric('rollup')
+            }}
+          />
+        </pre>
+      </Card.Content>
+    </Card>
   )
 }
 
 const StepFour: React.FC = () => {
   return (
-    <div>
-      <h2 className="pb-2 text-base">
-        <span className="font-semibold">Step 4:</span> Commit and push your
-        latest changes
-      </h2>
-      <p className="pb-2 text-sm">
-        The plugin requires at least one commit to be made to properly upload
-        bundle analysis information up to Codecov.
-      </p>
-      <pre className="flex w-full items-center justify-between gap-2 overflow-auto whitespace-pre-wrap rounded-md border border-ds-gray-secondary bg-ds-gray-primary p-4 font-mono">
-        {commitString}{' '}
-        <CopyClipboard
-          string={commitString}
-          testIdExtension="-commit-command"
-          onClick={() => {
-            copiedCommitMetric('rollup')
-          }}
-        />
-      </pre>
-    </div>
+    <Card>
+      <Card.Header>
+        <Card.Title size="base">
+          Step 4: Commit and push your latest changes
+        </Card.Title>
+      </Card.Header>
+      <Card.Content className="flex flex-col gap-4">
+        <p>
+          The plugin requires at least one commit to be made to properly upload
+          bundle analysis information up to Codecov.
+        </p>
+        <pre className="flex w-full items-center justify-between gap-2 overflow-auto whitespace-pre-wrap rounded-md border border-ds-gray-secondary bg-ds-gray-primary p-4 font-mono">
+          {commitString}{' '}
+          <CopyClipboard
+            string={commitString}
+            testIdExtension="-commit-command"
+            onClick={() => {
+              copiedCommitMetric('rollup')
+            }}
+          />
+        </pre>
+      </Card.Content>
+    </Card>
   )
 }
 
 const StepFive: React.FC = () => {
   return (
-    <div>
-      <h2 className="pb-2 text-base">
-        <span className="font-semibold">Step 5:</span> Build the application
-      </h2>
-      <p className="pb-2 text-sm">
-        When building your application the plugin will automatically upload the
-        stats information to Codecov.
-      </p>
-      <div className="flex flex-col gap-4">
+    <Card>
+      <Card.Header>
+        <Card.Title size="base">Step 5: Build the application</Card.Title>
+      </Card.Header>
+      <Card.Content className="flex flex-col gap-4">
+        <p>
+          When building your application the plugin will automatically upload
+          the stats information to Codecov.
+        </p>
         <pre className="flex w-full items-center justify-between gap-2 overflow-auto whitespace-pre-wrap rounded-md border border-ds-gray-secondary bg-ds-gray-primary p-4 font-mono">
           {npmBuild}{' '}
           <CopyClipboard
@@ -217,8 +227,28 @@ const StepFive: React.FC = () => {
             }}
           />
         </pre>
-      </div>
-    </div>
+      </Card.Content>
+    </Card>
+  )
+}
+
+function FeedbackCTA() {
+  return (
+    <Card>
+      <Card.Content>
+        <p>
+          <span className="font-semibold">How was your setup experience?</span>{' '}
+          Let us know in{' '}
+          <A
+            to={{ pageName: 'bundleConfigFeedback' }}
+            isExternal
+            hook="repo-config-feedback"
+          >
+            this issue
+          </A>
+        </p>
+      </Card.Content>
+    </Card>
   )
 }
 
@@ -246,19 +276,7 @@ const RollupOnboarding: React.FC = () => {
       <StepThree />
       <StepFour />
       <StepFive />
-      <div>
-        <p className="border-l-2 border-ds-gray-secondary pl-4">
-          <span className="font-semibold">How was your setup experience?</span>{' '}
-          Let us know in{' '}
-          <A
-            to={{ pageName: 'bundleConfigFeedback' }}
-            isExternal
-            hook="repo-config-feedback"
-          >
-            this issue
-          </A>
-        </p>
-      </div>
+      <FeedbackCTA />
     </div>
   )
 }

--- a/src/pages/RepoPage/BundlesTab/BundleOnboarding/ViteOnboarding/ViteOnboarding.spec.tsx
+++ b/src/pages/RepoPage/BundlesTab/BundleOnboarding/ViteOnboarding/ViteOnboarding.spec.tsx
@@ -107,11 +107,11 @@ describe('ViteOnboarding', () => {
       setup(null)
       render(<ViteOnboarding />, { wrapper })
 
-      const stepText = await screen.findByText('Step 1:')
+      const stepText = await screen.findByText(/Step 1:/)
       expect(stepText).toBeInTheDocument()
 
       const headerText = await screen.findByText(
-        'Install the Codecov Vite Plugin'
+        /Install the Codecov Vite Plugin/
       )
       expect(headerText).toBeInTheDocument()
     })
@@ -231,10 +231,10 @@ describe('ViteOnboarding', () => {
       setup(null)
       render(<ViteOnboarding />, { wrapper })
 
-      const stepText = await screen.findByText('Step 2:')
+      const stepText = await screen.findByText(/Step 2:/)
       expect(stepText).toBeInTheDocument()
 
-      const headerText = await screen.findByText('Copy Codecov token')
+      const headerText = await screen.findByText(/Copy Codecov token/)
       expect(headerText).toBeInTheDocument()
     })
 
@@ -298,10 +298,10 @@ describe('ViteOnboarding', () => {
       setup(null)
       render(<ViteOnboarding />, { wrapper })
 
-      const stepText = await screen.findByText('Step 3:')
+      const stepText = await screen.findByText(/Step 3:/)
       expect(stepText).toBeInTheDocument()
 
-      const headerText = await screen.findByText('Configure the bundler plugin')
+      const headerText = await screen.findByText(/Configure the bundler plugin/)
       expect(headerText).toBeInTheDocument()
     })
 
@@ -352,11 +352,11 @@ describe('ViteOnboarding', () => {
       setup(null)
       render(<ViteOnboarding />, { wrapper })
 
-      const stepText = await screen.findByText('Step 4:')
+      const stepText = await screen.findByText(/Step 4:/)
       expect(stepText).toBeInTheDocument()
 
       const headerText = await screen.findByText(
-        'Commit and push your latest changes'
+        /Commit and push your latest changes/
       )
       expect(headerText).toBeInTheDocument()
     })
@@ -407,10 +407,10 @@ describe('ViteOnboarding', () => {
       setup(null)
       render(<ViteOnboarding />, { wrapper })
 
-      const stepText = await screen.findByText('Step 5:')
+      const stepText = await screen.findByText(/Step 5:/)
       expect(stepText).toBeInTheDocument()
 
-      const headerText = await screen.findByText('Build the application')
+      const headerText = await screen.findByText(/Build the application/)
       expect(headerText).toBeInTheDocument()
     })
 

--- a/src/pages/RepoPage/BundlesTab/BundleOnboarding/ViteOnboarding/ViteOnboarding.tsx
+++ b/src/pages/RepoPage/BundlesTab/BundleOnboarding/ViteOnboarding/ViteOnboarding.tsx
@@ -55,7 +55,7 @@ const StepOne: React.FC = () => {
         to your project, use one of the following commands.
       </p>
       <div className="flex flex-col gap-4">
-        <pre className="flex w-full items-center justify-between gap-2 overflow-auto whitespace-pre-wrap rounded-md border-2 border-ds-gray-secondary bg-ds-gray-primary px-4 py-2 font-mono">
+        <pre className="flex w-full items-center justify-between gap-2 overflow-auto whitespace-pre-wrap rounded-md border border-ds-gray-secondary bg-ds-gray-primary p-4 font-mono">
           {npmInstall}{' '}
           <CopyClipboard
             string={npmInstall}
@@ -65,7 +65,7 @@ const StepOne: React.FC = () => {
             }}
           />
         </pre>
-        <pre className="flex w-full items-center justify-between gap-2 overflow-auto whitespace-pre-wrap rounded-md border-2 border-ds-gray-secondary bg-ds-gray-primary px-4 py-2 font-mono">
+        <pre className="flex w-full items-center justify-between gap-2 overflow-auto whitespace-pre-wrap rounded-md border border-ds-gray-secondary bg-ds-gray-primary p-4 font-mono">
           {yarnInstall}{' '}
           <CopyClipboard
             string={yarnInstall}
@@ -75,7 +75,7 @@ const StepOne: React.FC = () => {
             }}
           />
         </pre>
-        <pre className="flex w-full items-center justify-between gap-2 overflow-auto whitespace-pre-wrap rounded-md border-2 border-ds-gray-secondary bg-ds-gray-primary px-4 py-2 font-mono">
+        <pre className="flex w-full items-center justify-between gap-2 overflow-auto whitespace-pre-wrap rounded-md border border-ds-gray-secondary bg-ds-gray-primary p-4 font-mono">
           {pnpmInstall}{' '}
           <CopyClipboard
             string={pnpmInstall}
@@ -101,13 +101,13 @@ const StepTwo: React.FC<{ uploadToken: string }> = ({ uploadToken }) => {
         upload token.
       </p>
       <div className="flex gap-4">
-        <pre className="flex basis-1/3 items-center justify-between gap-2 rounded-md border-2 border-ds-gray-secondary bg-ds-gray-primary px-4 py-2 font-mono">
+        <pre className="flex basis-1/3 items-center justify-between gap-2 rounded-md border border-ds-gray-secondary bg-ds-gray-primary p-4 font-mono">
           <div className="w-0 flex-1 overflow-hidden" data-testid="token-key">
             CODECOV_TOKEN
           </div>
           <CopyClipboard string="CODECOV_TOKEN" />
         </pre>
-        <pre className="flex basis-2/3 items-center justify-between gap-2 rounded-md border-2 border-ds-gray-secondary bg-ds-gray-primary px-4 py-2 font-mono">
+        <pre className="flex basis-2/3 items-center justify-between gap-2 rounded-md border border-ds-gray-secondary bg-ds-gray-primary p-4 font-mono">
           <div className="w-0 flex-1 overflow-hidden">{uploadToken}</div>
           <CopyClipboard
             string={uploadToken}
@@ -137,7 +137,7 @@ const StepThree: React.FC = () => {
         </span>{' '}
         file.
       </p>
-      <pre className="flex items-start justify-between overflow-auto whitespace-pre rounded-md border-2 border-ds-gray-secondary bg-ds-gray-primary px-4 py-2 font-mono">
+      <pre className="flex items-start justify-between overflow-auto whitespace-pre rounded-md border border-ds-gray-secondary bg-ds-gray-primary p-4 font-mono">
         {pluginConfig}
         <CopyClipboard
           string={pluginConfig}
@@ -162,7 +162,7 @@ const StepFour: React.FC = () => {
         The plugin requires at least one commit to be made to properly upload
         bundle analysis information up to Codecov.
       </p>
-      <pre className="flex w-full items-center justify-between gap-2 overflow-auto whitespace-pre-wrap rounded-md border-2 border-ds-gray-secondary bg-ds-gray-primary px-4 py-2 font-mono">
+      <pre className="flex w-full items-center justify-between gap-2 overflow-auto whitespace-pre-wrap rounded-md border border-ds-gray-secondary bg-ds-gray-primary p-4 font-mono">
         {commitString}{' '}
         <CopyClipboard
           string={commitString}
@@ -187,7 +187,7 @@ const StepFive: React.FC = () => {
         stats information to Codecov.
       </p>
       <div className="flex flex-col gap-4">
-        <pre className="flex w-full items-center justify-between gap-2 overflow-auto whitespace-pre-wrap rounded-md border-2 border-ds-gray-secondary bg-ds-gray-primary px-4 py-2 font-mono">
+        <pre className="flex w-full items-center justify-between gap-2 overflow-auto whitespace-pre-wrap rounded-md border border-ds-gray-secondary bg-ds-gray-primary p-4 font-mono">
           {npmBuild}{' '}
           <CopyClipboard
             string={npmBuild}
@@ -197,7 +197,7 @@ const StepFive: React.FC = () => {
             }}
           />
         </pre>
-        <pre className="flex w-full items-center justify-between gap-2 overflow-auto whitespace-pre-wrap rounded-md border-2 border-ds-gray-secondary bg-ds-gray-primary px-4 py-2 font-mono">
+        <pre className="flex w-full items-center justify-between gap-2 overflow-auto whitespace-pre-wrap rounded-md border border-ds-gray-secondary bg-ds-gray-primary p-4 font-mono">
           {yarnBuild}{' '}
           <CopyClipboard
             string={yarnBuild}
@@ -207,7 +207,7 @@ const StepFive: React.FC = () => {
             }}
           />
         </pre>
-        <pre className="flex w-full items-center justify-between gap-2 overflow-auto whitespace-pre-wrap rounded-md border-2 border-ds-gray-secondary bg-ds-gray-primary px-4 py-2 font-mono">
+        <pre className="flex w-full items-center justify-between gap-2 overflow-auto whitespace-pre-wrap rounded-md border border-ds-gray-secondary bg-ds-gray-primary p-4 font-mono">
           {pnpmBuild}{' '}
           <CopyClipboard
             string={pnpmBuild}

--- a/src/pages/RepoPage/BundlesTab/BundleOnboarding/ViteOnboarding/ViteOnboarding.tsx
+++ b/src/pages/RepoPage/BundlesTab/BundleOnboarding/ViteOnboarding/ViteOnboarding.tsx
@@ -4,6 +4,7 @@ import { useParams } from 'react-router-dom'
 import { useOrgUploadToken } from 'services/orgUploadToken'
 import { useRepo } from 'services/repo'
 import A from 'ui/A'
+import { Card } from 'ui/Card'
 import CopyClipboard from 'ui/CopyClipboard'
 
 import {
@@ -42,19 +43,20 @@ const pnpmBuild = `pnpm run build`
 
 const StepOne: React.FC = () => {
   return (
-    <div className="pt-4">
-      <h2 className="pb-2 text-base">
-        <span className="font-semibold">Step 1:</span> Install the Codecov Vite
-        Plugin
-      </h2>
-      <p className="pb-2 text-sm">
-        To install the{' '}
-        <span className="bg-ds-gray-primary px-1 font-mono">
-          @codecov/vite-plugin
-        </span>{' '}
-        to your project, use one of the following commands.
-      </p>
-      <div className="flex flex-col gap-4">
+    <Card>
+      <Card.Header>
+        <Card.Title size="base">
+          Step 1: Install the Codecov Vite Plugin
+        </Card.Title>
+      </Card.Header>
+      <Card.Content className="flex flex-col gap-4">
+        <p>
+          To install the{' '}
+          <span className="bg-ds-gray-primary px-1 font-mono">
+            @codecov/vite-plugin
+          </span>{' '}
+          to your project, use one of the following commands.
+        </p>
         <pre className="flex w-full items-center justify-between gap-2 overflow-auto whitespace-pre-wrap rounded-md border border-ds-gray-secondary bg-ds-gray-primary p-4 font-mono">
           {npmInstall}{' '}
           <CopyClipboard
@@ -85,140 +87,170 @@ const StepOne: React.FC = () => {
             }}
           />
         </pre>
-      </div>
-    </div>
+      </Card.Content>
+    </Card>
   )
 }
 
 const StepTwo: React.FC<{ uploadToken: string }> = ({ uploadToken }) => {
   return (
-    <div className="pt-4">
-      <h2 className="pb-2 text-base">
-        <span className="font-semibold">Step 2:</span> Copy Codecov token
-      </h2>
-      <p className="pb-2 text-sm">
-        Set an environment variable in your build environment with the following
-        upload token.
-      </p>
-      <div className="flex gap-4">
-        <pre className="flex basis-1/3 items-center justify-between gap-2 rounded-md border border-ds-gray-secondary bg-ds-gray-primary p-4 font-mono">
-          <div className="w-0 flex-1 overflow-hidden" data-testid="token-key">
-            CODECOV_TOKEN
-          </div>
-          <CopyClipboard string="CODECOV_TOKEN" />
-        </pre>
-        <pre className="flex basis-2/3 items-center justify-between gap-2 rounded-md border border-ds-gray-secondary bg-ds-gray-primary p-4 font-mono">
-          <div className="w-0 flex-1 overflow-hidden">{uploadToken}</div>
-          <CopyClipboard
-            string={uploadToken}
-            testIdExtension="-upload-token"
-            onClick={() => {
-              copiedTokenMetric('vite')
-            }}
-          />
-        </pre>
-      </div>
-    </div>
+    <Card>
+      <Card.Header>
+        <Card.Title size="base">Step 2: Copy Codecov token</Card.Title>
+      </Card.Header>
+      <Card.Content className="flex flex-col gap-4">
+        <p>
+          Set an environment variable in your build environment with the
+          following upload token.
+        </p>
+        <div className="flex gap-4">
+          <pre className="flex basis-1/3 items-center justify-between gap-2 rounded-md border border-ds-gray-secondary bg-ds-gray-primary p-4 font-mono">
+            <div className="w-0 flex-1 overflow-hidden" data-testid="token-key">
+              CODECOV_TOKEN
+            </div>
+            <CopyClipboard string="CODECOV_TOKEN" />
+          </pre>
+          <pre className="flex basis-2/3 items-center justify-between gap-2 rounded-md border border-ds-gray-secondary bg-ds-gray-primary p-4 font-mono">
+            <div className="w-0 flex-1 overflow-hidden">{uploadToken}</div>
+            <CopyClipboard
+              string={uploadToken}
+              testIdExtension="-upload-token"
+              onClick={() => {
+                copiedTokenMetric('vite')
+              }}
+            />
+          </pre>
+        </div>
+      </Card.Content>
+    </Card>
   )
 }
 
 const StepThree: React.FC = () => {
   return (
-    <div>
-      <h2 className="pb-2 text-base">
-        <span className="font-semibold">Step 3:</span> Configure the bundler
-        plugin
-      </h2>
-      <p className="pb-2 selection:text-sm">
-        Import the bundler plugin, and add it to the end of your plugin array
-        found inside your{' '}
-        <span className="bg-ds-gray-primary px-1 font-mono">
-          vite.config.js
-        </span>{' '}
-        file.
-      </p>
-      <pre className="flex items-start justify-between overflow-auto whitespace-pre rounded-md border border-ds-gray-secondary bg-ds-gray-primary p-4 font-mono">
-        {pluginConfig}
-        <CopyClipboard
-          string={pluginConfig}
-          testIdExtension="-plugin-config"
-          onClick={() => {
-            copiedConfigMetric('vite')
-          }}
-        />
-      </pre>
-    </div>
+    <Card>
+      <Card.Header>
+        <Card.Title size="base">
+          Step 3: Configure the bundler plugin
+        </Card.Title>
+      </Card.Header>
+      <Card.Content className="flex flex-col gap-4">
+        <p>
+          Import the bundler plugin, and add it to the end of your plugin array
+          found inside your{' '}
+          <span className="bg-ds-gray-primary px-1 font-mono">
+            vite.config.js
+          </span>{' '}
+          file.
+        </p>
+        <pre className="relative flex items-start justify-between overflow-auto whitespace-pre rounded-md border border-ds-gray-secondary bg-ds-gray-primary p-4 font-mono">
+          {pluginConfig}
+          <CopyClipboard
+            string={pluginConfig}
+            testIdExtension="-plugin-config"
+            onClick={() => {
+              copiedConfigMetric('vite')
+            }}
+          />
+        </pre>
+      </Card.Content>
+    </Card>
   )
 }
 
 const StepFour: React.FC = () => {
   return (
-    <div>
-      <h2 className="pb-2 text-base">
-        <span className="font-semibold">Step 4:</span> Commit and push your
-        latest changes
-      </h2>
-      <p className="pb-2 text-sm">
-        The plugin requires at least one commit to be made to properly upload
-        bundle analysis information up to Codecov.
-      </p>
-      <pre className="flex w-full items-center justify-between gap-2 overflow-auto whitespace-pre-wrap rounded-md border border-ds-gray-secondary bg-ds-gray-primary p-4 font-mono">
-        {commitString}{' '}
-        <CopyClipboard
-          string={commitString}
-          testIdExtension="-commit-command"
-          onClick={() => {
-            copiedCommitMetric('vite')
-          }}
-        />
-      </pre>
-    </div>
+    <Card>
+      <Card.Header>
+        <Card.Title size="base">
+          Step 4: Commit and push your latest changes
+        </Card.Title>
+      </Card.Header>
+      <Card.Content className="flex flex-col gap-4">
+        <p>
+          The plugin requires at least one commit to be made to properly upload
+          bundle analysis information up to Codecov.
+        </p>
+        <pre className="flex w-full items-center justify-between gap-2 overflow-auto whitespace-pre-wrap rounded-md border border-ds-gray-secondary bg-ds-gray-primary p-4 font-mono">
+          {commitString}{' '}
+          <CopyClipboard
+            string={commitString}
+            testIdExtension="-commit-command"
+            onClick={() => {
+              copiedCommitMetric('vite')
+            }}
+          />
+        </pre>
+      </Card.Content>
+    </Card>
   )
 }
 
 const StepFive: React.FC = () => {
   return (
-    <div>
-      <h2 className="pb-2 text-base">
-        <span className="font-semibold">Step 5:</span> Build the application
-      </h2>
-      <p className="pb-2 text-sm">
-        When building your application the plugin will automatically upload the
-        stats information to Codecov.
-      </p>
-      <div className="flex flex-col gap-4">
-        <pre className="flex w-full items-center justify-between gap-2 overflow-auto whitespace-pre-wrap rounded-md border border-ds-gray-secondary bg-ds-gray-primary p-4 font-mono">
-          {npmBuild}{' '}
-          <CopyClipboard
-            string={npmBuild}
-            testIdExtension="-npm-build"
-            onClick={() => {
-              copiedBuildCommandMetric('npm', 'vite')
-            }}
-          />
-        </pre>
-        <pre className="flex w-full items-center justify-between gap-2 overflow-auto whitespace-pre-wrap rounded-md border border-ds-gray-secondary bg-ds-gray-primary p-4 font-mono">
-          {yarnBuild}{' '}
-          <CopyClipboard
-            string={yarnBuild}
-            testIdExtension="-yarn-build"
-            onClick={() => {
-              copiedBuildCommandMetric('yarn', 'vite')
-            }}
-          />
-        </pre>
-        <pre className="flex w-full items-center justify-between gap-2 overflow-auto whitespace-pre-wrap rounded-md border border-ds-gray-secondary bg-ds-gray-primary p-4 font-mono">
-          {pnpmBuild}{' '}
-          <CopyClipboard
-            string={pnpmBuild}
-            testIdExtension="-pnpm-build"
-            onClick={() => {
-              copiedBuildCommandMetric('pnpm', 'vite')
-            }}
-          />
-        </pre>
-      </div>
-    </div>
+    <Card>
+      <Card.Header>
+        <Card.Title size="base">Step 5: Build the application</Card.Title>
+      </Card.Header>
+      <Card.Content className="flex flex-col gap-4">
+        <p>
+          When building your application the plugin will automatically upload
+          the stats information to Codecov.
+        </p>
+        <div className="flex flex-col gap-4">
+          <pre className="flex w-full items-center justify-between gap-2 overflow-auto whitespace-pre-wrap rounded-md border border-ds-gray-secondary bg-ds-gray-primary p-4 font-mono">
+            {npmBuild}{' '}
+            <CopyClipboard
+              string={npmBuild}
+              testIdExtension="-npm-build"
+              onClick={() => {
+                copiedBuildCommandMetric('npm', 'vite')
+              }}
+            />
+          </pre>
+          <pre className="flex w-full items-center justify-between gap-2 overflow-auto whitespace-pre-wrap rounded-md border border-ds-gray-secondary bg-ds-gray-primary p-4 font-mono">
+            {yarnBuild}{' '}
+            <CopyClipboard
+              string={yarnBuild}
+              testIdExtension="-yarn-build"
+              onClick={() => {
+                copiedBuildCommandMetric('yarn', 'vite')
+              }}
+            />
+          </pre>
+          <pre className="flex w-full items-center justify-between gap-2 overflow-auto whitespace-pre-wrap rounded-md border border-ds-gray-secondary bg-ds-gray-primary p-4 font-mono">
+            {pnpmBuild}{' '}
+            <CopyClipboard
+              string={pnpmBuild}
+              testIdExtension="-pnpm-build"
+              onClick={() => {
+                copiedBuildCommandMetric('pnpm', 'vite')
+              }}
+            />
+          </pre>
+        </div>
+      </Card.Content>
+    </Card>
+  )
+}
+
+function FeedbackCTA() {
+  return (
+    <Card>
+      <Card.Content>
+        <p>
+          <span className="font-semibold">How was your setup experience?</span>{' '}
+          Let us know in{' '}
+          <A
+            to={{ pageName: 'bundleConfigFeedback' }}
+            isExternal
+            hook="repo-config-feedback"
+          >
+            this issue
+          </A>
+        </p>
+      </Card.Content>
+    </Card>
   )
 }
 
@@ -246,19 +278,7 @@ const ViteOnboarding: React.FC = () => {
       <StepThree />
       <StepFour />
       <StepFive />
-      <div>
-        <p className="border-l-2 border-ds-gray-secondary pl-4">
-          <span className="font-semibold">How was your setup experience?</span>{' '}
-          Let us know in{' '}
-          <A
-            to={{ pageName: 'bundleConfigFeedback' }}
-            isExternal
-            hook="repo-config-feedback"
-          >
-            this issue
-          </A>
-        </p>
-      </div>
+      <FeedbackCTA />
     </div>
   )
 }

--- a/src/pages/RepoPage/BundlesTab/BundleOnboarding/WebpackOnboarding/WebpackOnboarding.spec.tsx
+++ b/src/pages/RepoPage/BundlesTab/BundleOnboarding/WebpackOnboarding/WebpackOnboarding.spec.tsx
@@ -107,11 +107,11 @@ describe('WebpackOnboarding', () => {
       setup(null)
       render(<WebpackOnboarding />, { wrapper })
 
-      const stepText = await screen.findByText('Step 1:')
+      const stepText = await screen.findByText(/Step 1:/)
       expect(stepText).toBeInTheDocument()
 
       const headerText = await screen.findByText(
-        'Install the Codecov Webpack Plugin'
+        /Install the Codecov Webpack Plugin/
       )
       expect(headerText).toBeInTheDocument()
     })
@@ -231,10 +231,10 @@ describe('WebpackOnboarding', () => {
       setup(null)
       render(<WebpackOnboarding />, { wrapper })
 
-      const stepText = await screen.findByText('Step 2:')
+      const stepText = await screen.findByText(/Step 2:/)
       expect(stepText).toBeInTheDocument()
 
-      const headerText = await screen.findByText('Copy Codecov token')
+      const headerText = await screen.findByText(/Copy Codecov token/)
       expect(headerText).toBeInTheDocument()
     })
 
@@ -298,10 +298,10 @@ describe('WebpackOnboarding', () => {
       setup(null)
       render(<WebpackOnboarding />, { wrapper })
 
-      const stepText = await screen.findByText('Step 3:')
+      const stepText = await screen.findByText(/Step 3:/)
       expect(stepText).toBeInTheDocument()
 
-      const headerText = await screen.findByText('Configure the bundler plugin')
+      const headerText = await screen.findByText(/Configure the bundler plugin/)
       expect(headerText).toBeInTheDocument()
     })
 
@@ -352,11 +352,11 @@ describe('WebpackOnboarding', () => {
       setup(null)
       render(<WebpackOnboarding />, { wrapper })
 
-      const stepText = await screen.findByText('Step 4:')
+      const stepText = await screen.findByText(/Step 4:/)
       expect(stepText).toBeInTheDocument()
 
       const headerText = await screen.findByText(
-        'Commit and push your latest changes'
+        /Commit and push your latest changes/
       )
       expect(headerText).toBeInTheDocument()
     })
@@ -407,10 +407,10 @@ describe('WebpackOnboarding', () => {
       setup(null)
       render(<WebpackOnboarding />, { wrapper })
 
-      const stepText = await screen.findByText('Step 5:')
+      const stepText = await screen.findByText(/Step 5:/)
       expect(stepText).toBeInTheDocument()
 
-      const headerText = await screen.findByText('Build the application')
+      const headerText = await screen.findByText(/Build the application/)
       expect(headerText).toBeInTheDocument()
     })
 

--- a/src/pages/RepoPage/BundlesTab/BundleOnboarding/WebpackOnboarding/WebpackOnboarding.tsx
+++ b/src/pages/RepoPage/BundlesTab/BundleOnboarding/WebpackOnboarding/WebpackOnboarding.tsx
@@ -4,6 +4,7 @@ import { useParams } from 'react-router-dom'
 import { useOrgUploadToken } from 'services/orgUploadToken'
 import { useRepo } from 'services/repo'
 import A from 'ui/A'
+import { Card } from 'ui/Card'
 import CopyClipboard from 'ui/CopyClipboard'
 
 import {
@@ -43,19 +44,20 @@ const pnpmBuild = `pnpm run build`
 
 const StepOne: React.FC = () => {
   return (
-    <div className="pt-4">
-      <h2 className="pb-2 text-base">
-        <span className="font-semibold">Step 1:</span> Install the Codecov
-        Webpack Plugin
-      </h2>
-      <p className="pb-2 text-sm">
-        To install the{' '}
-        <span className="bg-ds-gray-primary px-1 font-mono">
-          @codecov/webpack-plugin
-        </span>{' '}
-        to your project, use one of the following commands.
-      </p>
-      <div className="flex flex-col gap-4">
+    <Card>
+      <Card.Header>
+        <Card.Title size="base">
+          Step 1: Install the Codecov Webpack Plugin
+        </Card.Title>
+      </Card.Header>
+      <Card.Content className="flex flex-col gap-4">
+        <p>
+          To install the{' '}
+          <span className="bg-ds-gray-primary px-1 font-mono">
+            @codecov/webpack-plugin
+          </span>{' '}
+          to your project, use one of the following commands.
+        </p>
         <pre className="flex w-full items-center justify-between gap-2 overflow-auto whitespace-pre-wrap rounded-md border border-ds-gray-secondary bg-ds-gray-primary p-4 font-mono">
           {npmInstall}{' '}
           <CopyClipboard
@@ -86,123 +88,131 @@ const StepOne: React.FC = () => {
             }}
           />
         </pre>
-      </div>
-    </div>
+      </Card.Content>
+    </Card>
   )
 }
 
 const StepTwo: React.FC<{ uploadToken: string }> = ({ uploadToken }) => {
   return (
-    <div className="pt-4">
-      <h2 className="pb-2 text-base">
-        <span className="font-semibold">Step 2:</span> Copy Codecov token
-      </h2>
-      <p className="pb-2 text-sm">
-        Set an environment variable in your build environment with the following
-        upload token.
-      </p>
-      <div className="flex gap-4">
-        <pre className="flex basis-1/3 items-center justify-between gap-2 rounded-md border border-ds-gray-secondary bg-ds-gray-primary p-4 font-mono">
-          <div className="w-0 flex-1 overflow-hidden" data-testid="token-key">
-            CODECOV_TOKEN
-          </div>
-          <CopyClipboard string="CODECOV_TOKEN" />
-        </pre>
-        <pre className="flex basis-2/3 items-center justify-between gap-2 rounded-md border border-ds-gray-secondary bg-ds-gray-primary p-4 font-mono">
-          <div className="w-0 flex-1 overflow-hidden">{uploadToken}</div>
-          <CopyClipboard
-            string={uploadToken}
-            testIdExtension="-upload-token"
-            onClick={() => {
-              copiedTokenMetric('webpack')
-            }}
-          />
-        </pre>
-      </div>
-    </div>
+    <Card>
+      <Card.Header>
+        <Card.Title size="base">Step 2: Copy Codecov token</Card.Title>
+      </Card.Header>
+      <Card.Content className="flex flex-col gap-4">
+        <p>
+          Set an environment variable in your build environment with the
+          following upload token.
+        </p>
+        <div className="flex gap-4">
+          <pre className="flex basis-1/3 items-center justify-between gap-2 rounded-md border border-ds-gray-secondary bg-ds-gray-primary p-4 font-mono">
+            <div className="w-0 flex-1 overflow-hidden" data-testid="token-key">
+              CODECOV_TOKEN
+            </div>
+            <CopyClipboard string="CODECOV_TOKEN" />
+          </pre>
+          <pre className="flex basis-2/3 items-center justify-between gap-2 rounded-md border border-ds-gray-secondary bg-ds-gray-primary p-4 font-mono">
+            <div className="w-0 flex-1 overflow-hidden">{uploadToken}</div>
+            <CopyClipboard
+              string={uploadToken}
+              testIdExtension="-upload-token"
+              onClick={() => {
+                copiedTokenMetric('webpack')
+              }}
+            />
+          </pre>
+        </div>
+      </Card.Content>
+    </Card>
   )
 }
 
 const StepThree: React.FC = () => {
   return (
-    <div>
-      <h2 className="pb-2 text-base">
-        <span className="font-semibold">Step 3:</span> Configure the bundler
-        plugin
-      </h2>
-      <p className="pb-2 text-sm">
-        Import the bundler plugin, and add it to the end of your plugin array
-        found inside your{' '}
-        <span className="bg-ds-gray-primary px-1 font-mono">
-          webpack.config.js
-        </span>{' '}
-        file.
-      </p>
-      <p className="pb-2 text-sm">
-        For NextJS users, please see their docs for configuring Webpack inside
-        the{' '}
-        <span className="bg-ds-gray-primary px-1 font-mono">
-          next.config.js
-        </span>{' '}
-        file{' '}
-        <A
-          isExternal
-          to={{ pageName: 'nextJSCustomConfig' }}
-          hook="custom-next-webpack-config"
-        >
-          here.
-        </A>
-      </p>
-      <pre className="flex items-start justify-between overflow-auto whitespace-pre rounded-md border border-ds-gray-secondary bg-ds-gray-primary p-4 font-mono">
-        {pluginConfig}
-        <CopyClipboard
-          string={pluginConfig}
-          testIdExtension="-plugin-config"
-          onClick={() => {
-            copiedConfigMetric('webpack')
-          }}
-        />
-      </pre>
-    </div>
+    <Card>
+      <Card.Header>
+        <Card.Title size="base">
+          Step 3: Configure the bundler plugin
+        </Card.Title>
+      </Card.Header>
+      <Card.Content className="flex flex-col gap-4">
+        <p>
+          Import the bundler plugin, and add it to the end of your plugin array
+          found inside your{' '}
+          <span className="bg-ds-gray-primary px-1 font-mono">
+            webpack.config.js
+          </span>{' '}
+          file.
+        </p>
+        <p>
+          For NextJS users, please see their docs for configuring Webpack inside
+          the{' '}
+          <span className="bg-ds-gray-primary px-1 font-mono">
+            next.config.js
+          </span>{' '}
+          file{' '}
+          <A
+            isExternal
+            to={{ pageName: 'nextJSCustomConfig' }}
+            hook="custom-next-webpack-config"
+          >
+            here.
+          </A>
+        </p>
+        <pre className="flex items-start justify-between overflow-auto whitespace-pre rounded-md border border-ds-gray-secondary bg-ds-gray-primary p-4 font-mono">
+          {pluginConfig}
+          <CopyClipboard
+            string={pluginConfig}
+            testIdExtension="-plugin-config"
+            onClick={() => {
+              copiedConfigMetric('webpack')
+            }}
+          />
+        </pre>
+      </Card.Content>
+    </Card>
   )
 }
 
 const StepFour: React.FC = () => {
   return (
-    <div>
-      <h2 className="pb-2 text-base">
-        <span className="font-semibold">Step 4:</span> Commit and push your
-        latest changes
-      </h2>
-      <p className="pb-2 text-sm">
-        The plugin requires at least one commit to be made to properly upload
-        bundle analysis information up to Codecov.
-      </p>
-      <pre className="flex w-full items-center justify-between gap-2 overflow-auto whitespace-pre-wrap rounded-md border border-ds-gray-secondary bg-ds-gray-primary p-4 font-mono">
-        {commitString}{' '}
-        <CopyClipboard
-          string={commitString}
-          testIdExtension="-commit-command"
-          onClick={() => {
-            copiedCommitMetric('webpack')
-          }}
-        />
-      </pre>
-    </div>
+    <Card>
+      <Card.Header>
+        <Card.Title size="base">
+          Step 4: Commit and push your latest changes
+        </Card.Title>
+      </Card.Header>
+      <Card.Content className="flex flex-col gap-4">
+        <p>
+          The plugin requires at least one commit to be made to properly upload
+          bundle analysis information up to Codecov.
+        </p>
+        <pre className="flex w-full items-center justify-between gap-2 overflow-auto whitespace-pre-wrap rounded-md border border-ds-gray-secondary bg-ds-gray-primary p-4 font-mono">
+          {commitString}{' '}
+          <CopyClipboard
+            string={commitString}
+            testIdExtension="-commit-command"
+            onClick={() => {
+              copiedCommitMetric('webpack')
+            }}
+          />
+        </pre>
+      </Card.Content>
+    </Card>
   )
 }
 
 const StepFive: React.FC = () => {
   return (
-    <div>
-      <h2 className="pb-2 text-base">
-        <span className="font-semibold">Step 5:</span> Build the application
-      </h2>
-      <p className="pb-2 text-sm">
-        When building your application the plugin will automatically upload the
-        stats information to Codecov.
-      </p>
-      <div className="flex flex-col gap-4">
+    <Card>
+      <Card.Header>
+        <Card.Title size="base">Step 5: Build the application</Card.Title>
+      </Card.Header>
+      <Card.Content className="flex flex-col gap-4">
+        <p>
+          When building your application the plugin will automatically upload
+          the stats information to Codecov.
+        </p>
         <pre className="flex w-full items-center justify-between gap-2 overflow-auto whitespace-pre-wrap rounded-md border border-ds-gray-secondary bg-ds-gray-primary p-4 font-mono">
           {npmBuild}{' '}
           <CopyClipboard
@@ -233,8 +243,28 @@ const StepFive: React.FC = () => {
             }}
           />
         </pre>
-      </div>
-    </div>
+      </Card.Content>
+    </Card>
+  )
+}
+
+function FeedbackCTA() {
+  return (
+    <Card>
+      <Card.Content>
+        <p>
+          <span className="font-semibold">How was your setup experience?</span>{' '}
+          Let us know in{' '}
+          <A
+            to={{ pageName: 'bundleConfigFeedback' }}
+            isExternal
+            hook="repo-config-feedback"
+          >
+            this issue
+          </A>
+        </p>
+      </Card.Content>
+    </Card>
   )
 }
 
@@ -262,19 +292,7 @@ const WebpackOnboarding: React.FC = () => {
       <StepThree />
       <StepFour />
       <StepFive />
-      <div>
-        <p className="border-l-2 border-ds-gray-secondary pl-4">
-          <span className="font-semibold">How was your setup experience?</span>{' '}
-          Let us know in{' '}
-          <A
-            to={{ pageName: 'bundleConfigFeedback' }}
-            isExternal
-            hook="repo-config-feedback"
-          >
-            this issue
-          </A>
-        </p>
-      </div>
+      <FeedbackCTA />
     </div>
   )
 }

--- a/src/pages/RepoPage/BundlesTab/BundleOnboarding/WebpackOnboarding/WebpackOnboarding.tsx
+++ b/src/pages/RepoPage/BundlesTab/BundleOnboarding/WebpackOnboarding/WebpackOnboarding.tsx
@@ -56,7 +56,7 @@ const StepOne: React.FC = () => {
         to your project, use one of the following commands.
       </p>
       <div className="flex flex-col gap-4">
-        <pre className="flex w-full items-center justify-between gap-2 overflow-auto whitespace-pre-wrap rounded-md border-2 border-ds-gray-secondary bg-ds-gray-primary px-4 py-2 font-mono">
+        <pre className="flex w-full items-center justify-between gap-2 overflow-auto whitespace-pre-wrap rounded-md border border-ds-gray-secondary bg-ds-gray-primary p-4 font-mono">
           {npmInstall}{' '}
           <CopyClipboard
             string={npmInstall}
@@ -66,7 +66,7 @@ const StepOne: React.FC = () => {
             }}
           />
         </pre>
-        <pre className="flex w-full items-center justify-between gap-2 overflow-auto whitespace-pre-wrap rounded-md border-2 border-ds-gray-secondary bg-ds-gray-primary px-4 py-2 font-mono">
+        <pre className="flex w-full items-center justify-between gap-2 overflow-auto whitespace-pre-wrap rounded-md border border-ds-gray-secondary bg-ds-gray-primary p-4 font-mono">
           {yarnInstall}{' '}
           <CopyClipboard
             string={yarnInstall}
@@ -76,7 +76,7 @@ const StepOne: React.FC = () => {
             }}
           />
         </pre>
-        <pre className="flex w-full items-center justify-between gap-2 overflow-auto whitespace-pre-wrap rounded-md border-2 border-ds-gray-secondary bg-ds-gray-primary px-4 py-2 font-mono">
+        <pre className="flex w-full items-center justify-between gap-2 overflow-auto whitespace-pre-wrap rounded-md border border-ds-gray-secondary bg-ds-gray-primary p-4 font-mono">
           {pnpmInstall}{' '}
           <CopyClipboard
             string={pnpmInstall}
@@ -102,13 +102,13 @@ const StepTwo: React.FC<{ uploadToken: string }> = ({ uploadToken }) => {
         upload token.
       </p>
       <div className="flex gap-4">
-        <pre className="flex basis-1/3 items-center justify-between gap-2 rounded-md border-2 border-ds-gray-secondary bg-ds-gray-primary px-4 py-2 font-mono">
+        <pre className="flex basis-1/3 items-center justify-between gap-2 rounded-md border border-ds-gray-secondary bg-ds-gray-primary p-4 font-mono">
           <div className="w-0 flex-1 overflow-hidden" data-testid="token-key">
             CODECOV_TOKEN
           </div>
           <CopyClipboard string="CODECOV_TOKEN" />
         </pre>
-        <pre className="flex basis-2/3 items-center justify-between gap-2 rounded-md border-2 border-ds-gray-secondary bg-ds-gray-primary px-4 py-2 font-mono">
+        <pre className="flex basis-2/3 items-center justify-between gap-2 rounded-md border border-ds-gray-secondary bg-ds-gray-primary p-4 font-mono">
           <div className="w-0 flex-1 overflow-hidden">{uploadToken}</div>
           <CopyClipboard
             string={uploadToken}
@@ -153,7 +153,7 @@ const StepThree: React.FC = () => {
           here.
         </A>
       </p>
-      <pre className="flex items-start justify-between overflow-auto whitespace-pre rounded-md border-2 border-ds-gray-secondary bg-ds-gray-primary px-4 py-2 font-mono">
+      <pre className="flex items-start justify-between overflow-auto whitespace-pre rounded-md border border-ds-gray-secondary bg-ds-gray-primary p-4 font-mono">
         {pluginConfig}
         <CopyClipboard
           string={pluginConfig}
@@ -178,7 +178,7 @@ const StepFour: React.FC = () => {
         The plugin requires at least one commit to be made to properly upload
         bundle analysis information up to Codecov.
       </p>
-      <pre className="flex w-full items-center justify-between gap-2 overflow-auto whitespace-pre-wrap rounded-md border-2 border-ds-gray-secondary bg-ds-gray-primary px-4 py-2 font-mono">
+      <pre className="flex w-full items-center justify-between gap-2 overflow-auto whitespace-pre-wrap rounded-md border border-ds-gray-secondary bg-ds-gray-primary p-4 font-mono">
         {commitString}{' '}
         <CopyClipboard
           string={commitString}
@@ -203,7 +203,7 @@ const StepFive: React.FC = () => {
         stats information to Codecov.
       </p>
       <div className="flex flex-col gap-4">
-        <pre className="flex w-full items-center justify-between gap-2 overflow-auto whitespace-pre-wrap rounded-md border-2 border-ds-gray-secondary bg-ds-gray-primary px-4 py-2 font-mono">
+        <pre className="flex w-full items-center justify-between gap-2 overflow-auto whitespace-pre-wrap rounded-md border border-ds-gray-secondary bg-ds-gray-primary p-4 font-mono">
           {npmBuild}{' '}
           <CopyClipboard
             string={npmBuild}
@@ -213,7 +213,7 @@ const StepFive: React.FC = () => {
             }}
           />
         </pre>
-        <pre className="flex w-full items-center justify-between gap-2 overflow-auto whitespace-pre-wrap rounded-md border-2 border-ds-gray-secondary bg-ds-gray-primary px-4 py-2 font-mono">
+        <pre className="flex w-full items-center justify-between gap-2 overflow-auto whitespace-pre-wrap rounded-md border border-ds-gray-secondary bg-ds-gray-primary p-4 font-mono">
           {yarnBuild}{' '}
           <CopyClipboard
             string={yarnBuild}
@@ -223,7 +223,7 @@ const StepFive: React.FC = () => {
             }}
           />
         </pre>
-        <pre className="flex w-full items-center justify-between gap-2 overflow-auto whitespace-pre-wrap rounded-md border-2 border-ds-gray-secondary bg-ds-gray-primary px-4 py-2 font-mono">
+        <pre className="flex w-full items-center justify-between gap-2 overflow-auto whitespace-pre-wrap rounded-md border border-ds-gray-secondary bg-ds-gray-primary p-4 font-mono">
           {pnpmBuild}{' '}
           <CopyClipboard
             string={pnpmBuild}


### PR DESCRIPTION
# Description

Adds Card component to the bundle analysis onboarding page. Two more increments to come.

Part of https://github.com/codecov/engineering-team/issues/1439

# Screenshots

Before:

<img width="1306" alt="Screenshot 2024-05-08 at 11 03 25" src="https://github.com/codecov/gazebo/assets/159931558/5c686cc7-3818-4ed6-b59a-f716a20a4cab">

After:

<img width="1304" alt="Screenshot 2024-05-08 at 11 02 27" src="https://github.com/codecov/gazebo/assets/159931558/f2f8b7fb-eb44-40c6-a51d-9181b2ca14ef">
