### PR TITLE
feat: Update Edit Payment Card Component to use Stripe Card Element

### DIFF
--- a/src/pages/PlanPage/subRoutes/CurrentOrgPlan/BillingDetails/EmailAddress/EmailAddress.tsx
+++ b/src/pages/PlanPage/subRoutes/CurrentOrgPlan/BillingDetails/EmailAddress/EmailAddress.tsx
@@ -79,7 +79,6 @@ function EmailAddress() {
             placeholder="Your email"
             disabled={isLoading}
             {...register('newCustomerEmail', { required: true })}
-            variant="billing"
           />
           {errors?.newCustomerEmail && (
             <p className="rounded-md bg-ds-error-quinary p-3 text-ds-error-nonary">

--- a/src/pages/PlanPage/subRoutes/CurrentOrgPlan/BillingDetails/PaymentCard/CreditCardForm.jsx
+++ b/src/pages/PlanPage/subRoutes/CurrentOrgPlan/BillingDetails/PaymentCard/CreditCardForm.jsx
@@ -43,11 +43,7 @@ function CreditCardForm({ closeForm, provider, owner }) {
               },
             }}
           />
-          {
-            <p className="mt-1 text-ds-primary-red">
-              {error && error?.message}
-            </p>
-          }
+          <p className="mt-1 text-ds-primary-red">{error && error.message}</p>
         </div>
         <div className="flex gap-1">
           <Button

--- a/src/pages/PlanPage/subRoutes/CurrentOrgPlan/BillingDetails/PaymentCard/CreditCardForm.jsx
+++ b/src/pages/PlanPage/subRoutes/CurrentOrgPlan/BillingDetails/PaymentCard/CreditCardForm.jsx
@@ -28,8 +28,8 @@ function CreditCardForm({ closeForm, provider, owner }) {
 
   return (
     <form onSubmit={submit} aria-label="form">
-      <div className={cs('flex flex-col gap-5')}>
-        <div className="flex flex-col gap-2">
+      <div className={cs('flex flex-col gap-3')}>
+        <div className="mt-2 flex flex-col gap-2">
           <CardElement
             onChange={resetError}
             options={{
@@ -43,11 +43,11 @@ function CreditCardForm({ closeForm, provider, owner }) {
               },
             }}
           />
-          {error ? (
-            <p className="mt-2 rounded-md bg-ds-error-quinary p-3 text-ds-error-nonary">
-              {error?.message}
+          {
+            <p className="mt-1 text-ds-primary-red">
+              {error && error?.message}
             </p>
-          ) : null}
+          }
         </div>
         <div className="flex gap-1">
           <Button

--- a/src/pages/PlanPage/subRoutes/CurrentOrgPlan/BillingDetails/PaymentCard/CreditCardForm.jsx
+++ b/src/pages/PlanPage/subRoutes/CurrentOrgPlan/BillingDetails/PaymentCard/CreditCardForm.jsx
@@ -1,9 +1,4 @@
-import {
-  CardCvcElement,
-  CardExpiryElement,
-  CardNumberElement,
-  useElements,
-} from '@stripe/react-stripe-js'
+import { CardElement, useElements } from '@stripe/react-stripe-js'
 import cs from 'classnames'
 import PropTypes from 'prop-types'
 
@@ -24,34 +19,35 @@ function CreditCardForm({ closeForm, provider, owner }) {
 
   function submit(e) {
     e.preventDefault()
-    updateCard(elements.getElement(CardNumberElement), {
+    updateCard(elements.getElement(CardElement), {
       onSuccess: closeForm,
     })
   }
 
-  const inputClass = 'bg-ds-gray-primary py-3 px-4 rounded '
   const resetError = error && reset
 
   return (
     <form onSubmit={submit} aria-label="form">
       <div className={cs('flex flex-col gap-5')}>
         <div className="flex flex-col gap-2">
-          <CardNumberElement onChange={resetError} className={inputClass} />
-          <div className="flex gap-2">
-            <CardExpiryElement
-              onChange={resetError}
-              className={cs(inputClass, 'w-1/2 mr-2')}
-            />
-            <CardCvcElement
-              onChange={resetError}
-              className={cs(inputClass, 'w-1/2 ml-2')}
-            />
-          </div>
-          {error && (
-            <p className="mt-4 rounded-md bg-ds-error-quinary p-3 text-ds-error-nonary">
-              {error?.data?.detail}
+          <CardElement
+            onChange={resetError}
+            options={{
+              disableLink: true,
+              hidePostalCode: true,
+              classes: {
+                empty: 'rounded border-ds-gray-tertiary border-2',
+                focus: 'rounded !border-ds-blue-darker border-4',
+                base: 'px-4 py-3',
+                invalid: 'rounded !border-ds-primary-red border-4',
+              },
+            }}
+          />
+          {error ? (
+            <p className="mt-2 rounded-md bg-ds-error-quinary p-3 text-ds-error-nonary">
+              {error?.message}
             </p>
-          )}
+          ) : null}
         </div>
         <div className="flex gap-1">
           <Button

--- a/src/pages/PlanPage/subRoutes/CurrentOrgPlan/BillingDetails/PaymentCard/PaymentCard.spec.jsx
+++ b/src/pages/PlanPage/subRoutes/CurrentOrgPlan/BillingDetails/PaymentCard/PaymentCard.spec.jsx
@@ -36,9 +36,7 @@ jest.mock('@stripe/react-stripe-js', () => {
       getElement: jest.fn(),
     }),
     useStripe: () => ({}),
-    CardExpiryElement: makeFakeComponent('CardExpiryElement'),
-    CardNumberElement: makeFakeComponent('CardNumberElement'),
-    CardCvcElement: makeFakeComponent('CardCvcElement'),
+    CardElement: makeFakeComponent('CardElement'),
   }
 })
 
@@ -287,7 +285,7 @@ describe('PaymentCard', () => {
       const randomError = 'not rich enough'
       useUpdateCard.mockReturnValue({
         mutate: jest.fn(),
-        error: { data: { detail: randomError } },
+        error: { message: randomError },
       })
       render(
         <PaymentCard

--- a/src/ui/TextInput/TextInput.tsx
+++ b/src/ui/TextInput/TextInput.tsx
@@ -10,14 +10,13 @@ interface TextInputProps extends HTMLProps<HTMLInputElement> {
   label?: string
   icon?: keyof OutlineIconCollection
   placeholder?: string
-  variant?: 'default' | 'topRounded' | 'billing'
+  variant?: 'default' | 'topRounded'
   dataMarketing?: string
 }
 
 const VariantClasses = {
   default: 'rounded border',
   topRounded: 'border-t border-r border-l focus:border rounded-tl rounded-tr',
-  billing: 'bg-ds-gray-primary py-3 px-4 rounded ',
 }
 
 const styles = {


### PR DESCRIPTION
# Description

Updates the payment card component from using the split payment card to the single line Card Element. Also fixes a bug where the error message was just showing an empty banner (potentially regression from the stripe version upgrades?)

This also updates the email styling from the "billing" style to the "default" style.

Closes https://github.com/codecov/engineering-team/issues/1779
Closes https://github.com/codecov/engineering-team/issues/1759

# Notable Changes

# Screenshots

**BEFORE**
<img width="857" alt="Screenshot 2024-05-30 at 2 26 28 PM" src="https://github.com/codecov/gazebo/assets/159853603/a6d3164e-0f02-42df-b7bc-3e2a123dfad5">


**AFTER**
<img width="874" alt="Screenshot 2024-05-30 at 2 18 21 PM" src="https://github.com/codecov/gazebo/assets/159853603/ab58819b-f7bd-48dd-9a22-85f2ce2a0e45">
<img width="841" alt="Screenshot 2024-05-30 at 2 18 28 PM" src="https://github.com/codecov/gazebo/assets/159853603/68bcda27-7c5e-4a0e-8e24-5e2fd4e58945">
![Screenshot 2024-05-30 at 3 39 34 PM](https://github.com/codecov/gazebo/assets/159853603/091947e3-4d5f-4e8d-a839-24bc5cddc5ea)



# Link to Sample Entry

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.