### PR TITLE
feat: Add intro banner to bundle onboarding

### DIFF
--- a/src/pages/RepoPage/BundlesTab/BundleOnboarding/BundleOnboarding.spec.tsx
+++ b/src/pages/RepoPage/BundlesTab/BundleOnboarding/BundleOnboarding.spec.tsx
@@ -115,6 +115,14 @@ describe('BundleOnboarding', () => {
     return { hardRedirect }
   }
 
+  it('renders IntroBlurb', async () => {
+    setup({ hasCommits: true, hasUploadToken: true })
+    render(<BundleOnboarding />, { wrapper: wrapper() })
+
+    const introBlurb = await screen.findByTestId('ba-intro-blurb')
+    expect(introBlurb).toBeInTheDocument()
+  })
+
   describe('on /new route', () => {
     describe('rendering tabs', () => {
       it('renders selected vite tab', async () => {

--- a/src/pages/RepoPage/BundlesTab/BundleOnboarding/BundleOnboarding.tsx
+++ b/src/pages/RepoPage/BundlesTab/BundleOnboarding/BundleOnboarding.tsx
@@ -66,13 +66,8 @@ const BundleOnboarding: React.FC = () => {
   }
 
   return (
-    <div className="flex flex-col gap-6">
-      <div className="mx-auto pt-6 lg:w-3/5">
-        <h1 className="mb-2 text-3xl font-semibold">
-          Configure bundle analysis
-        </h1>
-        <Content />
-      </div>
+    <div className="pt-2 lg:w-3/5">
+      <Content />
     </div>
   )
 }

--- a/src/pages/RepoPage/BundlesTab/BundleOnboarding/BundleOnboarding.tsx
+++ b/src/pages/RepoPage/BundlesTab/BundleOnboarding/BundleOnboarding.tsx
@@ -9,6 +9,7 @@ import { useRedirect } from 'shared/useRedirect'
 import Spinner from 'ui/Spinner'
 import TabNavigation from 'ui/TabNavigation'
 
+import IntroBlurb from './IntroBlurb'
 import RollupOnboarding from './RollupOnboarding'
 import ViteOnboarding from './ViteOnboarding'
 import WebpackOnboarding from './WebpackOnboarding'
@@ -35,21 +36,19 @@ const Content: React.FC = () => {
           { pageName: 'bundleWebpackOnboarding' },
         ]}
       />
-      <div className="pt-6">
-        <Suspense fallback={<Loader />}>
-          <Switch>
-            <SentryRoute path="/:provider/:owner/:repo/bundles/new" exact>
-              <ViteOnboarding />
-            </SentryRoute>
-            <SentryRoute path="/:provider/:owner/:repo/bundles/new/rollup">
-              <RollupOnboarding />
-            </SentryRoute>
-            <SentryRoute path="/:provider/:owner/:repo/bundles/new/webpack">
-              <WebpackOnboarding />
-            </SentryRoute>
-          </Switch>
-        </Suspense>
-      </div>
+      <Suspense fallback={<Loader />}>
+        <Switch>
+          <SentryRoute path="/:provider/:owner/:repo/bundles/new" exact>
+            <ViteOnboarding />
+          </SentryRoute>
+          <SentryRoute path="/:provider/:owner/:repo/bundles/new/rollup">
+            <RollupOnboarding />
+          </SentryRoute>
+          <SentryRoute path="/:provider/:owner/:repo/bundles/new/webpack">
+            <WebpackOnboarding />
+          </SentryRoute>
+        </Switch>
+      </Suspense>
     </>
   )
 }
@@ -66,7 +65,8 @@ const BundleOnboarding: React.FC = () => {
   }
 
   return (
-    <div className="pt-2 lg:w-3/5">
+    <div className="flex flex-col gap-6 pt-4 lg:w-3/5">
+      <IntroBlurb />
       <Content />
     </div>
   )

--- a/src/pages/RepoPage/BundlesTab/BundleOnboarding/IntroBlurb.tsx
+++ b/src/pages/RepoPage/BundlesTab/BundleOnboarding/IntroBlurb.tsx
@@ -8,8 +8,8 @@ const IntroBlurb = () => {
       <div className="flex flex-col gap-2" data-testid="ba-intro-blurb">
         <h2 className="text-base font-semibold">Configure Bundle Analysis</h2>
         <p>
-          Before integrating with Codecov, ensure that your project already uses
-          one of the bundlers below as we use them to generate our analysis.
+          Before integrating ensure that your project already uses one of the
+          bundlers below as we use them to generate our analysis.
         </p>
         <A
           to={{ pageName: 'bundleAnalysisDocs' }}

--- a/src/pages/RepoPage/BundlesTab/BundleOnboarding/IntroBlurb.tsx
+++ b/src/pages/RepoPage/BundlesTab/BundleOnboarding/IntroBlurb.tsx
@@ -8,12 +8,8 @@ const IntroBlurb = () => {
       <div className="flex flex-col gap-2" data-testid="ba-intro-blurb">
         <h2 className="text-base font-semibold">Configure Bundle Analysis</h2>
         <p>
-          Bundle Analysis helps improve your application&apos;s performance,
-          bandwidth usage, and load times by letting you know if what you’re
-          about to merge will cause any performance regressions. It will allow
-          you to explore all of the modules in your bundle and determine where
-          you might be able to streamline your bundle size as well as find areas
-          of concern.
+          Before integrating with Codecov, ensure that your project already uses
+          one of the bundlers below as we use them to generate our analysis.
         </p>
         <A
           to={{ pageName: 'bundleAnalysisDocs' }}

--- a/src/pages/RepoPage/BundlesTab/BundleOnboarding/IntroBlurb.tsx
+++ b/src/pages/RepoPage/BundlesTab/BundleOnboarding/IntroBlurb.tsx
@@ -1,0 +1,31 @@
+import A from 'ui/A'
+import Banner from 'ui/Banner'
+import Icon from 'ui/Icon'
+
+const IntroBlurb = () => {
+  return (
+    <Banner>
+      <div className="flex flex-col gap-2" data-testid="ba-intro-blurb">
+        <h2 className="text-base font-semibold">Configure Bundle Analysis</h2>
+        <p>
+          Bundle Analysis helps improve your application&apos;s performance,
+          bandwidth usage, and load times by letting you know if what you’re
+          about to merge will cause any performance regressions. It will allow
+          you to explore all of the modules in your bundle and determine where
+          you might be able to streamline your bundle size as well as find areas
+          of concern.
+        </p>
+        <A
+          to={{ pageName: 'bundleAnalysisDocs' }}
+          isExternal
+          hook="quick-start-link-bundle-analysis"
+        >
+          <Icon name="bookOpen" size="sm" />
+          Read our documentation
+        </A>
+      </div>
+    </Banner>
+  )
+}
+
+export default IntroBlurb

--- a/src/pages/RepoPage/CoverageOnboarding/IntroBlurb/IntroBlurb.tsx
+++ b/src/pages/RepoPage/CoverageOnboarding/IntroBlurb/IntroBlurb.tsx
@@ -1,29 +1,29 @@
 import A from 'ui/A'
+import Banner from 'ui/Banner'
 import Icon from 'ui/Icon'
 
 const IntroBlurb = () => {
   return (
-    <div
-      className="flex flex-col gap-2 overflow-auto border-l-4 border-ds-blue bg-ds-gray-primary p-4"
-      data-testid="intro-blurb"
-    >
-      <h2 className="text-base font-semibold">
-        Let&apos;s get your repo covered
-      </h2>
-      <p>
-        Before integrating with Codecov, ensure that your project already
-        generates coverage reports. Codecov relies on these reports to provide
-        the coverage analysis.
-      </p>
-      <A
-        to={{ pageName: 'quickStart' }}
-        isExternal
-        hook="quick-start-link-circle-ci-repo"
-      >
-        <Icon name="bookOpen" size="sm" />
-        Read our documentation
-      </A>
-    </div>
+    <Banner>
+      <div className="flex flex-col gap-2" data-testid="intro-blurb">
+        <h2 className="text-base font-semibold">
+          Let&apos;s get your repo covered
+        </h2>
+        <p>
+          Before integrating with Codecov, ensure that your project already
+          generates coverage reports. Codecov relies on these reports to provide
+          the coverage analysis.
+        </p>
+        <A
+          to={{ pageName: 'quickStart' }}
+          isExternal
+          hook="quick-start-link-circle-ci-repo"
+        >
+          <Icon name="bookOpen" size="sm" />
+          Read our documentation
+        </A>
+      </div>
+    </Banner>
   )
 }
 

--- a/src/services/navigation/useNavLinks/useStaticNavLinks.js
+++ b/src/services/navigation/useNavLinks/useStaticNavLinks.js
@@ -276,6 +276,12 @@ export function useStaticNavLinks() {
       isExternalLink: true,
       openNewTab: true,
     },
+    bundleAnalysisDocs: {
+      text: 'Bundle analysis set up documentation',
+      path: () => 'https://docs.codecov.com/docs/javascript-bundle-analysis',
+      isExternalLink: true,
+      openNewTab: true,
+    },
     bundleConfigFeedback: {
       text: 'New bundle analysis set up feedback',
       path: () => 'https://github.com/codecov/feedback/issues/270',


### PR DESCRIPTION
# Description

Adds an intro banner to the BA onboarding page and also left aligns the page's layout to match designs. Radio button navigation to come next.

Part of https://github.com/codecov/engineering-team/issues/1439

# Screenshots

Before:

![Screenshot 2024-05-13 at 16 18 36](https://github.com/codecov/gazebo/assets/159931558/bb4a9450-c6f4-4001-87ec-2f35cf9464ab)

After:

![Screenshot 2024-05-14 at 10 27 25](https://github.com/codecov/gazebo/assets/159931558/3d65bbb4-c821-4655-a1bc-7d1bb075b0ec)
