### PR TITLE
fix: Make commit totals type nullable

### DIFF
--- a/src/services/repo/useRepoCoverage.tsx
+++ b/src/services/repo/useRepoCoverage.tsx
@@ -12,11 +12,13 @@ import {
 
 const CommitSchema = z.object({
   yamlState: z.literal('DEFAULT').nullable(),
-  totals: z.object({
-    percentCovered: z.number().nullable(),
-    lineCount: z.number().nullable(),
-    hitsCount: z.number().nullable(),
-  }),
+  totals: z
+    .object({
+      percentCovered: z.number().nullable(),
+      lineCount: z.number().nullable(),
+      hitsCount: z.number().nullable(),
+    })
+    .nullable(),
 })
 
 const BranchSchema = z.object({


### PR DESCRIPTION
Fixes potential 404 on repo page. Noticed this causing a 404 due to failed parsing on a new repo today.
