### PR TITLE
fix: Directly render bundle onboarding

### DIFF
--- a/src/pages/RepoPage/BundlesTab/BundlesTab.tsx
+++ b/src/pages/RepoPage/BundlesTab/BundlesTab.tsx
@@ -1,13 +1,10 @@
 import { lazy, Suspense } from 'react'
-import { Switch, useParams } from 'react-router-dom'
-
-import { SentryRoute } from 'sentry'
+import { Redirect, Switch, useParams } from 'react-router-dom'
 
 import { useRepoOverview } from 'services/repo'
 import Spinner from 'ui/Spinner'
 
 const BundleContent = lazy(() => import('./BundleContent'))
-const BundleOnboarding = lazy(() => import('./BundleOnboarding'))
 
 interface URLParams {
   provider: string
@@ -15,13 +12,13 @@ interface URLParams {
   repo: string
 }
 
+const path = '/:provider/:owner/:repo'
+
 const Loader = () => (
   <div className="mt-16 flex flex-1 items-center justify-center">
     <Spinner />
   </div>
 )
-
-const path = '/:provider/:owner/:repo/bundles'
 
 const BundlesTab: React.FC = () => {
   const { provider, owner, repo } = useParams<URLParams>()
@@ -35,23 +32,12 @@ const BundlesTab: React.FC = () => {
     )
   }
 
-  if (data?.jsOrTsPresent) {
-    return (
-      <>
-        <Switch>
-          <SentryRoute
-            path={[`${path}/new`, `${path}/new/rollup`, `${path}/new/webpack`]}
-          >
-            <Suspense fallback={<Loader />}>
-              <BundleOnboarding />
-            </Suspense>
-          </SentryRoute>
-        </Switch>
-      </>
-    )
-  }
-
-  return null
+  return (
+    <Switch>
+      <Redirect from={`${path}/bundles`} to={path} />
+      <Redirect from={`${path}/bundles/*`} to={path} />
+    </Switch>
+  )
 }
 
 export default BundlesTab

--- a/src/pages/RepoPage/RepoPage.spec.tsx
+++ b/src/pages/RepoPage/RepoPage.spec.tsx
@@ -14,6 +14,7 @@ import { RepoBreadcrumbProvider } from './context'
 import RepoPage from './RepoPage'
 
 jest.mock('./BundlesTab', () => () => 'BundlesTab')
+jest.mock('./BundlesTab/BundleOnboarding', () => () => 'BundleOnboarding')
 jest.mock('./CommitsTab', () => () => 'CommitsTab')
 jest.mock('./CoverageTab', () => () => 'CoverageTab')
 jest.mock('./CoverageOnboarding', () => () => 'CoverageOnboarding')
@@ -350,7 +351,7 @@ describe('RepoPage', () => {
         })
 
         describe('bundles are disabled', () => {
-          it('renders bundles tab', async () => {
+          it('renders bundle onboarding', async () => {
             const { queryClient } = setup({
               bundleAnalysisEnabled: false,
               language: 'javascript',
@@ -363,8 +364,8 @@ describe('RepoPage', () => {
               }),
             })
 
-            const bundlesTab = await screen.findByText('BundlesTab')
-            expect(bundlesTab).toBeInTheDocument()
+            const bundleOnboarding = await screen.findByText('BundleOnboarding')
+            expect(bundleOnboarding).toBeInTheDocument()
           })
 
           describe('there is no js or ts present', () => {
@@ -407,7 +408,7 @@ describe('RepoPage', () => {
         })
 
         describe('bundles are disabled', () => {
-          it('renders bundles tab', async () => {
+          it('renders bundle onboarding tab', async () => {
             const { queryClient } = setup({
               bundleAnalysisEnabled: false,
               language: 'javascript',
@@ -419,8 +420,8 @@ describe('RepoPage', () => {
               }),
             })
 
-            const bundlesTab = await screen.findByText('BundlesTab')
-            expect(bundlesTab).toBeInTheDocument()
+            const bundleOnboarding = await screen.findByText('BundleOnboarding')
+            expect(bundleOnboarding).toBeInTheDocument()
           })
 
           describe('there is no js or ts present', () => {
@@ -462,7 +463,7 @@ describe('RepoPage', () => {
         })
 
         describe('bundles are disabled', () => {
-          it('renders bundles tab', async () => {
+          it('renders bundle onboarding tab', async () => {
             const { queryClient } = setup({
               bundleAnalysisEnabled: false,
               language: 'javascript',
@@ -474,8 +475,8 @@ describe('RepoPage', () => {
               }),
             })
 
-            const bundlesTab = await screen.findByText('BundlesTab')
-            expect(bundlesTab).toBeInTheDocument()
+            const bundleOnboarding = await screen.findByText('BundleOnboarding')
+            expect(bundleOnboarding).toBeInTheDocument()
           })
 
           describe('there is no js or ts present', () => {
@@ -690,7 +691,7 @@ describe('RepoPage', () => {
       })
 
       describe('testing bundles path', () => {
-        it('renders bundles tab', async () => {
+        it('renders bundle onboarding tab', async () => {
           const { queryClient } = setup({
             isRepoActive: false,
             hasRepoData: true,
@@ -704,8 +705,8 @@ describe('RepoPage', () => {
             }),
           })
 
-          const bundlesTab = await screen.findByText('BundlesTab')
-          expect(bundlesTab).toBeInTheDocument()
+          const bundleOnboarding = await screen.findByText('BundleOnboarding')
+          expect(bundleOnboarding).toBeInTheDocument()
         })
       })
 

--- a/src/pages/RepoPage/RepoPage.tsx
+++ b/src/pages/RepoPage/RepoPage.tsx
@@ -15,6 +15,7 @@ import RepoBreadcrumb from './RepoBreadcrumb'
 import RepoPageTabs from './RepoPageTabs'
 
 const BundlesTab = lazy(() => import('./BundlesTab'))
+const BundleOnboarding = lazy(() => import('./BundlesTab/BundleOnboarding'))
 const CommitsTab = lazy(() => import('./CommitsTab'))
 const CoverageTab = lazy(() => import('./CoverageTab'))
 const NewRepoTab = lazy(() => import('./CoverageOnboarding'))
@@ -123,7 +124,7 @@ function Routes({
             ]}
             exact
           >
-            <BundlesTab />
+            <BundleOnboarding />
           </SentryRoute>
         ) : null}
         {coverageEnabled && userAuthorizedtoViewRepo ? (
@@ -202,7 +203,7 @@ function Routes({
           ]}
           exact
         >
-          <BundlesTab />
+          <BundleOnboarding />
         </SentryRoute>
       ) : null}
       <SentryRoute path={`${path}/settings`}>


### PR DESCRIPTION
# Description

This PR shuffles around how we render bundle onboarding tackling an infinite redirect issue we're currently seeing when a repo is not active ... but has bundle analysis enabled.

# Notable Changes

- Render `BundleOnboarding` directly in `RepoPage`
- Remove `BundleOnboarding` from `BundlesTab`
- Update tests