### PR TITLE
feat: Implement CodeSnippet component

### DIFF
--- a/src/ui/CodeSnippet/CodeSnippet.spec.tsx
+++ b/src/ui/CodeSnippet/CodeSnippet.spec.tsx
@@ -1,0 +1,41 @@
+import { render, screen } from '@testing-library/react'
+
+import { CodeSnippet } from './CodeSnippet'
+
+describe('CodeSnippet', () => {
+  it('renders code', async () => {
+    render(<CodeSnippet>asdf</CodeSnippet>)
+
+    const code = await screen.findByText('asdf')
+    expect(code).toBeInTheDocument()
+  })
+
+  it('renders CopyClipboard', async () => {
+    render(<CodeSnippet clipboard="asdf">asdf</CodeSnippet>)
+
+    const code = await screen.findByTestId('clipboard-code-snippet')
+    expect(code).toBeInTheDocument()
+  })
+
+  describe('when clipboard prop is undefined', () => {
+    it('does not render CopyClipboard', async () => {
+      render(<CodeSnippet>asdf</CodeSnippet>)
+
+      const code = screen.queryByTestId('clipboard-code-snippet')
+      expect(code).not.toBeInTheDocument()
+    })
+  })
+
+  it('renders multiline code', async () => {
+    render(
+      <CodeSnippet>{`asdf
+asdf
+asdf
+asdf
+wow`}</CodeSnippet>
+    )
+
+    const code = await screen.findByText(/asdf\s+asdf\s+asdf\s+asdf\s+wow/)
+    expect(code).toBeInTheDocument()
+  })
+})

--- a/src/ui/CodeSnippet/CodeSnippet.spec.tsx
+++ b/src/ui/CodeSnippet/CodeSnippet.spec.tsx
@@ -1,8 +1,16 @@
-import { render, screen } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
+import { userEvent } from '@testing-library/user-event'
 
 import { CodeSnippet } from './CodeSnippet'
 
