### PR TITLE
fix: Small fix to remove jumping tab text

### DIFF
--- a/src/pages/RepoPage/FailedTestsTab/GitHubActions/FrameworkTabs/FrameworkTabs.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/GitHubActions/FrameworkTabs/FrameworkTabs.tsx
@@ -2,7 +2,6 @@ import { useState } from 'react'
 
 import { cn } from 'shared/utils/cn'
 import { CodeSnippet } from 'ui/CodeSnippet'
-import { CopyClipboard } from 'ui/CopyClipboard'
 
 const Frameworks = {
   PYTEST: 'Pytest',
@@ -28,27 +27,22 @@ export function FrameworkTabs() {
 
   return (
     <div>
-      <div className="flex justify-between">
-        <div className="flex gap-1">
-          {Object.values(Frameworks).map((framework) => (
-            <button
-              key={framework}
-              className={cn(
-                'px-4 py-2 border-b-2 border-transparent',
-                selectedFramework === framework && 'border-ds-gray-octonary'
-              )}
-              onClick={() => setSelectedFramework(framework)}
-            >
-              {framework}
-            </button>
-          ))}
-        </div>
+      <div className="flex gap-1">
+        {Object.values(Frameworks).map((framework) => (
+          <button
+            key={framework}
+            className={cn(
+              'px-4 py-2 border-b-2 border-transparent',
+              selectedFramework === framework && 'border-ds-gray-octonary'
+            )}
+            onClick={() => setSelectedFramework(framework)}
+          >
+            {framework}
+          </button>
+        ))}
       </div>
-      <CodeSnippet>
-        <div className="flex justify-between">
-          {FrameworkCopy[selectedFramework]}
-          <CopyClipboard value={FrameworkCopy[selectedFramework]} />
-        </div>
+      <CodeSnippet clipboard={FrameworkCopy[selectedFramework]}>
+        {FrameworkCopy[selectedFramework]}
       </CodeSnippet>
     </div>
   )

--- a/src/pages/RepoPage/FailedTestsTab/GitHubActions/FrameworkTabs/FrameworkTabs.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/GitHubActions/FrameworkTabs/FrameworkTabs.tsx
@@ -1,6 +1,6 @@
-import cs from 'classnames'
 import { useState } from 'react'
 
+import { cn } from 'shared/utils/cn'
 import { CodeSnippet } from 'ui/CodeSnippet'
 import { CopyClipboard } from 'ui/CopyClipboard'
 
@@ -30,16 +30,16 @@ export function FrameworkTabs() {
     <div>
       <div className="flex justify-between">
         <div className="flex gap-1">
-          {Object.keys(FrameworkCopy).map((f) => (
+          {Object.values(Frameworks).map((framework) => (
             <button
-              key={f}
-              className={cs(
-                'px-4 py-2',
-                selectedFramework === f && 'border-b-2 border-ds-gray-octonary'
+              key={framework}
+              className={cn(
+                'px-4 py-2 border-b-2 border-transparent',
+                selectedFramework === framework && 'border-ds-gray-octonary'
               )}
-              onClick={() => setSelectedFramework(f as FrameworkType)}
+              onClick={() => setSelectedFramework(framework)}
             >
-              {f}
+              {framework}
             </button>
           ))}
         </div>

--- a/src/pages/RepoPage/FailedTestsTab/GitHubActions/FrameworkTabs/FrameworkTabs.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/GitHubActions/FrameworkTabs/FrameworkTabs.tsx
@@ -14,10 +14,11 @@ const Frameworks = {
 type FrameworkType = (typeof Frameworks)[keyof typeof Frameworks]
 
 const FrameworkCopy = {
-  Pytest: 'pytest --cov --junitxml=junit.xml',
-  Vitest: 'vitest --reporter=junit',
-  Jest: 'npm i --save-dev jest-junit \njest --reporters=jest-junit',
-  PHPunit: './vendor/bin/phpunit --log-junit junit.xml',
+  [Frameworks.PYTEST]: 'pytest --cov --junitxml=junit.xml',
+  [Frameworks.VITEST]: 'vitest --reporter=junit',
+  [Frameworks.JEST]:
+    'npm i --save-dev jest-junit \njest --reporters=jest-junit',
+  [Frameworks.PHP_UNIT]: './vendor/bin/phpunit --log-junit junit.xml',
 } as const
 
 export function FrameworkTabs() {


### PR DESCRIPTION
# Description

Just a small fix to always apply a border that's transparent when not selected and set the colour when it is, which removes the jumping text when selected. Also a few tweaks to the TS so that we don't need to cast types.

# Notable Changes

- Use `border-transparent` as default style so that we always account for the border height
- Small TS tweaks
- Use the new built-in `clipboard` functionality from the `CodeSnippet` component (thanks @spalmurray-codecov)

# Screenshots

Before: 

https://github.com/codecov/gazebo/assets/105234307/1e9f4087-6326-4e99-8f59-333d75fcbbe9

After:

https://github.com/codecov/gazebo/assets/105234307/7f8090d1-5ece-4810-87ad-98ce3e0a2c69