### PR TITLE
components over time display name instead of id

### DIFF
--- a/src/pages/RepoPage/ComponentsTab/subroute/ComponentsTable/ComponentsTable.spec.tsx
+++ b/src/pages/RepoPage/ComponentsTab/subroute/ComponentsTable/ComponentsTable.spec.tsx
@@ -43,6 +43,7 @@ const mockedComponentMeasurements = {
       __typename: 'Repository',
       components: [
         {
+          componentId: 'components1_id',
           name: 'components1',
           percentCovered: 93.26,
           percentChange: -1.56,
@@ -50,6 +51,7 @@ const mockedComponentMeasurements = {
           measurements: [{ avg: 51.78 }, { avg: 93.356 }],
         },
         {
+          componentId: 'components2_id',
           name: 'component2',
           percentCovered: 91.74,
           percentChange: null,
@@ -58,6 +60,7 @@ const mockedComponentMeasurements = {
         },
 
         {
+          componentId: 'testtest_id',
           name: 'testtest',
           percentCovered: 1.0,
           percentChange: 1.0,
@@ -76,6 +79,7 @@ const mockNoReportsUploadedMeasurements = {
       components: [
         {
           name: 'components1',
+          componentId: 'components1_id',
           percentCovered: null,
           percentChange: null,
           lastUploaded: null,

--- a/src/pages/RepoPage/ComponentsTab/subroute/ComponentsTable/ComponentsTable.tsx
+++ b/src/pages/RepoPage/ComponentsTab/subroute/ComponentsTable/ComponentsTable.tsx
@@ -124,12 +124,14 @@ function createTableData({
 
   const data = tableData?.map(
     ({
+      componentId,
       name,
       percentCovered,
       percentChange,
       measurements,
       lastUploaded,
     }: {
+      componentId: string
       name: string
       percentCovered: number | null
       percentChange: number | null
@@ -180,7 +182,13 @@ function createTableData({
         <div className="flex items-center justify-center">
           <button
             data-testid="delete-component"
-            onClick={() => setModalInfo({ componentId: name, showModal: true })}
+            onClick={() =>
+              setModalInfo({
+                componentId: componentId,
+                name: name,
+                showModal: true,
+              })
+            }
             className="text-ds-gray-tertiary hover:text-ds-gray-senary"
             aria-label={'delete ' + name}
           >
@@ -308,6 +316,7 @@ function ComponentsTable() {
   const { data: repoConfigData } = useRepoConfig({ provider, owner, repo })
   const [modalInfo, setModalInfo] = useState({
     componentId: null,
+    name: null,
     showModal: false,
   })
   const [sorting, setSorting] = useState<SortingState>([
@@ -332,8 +341,9 @@ function ComponentsTable() {
     <>
       <DeleteComponentModal
         componentId={modalInfo?.componentId || ''}
+        name={modalInfo?.name || ''}
         closeModal={() => {
-          setModalInfo({ componentId: null, showModal: false })
+          setModalInfo({ componentId: null, name: null, showModal: false })
         }}
         isOpen={modalInfo?.showModal}
       />

--- a/src/pages/RepoPage/ComponentsTab/subroute/ComponentsTable/DeleteComponentModal/DeleteComponentModal.spec.tsx
+++ b/src/pages/RepoPage/ComponentsTab/subroute/ComponentsTable/DeleteComponentModal/DeleteComponentModal.spec.tsx
@@ -60,6 +60,7 @@ describe('DeleteComponentModal', () => {
       render(
         <DeleteComponentModal
           componentId="component-123"
+          name="componentName"
           closeModal={jest.fn()}
           isOpen
         />,
@@ -74,7 +75,7 @@ describe('DeleteComponentModal', () => {
       )
       expect(messagePartTwo).toBeInTheDocument()
 
-      const componentId = await screen.findAllByText(/component-123/)
+      const componentId = await screen.findAllByText(/componentName/)
       expect(componentId).toHaveLength(3)
     })
 
@@ -82,6 +83,7 @@ describe('DeleteComponentModal', () => {
       render(
         <DeleteComponentModal
           componentId="component-123"
+          name="componentName"
           closeModal={jest.fn()}
           isOpen
         />,
@@ -101,6 +103,7 @@ describe('DeleteComponentModal', () => {
       render(
         <DeleteComponentModal
           componentId="component-123"
+          name="componentName"
           closeModal={jest.fn()}
           isOpen
         />,
@@ -108,7 +111,7 @@ describe('DeleteComponentModal', () => {
           wrapper,
         }
       )
-      const title = await screen.findByTestId(/remove-component-123/)
+      const title = await screen.findByTestId(/remove-componentName/)
       expect(title).toBeInTheDocument()
     })
   })
@@ -120,6 +123,7 @@ describe('DeleteComponentModal', () => {
       render(
         <DeleteComponentModal
           componentId="component-123"
+          name="componentName"
           closeModal={closeModal}
           isOpen
         />,
@@ -143,6 +147,7 @@ describe('DeleteComponentModal', () => {
       render(
         <DeleteComponentModal
           componentId="component-123"
+          name="componentName"
           closeModal={closeModal}
           isOpen
         />,

--- a/src/pages/RepoPage/ComponentsTab/subroute/ComponentsTable/DeleteComponentModal/DeleteComponentModal.tsx
+++ b/src/pages/RepoPage/ComponentsTab/subroute/ComponentsTable/DeleteComponentModal/DeleteComponentModal.tsx
@@ -5,10 +5,16 @@ import Modal from 'ui/Modal'
 type Props = {
   isOpen: boolean
   componentId?: string
+  name?: string
   closeModal: () => void
 }
 
-const DeleteComponentModal = ({ isOpen, closeModal, componentId }: Props) => {
+const DeleteComponentModal = ({
+  isOpen,
+  closeModal,
+  componentId,
+  name,
+}: Props) => {
   const { mutate } = useDeleteComponentMeasurements()
 
   return (
@@ -18,22 +24,21 @@ const DeleteComponentModal = ({ isOpen, closeModal, componentId }: Props) => {
       hasCloseButton={true}
       size="small"
       title={
-        <span data-testid={`remove-${componentId}`} className="text-lg">
-          Remove <span className="italic">{componentId}</span>
+        <span data-testid={`remove-${name}`} className="text-lg">
+          Remove <span className="italic">{name}</span>
         </span>
       }
       body={
         <div>
           <p>
             This will remove the historical data of{' '}
-            <span className="font-semibold italic">{componentId}</span>{' '}
-            component in the app and we can’t retrieve the data.
+            <span className="font-semibold italic">{name}</span> component in
+            the app and we can’t retrieve the data.
           </p>
           <br></br>
           <p>
             <span className="font-semibold">Action required:</span> You’ll need
-            to remove{' '}
-            <span className="font-semibold italic">{componentId}</span>{' '}
+            to remove <span className="font-semibold italic">{name}</span>{' '}
             component in your yaml file otherwise you’ll still see it in this
             table.
           </p>

--- a/src/pages/RepoPage/ComponentsTab/subroute/ComponentsTable/hooks/useRepoComponentsTable.spec.tsx
+++ b/src/pages/RepoPage/ComponentsTab/subroute/ComponentsTable/hooks/useRepoComponentsTable.spec.tsx
@@ -82,6 +82,7 @@ const mockedComponentMeasurements = {
       components: [
         {
           name: 'component1',
+          componentId: 'component1Id',
           percentCovered: 93.26,
           percentChange: 1.65,
           lastUploaded: null,
@@ -89,6 +90,7 @@ const mockedComponentMeasurements = {
         },
         {
           name: 'component2',
+          componentId: 'component2Id',
           percentCovered: 91.74,
           percentChange: 2.65,
           lastUploaded: null,
@@ -111,6 +113,7 @@ const mockEmptyComponentMeasurements = {
 const componentsData = [
   {
     name: 'component1',
+    componentId: 'component1Id',
     percentCovered: 93.26,
     percentChange: 1.65,
     measurements: [],
@@ -118,6 +121,7 @@ const componentsData = [
   },
   {
     name: 'component2',
+    componentId: 'component2Id',
     percentCovered: 91.74,
     percentChange: 2.65,
     measurements: [],

--- a/src/services/repo/useRepoComponents.spec.tsx
+++ b/src/services/repo/useRepoComponents.spec.tsx
@@ -33,6 +33,7 @@ afterAll(() => server.close())
 const expectedData = [
   {
     name: 'component1',
+    componentId: 'component1Id',
     percentCovered: 93.26,
     percentChange: 1.65,
     lastUploaded: '2021-09-30T00:00:00Z',
@@ -45,6 +46,7 @@ const expectedData = [
   },
   {
     name: 'component2',
+    componentId: 'component2Id',
     percentCovered: 92.72,
     percentChange: 1.58,
     lastUploaded: null,

--- a/src/services/repo/useRepoComponents.tsx
+++ b/src/services/repo/useRepoComponents.tsx
@@ -33,6 +33,7 @@ query ComponentMeasurements(
           before: $before
           branch: $branch
         ) {
+          componentId
           name
           percentCovered
           percentChange
@@ -48,6 +49,7 @@ query ComponentMeasurements(
 `
 
 export const ComponentEdgeSchema = z.object({
+  componentId: z.string(),
   name: z.string(),
   percentCovered: z.number().nullable(),
   percentChange: z.number().nullable(),
@@ -160,6 +162,7 @@ function fetchRepoComponents({
       } satisfies NetworkErrorObject)
     }
 
+    // This returns something else 2
     return {
       components: data?.owner?.repository?.components,
     }


### PR DESCRIPTION
fixes: https://github.com/codecov/engineering-team/issues/1702

The components table now displays component name instead of ID. This also fixes linking to the code tree view via clicking on the component names on the table

![Screenshot 2024-05-07 at 4 09 43 PM](https://github.com/codecov/gazebo/assets/142266253/d935d1c9-0a31-41b8-8c1e-db530f80d0c3)
![Screenshot 2024-05-07 at 4 09 54 PM](https://github.com/codecov/gazebo/assets/142266253/c4e186d4-92f4-4eee-8b6a-71a62581820a)

The codecov.yml file looks like this for components. Notice that the name is being displayed now, and "banker" has no name so the ID is showing.
```
  individual_components:
    - component_id: dictionary
      name: DictionaryApp
      paths:
        - "**/dictionary.py"
    - component_id: calculator
      name: CalculatorApp
      paths:
        - "**/calculator.py"
      flag_regexes:
        - "unit"
    - component_id: banker
      paths:
        - "**/banker.py"
      flag_regexes:
        - "integration"
 ```

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.