+jest.mock('copy-to-clipboard', () => () => true)
+
 describe('CodeSnippet', () => {
+  function setup() {
+    const user = userEvent.setup()
+    return { user }
+  }
+
   it('renders code', async () => {
     render(<CodeSnippet>asdf</CodeSnippet>)
 
@@ -37,5 +45,22 @@ wow`}</CodeSnippet>
 
     const code = await screen.findByText(/asdf\s+asdf\s+asdf\s+asdf\s+wow/)
     expect(code).toBeInTheDocument()
+  })
+
+  it('passes clipboardOnClick through to CopyClipboard', async () => {
+    const { user } = setup()
+    const callback = jest.fn()
+    render(
+      <CodeSnippet clipboard="asdf" clipboardOnClick={callback}>
+        asdf
+      </CodeSnippet>
+    )
+
+    const clipboard = await screen.findByTestId('clipboard-code-snippet')
+    expect(clipboard).toBeInTheDocument()
+
+    await user.click(clipboard)
+
+    await waitFor(() => expect(callback).toHaveBeenCalledWith('asdf'))
   })
 })

--- a/src/ui/CodeSnippet/CodeSnippet.spec.tsx
+++ b/src/ui/CodeSnippet/CodeSnippet.spec.tsx
@@ -13,16 +13,16 @@ describe('CodeSnippet', () => {
   it('renders CopyClipboard', async () => {
     render(<CodeSnippet clipboard="asdf">asdf</CodeSnippet>)
 
-    const code = await screen.findByTestId('clipboard-code-snippet')
-    expect(code).toBeInTheDocument()
+    const clipboard = await screen.findByTestId('clipboard-code-snippet')
+    expect(clipboard).toBeInTheDocument()
   })
 
   describe('when clipboard prop is undefined', () => {
     it('does not render CopyClipboard', async () => {
       render(<CodeSnippet>asdf</CodeSnippet>)
 
-      const code = screen.queryByTestId('clipboard-code-snippet')
-      expect(code).not.toBeInTheDocument()
+      const clipboard = screen.queryByTestId('clipboard-code-snippet')
+      expect(clipboard).not.toBeInTheDocument()
     })
   })
 

--- a/src/ui/CodeSnippet/CodeSnippet.stories.tsx
+++ b/src/ui/CodeSnippet/CodeSnippet.stories.tsx
@@ -1,0 +1,58 @@
+import { Meta, StoryObj } from '@storybook/react'
+
+import { CodeSnippet } from './CodeSnippet'
+
+const meta: Meta<typeof CodeSnippet> = {
+  title: 'Components/CodeSnippet',
+  component: CodeSnippet,
+  argTypes: {
+    clipboard: {
+      description: "The string to be copied to the user's clipboard",
+      control: 'text',
+    },
+  },
+}
+export default meta
+
+type Story = StoryObj<typeof CodeSnippet>
+
+export const Default: Story = {
+  args: {
+    clipboard: 'CODECOV_TOKEN=asdf1234',
+  },
+  render: ({ clipboard }) => (
+    <CodeSnippet clipboard={clipboard}>{clipboard}</CodeSnippet>
+  ),
+}
+
+export const WithoutClipboard: Story = {
+  render: () => <CodeSnippet>CODECOV_TOKEN=asdf1234</CodeSnippet>,
+}
+
+const multiline = `- name: Upload coverage reports to Codecov
+uses: codecov/codecov-action@v4.0.1
+with:
+  token: \${{ secrets.CODECOV_TOKEN }}`
+
+export const Multiline: Story = {
+  render: () => <CodeSnippet clipboard={multiline}>{multiline}</CodeSnippet>,
+}
+
+const overflow = `# download Codecov CLI
+curl -Os https://cli.codecov.io/latest/linux/codecov
+
+# integrity check
+curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.gpg --import # One-time step  
+curl -Os https://cli.codecov.io/latest/linux/codecov
+curl -Os https://cli.codecov.io/latest/linux/codecov.SHA256SUM
+curl -Os https://cli.codecov.io/latest/linux/codecov.SHA256SUM.sig
+gpgv codecov.SHA256SUM.sig codecov.SHA256SUM
+
+shasum -a 256 -c codecov.SHA256SUM
+sudo chmod +x codecov
+./codecov --help
+`
+
+export const Overflow: Story = {
+  render: () => <CodeSnippet clipboard={overflow}>{overflow}</CodeSnippet>,
+}

--- a/src/ui/CodeSnippet/CodeSnippet.tsx
+++ b/src/ui/CodeSnippet/CodeSnippet.tsx
@@ -1,0 +1,40 @@
+import { cva, VariantProps } from 'cva'
+import React from 'react'
+
+import { cn } from 'shared/utils/cn'
+import { CopyClipboard } from 'ui/CopyClipboard'
+
+const codeSnippet = cva([
+  'rounded-md',
+  'border',
+  'border-ds-gray-secondary',
+  'bg-ds-gray-primary',
+  'font-mono',
+  'relative',
+])
+interface CodeSnippetProps
+  extends React.HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof codeSnippet> {
+  clipboard?: string
+}
+
+export const CodeSnippet = React.forwardRef<HTMLDivElement, CodeSnippetProps>(
+  ({ children, clipboard, className, ...props }, ref) => (
+    <div ref={ref} className={cn(codeSnippet({ className }))} {...props}>
+      <div className="overflow-auto p-4">
+        <pre className="whitespace-pre font-mono">{children}</pre>
+      </div>
+      {clipboard ? (
+        <div className="absolute right-0 top-0 p-4">
+          <div className="flex h-5 items-center rounded-md bg-ds-gray-primary">
+            <CopyClipboard
+              value={clipboard}
+              data-testid="clipboard-code-snippet"
+            />
+          </div>
+        </div>
+      ) : null}
+    </div>
+  )
+)
+CodeSnippet.displayName = 'CodeSnippet'

--- a/src/ui/CodeSnippet/CodeSnippet.tsx
+++ b/src/ui/CodeSnippet/CodeSnippet.tsx
@@ -16,10 +16,14 @@ interface CodeSnippetProps
   extends React.HTMLAttributes<HTMLDivElement>,
     VariantProps<typeof codeSnippet> {
   clipboard?: string
+  clipboardOnClick?: (value: string) => void
 }
 
 export const CodeSnippet = React.forwardRef<HTMLDivElement, CodeSnippetProps>(
-  ({ children, clipboard, className, ...props }, ref) => (
+  (
+    { children, clipboard, clipboardOnClick = () => {}, className, ...props },
+    ref
+  ) => (
     <div ref={ref} className={cn(codeSnippet({ className }))} {...props}>
       <div className="overflow-auto p-4">
         <pre className="whitespace-pre font-mono">{children}</pre>
@@ -29,6 +33,7 @@ export const CodeSnippet = React.forwardRef<HTMLDivElement, CodeSnippetProps>(
           <div className="flex h-5 items-center rounded-md bg-ds-gray-primary">
             <CopyClipboard
               value={clipboard}
+              onClick={clipboardOnClick}
               data-testid="clipboard-code-snippet"
             />
           </div>

--- a/src/ui/CodeSnippet/index.ts
+++ b/src/ui/CodeSnippet/index.ts
@@ -1,0 +1,1 @@
+export { CodeSnippet } from './CodeSnippet'


### PR DESCRIPTION
# Description

Creates a proper reusable component for the code snippets we use across the app. PR to refactor existing snippets into this component to follow.

Closes https://github.com/codecov/internal-issues/issues/481

# Screenshot

From Storybook:

<img width="1033" alt="Screenshot 2024-05-23 at 09 15 21" src="https://github.com/codecov/gazebo/assets/159931558/c908f55c-cdae-4c56-bc29-fbf87ef0d7fc">
