### PR TITLE
fix: Update NAN values to reflect - instead of 0

### DIFF
--- a/src/pages/RepoPage/CommitsTab/CommitsTable/createCommitsTableData.spec.tsx
+++ b/src/pages/RepoPage/CommitsTab/CommitsTable/createCommitsTableData.spec.tsx
@@ -109,7 +109,7 @@ describe('createCommitsTableData', () => {
       })
 
       describe('percent covered is null', () => {
-        it('returns patch total of 0', () => {
+        it('returns NAN value', () => {
           const commitData = {
             ciPassed: null,
             message: null,
@@ -145,7 +145,7 @@ describe('createCommitsTableData', () => {
               light={false}
               plain={true}
               showChange={false}
-              value={0}
+              value={NaN}
             />
           )
         })

--- a/src/pages/RepoPage/CommitsTab/CommitsTable/createCommitsTableData.tsx
+++ b/src/pages/RepoPage/CommitsTab/CommitsTable/createCommitsTableData.tsx
@@ -27,7 +27,7 @@ export const createCommitsTableData = ({ pages }: CommitsTableData) => {
     let patch = <p className="text-right">-</p>
     if (commit?.compareWithParent?.__typename === 'Comparison') {
       patchPercentage =
-        commit?.compareWithParent?.patchTotals?.percentCovered ?? 0
+        commit?.compareWithParent?.patchTotals?.percentCovered ?? NaN
       patch = (
         <TotalsNumber
           plain={true}


### PR DESCRIPTION
# Description
We are defaulting to 0 in commits tab patch totals, if the value does not exist, we should default to NAN which reflect `-` in the dashboard 

# Screenshots
Closes https://github.com/codecov/internal-issues/issues/470 


<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.