### PR TITLE
feat: Create a reusable component for expandable section

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@hookform/resolvers": "^2.8.5",
         "@radix-ui/react-accordion": "^1.1.2",
+        "@radix-ui/react-collapsible": "^1.0.3",
         "@radix-ui/react-label": "^2.0.2",
         "@radix-ui/react-popover": "^1.0.6",
         "@radix-ui/react-radio-group": "^1.1.3",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
   "dependencies": {
     "@hookform/resolvers": "^2.8.5",
     "@radix-ui/react-accordion": "^1.1.2",
+    "@radix-ui/react-collapsible": "^1.0.3",
     "@radix-ui/react-label": "^2.0.2",
     "@radix-ui/react-popover": "^1.0.6",
     "@radix-ui/react-radio-group": "^1.1.3",

--- a/src/ui/ExpandableSection/ExpandableSection.spec.tsx
+++ b/src/ui/ExpandableSection/ExpandableSection.spec.tsx
@@ -1,0 +1,46 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+import ExpandableSection from 'ui/ExpandableSection'
+
+describe('ExpandableSection', () => {
+  it('renders the title correctly', () => {
+    const title = 'Test Title'
+    render(
+      <ExpandableSection title={title}>
+        <div>Content</div>
+      </ExpandableSection>
+    )
+    const titleElement = screen.getByText(title)
+    expect(titleElement).toBeInTheDocument()
+  })
+
+  it('renders the children correctly after expanding', async () => {
+    render(
+      <ExpandableSection title="Test Title">
+        <div>Test Content</div>
+      </ExpandableSection>
+    )
+
+    const button = screen.getByRole('button')
+    await userEvent.click(button)
+
+    const contentElement = screen.getByText('Test Content')
+    expect(contentElement).toBeInTheDocument()
+  })
+
+  it('collapses the children after clicking the button twice', async () => {
+    render(
+      <ExpandableSection title="Test Title">Test Content</ExpandableSection>
+    )
+
+    const button = screen.getByRole('button')
+
+    await userEvent.click(button)
+    const contentElement = screen.getByText('Test Content')
+    expect(contentElement).toBeInTheDocument()
+
+    await userEvent.click(button)
+    expect(contentElement).not.toBeInTheDocument()
+  })
+})

--- a/src/ui/ExpandableSection/ExpandableSection.spec.tsx
+++ b/src/ui/ExpandableSection/ExpandableSection.spec.tsx
@@ -1,15 +1,40 @@
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import React, { ReactNode, useState } from 'react'
 
 import { ExpandableSection } from 'ui/ExpandableSection'
+
+interface TestExpandableSectionProps {
+  title: string
+  children: ReactNode
+}
+
+const TestExpandableSection: React.FC<TestExpandableSectionProps> = ({
+  title,
+  children,
+}) => {
+  const [isExpanded, setIsExpanded] = useState(false)
+
+  return (
+    <ExpandableSection>
+      <ExpandableSection.Trigger
+        isExpanded={isExpanded}
+        onClick={() => setIsExpanded(!isExpanded)}
+      >
+        {title}
+      </ExpandableSection.Trigger>
+      <ExpandableSection.Content>{children}</ExpandableSection.Content>
+    </ExpandableSection>
+  )
+}
 
 describe('ExpandableSection', () => {
   it('renders the title correctly', () => {
     const title = 'Test Title'
     render(
-      <ExpandableSection title={title}>
+      <TestExpandableSection title={title}>
         <div>Content</div>
-      </ExpandableSection>
+      </TestExpandableSection>
     )
     const titleElement = screen.getByText(title)
     expect(titleElement).toBeInTheDocument()
@@ -17,9 +42,9 @@ describe('ExpandableSection', () => {
 
   it('renders the children correctly after expanding', async () => {
     render(
-      <ExpandableSection title="Test Title">
+      <TestExpandableSection title="Test Title">
         <div>Test Content</div>
-      </ExpandableSection>
+      </TestExpandableSection>
     )
 
     const button = screen.getByRole('button')
@@ -31,7 +56,9 @@ describe('ExpandableSection', () => {
 
   it('collapses the children after clicking the button twice', async () => {
     render(
-      <ExpandableSection title="Test Title">Test Content</ExpandableSection>
+      <TestExpandableSection title="Test Title">
+        Test Content
+      </TestExpandableSection>
     )
 
     const button = screen.getByRole('button')

--- a/src/ui/ExpandableSection/ExpandableSection.spec.tsx
+++ b/src/ui/ExpandableSection/ExpandableSection.spec.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 
-import ExpandableSection from 'ui/ExpandableSection'
+import { ExpandableSection } from 'ui/ExpandableSection'
 
 describe('ExpandableSection', () => {
   it('renders the title correctly', () => {
@@ -41,6 +41,7 @@ describe('ExpandableSection', () => {
     expect(contentElement).toBeInTheDocument()
 
     await userEvent.click(button)
-    expect(contentElement).not.toBeInTheDocument()
+    const contentElementAfterCollapse = screen.queryByText('Test Content')
+    expect(contentElementAfterCollapse).not.toBeInTheDocument()
   })
 })

--- a/src/ui/ExpandableSection/ExpandableSection.stories.tsx
+++ b/src/ui/ExpandableSection/ExpandableSection.stories.tsx
@@ -1,50 +1,60 @@
 import { Meta, StoryObj } from '@storybook/react'
+import React, { useState } from 'react'
 
 import { ExpandableSection } from './ExpandableSection'
 
-type ExpandableSectionStory = {
-  title: string
-  children: React.ReactNode
-}
-
-const meta: Meta<ExpandableSectionStory> = {
+const meta: Meta<typeof ExpandableSection> = {
   title: 'Components/ExpandableSection',
   component: ExpandableSection,
-  argTypes: {
-    title: {
-      description: 'Title of the expandable section',
-      control: 'text',
-    },
-    children: {
-      description: 'Content of the expandable section',
-      control: 'text',
-    },
-  },
 }
 export default meta
 
-type Story = StoryObj<ExpandableSectionStory>
+type Story = StoryObj<typeof ExpandableSection>
+
+const DefaultStory: React.FC = () => {
+  const [isExpanded, setIsExpanded] = useState(false)
+  return (
+    <ExpandableSection>
+      <ExpandableSection.Trigger
+        isExpanded={isExpanded}
+        onClick={() => setIsExpanded(!isExpanded)}
+      >
+        Expandable Section
+      </ExpandableSection.Trigger>
+      <ExpandableSection.Content>
+        This is the content of the expandable section.
+      </ExpandableSection.Content>
+    </ExpandableSection>
+  )
+}
+
+const WithHtmlContentStory: React.FC = () => {
+  const [isExpanded, setIsExpanded] = useState(false)
+  return (
+    <ExpandableSection>
+      <ExpandableSection.Trigger
+        isExpanded={isExpanded}
+        onClick={() => setIsExpanded(!isExpanded)}
+      >
+        Expandable Section with HTML
+      </ExpandableSection.Trigger>
+      <ExpandableSection.Content>
+        <div>
+          <p>This is the content of the expandable section.</p>
+          <p>
+            It can contain HTML elements like <strong>bold text</strong> and{' '}
+            <em>italic text</em>.
+          </p>
+        </div>
+      </ExpandableSection.Content>
+    </ExpandableSection>
+  )
+}
 
 export const Default: Story = {
-  args: {
-    title: 'Expandable Section',
-    children: 'This is the content of the expandable section.',
-  },
-  render: (args) => <ExpandableSection {...args} />,
+  render: () => <DefaultStory />,
 }
 
 export const WithHtmlContent: Story = {
-  args: {
-    title: 'Expandable Section with HTML',
-    children: (
-      <div>
-        <p>This is the content of the expandable section.</p>
-        <p>
-          It can contain HTML elements like <strong>bold text</strong> and{' '}
-          <em>italic text</em>.
-        </p>
-      </div>
-    ),
-  },
-  render: (args) => <ExpandableSection {...args} />,
+  render: () => <WithHtmlContentStory />,
 }

--- a/src/ui/ExpandableSection/ExpandableSection.stories.tsx
+++ b/src/ui/ExpandableSection/ExpandableSection.stories.tsx
@@ -1,0 +1,50 @@
+import { Meta, StoryObj } from '@storybook/react'
+
+import ExpandableSection from './ExpandableSection'
+
+type ExpandableSectionStory = {
+  title: string
+  children: React.ReactNode
+}
+
+const meta: Meta<ExpandableSectionStory> = {
+  title: 'Components/ExpandableSection',
+  component: ExpandableSection,
+  argTypes: {
+    title: {
+      description: 'Title of the expandable section',
+      control: 'text',
+    },
+    children: {
+      description: 'Content of the expandable section',
+      control: 'text',
+    },
+  },
+}
+export default meta
+
+type Story = StoryObj<ExpandableSectionStory>
+
+export const Default: Story = {
+  args: {
+    title: 'Expandable Section',
+    children: 'This is the content of the expandable section.',
+  },
+  render: (args) => <ExpandableSection {...args} />,
+}
+
+export const WithHtmlContent: Story = {
+  args: {
+    title: 'Expandable Section with HTML',
+    children: (
+      <div>
+        <p>This is the content of the expandable section.</p>
+        <p>
+          It can contain HTML elements like <strong>bold text</strong> and{' '}
+          <em>italic text</em>.
+        </p>
+      </div>
+    ),
+  },
+  render: (args) => <ExpandableSection {...args} />,
+}

--- a/src/ui/ExpandableSection/ExpandableSection.stories.tsx
+++ b/src/ui/ExpandableSection/ExpandableSection.stories.tsx
@@ -1,6 +1,6 @@
 import { Meta, StoryObj } from '@storybook/react'
 
-import ExpandableSection from './ExpandableSection'
+import { ExpandableSection } from './ExpandableSection'
 
 type ExpandableSectionStory = {
   title: string

--- a/src/ui/ExpandableSection/ExpandableSection.tsx
+++ b/src/ui/ExpandableSection/ExpandableSection.tsx
@@ -1,32 +1,67 @@
 import * as Collapsible from '@radix-ui/react-collapsible'
-import React, { ReactNode } from 'react'
+import cs from 'classnames'
+import React, { forwardRef, ReactNode } from 'react'
 
 import Icon from 'ui/Icon'
 
-interface ExpandableSectionProps {
-  title: string
+const ExpandableSectionRoot = forwardRef<
+  React.ElementRef<typeof Collapsible.Root>,
+  React.ComponentPropsWithoutRef<typeof Collapsible.Root>
+>(({ children, className, ...props }, ref) => (
+  <Collapsible.Root
+    className={cs('my-2 border border-gray-200', className)}
+    {...props}
+    ref={ref}
+  >
+    {children}
+  </Collapsible.Root>
+))
+
+ExpandableSectionRoot.displayName = 'ExpandableSectionRoot'
+
+interface ExpandableSectionTriggerProps
+  extends React.ComponentPropsWithoutRef<typeof Collapsible.Trigger> {
+  isExpanded: boolean
   children: ReactNode
 }
 
-export const ExpandableSection: React.FC<ExpandableSectionProps> = ({
-  title,
-  children,
-}) => {
-  const [isExpanded, setIsExpanded] = React.useState(false)
+const ExpandableSectionTrigger = forwardRef<
+  React.ElementRef<typeof Collapsible.Trigger>,
+  ExpandableSectionTriggerProps
+>(({ isExpanded, className, children, ...props }, ref) => (
+  <Collapsible.Trigger asChild>
+    <button
+      className={cs(
+        'flex w-full items-center justify-between p-4 text-left font-semibold hover:bg-gray-100',
+        className
+      )}
+      {...props}
+      ref={ref}
+    >
+      <span>{children}</span>
+      <Icon name={isExpanded ? 'chevronUp' : 'chevronDown'} size="sm" />
+    </button>
+  </Collapsible.Trigger>
+))
 
-  return (
-    <div className="my-2 border border-gray-200">
-      <Collapsible.Root open={isExpanded} onOpenChange={setIsExpanded}>
-        <Collapsible.Trigger asChild>
-          <button className="flex w-full items-center justify-between p-4 text-left font-semibold hover:bg-gray-100">
-            <span>{title}</span>
-            <Icon name={isExpanded ? 'chevronUp' : 'chevronDown'} size="sm" />
-          </button>
-        </Collapsible.Trigger>
-        <Collapsible.Content className="border-t border-gray-200 p-4">
-          {children}
-        </Collapsible.Content>
-      </Collapsible.Root>
-    </div>
-  )
-}
+ExpandableSectionTrigger.displayName = 'ExpandableSectionTrigger'
+
+const ExpandableSectionContent = forwardRef<
+  React.ElementRef<typeof Collapsible.Content>,
+  React.ComponentPropsWithoutRef<typeof Collapsible.Content>
+>(({ children, className, ...props }, ref) => (
+  <Collapsible.Content
+    className={cs('border-t border-gray-200 p-4', className)}
+    {...props}
+    ref={ref}
+  >
+    {children}
+  </Collapsible.Content>
+))
+
+ExpandableSectionContent.displayName = 'ExpandableSectionContent'
+
+export const ExpandableSection = Object.assign(ExpandableSectionRoot, {
+  Trigger: ExpandableSectionTrigger,
+  Content: ExpandableSectionContent,
+})

--- a/src/ui/ExpandableSection/ExpandableSection.tsx
+++ b/src/ui/ExpandableSection/ExpandableSection.tsx
@@ -1,4 +1,5 @@
-import React, { ReactNode, useState } from 'react'
+import * as Collapsible from '@radix-ui/react-collapsible'
+import React, { ReactNode } from 'react'
 
 import Icon from 'ui/Icon'
 
@@ -7,28 +8,25 @@ interface ExpandableSectionProps {
   children: ReactNode
 }
 
-const ExpandableSection: React.FC<ExpandableSectionProps> = ({
+export const ExpandableSection: React.FC<ExpandableSectionProps> = ({
   title,
   children,
 }) => {
-  const [isExpanded, setIsExpanded] = useState(false)
+  const [isExpanded, setIsExpanded] = React.useState(false)
 
   return (
     <div className="my-2 border border-gray-200">
-      <button
-        onClick={() => {
-          setIsExpanded(!isExpanded)
-        }}
-        className="flex w-full items-center justify-between p-4 text-left font-semibold hover:bg-gray-100"
-      >
-        <span>{title}</span>
-        <Icon name={isExpanded ? 'chevronUp' : 'chevronDown'} size="sm" />
-      </button>
-      {isExpanded && (
-        <div className="border-t border-gray-200 p-4">{children}</div>
-      )}
+      <Collapsible.Root open={isExpanded} onOpenChange={setIsExpanded}>
+        <Collapsible.Trigger asChild>
+          <button className="flex w-full items-center justify-between p-4 text-left font-semibold hover:bg-gray-100">
+            <span>{title}</span>
+            <Icon name={isExpanded ? 'chevronUp' : 'chevronDown'} size="sm" />
+          </button>
+        </Collapsible.Trigger>
+        <Collapsible.Content className="border-t border-gray-200 p-4">
+          {children}
+        </Collapsible.Content>
+      </Collapsible.Root>
     </div>
   )
 }
-
-export default ExpandableSection

--- a/src/ui/ExpandableSection/ExpandableSection.tsx
+++ b/src/ui/ExpandableSection/ExpandableSection.tsx
@@ -1,7 +1,7 @@
 import * as Collapsible from '@radix-ui/react-collapsible'
-import cs from 'classnames'
 import React, { forwardRef, ReactNode } from 'react'
 
+import { cn } from 'shared/utils/cn'
 import Icon from 'ui/Icon'
 
 const ExpandableSectionRoot = forwardRef<
@@ -9,7 +9,7 @@ const ExpandableSectionRoot = forwardRef<
   React.ComponentPropsWithoutRef<typeof Collapsible.Root>
 >(({ children, className, ...props }, ref) => (
   <Collapsible.Root
-    className={cs('my-2 border border-gray-200', className)}
+    className={cn('my-2 border border-gray-200', className)}
     {...props}
     ref={ref}
   >
@@ -31,7 +31,7 @@ const ExpandableSectionTrigger = forwardRef<
 >(({ isExpanded, className, children, ...props }, ref) => (
   <Collapsible.Trigger asChild>
     <button
-      className={cs(
+      className={cn(
         'flex w-full items-center justify-between p-4 text-left font-semibold hover:bg-gray-100',
         className
       )}
@@ -51,7 +51,7 @@ const ExpandableSectionContent = forwardRef<
   React.ComponentPropsWithoutRef<typeof Collapsible.Content>
 >(({ children, className, ...props }, ref) => (
   <Collapsible.Content
-    className={cs('border-t border-gray-200 p-4', className)}
+    className={cn('border-t border-gray-200 p-4', className)}
     {...props}
     ref={ref}
   >

--- a/src/ui/ExpandableSection/ExpandableSection.tsx
+++ b/src/ui/ExpandableSection/ExpandableSection.tsx
@@ -1,0 +1,34 @@
+import React, { ReactNode, useState } from 'react'
+
+import Icon from 'ui/Icon'
+
+interface ExpandableSectionProps {
+  title: string
+  children: ReactNode
+}
+
+const ExpandableSection: React.FC<ExpandableSectionProps> = ({
+  title,
+  children,
+}) => {
+  const [isExpanded, setIsExpanded] = useState(false)
+
+  return (
+    <div className="my-2 border border-gray-200">
+      <button
+        onClick={() => {
+          setIsExpanded(!isExpanded)
+        }}
+        className="flex w-full items-center justify-between p-4 text-left font-semibold hover:bg-gray-100"
+      >
+        <span>{title}</span>
+        <Icon name={isExpanded ? 'chevronUp' : 'chevronDown'} size="sm" />
+      </button>
+      {isExpanded && (
+        <div className="border-t border-gray-200 p-4">{children}</div>
+      )}
+    </div>
+  )
+}
+
+export default ExpandableSection

--- a/src/ui/ExpandableSection/index.ts
+++ b/src/ui/ExpandableSection/index.ts
@@ -1,0 +1,1 @@
+export { default } from './ExpandableSection'

--- a/src/ui/ExpandableSection/index.ts
+++ b/src/ui/ExpandableSection/index.ts
@@ -1,1 +1,1 @@
-export { default } from './ExpandableSection'
+export { ExpandableSection } from './ExpandableSection'


### PR DESCRIPTION
# Description
This was requested by @Adal3n3 as we foresee this being used more in the future, this will be used in several areas in new onboarding for failed tests.

# Code Example
```
<ExpandableSection title="Click here">
   <div>This is the collapsed section</div>
<ExpandableSection />

```

# Notable Changes
Create new ui component and stories.

# Screenshots

https://github.com/codecov/gazebo/assets/91732700/d23b6470-4388-441f-8b70-e972ea44d3e4



# Link to Sample Entry

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.