### PR TITLE
Correctly display cff's when many flags per upload

### DIFF
--- a/src/shared/utils/extractUploads.js
+++ b/src/shared/utils/extractUploads.js
@@ -14,7 +14,7 @@ function deleteDuplicateCFFUploads({ uploads }) {
   const nonCFFFlags = []
   const duplicateUploads = uploads && [...uploads]
 
-  // Get all the non cff flags
+  // Get all the flags from "uploaded" uploads
   duplicateUploads?.forEach((upload) => {
     if (
       upload?.uploadType !== UploadTypeEnum.CARRIED_FORWARD &&
@@ -25,7 +25,11 @@ function deleteDuplicateCFFUploads({ uploads }) {
   })
 
   // Filter out cff uploads with repeated flags
-  duplicateUploads?.forEach((upload, index) => {
+  // We're looping in reverse as splicing reindexes the array, making us
+  // skip the index that's removed. Indices are preserved when you
+  // loop backwards.
+  for (let index = duplicateUploads.length - 1; index >= 0; index--) {
+    const upload = duplicateUploads[index]
     if (
       upload?.uploadType === UploadTypeEnum.CARRIED_FORWARD &&
       upload?.flags
@@ -36,7 +40,7 @@ function deleteDuplicateCFFUploads({ uploads }) {
         }
       })
     }
-  })
+  }
 
   return duplicateUploads
 }

--- a/src/shared/utils/extractUploads.js
+++ b/src/shared/utils/extractUploads.js
@@ -34,11 +34,12 @@ function deleteDuplicateCFFUploads({ uploads }) {
       upload?.uploadType === UploadTypeEnum.CARRIED_FORWARD &&
       upload?.flags
     ) {
-      upload.flags.forEach((flag) => {
+      for (const flag of upload.flags) {
         if (nonCFFFlags.includes(flag)) {
           duplicateUploads.splice(index, 1)
+          break
         }
-      })
+      }
     }
   }
 

