### PR TITLE
style: Fix radio tile group indicator shifting on certain screen sizes

### DIFF
--- a/src/ui/RadioTileGroup/RadioTileGroup.spec.tsx
+++ b/src/ui/RadioTileGroup/RadioTileGroup.spec.tsx
@@ -1,3 +1,4 @@
+import * as RadioGroupPrimitive from '@radix-ui/react-radio-group'
 import { render, screen } from '@testing-library/react'
 import { userEvent } from '@testing-library/user-event'
 
@@ -41,8 +42,14 @@ describe('RadioTileGroup', () => {
       expect(label.hasAttribute('for')).toBeTruthy()
     })
 
-    it('does not have htmlFor attribute when used outside of Item', async () => {
-      render(<RadioTileGroup.Label>Label</RadioTileGroup.Label>)
+    it('does not have htmlFor attribute when Context is null', async () => {
+      render(
+        <RadioGroupPrimitive.Root>
+          <RadioGroupPrimitive.Item value="asdf">
+            <RadioTileGroup.Label>Label</RadioTileGroup.Label>
+          </RadioGroupPrimitive.Item>
+        </RadioGroupPrimitive.Root>
+      )
       const label = await screen.findByText('Label')
       expect(label).toBeInTheDocument()
       expect(label.hasAttribute('for')).toBeFalsy()

--- a/src/ui/RadioTileGroup/RadioTileGroup.stories.tsx
+++ b/src/ui/RadioTileGroup/RadioTileGroup.stories.tsx
@@ -57,7 +57,8 @@ export const WithDescription: Story = {
       <RadioTileGroup.Item value="description" flex={args.flex}>
         <RadioTileGroup.Label>Description</RadioTileGroup.Label>
         <RadioTileGroup.Description>
-          A RadioTileGroup Item can optionally have a description
+          A RadioTileGroup Item can optionally have a description, which is a
+          great way to elaborate on the value of the option.
         </RadioTileGroup.Description>
       </RadioTileGroup.Item>
       <RadioTileGroup.Item value="noDescription" flex={args.flex}>

--- a/src/ui/RadioTileGroup/RadioTileGroup.tsx
+++ b/src/ui/RadioTileGroup/RadioTileGroup.tsx
@@ -63,17 +63,10 @@ const Item = React.forwardRef<
       {...props}
     >
       <ItemContext.Provider value={itemId}>
-        <div className="flex h-full flex-col gap-2 rounded-md border border-ds-gray-quaternary p-4">
+        <div className="flex h-full flex-col justify-center gap-2 rounded-md border border-ds-gray-quaternary p-4">
           {children}
         </div>
-        <RadioGroupPrimitive.Indicator className="absolute right-0 top-0 h-full w-full">
-          <div className="absolute h-full w-full rounded-md border-2 border-ds-blue-darker" />
-          <div className="h-full w-full rounded-md border border-ds-blue-darker p-4">
-            <div className="flex h-5 w-full items-center justify-end">
-              <RadioButtonCircle selected />
-            </div>
-          </div>
-        </RadioGroupPrimitive.Indicator>
+        <RadioGroupPrimitive.Indicator className="absolute right-0 top-0 h-full w-full rounded-md border-2 border-ds-blue-darker" />
       </ItemContext.Provider>
     </RadioGroupPrimitive.Item>
   )
@@ -91,7 +84,7 @@ const Label = React.forwardRef<
 >(({ className, ...props }, ref) => {
   const itemId = useContext(ItemContext)
   return (
-    <div className="flex items-center justify-between gap-4">
+    <div className="relative flex items-center justify-between gap-4">
       <LabelPrimitive.Root
         {...{ htmlFor: itemId ?? undefined }}
         ref={ref}
@@ -99,6 +92,9 @@ const Label = React.forwardRef<
         {...props}
       />
       <RadioButtonCircle />
+      <RadioGroupPrimitive.Indicator className="absolute right-0">
+        <RadioButtonCircle selected />
+      </RadioGroupPrimitive.Indicator>
     </div>
   )
 })
@@ -130,7 +126,7 @@ function RadioButtonCircle({ selected = false }: { selected?: boolean }) {
     </div>
   ) : (
     <div
-      className="h-4 w-4 rounded-full border border-ds-gray-quaternary"
+      className="h-4 w-4 flex-none rounded-full border border-ds-gray-quaternary"
       data-testid="radio-button-circle-unselected"
     />
   )

--- a/src/ui/RadioTileGroup/RadioTileGroup.tsx
+++ b/src/ui/RadioTileGroup/RadioTileGroup.tsx
@@ -73,7 +73,7 @@ const Item = React.forwardRef<
 })
 Item.displayName = 'RadioTileGroup.Item'
 
-const label = cva(['font-medium'])
+const label = cva(['text-left font-medium'])
 interface LabelProps
   extends React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root>,
     VariantProps<typeof label> {}


### PR DESCRIPTION
Adjusts the RadioTileGroup item's circle indicator such that it will overlay on the unselected indicator on all screen sizes. Happens to also simplify the css quite a bit!

Before:

![Screenshot 2024-05-09 at 14 50 32](https://github.com/codecov/gazebo/assets/159931558/9fcd4a29-302e-49f5-9cf0-5388fac662ff)

After:

![Screenshot 2024-05-09 at 15 02 56](https://github.com/codecov/gazebo/assets/159931558/364e4ff7-6d80-41b2-9d4a-dac56f3c9e2c)

