### PR TITLE
ref: Convert onboarding code snippets to new component

### DIFF
--- a/src/pages/RepoPage/BundlesTab/BundleOnboarding/RollupOnboarding/RollupOnboarding.spec.tsx
+++ b/src/pages/RepoPage/BundlesTab/BundleOnboarding/RollupOnboarding/RollupOnboarding.spec.tsx
@@ -1,6 +1,6 @@
 import * as Sentry from '@sentry/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { render, screen, waitFor } from '@testing-library/react'
+import { render, screen, waitFor, within } from '@testing-library/react'
 import { userEvent } from '@testing-library/user-event'
 import { graphql } from 'msw'
 import { setupServer } from 'msw/node'
@@ -145,9 +145,11 @@ describe('RollupOnboarding', () => {
             const { user } = setup(null)
             render(<RollupOnboarding />, { wrapper })
 
-            const npmInstallCopy = await screen.findByTestId(
-              'clipboard-npm-install'
+            const npmInstall = await screen.findByTestId('rollup-npm-install')
+            const npmInstallCopy = await within(npmInstall).findByTestId(
+              'clipboard-code-snippet'
             )
+
             await user.click(npmInstallCopy)
 
             await waitFor(() =>
@@ -177,9 +179,11 @@ describe('RollupOnboarding', () => {
             const { user } = setup(null)
             render(<RollupOnboarding />, { wrapper })
 
-            const yarnInstallCopy = await screen.findByTestId(
-              'clipboard-yarn-install'
+            const yarnInstall = await screen.findByTestId('rollup-yarn-install')
+            const yarnInstallCopy = await within(yarnInstall).findByTestId(
+              'clipboard-code-snippet'
             )
+
             await user.click(yarnInstallCopy)
 
             await waitFor(() =>
@@ -209,9 +213,11 @@ describe('RollupOnboarding', () => {
             const { user } = setup(null)
             render(<RollupOnboarding />, { wrapper })
 
-            const pnpmInstallCopy = await screen.findByTestId(
-              'clipboard-pnpm-install'
+            const pnpmInstall = await screen.findByTestId('rollup-pnpm-install')
+            const pnpmInstallCopy = await within(pnpmInstall).findByTestId(
+              'clipboard-code-snippet'
             )
+
             await user.click(pnpmInstallCopy)
 
             await waitFor(() =>
@@ -278,9 +284,11 @@ describe('RollupOnboarding', () => {
         const { user } = setup(true)
         render(<RollupOnboarding />, { wrapper })
 
-        const uploadTokenCopy = await screen.findByTestId(
-          'clipboard-upload-token'
+        const uploadToken = await screen.findByTestId('rollup-upload-token')
+        const uploadTokenCopy = await within(uploadToken).findByTestId(
+          'clipboard-code-snippet'
         )
+
         await user.click(uploadTokenCopy)
 
         await waitFor(() =>
@@ -332,9 +340,11 @@ describe('RollupOnboarding', () => {
         const { user } = setup(true)
         render(<RollupOnboarding />, { wrapper })
 
-        const pluginConfigCopy = await screen.findByTestId(
-          'clipboard-plugin-config'
+        const pluginConfig = await screen.findByTestId('rollup-plugin-config')
+        const pluginConfigCopy = await within(pluginConfig).findByTestId(
+          'clipboard-code-snippet'
         )
+
         await user.click(pluginConfigCopy)
 
         await waitFor(() =>
@@ -387,10 +397,12 @@ describe('RollupOnboarding', () => {
         const { user } = setup(true)
         render(<RollupOnboarding />, { wrapper })
 
-        const commitCommand = await screen.findByTestId(
-          'clipboard-commit-command'
+        const commitCommand = await screen.findByTestId('rollup-commit-command')
+        const commitCommandCopy = await within(commitCommand).findByTestId(
+          'clipboard-code-snippet'
         )
-        await user.click(commitCommand)
+
+        await user.click(commitCommandCopy)
 
         await waitFor(() =>
           expect(Sentry.metrics.increment).toHaveBeenCalledWith(
@@ -440,10 +452,12 @@ describe('RollupOnboarding', () => {
             const { user } = setup(true)
             render(<RollupOnboarding />, { wrapper })
 
-            const npmBuildCommand = await screen.findByTestId(
-              'clipboard-npm-build'
+            const buildCommand = await screen.findByTestId('rollup-npm-build')
+            const buildCommandCopy = await within(buildCommand).findByTestId(
+              'clipboard-code-snippet'
             )
-            await user.click(npmBuildCommand)
+
+            await user.click(buildCommandCopy)
 
             await waitFor(() =>
               expect(Sentry.metrics.increment).toHaveBeenCalledWith(
@@ -470,10 +484,12 @@ describe('RollupOnboarding', () => {
             const { user } = setup(true)
             render(<RollupOnboarding />, { wrapper })
 
-            const yarnBuildCommand = await screen.findByTestId(
-              'clipboard-yarn-build'
+            const buildCommand = await screen.findByTestId('rollup-yarn-build')
+            const buildCommandCopy = await within(buildCommand).findByTestId(
+              'clipboard-code-snippet'
             )
-            await user.click(yarnBuildCommand)
+
+            await user.click(buildCommandCopy)
 
             await waitFor(() =>
               expect(Sentry.metrics.increment).toHaveBeenCalledWith(
@@ -500,10 +516,12 @@ describe('RollupOnboarding', () => {
             const { user } = setup(true)
             render(<RollupOnboarding />, { wrapper })
 
-            const pnpmBuildCommand = await screen.findByTestId(
-              'clipboard-pnpm-build'
+            const buildCommand = await screen.findByTestId('rollup-pnpm-build')
+            const buildCommandCopy = await within(buildCommand).findByTestId(
+              'clipboard-code-snippet'
             )
-            await user.click(pnpmBuildCommand)
+
+            await user.click(buildCommandCopy)
 
             await waitFor(() =>
               expect(Sentry.metrics.increment).toHaveBeenCalledWith(

--- a/src/pages/RepoPage/BundlesTab/BundleOnboarding/RollupOnboarding/RollupOnboarding.tsx
+++ b/src/pages/RepoPage/BundlesTab/BundleOnboarding/RollupOnboarding/RollupOnboarding.tsx
@@ -60,24 +60,27 @@ const StepOne: React.FC = () => {
         <CodeSnippet
           clipboard={npmInstall}
           clipboardOnClick={() => {
-            copiedInstallCommandMetric('npm', 'vite')
+            copiedInstallCommandMetric('npm', 'rollup')
           }}
+          data-testid="rollup-npm-install"
         >
           {npmInstall}
         </CodeSnippet>
         <CodeSnippet
           clipboard={yarnInstall}
           clipboardOnClick={() => {
-            copiedInstallCommandMetric('yarn', 'vite')
+            copiedInstallCommandMetric('yarn', 'rollup')
           }}
+          data-testid="rollup-yarn-install"
         >
           {yarnInstall}
         </CodeSnippet>
         <CodeSnippet
           clipboard={pnpmInstall}
           clipboardOnClick={() => {
-            copiedInstallCommandMetric('pnpm', 'vite')
+            copiedInstallCommandMetric('pnpm', 'rollup')
           }}
+          data-testid="rollup-pnpm-install"
         >
           {pnpmInstall}
         </CodeSnippet>
@@ -105,8 +108,9 @@ const StepTwo: React.FC<{ uploadToken: string }> = ({ uploadToken }) => {
             className="basis-2/3"
             clipboard={uploadToken}
             clipboardOnClick={() => {
-              copiedTokenMetric('vite')
+              copiedTokenMetric('rollup')
             }}
+            data-testid="rollup-upload-token"
           >
             {uploadToken}
           </CodeSnippet>
@@ -136,8 +140,9 @@ const StepThree: React.FC = () => {
         <CodeSnippet
           clipboard={pluginConfig}
           clipboardOnClick={() => {
-            copiedConfigMetric('vite')
+            copiedConfigMetric('rollup')
           }}
+          data-testid="rollup-plugin-config"
         >
           {pluginConfig}
         </CodeSnippet>
@@ -162,8 +167,9 @@ const StepFour: React.FC = () => {
         <CodeSnippet
           clipboard={commitString}
           clipboardOnClick={() => {
-            copiedCommitMetric('vite')
+            copiedCommitMetric('rollup')
           }}
+          data-testid="rollup-commit-command"
         >
           {commitString}
         </CodeSnippet>
@@ -186,24 +192,27 @@ const StepFive: React.FC = () => {
         <CodeSnippet
           clipboard={npmBuild}
           clipboardOnClick={() => {
-            copiedBuildCommandMetric('npm', 'vite')
+            copiedBuildCommandMetric('npm', 'rollup')
           }}
+          data-testid="rollup-npm-build"
         >
           {npmBuild}
         </CodeSnippet>
         <CodeSnippet
           clipboard={yarnBuild}
           clipboardOnClick={() => {
-            copiedBuildCommandMetric('yarn', 'vite')
+            copiedBuildCommandMetric('yarn', 'rollup')
           }}
+          data-testid="rollup-yarn-build"
         >
           {yarnBuild}
         </CodeSnippet>
         <CodeSnippet
           clipboard={pnpmBuild}
           clipboardOnClick={() => {
-            copiedBuildCommandMetric('pnpm', 'vite')
+            copiedBuildCommandMetric('pnpm', 'rollup')
           }}
+          data-testid="rollup-pnpm-build"
         >
           {pnpmBuild}
         </CodeSnippet>

--- a/src/pages/RepoPage/BundlesTab/BundleOnboarding/RollupOnboarding/RollupOnboarding.tsx
+++ b/src/pages/RepoPage/BundlesTab/BundleOnboarding/RollupOnboarding/RollupOnboarding.tsx
@@ -5,7 +5,7 @@ import { useOrgUploadToken } from 'services/orgUploadToken'
 import { useRepo } from 'services/repo'
 import A from 'ui/A'
 import { Card } from 'ui/Card'
-import { CopyClipboard } from 'ui/CopyClipboard'
+import { CodeSnippet } from 'ui/CodeSnippet'
 
 import {
   copiedBuildCommandMetric,
@@ -57,36 +57,30 @@ const StepOne: React.FC = () => {
           </span>{' '}
           to your project, use one of the following commands.
         </p>
-        <pre className="flex w-full items-center justify-between gap-2 overflow-auto whitespace-pre-wrap rounded-md border border-ds-gray-secondary bg-ds-gray-primary p-4 font-mono">
-          {npmInstall}{' '}
-          <CopyClipboard
-            value={npmInstall}
-            data-testid="clipboard-npm-install"
-            onClick={() => {
-              copiedInstallCommandMetric('npm', 'rollup')
-            }}
-          />
-        </pre>
-        <pre className="flex w-full items-center justify-between gap-2 overflow-auto whitespace-pre-wrap rounded-md border border-ds-gray-secondary bg-ds-gray-primary p-4 font-mono">
-          {yarnInstall}{' '}
-          <CopyClipboard
-            value={yarnInstall}
-            data-testid="clipboard-yarn-install"
-            onClick={() => {
-              copiedInstallCommandMetric('yarn', 'rollup')
-            }}
-          />
-        </pre>
-        <pre className="flex w-full items-center justify-between gap-2 overflow-auto whitespace-pre-wrap rounded-md border border-ds-gray-secondary bg-ds-gray-primary p-4 font-mono">
-          {pnpmInstall}{' '}
-          <CopyClipboard
-            value={pnpmInstall}
-            data-testid="clipboard-pnpm-install"
-            onClick={() => {
-              copiedInstallCommandMetric('pnpm', 'rollup')
-            }}
-          />
-        </pre>
+        <CodeSnippet
+          clipboard={npmInstall}
+          clipboardOnClick={() => {
+            copiedInstallCommandMetric('npm', 'vite')
+          }}
+        >
+          {npmInstall}
+        </CodeSnippet>
+        <CodeSnippet
+          clipboard={yarnInstall}
+          clipboardOnClick={() => {
+            copiedInstallCommandMetric('yarn', 'vite')
+          }}
+        >
+          {yarnInstall}
+        </CodeSnippet>
+        <CodeSnippet
+          clipboard={pnpmInstall}
+          clipboardOnClick={() => {
+            copiedInstallCommandMetric('pnpm', 'vite')
+          }}
+        >
+          {pnpmInstall}
+        </CodeSnippet>
       </Card.Content>
     </Card>
   )
@@ -104,22 +98,18 @@ const StepTwo: React.FC<{ uploadToken: string }> = ({ uploadToken }) => {
           following upload token.
         </p>
         <div className="flex gap-4">
-          <pre className="flex basis-1/3 items-center justify-between gap-2 rounded-md border border-ds-gray-secondary bg-ds-gray-primary p-4 font-mono">
-            <div className="w-0 flex-1 overflow-hidden" data-testid="token-key">
-              CODECOV_TOKEN
-            </div>
-            <CopyClipboard value="CODECOV_TOKEN" />
-          </pre>
-          <pre className="flex basis-2/3 items-center justify-between gap-2 rounded-md border border-ds-gray-secondary bg-ds-gray-primary p-4 font-mono">
-            <div className="w-0 flex-1 overflow-hidden">{uploadToken}</div>
-            <CopyClipboard
-              value={uploadToken}
-              data-testid="clipboard-upload-token"
-              onClick={() => {
-                copiedTokenMetric('rollup')
-              }}
-            />
-          </pre>
+          <CodeSnippet className="basis-1/3" clipboard="CODECOV_TOKEN">
+            CODECOV_TOKEN
+          </CodeSnippet>
+          <CodeSnippet
+            className="basis-2/3"
+            clipboard={uploadToken}
+            clipboardOnClick={() => {
+              copiedTokenMetric('vite')
+            }}
+          >
+            {uploadToken}
+          </CodeSnippet>
         </div>
       </Card.Content>
     </Card>
@@ -143,17 +133,14 @@ const StepThree: React.FC = () => {
           </span>{' '}
           file.
         </p>
-        <pre className="flex items-start justify-between overflow-auto whitespace-pre rounded-md border border-ds-gray-secondary bg-ds-gray-primary p-4 font-mono">
+        <CodeSnippet
+          clipboard={pluginConfig}
+          clipboardOnClick={() => {
+            copiedConfigMetric('vite')
+          }}
+        >
           {pluginConfig}
-          <CopyClipboard
-            value={pluginConfig}
-            label="Copy bundler plugin configuration"
-            data-testid="clipboard-plugin-config"
-            onClick={() => {
-              copiedConfigMetric('rollup')
-            }}
-          />
-        </pre>
+        </CodeSnippet>
       </Card.Content>
     </Card>
   )
@@ -172,17 +159,14 @@ const StepFour: React.FC = () => {
           The plugin requires at least one commit to be made to properly upload
           bundle analysis information up to Codecov.
         </p>
-        <pre className="flex w-full items-center justify-between gap-2 overflow-auto whitespace-pre-wrap rounded-md border border-ds-gray-secondary bg-ds-gray-primary p-4 font-mono">
-          {commitString}{' '}
-          <CopyClipboard
-            value={commitString}
-            label="Copy git commit and push commands"
-            data-testid="clipboard-commit-command"
-            onClick={() => {
-              copiedCommitMetric('rollup')
-            }}
-          />
-        </pre>
+        <CodeSnippet
+          clipboard={commitString}
+          clipboardOnClick={() => {
+            copiedCommitMetric('vite')
+          }}
+        >
+          {commitString}
+        </CodeSnippet>
       </Card.Content>
     </Card>
   )
@@ -199,36 +183,30 @@ const StepFive: React.FC = () => {
           When building your application the plugin will automatically upload
           the stats information to Codecov.
         </p>
-        <pre className="flex w-full items-center justify-between gap-2 overflow-auto whitespace-pre-wrap rounded-md border border-ds-gray-secondary bg-ds-gray-primary p-4 font-mono">
-          {npmBuild}{' '}
-          <CopyClipboard
-            value={npmBuild}
-            data-testid="clipboard-npm-build"
-            onClick={() => {
-              copiedBuildCommandMetric('npm', 'rollup')
-            }}
-          />
-        </pre>
-        <pre className="flex w-full items-center justify-between gap-2 overflow-auto whitespace-pre-wrap rounded-md border border-ds-gray-secondary bg-ds-gray-primary p-4 font-mono">
-          {yarnBuild}{' '}
-          <CopyClipboard
-            value={yarnBuild}
-            data-testid="clipboard-yarn-build"
-            onClick={() => {
-              copiedBuildCommandMetric('yarn', 'rollup')
-            }}
-          />
-        </pre>
-        <pre className="flex w-full items-center justify-between gap-2 overflow-auto whitespace-pre-wrap rounded-md border border-ds-gray-secondary bg-ds-gray-primary p-4 font-mono">
-          {pnpmBuild}{' '}
-          <CopyClipboard
-            value={pnpmBuild}
-            data-testid="clipboard-pnpm-build"
-            onClick={() => {
-              copiedBuildCommandMetric('pnpm', 'rollup')
-            }}
-          />
-        </pre>
+        <CodeSnippet
+          clipboard={npmBuild}
+          clipboardOnClick={() => {
+            copiedBuildCommandMetric('npm', 'vite')
+          }}
+        >
+          {npmBuild}
+        </CodeSnippet>
+        <CodeSnippet
+          clipboard={yarnBuild}
+          clipboardOnClick={() => {
+            copiedBuildCommandMetric('yarn', 'vite')
+          }}
+        >
+          {yarnBuild}
+        </CodeSnippet>
+        <CodeSnippet
+          clipboard={pnpmBuild}
+          clipboardOnClick={() => {
+            copiedBuildCommandMetric('pnpm', 'vite')
+          }}
+        >
+          {pnpmBuild}
+        </CodeSnippet>
       </Card.Content>
     </Card>
   )

--- a/src/pages/RepoPage/BundlesTab/BundleOnboarding/ViteOnboarding/ViteOnboarding.spec.tsx
+++ b/src/pages/RepoPage/BundlesTab/BundleOnboarding/ViteOnboarding/ViteOnboarding.spec.tsx
@@ -1,6 +1,6 @@
 import * as Sentry from '@sentry/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { render, screen, waitFor } from '@testing-library/react'
+import { render, screen, waitFor, within } from '@testing-library/react'
 import { userEvent } from '@testing-library/user-event'
 import { graphql } from 'msw'
 import { setupServer } from 'msw/node'
@@ -145,9 +145,11 @@ describe('ViteOnboarding', () => {
             const { user } = setup(null)
             render(<ViteOnboarding />, { wrapper })
 
-            const npmInstallCopy = await screen.findByTestId(
-              'clipboard-npm-install'
+            const npmInstall = await screen.findByTestId('vite-npm-install')
+            const npmInstallCopy = await within(npmInstall).findByTestId(
+              'clipboard-code-snippet'
             )
+
             await user.click(npmInstallCopy)
 
             await waitFor(() =>
@@ -177,9 +179,11 @@ describe('ViteOnboarding', () => {
             const { user } = setup(null)
             render(<ViteOnboarding />, { wrapper })
 
-            const yarnInstallCopy = await screen.findByTestId(
-              'clipboard-yarn-install'
+            const yarnInstall = await screen.findByTestId('vite-yarn-install')
+            const yarnInstallCopy = await within(yarnInstall).findByTestId(
+              'clipboard-code-snippet'
             )
+
             await user.click(yarnInstallCopy)
 
             await waitFor(() =>
@@ -209,9 +213,11 @@ describe('ViteOnboarding', () => {
             const { user } = setup(null)
             render(<ViteOnboarding />, { wrapper })
 
-            const pnpmInstallCopy = await screen.findByTestId(
-              'clipboard-pnpm-install'
+            const pnpmInstall = await screen.findByTestId('vite-pnpm-install')
+            const pnpmInstallCopy = await within(pnpmInstall).findByTestId(
+              'clipboard-code-snippet'
             )
+
             await user.click(pnpmInstallCopy)
 
             await waitFor(() =>
@@ -278,9 +284,11 @@ describe('ViteOnboarding', () => {
         const { user } = setup(true)
         render(<ViteOnboarding />, { wrapper })
 
-        const uploadTokenCopy = await screen.findByTestId(
-          'clipboard-upload-token'
+        const uploadToken = await screen.findByTestId('vite-upload-token')
+        const uploadTokenCopy = await within(uploadToken).findByTestId(
+          'clipboard-code-snippet'
         )
+
         await user.click(uploadTokenCopy)
 
         await waitFor(() =>
@@ -332,9 +340,11 @@ describe('ViteOnboarding', () => {
         const { user } = setup(true)
         render(<ViteOnboarding />, { wrapper })
 
-        const pluginConfigCopy = await screen.findByTestId(
-          'clipboard-plugin-config'
+        const pluginConfig = await screen.findByTestId('vite-plugin-config')
+        const pluginConfigCopy = await within(pluginConfig).findByTestId(
+          'clipboard-code-snippet'
         )
+
         await user.click(pluginConfigCopy)
 
         await waitFor(() =>
@@ -387,10 +397,12 @@ describe('ViteOnboarding', () => {
         const { user } = setup(true)
         render(<ViteOnboarding />, { wrapper })
 
-        const commitCommand = await screen.findByTestId(
-          'clipboard-commit-command'
+        const commitCommand = await screen.findByTestId('vite-commit-command')
+        const commitCommandCopy = await within(commitCommand).findByTestId(
+          'clipboard-code-snippet'
         )
-        await user.click(commitCommand)
+
+        await user.click(commitCommandCopy)
 
         await waitFor(() =>
           expect(Sentry.metrics.increment).toHaveBeenCalledWith(
@@ -440,10 +452,12 @@ describe('ViteOnboarding', () => {
             const { user } = setup(true)
             render(<ViteOnboarding />, { wrapper })
 
-            const npmBuildCommand = await screen.findByTestId(
-              'clipboard-npm-build'
+            const buildCommand = await screen.findByTestId('vite-npm-build')
+            const buildCommandCopy = await within(buildCommand).findByTestId(
+              'clipboard-code-snippet'
             )
-            await user.click(npmBuildCommand)
+
+            await user.click(buildCommandCopy)
 
             await waitFor(() =>
               expect(Sentry.metrics.increment).toHaveBeenCalledWith(
@@ -470,10 +484,12 @@ describe('ViteOnboarding', () => {
             const { user } = setup(true)
             render(<ViteOnboarding />, { wrapper })
 
-            const yarnBuildCommand = await screen.findByTestId(
-              'clipboard-yarn-build'
+            const buildCommand = await screen.findByTestId('vite-yarn-build')
+            const buildCommandCopy = await within(buildCommand).findByTestId(
+              'clipboard-code-snippet'
             )
-            await user.click(yarnBuildCommand)
+
+            await user.click(buildCommandCopy)
 
             await waitFor(() =>
               expect(Sentry.metrics.increment).toHaveBeenCalledWith(
@@ -500,10 +516,12 @@ describe('ViteOnboarding', () => {
             const { user } = setup(true)
             render(<ViteOnboarding />, { wrapper })
 
-            const pnpmBuildCommand = await screen.findByTestId(
-              'clipboard-pnpm-build'
+            const buildCommand = await screen.findByTestId('vite-pnpm-build')
+            const buildCommandCopy = await within(buildCommand).findByTestId(
+              'clipboard-code-snippet'
             )
-            await user.click(pnpmBuildCommand)
+
+            await user.click(buildCommandCopy)
 
             await waitFor(() =>
               expect(Sentry.metrics.increment).toHaveBeenCalledWith(

--- a/src/pages/RepoPage/BundlesTab/BundleOnboarding/ViteOnboarding/ViteOnboarding.tsx
+++ b/src/pages/RepoPage/BundlesTab/BundleOnboarding/ViteOnboarding/ViteOnboarding.tsx
@@ -62,6 +62,7 @@ const StepOne: React.FC = () => {
           clipboardOnClick={() => {
             copiedInstallCommandMetric('npm', 'vite')
           }}
+          data-testid="vite-npm-install"
         >
           {npmInstall}
         </CodeSnippet>
@@ -70,6 +71,7 @@ const StepOne: React.FC = () => {
           clipboardOnClick={() => {
             copiedInstallCommandMetric('yarn', 'vite')
           }}
+          data-testid="vite-yarn-install"
         >
           {yarnInstall}
         </CodeSnippet>
@@ -78,6 +80,7 @@ const StepOne: React.FC = () => {
           clipboardOnClick={() => {
             copiedInstallCommandMetric('pnpm', 'vite')
           }}
+          data-testid="vite-pnpm-install"
         >
           {pnpmInstall}
         </CodeSnippet>
@@ -107,6 +110,7 @@ const StepTwo: React.FC<{ uploadToken: string }> = ({ uploadToken }) => {
             clipboardOnClick={() => {
               copiedTokenMetric('vite')
             }}
+            data-testid="vite-upload-token"
           >
             {uploadToken}
           </CodeSnippet>
@@ -138,6 +142,7 @@ const StepThree: React.FC = () => {
           clipboardOnClick={() => {
             copiedConfigMetric('vite')
           }}
+          data-testid="vite-plugin-config"
         >
           {pluginConfig}
         </CodeSnippet>
@@ -164,6 +169,7 @@ const StepFour: React.FC = () => {
           clipboardOnClick={() => {
             copiedCommitMetric('vite')
           }}
+          data-testid="vite-commit-command"
         >
           {commitString}
         </CodeSnippet>
@@ -189,6 +195,7 @@ const StepFive: React.FC = () => {
             clipboardOnClick={() => {
               copiedBuildCommandMetric('npm', 'vite')
             }}
+            data-testid="vite-npm-build"
           >
             {npmBuild}
           </CodeSnippet>
@@ -197,6 +204,7 @@ const StepFive: React.FC = () => {
             clipboardOnClick={() => {
               copiedBuildCommandMetric('yarn', 'vite')
             }}
+            data-testid="vite-yarn-build"
           >
             {yarnBuild}
           </CodeSnippet>
@@ -205,6 +213,7 @@ const StepFive: React.FC = () => {
             clipboardOnClick={() => {
               copiedBuildCommandMetric('pnpm', 'vite')
             }}
+            data-testid="vite-pnpm-build"
           >
             {pnpmBuild}
           </CodeSnippet>

--- a/src/pages/RepoPage/BundlesTab/BundleOnboarding/ViteOnboarding/ViteOnboarding.tsx
+++ b/src/pages/RepoPage/BundlesTab/BundleOnboarding/ViteOnboarding/ViteOnboarding.tsx
@@ -5,7 +5,7 @@ import { useOrgUploadToken } from 'services/orgUploadToken'
 import { useRepo } from 'services/repo'
 import A from 'ui/A'
 import { Card } from 'ui/Card'
-import { CopyClipboard } from 'ui/CopyClipboard'
+import { CodeSnippet } from 'ui/CodeSnippet'
 
 import {
   copiedBuildCommandMetric,
@@ -57,36 +57,30 @@ const StepOne: React.FC = () => {
           </span>{' '}
           to your project, use one of the following commands.
         </p>
-        <pre className="flex w-full items-center justify-between gap-2 overflow-auto whitespace-pre-wrap rounded-md border border-ds-gray-secondary bg-ds-gray-primary p-4 font-mono">
-          {npmInstall}{' '}
-          <CopyClipboard
-            value={npmInstall}
-            data-testid="clipboard-npm-install"
-            onClick={() => {
-              copiedInstallCommandMetric('npm', 'vite')
-            }}
-          />
-        </pre>
-        <pre className="flex w-full items-center justify-between gap-2 overflow-auto whitespace-pre-wrap rounded-md border border-ds-gray-secondary bg-ds-gray-primary p-4 font-mono">
-          {yarnInstall}{' '}
-          <CopyClipboard
-            value={yarnInstall}
-            data-testid="clipboard-yarn-install"
-            onClick={() => {
-              copiedInstallCommandMetric('yarn', 'vite')
-            }}
-          />
-        </pre>
-        <pre className="flex w-full items-center justify-between gap-2 overflow-auto whitespace-pre-wrap rounded-md border border-ds-gray-secondary bg-ds-gray-primary p-4 font-mono">
-          {pnpmInstall}{' '}
-          <CopyClipboard
-            value={pnpmInstall}
-            data-testid="clipboard-pnpm-install"
-            onClick={() => {
-              copiedInstallCommandMetric('pnpm', 'vite')
-            }}
-          />
-        </pre>
+        <CodeSnippet
+          clipboard={npmInstall}
+          clipboardOnClick={() => {
+            copiedInstallCommandMetric('npm', 'vite')
+          }}
+        >
+          {npmInstall}
+        </CodeSnippet>
+        <CodeSnippet
+          clipboard={yarnInstall}
+          clipboardOnClick={() => {
+            copiedInstallCommandMetric('yarn', 'vite')
+          }}
+        >
+          {yarnInstall}
+        </CodeSnippet>
+        <CodeSnippet
+          clipboard={pnpmInstall}
+          clipboardOnClick={() => {
+            copiedInstallCommandMetric('pnpm', 'vite')
+          }}
+        >
+          {pnpmInstall}
+        </CodeSnippet>
       </Card.Content>
     </Card>
   )
@@ -104,22 +98,18 @@ const StepTwo: React.FC<{ uploadToken: string }> = ({ uploadToken }) => {
           following upload token.
         </p>
         <div className="flex gap-4">
-          <pre className="flex basis-1/3 items-center justify-between gap-2 rounded-md border border-ds-gray-secondary bg-ds-gray-primary p-4 font-mono">
-            <div className="w-0 flex-1 overflow-hidden" data-testid="token-key">
-              CODECOV_TOKEN
-            </div>
-            <CopyClipboard value="CODECOV_TOKEN" />
-          </pre>
-          <pre className="flex basis-2/3 items-center justify-between gap-2 rounded-md border border-ds-gray-secondary bg-ds-gray-primary p-4 font-mono">
-            <div className="w-0 flex-1 overflow-hidden">{uploadToken}</div>
-            <CopyClipboard
-              value={uploadToken}
-              data-testid="clipboard-upload-token"
-              onClick={() => {
-                copiedTokenMetric('vite')
-              }}
-            />
-          </pre>
+          <CodeSnippet className="basis-1/3" clipboard="CODECOV_TOKEN">
+            CODECOV_TOKEN
+          </CodeSnippet>
+          <CodeSnippet
+            className="basis-2/3"
+            clipboard={uploadToken}
+            clipboardOnClick={() => {
+              copiedTokenMetric('vite')
+            }}
+          >
+            {uploadToken}
+          </CodeSnippet>
         </div>
       </Card.Content>
     </Card>
@@ -143,17 +133,14 @@ const StepThree: React.FC = () => {
           </span>{' '}
           file.
         </p>
-        <pre className="relative flex items-start justify-between overflow-auto whitespace-pre rounded-md border border-ds-gray-secondary bg-ds-gray-primary p-4 font-mono">
+        <CodeSnippet
+          clipboard={pluginConfig}
+          clipboardOnClick={() => {
+            copiedConfigMetric('vite')
+          }}
+        >
           {pluginConfig}
-          <CopyClipboard
-            value={pluginConfig}
-            label="Copy bundler plugin configuration"
-            data-testid="clipboard-plugin-config"
-            onClick={() => {
-              copiedConfigMetric('vite')
-            }}
-          />
-        </pre>
+        </CodeSnippet>
       </Card.Content>
     </Card>
   )
@@ -172,17 +159,14 @@ const StepFour: React.FC = () => {
           The plugin requires at least one commit to be made to properly upload
           bundle analysis information up to Codecov.
         </p>
-        <pre className="flex w-full items-center justify-between gap-2 overflow-auto whitespace-pre-wrap rounded-md border border-ds-gray-secondary bg-ds-gray-primary p-4 font-mono">
-          {commitString}{' '}
-          <CopyClipboard
-            value={commitString}
-            label="Copy git commit and push commands"
-            data-testid="clipboard-commit-command"
-            onClick={() => {
-              copiedCommitMetric('vite')
-            }}
-          />
-        </pre>
+        <CodeSnippet
+          clipboard={commitString}
+          clipboardOnClick={() => {
+            copiedCommitMetric('vite')
+          }}
+        >
+          {commitString}
+        </CodeSnippet>
       </Card.Content>
     </Card>
   )
@@ -200,36 +184,30 @@ const StepFive: React.FC = () => {
           the stats information to Codecov.
         </p>
         <div className="flex flex-col gap-4">
-          <pre className="flex w-full items-center justify-between gap-2 overflow-auto whitespace-pre-wrap rounded-md border border-ds-gray-secondary bg-ds-gray-primary p-4 font-mono">
-            {npmBuild}{' '}
-            <CopyClipboard
-              value={npmBuild}
-              data-testid="clipboard-npm-build"
-              onClick={() => {
-                copiedBuildCommandMetric('npm', 'vite')
-              }}
-            />
-          </pre>
-          <pre className="flex w-full items-center justify-between gap-2 overflow-auto whitespace-pre-wrap rounded-md border border-ds-gray-secondary bg-ds-gray-primary p-4 font-mono">
-            {yarnBuild}{' '}
-            <CopyClipboard
-              value={yarnBuild}
-              data-testid="clipboard-yarn-build"
-              onClick={() => {
-                copiedBuildCommandMetric('yarn', 'vite')
-              }}
-            />
-          </pre>
-          <pre className="flex w-full items-center justify-between gap-2 overflow-auto whitespace-pre-wrap rounded-md border border-ds-gray-secondary bg-ds-gray-primary p-4 font-mono">
-            {pnpmBuild}{' '}
-            <CopyClipboard
-              value={pnpmBuild}
-              data-testid="clipboard-pnpm-build"
-              onClick={() => {
-                copiedBuildCommandMetric('pnpm', 'vite')
-              }}
-            />
-          </pre>
+          <CodeSnippet
+            clipboard={npmBuild}
+            clipboardOnClick={() => {
+              copiedBuildCommandMetric('npm', 'vite')
+            }}
+          >
+            {npmBuild}
+          </CodeSnippet>
+          <CodeSnippet
+            clipboard={yarnBuild}
+            clipboardOnClick={() => {
+              copiedBuildCommandMetric('yarn', 'vite')
+            }}
+          >
+            {yarnBuild}
+          </CodeSnippet>
+          <CodeSnippet
+            clipboard={pnpmBuild}
+            clipboardOnClick={() => {
+              copiedBuildCommandMetric('pnpm', 'vite')
+            }}
+          >
+            {pnpmBuild}
+          </CodeSnippet>
         </div>
       </Card.Content>
     </Card>

--- a/src/pages/RepoPage/BundlesTab/BundleOnboarding/WebpackOnboarding/WebpackOnboarding.spec.tsx
+++ b/src/pages/RepoPage/BundlesTab/BundleOnboarding/WebpackOnboarding/WebpackOnboarding.spec.tsx
@@ -1,6 +1,6 @@
 import * as Sentry from '@sentry/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { render, screen, waitFor } from '@testing-library/react'
+import { render, screen, waitFor, within } from '@testing-library/react'
 import { userEvent } from '@testing-library/user-event'
 import { graphql } from 'msw'
 import { setupServer } from 'msw/node'
@@ -145,9 +145,11 @@ describe('WebpackOnboarding', () => {
             const { user } = setup(null)
             render(<WebpackOnboarding />, { wrapper })
 
-            const npmInstallCopy = await screen.findByTestId(
-              'clipboard-npm-install'
+            const npmInstall = await screen.findByTestId('webpack-npm-install')
+            const npmInstallCopy = await within(npmInstall).findByTestId(
+              'clipboard-code-snippet'
             )
+
             await user.click(npmInstallCopy)
 
             await waitFor(() =>
@@ -177,9 +179,13 @@ describe('WebpackOnboarding', () => {
             const { user } = setup(null)
             render(<WebpackOnboarding />, { wrapper })
 
-            const yarnInstallCopy = await screen.findByTestId(
-              'clipboard-yarn-install'
+            const yarnInstall = await screen.findByTestId(
+              'webpack-yarn-install'
             )
+            const yarnInstallCopy = await within(yarnInstall).findByTestId(
+              'clipboard-code-snippet'
+            )
+
             await user.click(yarnInstallCopy)
 
             await waitFor(() =>
@@ -209,9 +215,13 @@ describe('WebpackOnboarding', () => {
             const { user } = setup(null)
             render(<WebpackOnboarding />, { wrapper })
 
-            const pnpmInstallCopy = await screen.findByTestId(
-              'clipboard-pnpm-install'
+            const pnpmInstall = await screen.findByTestId(
+              'webpack-pnpm-install'
             )
+            const pnpmInstallCopy = await within(pnpmInstall).findByTestId(
+              'clipboard-code-snippet'
+            )
+
             await user.click(pnpmInstallCopy)
 
             await waitFor(() =>
@@ -278,9 +288,11 @@ describe('WebpackOnboarding', () => {
         const { user } = setup(true)
         render(<WebpackOnboarding />, { wrapper })
 
-        const uploadTokenCopy = await screen.findByTestId(
-          'clipboard-upload-token'
+        const uploadToken = await screen.findByTestId('webpack-upload-token')
+        const uploadTokenCopy = await within(uploadToken).findByTestId(
+          'clipboard-code-snippet'
         )
+
         await user.click(uploadTokenCopy)
 
         await waitFor(() =>
@@ -332,9 +344,11 @@ describe('WebpackOnboarding', () => {
         const { user } = setup(true)
         render(<WebpackOnboarding />, { wrapper })
 
-        const pluginConfigCopy = await screen.findByTestId(
-          'clipboard-plugin-config'
+        const pluginConfig = await screen.findByTestId('webpack-plugin-config')
+        const pluginConfigCopy = await within(pluginConfig).findByTestId(
+          'clipboard-code-snippet'
         )
+
         await user.click(pluginConfigCopy)
 
         await waitFor(() =>
@@ -388,9 +402,13 @@ describe('WebpackOnboarding', () => {
         render(<WebpackOnboarding />, { wrapper })
 
         const commitCommand = await screen.findByTestId(
-          'clipboard-commit-command'
+          'webpack-commit-command'
         )
-        await user.click(commitCommand)
+        const commitCommandCopy = await within(commitCommand).findByTestId(
+          'clipboard-code-snippet'
+        )
+
+        await user.click(commitCommandCopy)
 
         await waitFor(() =>
           expect(Sentry.metrics.increment).toHaveBeenCalledWith(
@@ -440,10 +458,12 @@ describe('WebpackOnboarding', () => {
             const { user } = setup(true)
             render(<WebpackOnboarding />, { wrapper })
 
-            const npmBuildCommand = await screen.findByTestId(
-              'clipboard-npm-build'
+            const buildCommand = await screen.findByTestId('webpack-npm-build')
+            const buildCommandCopy = await within(buildCommand).findByTestId(
+              'clipboard-code-snippet'
             )
-            await user.click(npmBuildCommand)
+
+            await user.click(buildCommandCopy)
 
             await waitFor(() =>
               expect(Sentry.metrics.increment).toHaveBeenCalledWith(
@@ -470,10 +490,12 @@ describe('WebpackOnboarding', () => {
             const { user } = setup(true)
             render(<WebpackOnboarding />, { wrapper })
 
-            const yarnBuildCommand = await screen.findByTestId(
-              'clipboard-yarn-build'
+            const buildCommand = await screen.findByTestId('webpack-yarn-build')
+            const buildCommandCopy = await within(buildCommand).findByTestId(
+              'clipboard-code-snippet'
             )
-            await user.click(yarnBuildCommand)
+
+            await user.click(buildCommandCopy)
 
             await waitFor(() =>
               expect(Sentry.metrics.increment).toHaveBeenCalledWith(
@@ -500,10 +522,12 @@ describe('WebpackOnboarding', () => {
             const { user } = setup(true)
             render(<WebpackOnboarding />, { wrapper })
 
-            const pnpmBuildCommand = await screen.findByTestId(
-              'clipboard-pnpm-build'
+            const buildCommand = await screen.findByTestId('webpack-pnpm-build')
+            const buildCommandCopy = await within(buildCommand).findByTestId(
+              'clipboard-code-snippet'
             )
-            await user.click(pnpmBuildCommand)
+
+            await user.click(buildCommandCopy)
 
             await waitFor(() =>
               expect(Sentry.metrics.increment).toHaveBeenCalledWith(

--- a/src/pages/RepoPage/BundlesTab/BundleOnboarding/WebpackOnboarding/WebpackOnboarding.tsx
+++ b/src/pages/RepoPage/BundlesTab/BundleOnboarding/WebpackOnboarding/WebpackOnboarding.tsx
@@ -63,6 +63,7 @@ const StepOne: React.FC = () => {
           clipboardOnClick={() => {
             copiedInstallCommandMetric('npm', 'webpack')
           }}
+          data-testid="webpack-npm-install"
         >
           {npmInstall}
         </CodeSnippet>
@@ -71,6 +72,7 @@ const StepOne: React.FC = () => {
           clipboardOnClick={() => {
             copiedInstallCommandMetric('yarn', 'webpack')
           }}
+          data-testid="webpack-yarn-install"
         >
           {yarnInstall}
         </CodeSnippet>
@@ -79,6 +81,7 @@ const StepOne: React.FC = () => {
           clipboardOnClick={() => {
             copiedInstallCommandMetric('pnpm', 'webpack')
           }}
+          data-testid="webpack-pnpm-install"
         >
           {pnpmInstall}
         </CodeSnippet>
@@ -108,6 +111,7 @@ const StepTwo: React.FC<{ uploadToken: string }> = ({ uploadToken }) => {
             clipboardOnClick={() => {
               copiedTokenMetric('webpack')
             }}
+            data-testid="webpack-upload-token"
           >
             {uploadToken}
           </CodeSnippet>
@@ -154,6 +158,7 @@ const StepThree: React.FC = () => {
           clipboardOnClick={() => {
             copiedConfigMetric('webpack')
           }}
+          data-testid="webpack-plugin-config"
         >
           {pluginConfig}
         </CodeSnippet>
@@ -180,6 +185,7 @@ const StepFour: React.FC = () => {
           clipboardOnClick={() => {
             copiedCommitMetric('webpack')
           }}
+          data-testid="webpack-commit-command"
         >
           {commitString}
         </CodeSnippet>
@@ -204,6 +210,7 @@ const StepFive: React.FC = () => {
           clipboardOnClick={() => {
             copiedBuildCommandMetric('npm', 'webpack')
           }}
+          data-testid="webpack-npm-build"
         >
           {npmBuild}
         </CodeSnippet>
@@ -212,6 +219,7 @@ const StepFive: React.FC = () => {
           clipboardOnClick={() => {
             copiedBuildCommandMetric('yarn', 'webpack')
           }}
+          data-testid="webpack-yarn-build"
         >
           {yarnBuild}
         </CodeSnippet>
@@ -220,6 +228,7 @@ const StepFive: React.FC = () => {
           clipboardOnClick={() => {
             copiedBuildCommandMetric('pnpm', 'webpack')
           }}
+          data-testid="webpack-pnpm-build"
         >
           {pnpmBuild}
         </CodeSnippet>

--- a/src/pages/RepoPage/BundlesTab/BundleOnboarding/WebpackOnboarding/WebpackOnboarding.tsx
+++ b/src/pages/RepoPage/BundlesTab/BundleOnboarding/WebpackOnboarding/WebpackOnboarding.tsx
@@ -5,7 +5,7 @@ import { useOrgUploadToken } from 'services/orgUploadToken'
 import { useRepo } from 'services/repo'
 import A from 'ui/A'
 import { Card } from 'ui/Card'
-import { CopyClipboard } from 'ui/CopyClipboard'
+import { CodeSnippet } from 'ui/CodeSnippet'
 
 import {
   copiedBuildCommandMetric,
@@ -58,36 +58,30 @@ const StepOne: React.FC = () => {
           </span>{' '}
           to your project, use one of the following commands.
         </p>
-        <pre className="flex w-full items-center justify-between gap-2 overflow-auto whitespace-pre-wrap rounded-md border border-ds-gray-secondary bg-ds-gray-primary p-4 font-mono">
-          {npmInstall}{' '}
-          <CopyClipboard
-            value={npmInstall}
-            data-testid="clipboard-npm-install"
-            onClick={() => {
-              copiedInstallCommandMetric('npm', 'webpack')
-            }}
-          />
-        </pre>
-        <pre className="flex w-full items-center justify-between gap-2 overflow-auto whitespace-pre-wrap rounded-md border border-ds-gray-secondary bg-ds-gray-primary p-4 font-mono">
-          {yarnInstall}{' '}
-          <CopyClipboard
-            value={yarnInstall}
-            data-testid="clipboard-yarn-install"
-            onClick={() => {
-              copiedInstallCommandMetric('yarn', 'webpack')
-            }}
-          />
-        </pre>
-        <pre className="flex w-full items-center justify-between gap-2 overflow-auto whitespace-pre-wrap rounded-md border border-ds-gray-secondary bg-ds-gray-primary p-4 font-mono">
-          {pnpmInstall}{' '}
-          <CopyClipboard
-            value={pnpmInstall}
-            data-testid="clipboard-pnpm-install"
-            onClick={() => {
-              copiedInstallCommandMetric('pnpm', 'webpack')
-            }}
-          />
-        </pre>
+        <CodeSnippet
+          clipboard={npmInstall}
+          clipboardOnClick={() => {
+            copiedInstallCommandMetric('npm', 'webpack')
+          }}
+        >
+          {npmInstall}
+        </CodeSnippet>
+        <CodeSnippet
+          clipboard={yarnInstall}
+          clipboardOnClick={() => {
+            copiedInstallCommandMetric('yarn', 'webpack')
+          }}
+        >
+          {yarnInstall}
+        </CodeSnippet>
+        <CodeSnippet
+          clipboard={pnpmInstall}
+          clipboardOnClick={() => {
+            copiedInstallCommandMetric('pnpm', 'webpack')
+          }}
+        >
+          {pnpmInstall}
+        </CodeSnippet>
       </Card.Content>
     </Card>
   )
@@ -105,22 +99,18 @@ const StepTwo: React.FC<{ uploadToken: string }> = ({ uploadToken }) => {
           following upload token.
         </p>
         <div className="flex gap-4">
-          <pre className="flex basis-1/3 items-center justify-between gap-2 rounded-md border border-ds-gray-secondary bg-ds-gray-primary p-4 font-mono">
-            <div className="w-0 flex-1 overflow-hidden" data-testid="token-key">
-              CODECOV_TOKEN
-            </div>
-            <CopyClipboard value="CODECOV_TOKEN" />
-          </pre>
-          <pre className="flex basis-2/3 items-center justify-between gap-2 rounded-md border border-ds-gray-secondary bg-ds-gray-primary p-4 font-mono">
-            <div className="w-0 flex-1 overflow-hidden">{uploadToken}</div>
-            <CopyClipboard
-              value={uploadToken}
-              data-testid="clipboard-upload-token"
-              onClick={() => {
-                copiedTokenMetric('webpack')
-              }}
-            />
-          </pre>
+          <CodeSnippet className="basis-1/3" clipboard="CODECOV_TOKEN">
+            CODECOV_TOKEN
+          </CodeSnippet>
+          <CodeSnippet
+            className="basis-2/3"
+            clipboard={uploadToken}
+            clipboardOnClick={() => {
+              copiedTokenMetric('webpack')
+            }}
+          >
+            {uploadToken}
+          </CodeSnippet>
         </div>
       </Card.Content>
     </Card>
@@ -159,17 +149,14 @@ const StepThree: React.FC = () => {
             here.
           </A>
         </p>
-        <pre className="flex items-start justify-between overflow-auto whitespace-pre rounded-md border border-ds-gray-secondary bg-ds-gray-primary p-4 font-mono">
+        <CodeSnippet
+          clipboard={pluginConfig}
+          clipboardOnClick={() => {
+            copiedConfigMetric('webpack')
+          }}
+        >
           {pluginConfig}
-          <CopyClipboard
-            value={pluginConfig}
-            label="Copy bundler plugin configuration"
-            data-testid="clipboard-plugin-config"
-            onClick={() => {
-              copiedConfigMetric('webpack')
-            }}
-          />
-        </pre>
+        </CodeSnippet>
       </Card.Content>
     </Card>
   )
@@ -188,17 +175,14 @@ const StepFour: React.FC = () => {
           The plugin requires at least one commit to be made to properly upload
           bundle analysis information up to Codecov.
         </p>
-        <pre className="flex w-full items-center justify-between gap-2 overflow-auto whitespace-pre-wrap rounded-md border border-ds-gray-secondary bg-ds-gray-primary p-4 font-mono">
-          {commitString}{' '}
-          <CopyClipboard
-            value={commitString}
-            label="Copy git commit and push commands"
-            data-testid="clipboard-commit-command"
-            onClick={() => {
-              copiedCommitMetric('webpack')
-            }}
-          />
-        </pre>
+        <CodeSnippet
+          clipboard={commitString}
+          clipboardOnClick={() => {
+            copiedCommitMetric('webpack')
+          }}
+        >
+          {commitString}
+        </CodeSnippet>
       </Card.Content>
     </Card>
   )
@@ -215,36 +199,30 @@ const StepFive: React.FC = () => {
           When building your application the plugin will automatically upload
           the stats information to Codecov.
         </p>
-        <pre className="flex w-full items-center justify-between gap-2 overflow-auto whitespace-pre-wrap rounded-md border border-ds-gray-secondary bg-ds-gray-primary p-4 font-mono">
-          {npmBuild}{' '}
-          <CopyClipboard
-            value={npmBuild}
-            data-testid="clipboard-npm-build"
-            onClick={() => {
-              copiedBuildCommandMetric('npm', 'webpack')
-            }}
-          />
-        </pre>
-        <pre className="flex w-full items-center justify-between gap-2 overflow-auto whitespace-pre-wrap rounded-md border border-ds-gray-secondary bg-ds-gray-primary p-4 font-mono">
-          {yarnBuild}{' '}
-          <CopyClipboard
-            value={yarnBuild}
-            data-testid="clipboard-yarn-build"
-            onClick={() => {
-              copiedBuildCommandMetric('yarn', 'webpack')
-            }}
-          />
-        </pre>
-        <pre className="flex w-full items-center justify-between gap-2 overflow-auto whitespace-pre-wrap rounded-md border border-ds-gray-secondary bg-ds-gray-primary p-4 font-mono">
-          {pnpmBuild}{' '}
-          <CopyClipboard
-            value={pnpmBuild}
-            data-testid="clipboard-pnpm-build"
-            onClick={() => {
-              copiedBuildCommandMetric('pnpm', 'webpack')
-            }}
-          />
-        </pre>
+        <CodeSnippet
+          clipboard={npmBuild}
+          clipboardOnClick={() => {
+            copiedBuildCommandMetric('npm', 'webpack')
+          }}
+        >
+          {npmBuild}
+        </CodeSnippet>
+        <CodeSnippet
+          clipboard={yarnBuild}
+          clipboardOnClick={() => {
+            copiedBuildCommandMetric('yarn', 'webpack')
+          }}
+        >
+          {yarnBuild}
+        </CodeSnippet>
+        <CodeSnippet
+          clipboard={pnpmBuild}
+          clipboardOnClick={() => {
+            copiedBuildCommandMetric('pnpm', 'webpack')
+          }}
+        >
+          {pnpmBuild}
+        </CodeSnippet>
       </Card.Content>
     </Card>
   )

--- a/src/pages/RepoPage/CoverageOnboarding/CircleCI/CircleCI.tsx
+++ b/src/pages/RepoPage/CoverageOnboarding/CircleCI/CircleCI.tsx
@@ -6,7 +6,7 @@ import { useFlags } from 'shared/featureFlags'
 import { providerToInternalProvider } from 'shared/utils/provider'
 import A from 'ui/A'
 import { Card } from 'ui/Card'
-import { CopyClipboard } from 'ui/CopyClipboard'
+import { CodeSnippet } from 'ui/CodeSnippet'
 
 import ExampleBlurb from '../ExampleBlurb'
 
@@ -86,16 +86,12 @@ function Step1({ tokenCopy, uploadToken, providerName }: Step1Props) {
           Environment variables in CircleCI can be found in project settings.
         </p>
         <div className="flex gap-4">
-          <pre className="flex basis-1/3 items-center justify-between gap-2 rounded-md border border-ds-gray-secondary bg-ds-gray-primary p-4 font-mono">
-            <div className="w-0 flex-1 overflow-hidden" data-testid="token-key">
-              CODECOV_TOKEN
-            </div>
-            <CopyClipboard value="CODECOV_TOKEN" />
-          </pre>
-          <pre className="flex basis-2/3 items-center justify-between gap-2 rounded-md border border-ds-gray-secondary bg-ds-gray-primary p-4 font-mono">
-            <div className="w-0 flex-1 overflow-hidden">{uploadToken}</div>
-            <CopyClipboard value={uploadToken ?? ''} />
-          </pre>
+          <CodeSnippet className="basis-1/3" clipboard="CODECOV_TOKEN">
+            CODECOV_TOKEN
+          </CodeSnippet>
+          <CodeSnippet className="basis-2/3" clipboard={uploadToken}>
+            {uploadToken}
+          </CodeSnippet>
         </div>
       </Card.Content>
     </Card>
@@ -129,13 +125,7 @@ function Step2({ defaultBranch }: Step2Props) {
           Add the following to your .circleci/config.yaml and push changes to
           repository.
         </p>
-        <div className="flex items-start justify-between overflow-auto whitespace-pre-line rounded-md border border-ds-gray-secondary bg-ds-gray-primary p-4 font-mono">
-          <pre className="whitespace-pre">{orbsString}</pre>
-          <CopyClipboard
-            value={orbsString}
-            label="Copy Codecov orb configuration"
-          />
-        </div>
+        <CodeSnippet clipboard={orbsString}>{orbsString}</CodeSnippet>
         <ExampleBlurb />
       </Card.Content>
     </Card>

--- a/src/pages/RepoPage/CoverageOnboarding/GitHubActions/GitHubActions.tsx
+++ b/src/pages/RepoPage/CoverageOnboarding/GitHubActions/GitHubActions.tsx
@@ -5,7 +5,7 @@ import { useRepo } from 'services/repo'
 import { useFlags } from 'shared/featureFlags'
 import A from 'ui/A'
 import { Card } from 'ui/Card'
-import { CopyClipboard } from 'ui/CopyClipboard'
+import { CodeSnippet } from 'ui/CodeSnippet'
 
 import ExampleBlurb from '../ExampleBlurb'
 
@@ -78,17 +78,12 @@ function Step1({ tokenCopy, uploadToken }: Step1Props) {
           actions
         </p>
         <div className="flex gap-4">
-          {/* We have plans to make this a component. Too much copy pasta */}
-          <pre className="flex basis-1/3 items-center justify-between gap-2 rounded-md border border-ds-gray-secondary bg-ds-gray-primary p-4 font-mono">
-            <div className="w-0 flex-1 overflow-hidden" data-testid="token-key">
-              CODECOV_TOKEN
-            </div>
-            <CopyClipboard value="CODECOV_TOKEN" />
-          </pre>
-          <pre className="flex basis-2/3 items-center justify-between gap-2 rounded-md border border-ds-gray-secondary bg-ds-gray-primary p-4 font-mono">
-            <div className="w-0 flex-1 overflow-hidden">{uploadToken}</div>
-            <CopyClipboard value={uploadToken ?? ''} />
-          </pre>
+          <CodeSnippet className="basis-1/3" clipboard="CODECOV_TOKEN">
+            CODECOV_TOKEN
+          </CodeSnippet>
+          <CodeSnippet className="basis-2/3" clipboard={uploadToken}>
+            {uploadToken}
+          </CodeSnippet>
         </div>
       </Card.Content>
     </Card>
@@ -123,13 +118,7 @@ function Step2({ defaultBranch, actionString }: Step2Props) {
           After tests run, this will upload your coverage report to Codecov:
         </p>
 
-        <div className="flex items-start justify-between overflow-auto rounded-md border border-ds-gray-secondary bg-ds-gray-primary p-4 font-mono">
-          <pre className="whitespace-pre">{actionString}</pre>
-          <CopyClipboard
-            value={actionString}
-            label="Copy Codecov Action configuration"
-          />
-        </div>
+        <CodeSnippet clipboard={actionString}>{actionString}</CodeSnippet>
         <ExampleBlurb />
       </Card.Content>
     </Card>

--- a/src/pages/RepoPage/CoverageOnboarding/GitHubActions/GitHubActions.tsx
+++ b/src/pages/RepoPage/CoverageOnboarding/GitHubActions/GitHubActions.tsx
@@ -78,7 +78,11 @@ function Step1({ tokenCopy, uploadToken }: Step1Props) {
           actions
         </p>
         <div className="flex gap-4">
-          <CodeSnippet className="basis-1/3" clipboard="CODECOV_TOKEN">
+          <CodeSnippet
+            className="basis-1/3"
+            clipboard="CODECOV_TOKEN"
+            data-testid="token-key"
+          >
             CODECOV_TOKEN
           </CodeSnippet>
           <CodeSnippet className="basis-2/3" clipboard={uploadToken}>

--- a/src/pages/RepoPage/CoverageOnboarding/OtherCI/OtherCI.tsx
+++ b/src/pages/RepoPage/CoverageOnboarding/OtherCI/OtherCI.tsx
@@ -5,7 +5,7 @@ import { useRepo } from 'services/repo'
 import { useFlags } from 'shared/featureFlags'
 import A from 'ui/A'
 import { Card } from 'ui/Card'
-import { CopyClipboard } from 'ui/CopyClipboard'
+import { CodeSnippet } from 'ui/CodeSnippet'
 
 import { InstructionBox } from './TerminalInstructions'
 
@@ -64,16 +64,12 @@ function Step1({ tokenCopy, uploadToken }: Step1Props) {
       </Card.Header>
       <Card.Content className="flex flex-col gap-4">
         <div className="flex gap-4">
-          <pre className="flex basis-1/3 items-center justify-between gap-2 rounded-md border border-ds-gray-secondary bg-ds-gray-primary p-4 font-mono">
-            <div className="w-0 flex-1 overflow-hidden" data-testid="token-key">
-              CODECOV_TOKEN
-            </div>
-            <CopyClipboard value="CODECOV_TOKEN" />
-          </pre>
-          <pre className="flex basis-2/3 items-center justify-between gap-2 rounded-md border border-ds-gray-secondary bg-ds-gray-primary p-4 font-mono">
-            <div className="w-0 flex-1 overflow-hidden">{uploadToken}</div>
-            <CopyClipboard value={uploadToken ?? ''} />
-          </pre>
+          <CodeSnippet className="basis-1/3" clipboard="CODECOV_TOKEN">
+            CODECOV_TOKEN
+          </CodeSnippet>
+          <CodeSnippet className="basis-2/3" clipboard={uploadToken}>
+            {uploadToken}
+          </CodeSnippet>
         </div>
       </Card.Content>
     </Card>
@@ -116,13 +112,7 @@ function Step3({ uploadCommand }: Step3Props) {
         </Card.Title>
       </Card.Header>
       <Card.Content className="flex flex-col gap-4">
-        <pre className="flex basis-2/3 items-center justify-between gap-2 rounded-md border border-ds-gray-secondary bg-ds-gray-primary p-4 font-mono">
-          <div className="w-0 flex-1 overflow-hidden">{uploadCommand}</div>
-          <CopyClipboard
-            value={uploadCommand}
-            label="Copy Codecov CLI's upload command"
-          />
-        </pre>
+        <CodeSnippet clipboard={uploadCommand}>{uploadCommand}</CodeSnippet>
         <ExampleBlurb />
       </Card.Content>
     </Card>


### PR DESCRIPTION
Refactors code snippet instances to use the new `CodeSnippet` component. Some tests had to be changed as a result of test id of the copyclipboard no longer being directly exposed - which is a drawback of the less than fully composable implementation we went with.

Closes https://github.com/codecov/internal-issues/issues/482
