### PR TITLE
feat: Add radio button navigation to bundle analysis onboarding

### DIFF
--- a/src/pages/RepoPage/BundlesTab/BundleOnboarding/BundleOnboarding.spec.tsx
+++ b/src/pages/RepoPage/BundlesTab/BundleOnboarding/BundleOnboarding.spec.tsx
@@ -129,27 +129,27 @@ describe('BundleOnboarding', () => {
         setup({ hasCommits: true, hasUploadToken: true })
         render(<BundleOnboarding />, { wrapper: wrapper() })
 
-        const viteTab = await screen.findByText('Vite')
+        const viteTab = await screen.findByTestId('vite-radio')
         expect(viteTab).toBeInTheDocument()
-        expect(viteTab).toHaveAttribute('aria-current', 'page')
+        expect(viteTab).toHaveAttribute('data-state', 'checked')
       })
 
       it('renders rollup tab', async () => {
         setup({ hasCommits: true, hasUploadToken: true })
         render(<BundleOnboarding />, { wrapper: wrapper() })
 
-        const rollupTab = await screen.findByText('Rollup')
+        const rollupTab = await screen.findByTestId('rollup-radio')
         expect(rollupTab).toBeInTheDocument()
-        expect(rollupTab).not.toHaveAttribute('aria-current', 'page')
+        expect(rollupTab).toHaveAttribute('data-state', 'unchecked')
       })
 
       it('renders webpack tab', async () => {
         setup({ hasCommits: true, hasUploadToken: true })
         render(<BundleOnboarding />, { wrapper: wrapper() })
 
-        const webpackTab = await screen.findByText('Webpack')
+        const webpackTab = await screen.findByTestId('webpack-radio')
         expect(webpackTab).toBeInTheDocument()
-        expect(webpackTab).not.toHaveAttribute('aria-current', 'page')
+        expect(webpackTab).toHaveAttribute('data-state', 'unchecked')
       })
     })
 
@@ -174,9 +174,9 @@ describe('BundleOnboarding', () => {
           wrapper: wrapper('/gh/codecov/test-repo/bundles/new/rollup'),
         })
 
-        const viteTab = await screen.findByText('Vite')
+        const viteTab = await screen.findByTestId('vite-radio')
         expect(viteTab).toBeInTheDocument()
-        expect(viteTab).not.toHaveAttribute('aria-current', 'page')
+        expect(viteTab).toHaveAttribute('data-state', 'unchecked')
       })
 
       it('renders selected rollup tab', async () => {
@@ -185,9 +185,9 @@ describe('BundleOnboarding', () => {
           wrapper: wrapper('/gh/codecov/test-repo/bundles/new/rollup'),
         })
 
-        const rollupTab = await screen.findByText('Rollup')
+        const rollupTab = await screen.findByTestId('rollup-radio')
         expect(rollupTab).toBeInTheDocument()
-        expect(rollupTab).toHaveAttribute('aria-current', 'page')
+        expect(rollupTab).toHaveAttribute('data-state', 'checked')
       })
 
       it('renders webpack tab', async () => {
@@ -196,9 +196,9 @@ describe('BundleOnboarding', () => {
           wrapper: wrapper('/gh/codecov/test-repo/bundles/new/rollup'),
         })
 
-        const webpackTab = await screen.findByText('Webpack')
+        const webpackTab = await screen.findByTestId('webpack-radio')
         expect(webpackTab).toBeInTheDocument()
-        expect(webpackTab).not.toHaveAttribute('aria-current', 'page')
+        expect(webpackTab).toHaveAttribute('data-state', 'unchecked')
       })
     })
 
@@ -225,9 +225,9 @@ describe('BundleOnboarding', () => {
           wrapper: wrapper('/gh/codecov/test-repo/bundles/new/webpack'),
         })
 
-        const viteTab = await screen.findByText('Vite')
+        const viteTab = await screen.findByTestId('vite-radio')
         expect(viteTab).toBeInTheDocument()
