### PR TITLE
feat: Use new POST endpoint for logout

### DIFF
--- a/src/layouts/Header/Dropdown.spec.tsx
+++ b/src/layouts/Header/Dropdown.spec.tsx
@@ -1,6 +1,9 @@
-import { render, screen } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import Cookies from 'js-cookie'
+import { rest } from 'msw'
+import { setupServer } from 'msw/node'
 import { MemoryRouter, Route, Switch } from 'react-router-dom'
 
 import config, {
@@ -24,18 +27,36 @@ jest.mock('config')
 
 jest.mock('js-cookie')
 
+const queryClient = new QueryClient({
+  defaultOptions: { queries: { retry: false } },
+})
+const server = setupServer()
+
 const wrapper: (initialEntries?: string) => React.FC<React.PropsWithChildren> =
   (initialEntries = '/gh') =>
   ({ children }) =>
     (
-      <MemoryRouter initialEntries={[initialEntries]}>
-        <Switch>
-          <Route path="/:provider" exact>
-            {children}
-          </Route>
-        </Switch>
-      </MemoryRouter>
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter initialEntries={[initialEntries]}>
+          <Switch>
+            <Route path="/:provider" exact>
+              {children}
+            </Route>
+          </Switch>
+        </MemoryRouter>
+      </QueryClientProvider>
     )
+
+beforeAll(() => {
+  server.listen()
+})
+afterEach(() => {
+  queryClient.clear()
+  server.resetHandlers()
+})
+afterAll(() => {
+  server.close()
+})
 
 describe('Dropdown', () => {
   function setup({ selfHosted } = { selfHosted: false }) {
@@ -46,10 +67,13 @@ describe('Dropdown', () => {
       error: null,
     })
     config.IS_SELF_HOSTED = selfHosted
+    config.API_URL = ''
     const mockRemoveItem = jest.spyOn(
       window.localStorage.__proto__,
       'removeItem'
     )
+
+    server.use(rest.post('/logout', (req, res, ctx) => res(ctx.status(205))))
 
     return {
       user: userEvent.setup(),
@@ -91,7 +115,7 @@ describe('Dropdown', () => {
         expect(link).toHaveAttribute('href', '/account/gh/chetney')
       })
 
-      it('shows sign out link', async () => {
+      it('shows sign out button', async () => {
         const { user } = setup()
         render(<Dropdown currentUser={currentUser} />, {
           wrapper: wrapper(),
@@ -104,10 +128,9 @@ describe('Dropdown', () => {
 
         const link = screen.getByText('Sign Out')
         expect(link).toBeVisible()
-        expect(link).toHaveAttribute('href', '/logout/gh')
       })
 
-      it('removes session expiry tracking key and session_expiry cookie on sign out', async () => {
+      it('handles sign out', async () => {
         const { user, mockRemoveItem } = setup()
 
         jest.spyOn(console, 'error').mockImplementation()
@@ -119,14 +142,18 @@ describe('Dropdown', () => {
         const openSelect = screen.getByRole('combobox')
         await user.click(openSelect)
 
-        const link = screen.getByText('Sign Out')
-        expect(link).toBeVisible()
-        await user.click(link)
+        const button = screen.getByText('Sign Out')
+        expect(button).toBeVisible()
+        await user.click(button)
 
-        expect(mockRemoveItem).toHaveBeenCalledWith(
-          LOCAL_STORAGE_SESSION_TRACKING_KEY
+        await waitFor(() =>
+          expect(mockRemoveItem).toHaveBeenCalledWith(
+            LOCAL_STORAGE_SESSION_TRACKING_KEY
+          )
         )
-        expect(removeSpy).toHaveBeenCalledWith(COOKIE_SESSION_EXPIRY)
+        await waitFor(() =>
+          expect(removeSpy).toHaveBeenCalledWith(COOKIE_SESSION_EXPIRY)
+        )
       })
 
       it('shows manage app access link', async () => {
@@ -169,7 +196,7 @@ describe('Dropdown', () => {
         expect(link).toHaveAttribute('href', '/account/gl/chetney')
       })
 
-      it('shows sign out link', async () => {
+      it('shows sign out button', async () => {
         const { user } = setup()
         render(<Dropdown currentUser={currentUser} />, {
           wrapper: wrapper('/gl'),
@@ -182,7 +209,32 @@ describe('Dropdown', () => {
 
         const link = screen.getByText('Sign Out')
         expect(link).toBeVisible()
-        expect(link).toHaveAttribute('href', '/logout/gl')
+      })
+
+      it('handles sign out', async () => {
+        const { user, mockRemoveItem } = setup()
+
+        jest.spyOn(console, 'error').mockImplementation()
+        const removeSpy = jest.spyOn(Cookies, 'remove').mockReturnValue()
+        render(<Dropdown currentUser={currentUser} />, {
+          wrapper: wrapper(),
+        })
+
+        const openSelect = screen.getByRole('combobox')
+        await user.click(openSelect)
+
+        const button = screen.getByText('Sign Out')
+        expect(button).toBeVisible()
+        await user.click(button)
+
+        await waitFor(() =>
+          expect(mockRemoveItem).toHaveBeenCalledWith(
+            LOCAL_STORAGE_SESSION_TRACKING_KEY
+          )
+        )
+        await waitFor(() =>
+          expect(removeSpy).toHaveBeenCalledWith(COOKIE_SESSION_EXPIRY)
+        )
       })
 
       it('does not show manage app access link', async () => {

--- a/src/layouts/Header/Dropdown.tsx
+++ b/src/layouts/Header/Dropdown.tsx
@@ -26,6 +26,7 @@ type CurrentUser = {
 
 type itemProps = {
   to?: toProps
+  hook?: string
   onClick?: () => void
 }
 
@@ -51,11 +52,9 @@ function Dropdown({ currentUser }: { currentUser: CurrentUser }) {
       : []
 
   const handleSignOut = async () => {
-    console.log('signing out')
-    await fetch('http://localhost:8000/logout/gh', {
+    await fetch(`${config.API_URL}/logout`, {
       method: 'POST',
       credentials: 'include',
-      redirect: 'follow',
     })
     localStorage.removeItem(LOCAL_STORAGE_SESSION_TRACKING_KEY)
     Cookies.remove(COOKIE_SESSION_EXPIRY)
@@ -75,6 +74,7 @@ function Dropdown({ currentUser }: { currentUser: CurrentUser }) {
     {
       props: {
         onClick: handleSignOut,
+        hook: 'header-dropdown-sign-out',
       },
       children: 'Sign Out',
     }

--- a/src/layouts/Header/Dropdown.tsx
+++ b/src/layouts/Header/Dropdown.tsx
@@ -1,7 +1,7 @@
 import cs from 'classnames'
 import { useSelect } from 'downshift'
 import Cookies from 'js-cookie'
-import { useParams } from 'react-router-dom'
+import { useHistory, useParams } from 'react-router-dom'
 
 import config, {
   COOKIE_SESSION_EXPIRY,
@@ -25,7 +25,7 @@ type CurrentUser = {
 }
 
 type itemProps = {
-  to: toProps
+  to?: toProps
   onClick?: () => void
 }
 
@@ -38,8 +38,7 @@ type toProps = {
 function Dropdown({ currentUser }: { currentUser: CurrentUser }) {
   const { provider } = useParams<URLParams>()
   const isGh = providerToName(provider) === 'Github'
-
-  const to = `${window.location.protocol}//${window.location.host}/login`
+  const history = useHistory()
 
   const items =
     !config.IS_SELF_HOSTED && isGh
@@ -51,9 +50,16 @@ function Dropdown({ currentUser }: { currentUser: CurrentUser }) {
         ]
       : []
 
-  const handleSignOut = () => {
+  const handleSignOut = async () => {
+    console.log('signing out')
+    await fetch('http://localhost:8000/logout/gh', {
+      method: 'POST',
+      credentials: 'include',
+      redirect: 'follow',
+    })
     localStorage.removeItem(LOCAL_STORAGE_SESSION_TRACKING_KEY)
     Cookies.remove(COOKIE_SESSION_EXPIRY)
+    history.replace('/login')
   }
 
   items.push(
@@ -68,7 +74,6 @@ function Dropdown({ currentUser }: { currentUser: CurrentUser }) {
     },
     {
       props: {
-        to: { pageName: 'signOut', options: { to } },
         onClick: handleSignOut,
       },
       children: 'Sign Out',


### PR DESCRIPTION
# Description

Uses the new POST endpoint for Gazebo's sign out button. Currently logout by both POST and GET are supported on the API side, so we will change this and monitor for a day or so before completing the process and removing the GET endpoint API side.

Closes https://github.com/codecov/internal-issues/issues/487

# Demo

![Recording 2024-05-31 at 14 37 35](https://github.com/codecov/gazebo/assets/159931558/ad899932-5194-4c16-b1f1-ae9472e5161b)

