### PR TITLE
feat: Implement radio button navigator for coverage tab

### DIFF
--- a/src/pages/RepoPage/CoverageTab/Navigator/Navigator.spec.tsx
+++ b/src/pages/RepoPage/CoverageTab/Navigator/Navigator.spec.tsx
@@ -31,9 +31,16 @@ const wrapper: (initialEntries?: string) => React.FC<React.PropsWithChildren> =
       </MemoryRouter>
     )
 
+const provider = 'gh'
+const owner = 'codecov'
+const repo = 'cool-repo'
+
 describe('CoverageTabNavigator', () => {
   it('renders', async () => {
-    render(<CoverageTabNavigator />, { wrapper: wrapper() })
+    render(
+      <CoverageTabNavigator provider={provider} owner={owner} repo={repo} />,
+      { wrapper: wrapper() }
+    )
 
     const overview = await screen.findByText('Overview')
     const flags = await screen.findByText('Flags')
@@ -46,7 +53,14 @@ describe('CoverageTabNavigator', () => {
   describe('initial selection', () => {
     describe('when not on flags or components tabs', () => {
       it('selects Overview as default', async () => {
-        render(<CoverageTabNavigator />, { wrapper: wrapper() })
+        render(
+          <CoverageTabNavigator
+            provider={provider}
+            owner={owner}
+            repo={repo}
+          />,
+          { wrapper: wrapper() }
+        )
 
         const overview = await screen.findByTestId('overview-radio')
         expect(overview).toBeInTheDocument()
@@ -56,9 +70,16 @@ describe('CoverageTabNavigator', () => {
 
     describe('when loaded with flags url', () => {
       it('selects flags as default', async () => {
-        render(<CoverageTabNavigator />, {
-          wrapper: wrapper('/gh/codecov/cool-repo/flags'),
-        })
+        render(
+          <CoverageTabNavigator
+            provider={provider}
+            owner={owner}
+            repo={repo}
+          />,
+          {
+            wrapper: wrapper('/gh/codecov/cool-repo/flags'),
+          }
+        )
 
         const flags = await screen.findByTestId('flags-radio')
         expect(flags).toBeInTheDocument()
@@ -68,9 +89,16 @@ describe('CoverageTabNavigator', () => {
 
     describe('when loaded with components url', () => {
       it('selects components as default', async () => {
-        render(<CoverageTabNavigator />, {
-          wrapper: wrapper('/gh/codecov/cool-repo/components'),
-        })
+        render(
+          <CoverageTabNavigator
+            provider={provider}
+            owner={owner}
+            repo={repo}
+          />,
+          {
+            wrapper: wrapper('/gh/codecov/cool-repo/components'),
+          }
+        )
 
         const components = await screen.findByTestId('components-radio')
         expect(components).toBeInTheDocument()
@@ -83,9 +111,16 @@ describe('CoverageTabNavigator', () => {
     describe('when Overview is selected', () => {
       it('should navigate to base coverage tab', async () => {
         const user = userEvent.setup()
-        render(<CoverageTabNavigator />, {
-          wrapper: wrapper('/gh/codecov/cool-repo/flags'),
-        })
+        render(
+          <CoverageTabNavigator
+            provider={provider}
+            owner={owner}
+            repo={repo}
+          />,
+          {
+            wrapper: wrapper('/gh/codecov/cool-repo/flags'),
+          }
+        )
 
         const overview = await screen.findByTestId('overview-radio')
         expect(overview).toBeInTheDocument()
@@ -103,9 +138,16 @@ describe('CoverageTabNavigator', () => {
     describe('when Flags is selected', () => {
       it('should navigate to flags coverage tab', async () => {
         const user = userEvent.setup()
-        render(<CoverageTabNavigator />, {
-          wrapper: wrapper('/gh/codecov/cool-repo'),
-        })
+        render(
+          <CoverageTabNavigator
+            provider={provider}
+            owner={owner}
+            repo={repo}
+          />,
+          {
+            wrapper: wrapper('/gh/codecov/cool-repo'),
+          }
+        )
 
         const flags = await screen.findByTestId('flags-radio')
         expect(flags).toBeInTheDocument()
@@ -123,9 +165,16 @@ describe('CoverageTabNavigator', () => {
     describe('when Components is selected', () => {
       it('should navigate to components coverage tab', async () => {
         const user = userEvent.setup()
-        render(<CoverageTabNavigator />, {
-          wrapper: wrapper('/gh/codecov/cool-repo'),
-        })
+        render(
+          <CoverageTabNavigator
+            provider={provider}
+            owner={owner}
+            repo={repo}
+          />,
+          {
+            wrapper: wrapper('/gh/codecov/cool-repo'),
+          }
+        )
 
         const components = await screen.findByTestId('components-radio')
         expect(components).toBeInTheDocument()

--- a/src/pages/RepoPage/CoverageTab/Navigator/Navigator.spec.tsx
+++ b/src/pages/RepoPage/CoverageTab/Navigator/Navigator.spec.tsx
@@ -31,16 +31,9 @@ const wrapper: (initialEntries?: string) => React.FC<React.PropsWithChildren> =
       </MemoryRouter>
     )
 
-const provider = 'gh'
-const owner = 'codecov'
-const repo = 'cool-repo'
-
 describe('CoverageTabNavigator', () => {
   it('renders', async () => {
-    render(
-      <CoverageTabNavigator provider={provider} owner={owner} repo={repo} />,
-      { wrapper: wrapper() }
-    )
+    render(<CoverageTabNavigator />, { wrapper: wrapper() })
 
     const overview = await screen.findByText('Overview')
     const flags = await screen.findByText('Flags')
@@ -53,14 +46,7 @@ describe('CoverageTabNavigator', () => {
   describe('initial selection', () => {
     describe('when not on flags or components tabs', () => {
       it('selects Overview as default', async () => {
-        render(
-          <CoverageTabNavigator
-            provider={provider}
-            owner={owner}
-            repo={repo}
-          />,
-          { wrapper: wrapper() }
-        )
+        render(<CoverageTabNavigator />, { wrapper: wrapper() })
 
         const overview = await screen.findByTestId('overview-radio')
         expect(overview).toBeInTheDocument()
@@ -70,16 +56,9 @@ describe('CoverageTabNavigator', () => {
 
     describe('when loaded with flags url', () => {
       it('selects flags as default', async () => {
-        render(
-          <CoverageTabNavigator
-            provider={provider}
-            owner={owner}
-            repo={repo}
-          />,
-          {
-            wrapper: wrapper('/gh/codecov/cool-repo/flags'),
-          }
-        )
+        render(<CoverageTabNavigator />, {
+          wrapper: wrapper('/gh/codecov/cool-repo/flags'),
+        })
 
         const flags = await screen.findByTestId('flags-radio')
         expect(flags).toBeInTheDocument()
@@ -89,21 +68,24 @@ describe('CoverageTabNavigator', () => {
 
     describe('when loaded with components url', () => {
       it('selects components as default', async () => {
-        render(
-          <CoverageTabNavigator
-            provider={provider}
-            owner={owner}
-            repo={repo}
-          />,
-          {
-            wrapper: wrapper('/gh/codecov/cool-repo/components'),
-          }
-        )
+        render(<CoverageTabNavigator />, {
+          wrapper: wrapper('/gh/codecov/cool-repo/components'),
+        })
 
         const components = await screen.findByTestId('components-radio')
         expect(components).toBeInTheDocument()
         expect(components).toHaveAttribute('data-state', 'checked')
       })
+    })
+
+    it('matches path with query params', async () => {
+      render(<CoverageTabNavigator />, {
+        wrapper: wrapper('/gh/codecov/cool-repo/components?branch=asdf'),
+      })
+
+      const components = await screen.findByTestId('components-radio')
+      expect(components).toBeInTheDocument()
+      expect(components).toHaveAttribute('data-state', 'checked')
     })
   })
 
@@ -111,16 +93,9 @@ describe('CoverageTabNavigator', () => {
     describe('when Overview is selected', () => {
       it('should navigate to base coverage tab', async () => {
         const user = userEvent.setup()
-        render(
-          <CoverageTabNavigator
-            provider={provider}
-            owner={owner}
-            repo={repo}
-          />,
-          {
-            wrapper: wrapper('/gh/codecov/cool-repo/flags'),
-          }
-        )
+        render(<CoverageTabNavigator />, {
+          wrapper: wrapper('/gh/codecov/cool-repo/flags'),
+        })
 
         const overview = await screen.findByTestId('overview-radio')
         expect(overview).toBeInTheDocument()
@@ -138,16 +113,9 @@ describe('CoverageTabNavigator', () => {
     describe('when Flags is selected', () => {
       it('should navigate to flags coverage tab', async () => {
         const user = userEvent.setup()
-        render(
-          <CoverageTabNavigator
-            provider={provider}
-            owner={owner}
-            repo={repo}
-          />,
-          {
-            wrapper: wrapper('/gh/codecov/cool-repo'),
-          }
-        )
+        render(<CoverageTabNavigator />, {
+          wrapper: wrapper('/gh/codecov/cool-repo'),
+        })
 
         const flags = await screen.findByTestId('flags-radio')
         expect(flags).toBeInTheDocument()
@@ -165,16 +133,9 @@ describe('CoverageTabNavigator', () => {
     describe('when Components is selected', () => {
       it('should navigate to components coverage tab', async () => {
         const user = userEvent.setup()
-        render(
-          <CoverageTabNavigator
-            provider={provider}
-            owner={owner}
-            repo={repo}
-          />,
-          {
-            wrapper: wrapper('/gh/codecov/cool-repo'),
-          }
-        )
+        render(<CoverageTabNavigator />, {
+          wrapper: wrapper('/gh/codecov/cool-repo'),
+        })
 
         const components = await screen.findByTestId('components-radio')
         expect(components).toBeInTheDocument()

--- a/src/pages/RepoPage/CoverageTab/Navigator/Navigator.spec.tsx
+++ b/src/pages/RepoPage/CoverageTab/Navigator/Navigator.spec.tsx
@@ -1,0 +1,143 @@
+import { render, screen } from '@testing-library/react'
+import { userEvent } from '@testing-library/user-event'
+import { Suspense } from 'react'
+import { MemoryRouter, Route, useLocation } from 'react-router-dom'
+
+import { CoverageTabNavigator } from '.'
+
+let testLocation: ReturnType<typeof useLocation>
+
+const wrapper: (initialEntries?: string) => React.FC<React.PropsWithChildren> =
+  (initialEntries = '/gh/codecov/cool-repo') =>
+  ({ children }) =>
+    (
+      <MemoryRouter initialEntries={[initialEntries]}>
+        <Route
+          path={[
+            '/:provider/:owner/:repo',
+            '/:provider/:owner/:repo/flags',
+            '/:provider/:owner/:repo/components',
+          ]}
+        >
+          <Suspense fallback={null}>{children}</Suspense>
+        </Route>
+        <Route
+          path="*"
+          render={({ location }) => {
+            testLocation = location
+            return null
+          }}
+        />
+      </MemoryRouter>
+    )
+
+describe('CoverageTabNavigator', () => {
+  it('renders', async () => {
+    render(<CoverageTabNavigator />, { wrapper: wrapper() })
+
+    const overview = await screen.findByText('Overview')
+    const flags = await screen.findByText('Flags')
+    const components = await screen.findByText('Components')
+    expect(overview).toBeInTheDocument()
+    expect(flags).toBeInTheDocument()
+    expect(components).toBeInTheDocument()
+  })
+
+  describe('initial selection', () => {
+    describe('when not on flags or components tabs', () => {
+      it('selects Overview as default', async () => {
+        render(<CoverageTabNavigator />, { wrapper: wrapper() })
+
+        const overview = await screen.findByTestId('overview-radio')
+        expect(overview).toBeInTheDocument()
+        expect(overview).toHaveAttribute('data-state', 'checked')
+      })
+    })
+
+    describe('when loaded with flags url', () => {
+      it('selects flags as default', async () => {
+        render(<CoverageTabNavigator />, {
+          wrapper: wrapper('/gh/codecov/cool-repo/flags'),
+        })
+
+        const flags = await screen.findByTestId('flags-radio')
+        expect(flags).toBeInTheDocument()
+        expect(flags).toHaveAttribute('data-state', 'checked')
+      })
+    })
+
+    describe('when loaded with components url', () => {
+      it('selects components as default', async () => {
+        render(<CoverageTabNavigator />, {
+          wrapper: wrapper('/gh/codecov/cool-repo/components'),
+        })
+
+        const components = await screen.findByTestId('components-radio')
+        expect(components).toBeInTheDocument()
+        expect(components).toHaveAttribute('data-state', 'checked')
+      })
+    })
+  })
+
+  describe('navigation', () => {
+    describe('when Overview is selected', () => {
+      it('should navigate to base coverage tab', async () => {
+        const user = userEvent.setup()
+        render(<CoverageTabNavigator />, {
+          wrapper: wrapper('/gh/codecov/cool-repo/flags'),
+        })
+
+        const overview = await screen.findByTestId('overview-radio')
+        expect(overview).toBeInTheDocument()
+        expect(overview).toHaveAttribute('data-state', 'unchecked')
+
+        await user.click(overview)
+
+        expect(overview).toBeInTheDocument()
+        expect(overview).toHaveAttribute('data-state', 'checked')
+
+        expect(testLocation.pathname).toBe('/gh/codecov/cool-repo')
+      })
+    })
+
+    describe('when Flags is selected', () => {
+      it('should navigate to flags coverage tab', async () => {
+        const user = userEvent.setup()
+        render(<CoverageTabNavigator />, {
+          wrapper: wrapper('/gh/codecov/cool-repo'),
+        })
+
+        const flags = await screen.findByTestId('flags-radio')
+        expect(flags).toBeInTheDocument()
+        expect(flags).toHaveAttribute('data-state', 'unchecked')
+
+        await user.click(flags)
+
+        expect(flags).toBeInTheDocument()
+        expect(flags).toHaveAttribute('data-state', 'checked')
+
+        expect(testLocation.pathname).toBe('/gh/codecov/cool-repo/flags')
+      })
+    })
+
+    describe('when Components is selected', () => {
+      it('should navigate to components coverage tab', async () => {
+        const user = userEvent.setup()
+        render(<CoverageTabNavigator />, {
+          wrapper: wrapper('/gh/codecov/cool-repo'),
+        })
+
+        const components = await screen.findByTestId('components-radio')
+        expect(components).toBeInTheDocument()
+        expect(components).toHaveAttribute('data-state', 'unchecked')
+
+        await user.click(components)
+
+        expect(components).toBeInTheDocument()
+        expect(components).toHaveAttribute('data-state', 'checked')
+
+        expect(testLocation.pathname).toBe('/gh/codecov/cool-repo/components')
+      })
+    })
+  })
+})

--- a/src/pages/RepoPage/CoverageTab/Navigator/Navigator.tsx
+++ b/src/pages/RepoPage/CoverageTab/Navigator/Navigator.tsx
@@ -1,35 +1,34 @@
-import { useHistory, useLocation } from 'react-router-dom'
+import { useHistory, useLocation, useParams } from 'react-router-dom'
 
 import { useNavLinks } from 'services/navigation'
 import { RadioTileGroup } from 'ui/RadioTileGroup'
 
 const TABS = {
-  overview: 'Overview',
-  flags: 'Flags',
-  components: 'Components',
+  Overview: 'Overview',
+  Flags: 'Flags',
+  Components: 'Components',
 } as const
 type TabsValue = (typeof TABS)[keyof typeof TABS]
+type TabsUrls = Record<keyof typeof TABS, string>
 
-function getInitialSelection(path: string) {
-  if (path.includes('/flags')) {
-    return TABS.flags
-  } else if (path.includes('/components')) {
-    return TABS.components
+function getInitialSelection(path: string, urls: TabsUrls) {
+  if (path === urls.Flags) {
+    return TABS.Flags
   }
-  return TABS.overview
+  if (path === urls.Components) {
+    return TABS.Components
+  }
+  return TABS.Overview
 }
 
-interface CoverageTabNavigatorProps {
+interface URLParams {
   provider: string
   owner: string
   repo: string
 }
 
-function CoverageTabNavigator({
-  provider,
-  owner,
-  repo,
-}: CoverageTabNavigatorProps) {
+function CoverageTabNavigator() {
+  const { provider, owner, repo } = useParams<URLParams>()
   const location = useLocation()
   const history = useHistory()
 
@@ -42,23 +41,23 @@ function CoverageTabNavigator({
 
   return (
     <RadioTileGroup
-      defaultValue={getInitialSelection(location.pathname)}
+      defaultValue={getInitialSelection(location.pathname, urls)}
       onValueChange={(value: TabsValue) => {
         history.replace(urls[value])
       }}
       className="py-2"
     >
-      <RadioTileGroup.Item value={TABS.overview} data-testid="overview-radio">
-        <RadioTileGroup.Label>{TABS.overview}</RadioTileGroup.Label>
+      <RadioTileGroup.Item value={TABS.Overview} data-testid="overview-radio">
+        <RadioTileGroup.Label>{TABS.Overview}</RadioTileGroup.Label>
       </RadioTileGroup.Item>
-      <RadioTileGroup.Item value={TABS.flags} data-testid="flags-radio">
-        <RadioTileGroup.Label>{TABS.flags}</RadioTileGroup.Label>
+      <RadioTileGroup.Item value={TABS.Flags} data-testid="flags-radio">
+        <RadioTileGroup.Label>{TABS.Flags}</RadioTileGroup.Label>
       </RadioTileGroup.Item>
       <RadioTileGroup.Item
-        value={TABS.components}
+        value={TABS.Components}
         data-testid="components-radio"
       >
-        <RadioTileGroup.Label>{TABS.components}</RadioTileGroup.Label>
+        <RadioTileGroup.Label>{TABS.Components}</RadioTileGroup.Label>
       </RadioTileGroup.Item>
     </RadioTileGroup>
   )

--- a/src/pages/RepoPage/CoverageTab/Navigator/Navigator.tsx
+++ b/src/pages/RepoPage/CoverageTab/Navigator/Navigator.tsx
@@ -1,0 +1,67 @@
+import { useHistory, useLocation } from 'react-router-dom'
+
+import { useNavLinks } from 'services/navigation'
+import { RadioTileGroup } from 'ui/RadioTileGroup'
+
+const TABS = {
+  overview: 'Overview',
+  flags: 'Flags',
+  components: 'Components',
+} as const
+type TabsValue = (typeof TABS)[keyof typeof TABS]
+
+function getInitialSelection(path: string) {
+  if (path.includes('/flags')) {
+    return TABS.flags
+  } else if (path.includes('/components')) {
+    return TABS.components
+  }
+  return TABS.overview
+}
+
+interface CoverageTabNavigatorProps {
+  provider: string
+  owner: string
+  repo: string
+}
+
+function CoverageTabNavigator({
+  provider,
+  owner,
+  repo,
+}: CoverageTabNavigatorProps) {
+  const location = useLocation()
+  const history = useHistory()
+
+  const { coverage, flagsTab, componentsTab } = useNavLinks()
+  const urls = {
+    Overview: coverage.path({ provider, owner, repo }),
+    Flags: flagsTab.path({ provider, owner, repo }),
+    Components: componentsTab.path({ provider, owner, repo }),
+  }
+
+  return (
+    <RadioTileGroup
+      defaultValue={getInitialSelection(location.pathname)}
+      onValueChange={(value: TabsValue) => {
+        history.replace(urls[value])
+      }}
+      className="py-2"
+    >
+      <RadioTileGroup.Item value={TABS.overview} data-testid="overview-radio">
+        <RadioTileGroup.Label>{TABS.overview}</RadioTileGroup.Label>
+      </RadioTileGroup.Item>
+      <RadioTileGroup.Item value={TABS.flags} data-testid="flags-radio">
+        <RadioTileGroup.Label>{TABS.flags}</RadioTileGroup.Label>
+      </RadioTileGroup.Item>
+      <RadioTileGroup.Item
+        value={TABS.components}
+        data-testid="components-radio"
+      >
+        <RadioTileGroup.Label>{TABS.components}</RadioTileGroup.Label>
+      </RadioTileGroup.Item>
+    </RadioTileGroup>
+  )
+}
+
+export { CoverageTabNavigator }

--- a/src/pages/RepoPage/CoverageTab/Navigator/index.ts
+++ b/src/pages/RepoPage/CoverageTab/Navigator/index.ts
@@ -1,0 +1,1 @@
+export { CoverageTabNavigator } from './Navigator'


### PR DESCRIPTION
# Description

Implements and tests a radio button navigator for coverage tab navigation. This PR does not add the component to the page, however. That will be done in a future PR.

[Design](https://www.figma.com/design/4tPhxbAWxX2jAnoT2oXQPe/GH-722?node-id=291-4823&t=3n9YCviNQZkfXmkW-0)

Closes https://github.com/codecov/engineering-team/issues/1792

# Screenshot

![Screenshot 2024-05-28 at 17 14 27](https://github.com/codecov/gazebo/assets/159931558/6e3b99d8-74a4-466e-ada2-adebb0d2d3df)