-        expect(viteTab).not.toHaveAttribute('aria-current', 'page')
+        expect(viteTab).toHaveAttribute('data-state', 'unchecked')
       })
 
       it('renders rollup tab', async () => {
@@ -236,9 +236,9 @@ describe('BundleOnboarding', () => {
           wrapper: wrapper('/gh/codecov/test-repo/bundles/new/webpack'),
         })
 
-        const rollupTab = await screen.findByText('Rollup')
+        const rollupTab = await screen.findByTestId('rollup-radio')
         expect(rollupTab).toBeInTheDocument()
-        expect(rollupTab).not.toHaveAttribute('aria-current', 'page')
+        expect(rollupTab).toHaveAttribute('data-state', 'unchecked')
       })
 
       it('renders selected webpack tab', async () => {
@@ -247,9 +247,9 @@ describe('BundleOnboarding', () => {
           wrapper: wrapper('/gh/codecov/test-repo/bundles/new/webpack'),
         })
 
-        const webpackTab = await screen.findByText('Webpack')
+        const webpackTab = await screen.findByTestId('webpack-radio')
         expect(webpackTab).toBeInTheDocument()
-        expect(webpackTab).toHaveAttribute('aria-current', 'page')
+        expect(webpackTab).toHaveAttribute('data-state', 'checked')
       })
     })
 

--- a/src/pages/RepoPage/BundlesTab/BundleOnboarding/BundleOnboarding.tsx
+++ b/src/pages/RepoPage/BundlesTab/BundleOnboarding/BundleOnboarding.tsx
@@ -1,4 +1,4 @@
-import { Suspense, useMemo } from 'react'
+import { Suspense } from 'react'
 import { Switch, useHistory, useLocation, useParams } from 'react-router-dom'
 
 import { SentryRoute } from 'sentry'
@@ -57,21 +57,11 @@ function BundlerSelector({ provider, owner, repo }: BundlerSelectorProps) {
   const history = useHistory()
   const { bundleOnboarding, bundleWebpackOnboarding, bundleRollupOnboarding } =
     useNavLinks()
-  const urls = useMemo(
-    () => ({
-      Vite: bundleOnboarding.path({ provider, owner, repo }),
-      Rollup: bundleRollupOnboarding.path({ provider, owner, repo }),
-      Webpack: bundleWebpackOnboarding.path({ provider, owner, repo }),
-    }),
-    [
-      bundleOnboarding,
-      bundleWebpackOnboarding,
-      bundleRollupOnboarding,
-      provider,
-      owner,
-      repo,
-    ]
-  )
+  const urls = {
+    Vite: bundleOnboarding.path({ provider, owner, repo }),
+    Rollup: bundleRollupOnboarding.path({ provider, owner, repo }),
+    Webpack: bundleWebpackOnboarding.path({ provider, owner, repo }),
+  }
 
   return (
     <Card>

--- a/src/pages/RepoPage/CoverageOnboarding/NewRepoTab.spec.tsx
+++ b/src/pages/RepoPage/CoverageOnboarding/NewRepoTab.spec.tsx
@@ -173,8 +173,7 @@ describe('NewRepoTab', () => {
             'github-actions-radio'
           )
           expect(githubActions).toBeInTheDocument()
-          expect(githubActions.hasAttribute('data-state')).toBeTruthy()
-          expect(githubActions.getAttribute('data-state')).toBe('checked')
+          expect(githubActions).toHaveAttribute('data-state', 'checked')
         })
       })
 
@@ -187,8 +186,7 @@ describe('NewRepoTab', () => {
 
           const otherCI = await screen.findByTestId('other-ci-radio')
           expect(otherCI).toBeInTheDocument()
-          expect(otherCI.hasAttribute('data-state')).toBeTruthy()
-          expect(otherCI.getAttribute('data-state')).toBe('checked')
+          expect(otherCI).toHaveAttribute('data-state', 'checked')
         })
       })
 
@@ -201,8 +199,7 @@ describe('NewRepoTab', () => {
 
           const circleCI = await screen.findByTestId('circle-ci-radio')
           expect(circleCI).toBeInTheDocument()
-          expect(circleCI.hasAttribute('data-state')).toBeTruthy()
-          expect(circleCI.getAttribute('data-state')).toBe('checked')
+          expect(circleCI).toHaveAttribute('data-state', 'checked')
         })
       })
 
@@ -215,8 +212,7 @@ describe('NewRepoTab', () => {
 
           const otherCI = await screen.findByTestId('other-ci-radio')
           expect(otherCI).toBeInTheDocument()
-          expect(otherCI.hasAttribute('data-state')).toBeTruthy()
-          expect(otherCI.getAttribute('data-state')).toBe('checked')
+          expect(otherCI).toHaveAttribute('data-state', 'checked')
         })
       })
     })