--- a/src/shared/utils/extractUploads.spec.js
+++ b/src/shared/utils/extractUploads.spec.js
@@ -1,3 +1,4 @@
+import { UploadTypeEnum } from './commit'
 import { extractUploads } from './extractUploads'
 
 const travisObject = {
@@ -72,6 +73,95 @@ describe('extractUploads', () => {
       expect(erroredUploads).toStrictEqual({
         circleci: [circleciObject],
       })
+    })
+  })
+
+  it('returns non-duplicate cff and regular uploads', () => {
+    const uploads = [
+      {
+        state: 'COMPLETE',
+        provider: 'circleci',
+        createdAt: '2020-08-25T16:36:19.559474+00:00',
+        updatedAt: '2020-08-25T16:36:19.679868+00:00',
+        flags: ['test-one'],
+        name: 'upload - 1',
+        downloadUrl:
+          '/api/gh/febg/repo-test/download/build?path=v4/raw/2020-08-25/F84D6D9A7F883055E40E3B380280BC44/f00162848a3cebc0728d915763c2fd9e92132408/7826783-de37-4272-ad50-c4dc805802fb.txt',
+        ciUrl: 'https://circleci.com/febg/repo-test/jobs/721065746',
+        uploadType: UploadTypeEnum.CARRIED_FORWARD,
+        errors: [],
+      },
+      {
+        state: 'COMPLETE',
+        provider: 'circleci',
+        createdAt: '2020-08-25T16:36:19.559474+00:00',
+        updatedAt: '2020-08-25T16:36:19.679868+00:00',
+        flags: ['test-one'],
+        name: 'upload - 2',
+        downloadUrl:
+          '/api/gh/febg/repo-test/download/build?path=v4/raw/2020-08-25/F84D6D9A7F883055E40E3B380280BC44/f00162848a3cebc0728d915763c2fd9e92132408/30582d33-de37-4272-ad50-c4dc805802fb.txt',
+        ciUrl: 'https://circleci.com/febg/repo-test/jobs/721065746',
+        uploadType: UploadTypeEnum.CARRIED_FORWARD,
+        errors: [],
+      },
+      {
+        state: 'COMPLETE',
+        provider: 'circleci',
+        createdAt: '2020-08-25T16:36:19.559474+00:00',
+        updatedAt: '2020-08-25T16:36:19.679868+00:00',
+        flags: ['test-two'],
+        name: 'test - 3',
+        downloadUrl:
+          '/api/gh/febg/repo-test/download/build?path=v4/raw/2020-08-25/F84D6D9A7F883055E40E3B380280BC44/f00162848a3cebc0728d915763c2fd9e92132408/30582d33-de37-4272-ad50-c4dc805802fb.txt',
+        ciUrl: 'https://travis-ci.com/febg/repo-test/jobs/721065746',
+        uploadType: UploadTypeEnum.CARRIED_FORWARD,
+        errors: [],
+      },
+      {
+        state: 'PROCESSED',
+        provider: 'circleci',
+        createdAt: '2020-08-25T16:36:19.559474+00:00',
+        updatedAt: '2020-08-25T16:36:19.679868+00:00',
+        flags: ['test-one'],
+        name: 'upload - 1',
+        downloadUrl:
+          '/api/gh/febg/repo-test/download/build?path=v4/raw/2020-08-25/F84D6D9A7F883055E40E3B380280BC44/f00162848a3cebc0728d915763c2fd9e92132408/30582d33-de37-4272-ad50-c4dc805802fb.txt',
+        ciUrl: 'https://travis-ci.com/febg/repo-test/jobs/721065746',
+        uploadType: UploadTypeEnum.UPLOADED,
+        errors: [],
+      },
+    ]
+
+    const { sortedUploads } = extractUploads({ unfilteredUploads: uploads })
+    expect(sortedUploads).toStrictEqual({
+      circleci: [
+        {
+          state: 'COMPLETE',
+          provider: 'circleci',
+          createdAt: '2020-08-25T16:36:19.559474+00:00',
+          updatedAt: '2020-08-25T16:36:19.679868+00:00',
+          flags: ['test-two'],
+          name: 'test - 3',
+          downloadUrl:
+            '/api/gh/febg/repo-test/download/build?path=v4/raw/2020-08-25/F84D6D9A7F883055E40E3B380280BC44/f00162848a3cebc0728d915763c2fd9e92132408/30582d33-de37-4272-ad50-c4dc805802fb.txt',
+          ciUrl: 'https://travis-ci.com/febg/repo-test/jobs/721065746',
+          uploadType: UploadTypeEnum.CARRIED_FORWARD,
+          errors: [],
+        },
+        {
+          state: 'PROCESSED',
+          provider: 'circleci',
+          createdAt: '2020-08-25T16:36:19.559474+00:00',
+          updatedAt: '2020-08-25T16:36:19.679868+00:00',
+          flags: ['test-one'],
+          name: 'upload - 1',
+          downloadUrl:
+            '/api/gh/febg/repo-test/download/build?path=v4/raw/2020-08-25/F84D6D9A7F883055E40E3B380280BC44/f00162848a3cebc0728d915763c2fd9e92132408/30582d33-de37-4272-ad50-c4dc805802fb.txt',
+          ciUrl: 'https://travis-ci.com/febg/repo-test/jobs/721065746',
+          uploadType: UploadTypeEnum.UPLOADED,
+          errors: [],
+        },
+      ],
     })
   })
 })


### PR DESCRIPTION
# Description
We have custom logic on how we display regular and carried forward uploads in our commit page. The previous implementation omitted certain sessions due to the implementation of splice skipping indexes - more here https://stackoverflow.com/questions/9882284/looping-through-array-and-removing-items-without-breaking-for-loop. This change is to fix the implementation there.

Ticket: https://github.com/codecov/feedback/issues/352

# Notable Changes
- Adjusted the deleteDuplicate fn and added test for it

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.