### PR TITLE
chore: Update codecov.yml so that PR comment isn't send until 8 uploads

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -23,7 +23,7 @@ comment:
   require_changes: no
   require_base: no
   require_head: yes
-  after_n_builds: 6
+  after_n_builds: 8 # number of test files / 80. See ci.yml for more details.
 
 ignore:
   - ./src/**/*.stories.js


### PR DESCRIPTION
Updates codecov.yml's `after_n_builds` for PR comments. We dynamically scale our test runner count based on the number of test files and it seems that we've added quite a few tests since the last time this was updated, causing the PR comment to come after just 6 uploads- resulting in unnecessary premature comment updates on our PRs. Currently, we split up into 8 test runners not 6.