@@ -233,14 +229,12 @@ describe('NewRepoTab', () => {
             'github-actions-radio'
           )
           expect(githubActions).toBeInTheDocument()
-          expect(githubActions.hasAttribute('data-state')).toBeTruthy()
-          expect(githubActions.getAttribute('data-state')).toBe('unchecked')
+          expect(githubActions).toHaveAttribute('data-state', 'unchecked')
 
           await user.click(githubActions)
 
           expect(githubActions).toBeInTheDocument()
-          expect(githubActions.hasAttribute('data-state')).toBeTruthy()
-          expect(githubActions.getAttribute('data-state')).toBe('checked')
+          expect(githubActions).toHaveAttribute('data-state', 'checked')
 
           expect(testLocation.pathname).toBe('/gh/codecov/cool-repo/new')
         })
@@ -253,14 +247,12 @@ describe('NewRepoTab', () => {
 
           const circleCI = await screen.findByTestId('circle-ci-radio')
           expect(circleCI).toBeInTheDocument()
-          expect(circleCI.hasAttribute('data-state')).toBeTruthy()
-          expect(circleCI.getAttribute('data-state')).toBe('unchecked')
+          expect(circleCI).toHaveAttribute('data-state', 'unchecked')
 
           await user.click(circleCI)
 
           expect(circleCI).toBeInTheDocument()
-          expect(circleCI.hasAttribute('data-state')).toBeTruthy()
-          expect(circleCI.getAttribute('data-state')).toBe('checked')
+          expect(circleCI).toHaveAttribute('data-state', 'checked')
 
           expect(testLocation.pathname).toBe(
             '/gh/codecov/cool-repo/new/circle-ci'
@@ -275,14 +267,12 @@ describe('NewRepoTab', () => {
 
           const otherCI = await screen.findByTestId('other-ci-radio')
           expect(otherCI).toBeInTheDocument()
-          expect(otherCI.hasAttribute('data-state')).toBeTruthy()
-          expect(otherCI.getAttribute('data-state')).toBe('unchecked')
+          expect(otherCI).toHaveAttribute('data-state', 'unchecked')
 
           await user.click(otherCI)
 
           expect(otherCI).toBeInTheDocument()
-          expect(otherCI.hasAttribute('data-state')).toBeTruthy()
-          expect(otherCI.getAttribute('data-state')).toBe('checked')
+          expect(otherCI).toHaveAttribute('data-state', 'checked')
 
           expect(testLocation.pathname).toBe(
             '/gh/codecov/cool-repo/new/other-ci'

--- a/src/pages/RepoPage/CoverageOnboarding/NewRepoTab.tsx
+++ b/src/pages/RepoPage/CoverageOnboarding/NewRepoTab.tsx
@@ -1,4 +1,4 @@
-import { lazy, Suspense, useMemo } from 'react'
+import { lazy, Suspense } from 'react'
 import { Switch, useHistory, useLocation, useParams } from 'react-router-dom'
 
 import { SentryRoute } from 'sentry'
@@ -57,14 +57,11 @@ function CISelector({ provider, owner, repo }: CISelectorProps) {
   const location = useLocation()
   const history = useHistory()
   const { new: githubActions, circleCI, newOtherCI } = useNavLinks()
-  const urls = useMemo(
-    () => ({
-      GitHubActions: githubActions.path({ provider, owner, repo }),
-      CircleCI: circleCI.path({ provider, owner, repo }),
-      OtherCI: newOtherCI.path({ provider, owner, repo }),
-    }),
-    [githubActions, circleCI, newOtherCI, provider, owner, repo]
-  )
+  const urls = {
+    GitHubActions: githubActions.path({ provider, owner, repo }),
+    CircleCI: circleCI.path({ provider, owner, repo }),
+    OtherCI: newOtherCI.path({ provider, owner, repo }),
+  }
 
   return (
     <Card>


### PR DESCRIPTION
# Description

Converts the tab navigation on bundle analysis onboarding to use the new RadioTileGroup component.

Closes https://github.com/codecov/engineering-team/issues/1439

# Screenshots

Before:


After:

