### PR TITLE
fix: Update /tests routes to reflect other onboarding routes

### DIFF
--- a/src/pages/RepoPage/FailedTestsTab/FailedTestsTab.spec.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/FailedTestsTab.spec.tsx
@@ -10,7 +10,6 @@ import FailedTestsTab from './FailedTestsTab'
 jest.mock('shared/useRedirect')
 jest.mock('./GitHubActions', () => () => 'GitHub Actions tab')
 
-
 const mockedUseRedirect = useRedirect as jest.Mock
 
 jest.mock('./CodecovCLI', () => () => 'Codecov CLI tab')
@@ -18,14 +17,14 @@ jest.mock('./CodecovCLI', () => () => 'Codecov CLI tab')
 let testLocation: ReturnType<typeof useLocation>
 
 const wrapper: (initialEntries?: string) => React.FC<PropsWithChildren> =
-  (initialEntries = '/gh/codecov/cool-repo/tests') =>
+  (initialEntries = '/gh/codecov/cool-repo/tests/new') =>
   ({ children }) =>
     (
       <MemoryRouter initialEntries={[initialEntries]}>
         <Route
           path={[
-            '/:provider/:owner/:repo/tests',
-            '/:provider/:owner/:repo/tests/codecov-cli',
+            '/:provider/:owner/:repo/tests/new',
+            '/:provider/:owner/:repo/tests/new/codecov-cli',
             '/:provider/:owner/:repo/tests/random-path',
           ]}
         >
@@ -94,11 +93,11 @@ describe('FailedTestsTab', () => {
         })
       })
 
-      describe('when on /tests/codecov-cli path', () => {
+      describe('when on /tests/new/codecov-cli path', () => {
         it('selects Codecov CLI as default', () => {
           setup()
           render(<FailedTestsTab />, {
-            wrapper: wrapper('/gl/codecov/cool-repo/tests/codecov-cli'),
+            wrapper: wrapper('/gl/codecov/cool-repo/tests/new/codecov-cli'),
           })
 
           const codecovCLI = screen.getByTestId('codecov-cli-radio')
@@ -123,10 +122,10 @@ describe('FailedTestsTab', () => {
 
     describe('navigation', () => {
       describe('when GitHub Actions is selected', () => {
-        it('should navigate to /tests', async () => {
+        it('should navigate to /tests/new', async () => {
           const { user } = setup()
           render(<FailedTestsTab />, {
-            wrapper: wrapper('/gh/codecov/cool-repo/tests/codecov-cli'),
+            wrapper: wrapper('/gh/codecov/cool-repo/tests/new/codecov-cli'),
           })
 
           const githubActions = screen.getByTestId('github-actions-radio')
@@ -138,7 +137,7 @@ describe('FailedTestsTab', () => {
           expect(githubActions).toBeInTheDocument()
           expect(githubActions).toHaveAttribute('data-state', 'checked')
 
-          expect(testLocation.pathname).toBe('/gh/codecov/cool-repo/tests')
+          expect(testLocation.pathname).toBe('/gh/codecov/cool-repo/tests/new')
         })
       })
 
@@ -157,7 +156,7 @@ describe('FailedTestsTab', () => {
           expect(codecovCLI).toHaveAttribute('data-state', 'checked')
 
           expect(testLocation.pathname).toBe(
-            '/gh/codecov/cool-repo/tests/codecov-cli'
+            '/gh/codecov/cool-repo/tests/new/codecov-cli'
           )
         })
       })
@@ -175,7 +174,7 @@ describe('FailedTestsTab', () => {
     it('renders Codecov CLI', () => {
       setup()
       render(<FailedTestsTab />, {
-        wrapper: wrapper('/gh/codecov/cool-repo/tests/codecov-cli'),
+        wrapper: wrapper('/gh/codecov/cool-repo/tests/new/codecov-cli'),
       })
       const content = screen.getByText(/Codecov CLI tab/)
       expect(content).toBeInTheDocument()

--- a/src/pages/RepoPage/FailedTestsTab/FailedTestsTab.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/FailedTestsTab.tsx
@@ -19,8 +19,10 @@ type SetupOptionsValue = (typeof SETUP_OPTIONS)[keyof typeof SETUP_OPTIONS]
 function SetupOptionSelector() {
   const location = useLocation()
   const history = useHistory()
-  const { failedTestsTab: githubActions, failedTestsCodecovCLI: codecovCLI } =
-    useNavLinks()
+  const {
+    failedTestsOnboarding: githubActions,
+    failedTestsCodecovCLI: codecovCLI,
+  } = useNavLinks()
   const urls = {
     GitHubActions: githubActions.path(),
     CodecovCLI: codecovCLI.path(),
@@ -79,10 +81,10 @@ function SetupOptionSelector() {
 function Content() {
   return (
     <Switch>
-      <SentryRoute path="/:provider/:owner/:repo/tests" exact>
+      <SentryRoute path="/:provider/:owner/:repo/tests/new" exact>
         <GitHubActions />
       </SentryRoute>
-      <SentryRoute path="/:provider/:owner/:repo/tests/codecov-cli" exact>
+      <SentryRoute path="/:provider/:owner/:repo/tests/new/codecov-cli" exact>
         <CodecovCLI />
       </SentryRoute>
     </Switch>

--- a/src/pages/RepoPage/RepoPage.spec.tsx
+++ b/src/pages/RepoPage/RepoPage.spec.tsx
@@ -116,8 +116,8 @@ const wrapper =
                 '/:provider/:owner/:repo/tree/:branch',
                 '/:provider/:owner/:repo/tree/:branch/:path+',
                 '/:provider/:owner/:repo',
-                '/:provider/:owner/:repo/tests',
-                '/:provider/:owner/:repo/tests/codecov-cli',
+                '/:provider/:owner/:repo/tests/new',
+                '/:provider/:owner/:repo/tests/new/codecov-cli',
               ]}
             >
               <Suspense fallback={null}>
@@ -728,7 +728,7 @@ describe('RepoPage', () => {
           render(<RepoPage />, {
             wrapper: wrapper({
               queryClient,
-              initialEntries: '/gh/codecov/cool-repo/tests',
+              initialEntries: '/gh/codecov/cool-repo/tests/new',
             }),
           })
 
@@ -745,7 +745,7 @@ describe('RepoPage', () => {
           render(<RepoPage />, {
             wrapper: wrapper({
               queryClient,
-              initialEntries: '/gh/codecov/cool-repo/tests/codecov-cli',
+              initialEntries: '/gh/codecov/cool-repo/tests/new/codecov-cli',
             }),
           })
 
@@ -763,7 +763,7 @@ describe('RepoPage', () => {
           render(<RepoPage />, {
             wrapper: wrapper({
               queryClient,
-              initialEntries: '/gh/codecov/cool-repo/tests',
+              initialEntries: '/gh/codecov/cool-repo/tests/new',
             }),
           })
 
@@ -781,7 +781,7 @@ describe('RepoPage', () => {
           render(<RepoPage />, {
             wrapper: wrapper({
               queryClient,
-              initialEntries: '/gh/codecov/cool-repo/tests/codecov-cli',
+              initialEntries: '/gh/codecov/cool-repo/tests/new/codecov-cli',
             }),
           })
 

--- a/src/pages/RepoPage/RepoPage.tsx
+++ b/src/pages/RepoPage/RepoPage.tsx
@@ -131,7 +131,7 @@ function Routes({
         ) : null}
         {onboardingFailedTests ? (
           <SentryRoute
-            path={[`${path}/tests`, `${path}/tests/codecov-cli`]}
+            path={[`${path}/tests/new`, `${path}/tests/new/codecov-cli`]}
             exact
           >
             <FailedTestsTab />
@@ -206,7 +206,7 @@ function Routes({
       </SentryRoute>
       {onboardingFailedTests ? (
         <SentryRoute
-          path={[`${path}/tests`, `${path}/tests/codecov-cli`]}
+          path={[`${path}/tests/new`, `${path}/tests/new/codecov-cli`]}
           exact
         >
           <FailedTestsTab />
@@ -229,7 +229,9 @@ function Routes({
       </SentryRoute>
       <Redirect from={`${path}/bundles`} to={`${path}/bundles/new`} />
       <Redirect from={`${path}/bundles/*`} to={`${path}/bundles/new`} />
-      <Redirect from={`${path}/tests/*`} to={`${path}/tests`} />
+      {onboardingFailedTests ? (
+        <Redirect from={`${path}/tests`} to={`${path}/tests/new`} />
+      ) : null}
       <Redirect from={path} to={`${path}/new`} />
       <Redirect from={`${path}/*`} to={`${path}/new`} />
     </Switch>

--- a/src/pages/RepoPage/RepoPageTabs.spec.tsx
+++ b/src/pages/RepoPage/RepoPageTabs.spec.tsx
@@ -464,13 +464,13 @@ describe('RepoPageTabs', () => {
         onboardingFailedTests: true,
       })
       render(<RepoPageTabs refetchEnabled={false} />, {
-        wrapper: wrapper('/gh/codecov/test-repo/tests'),
+        wrapper: wrapper('/gh/codecov/test-repo/tests/new'),
       })
 
       const tab = await screen.findByText('Tests')
       expect(tab).toBeInTheDocument()
       expect(tab).toHaveAttribute('aria-current', 'page')
-      expect(tab).toHaveAttribute('href', '/gh/codecov/test-repo/tests')
+      expect(tab).toHaveAttribute('href', '/gh/codecov/test-repo/tests/new')
     })
 
     it('renders beta badge', async () => {
@@ -479,7 +479,7 @@ describe('RepoPageTabs', () => {
         onboardingFailedTests: true,
       })
       render(<RepoPageTabs refetchEnabled={false} />, {
-        wrapper: wrapper('/gh/codecov/test-repo/tests'),
+        wrapper: wrapper('/gh/codecov/test-repo/tests/new'),
       })
 
       const betaBadge = await screen.findByText('beta')

--- a/src/pages/RepoPage/RepoPageTabs.tsx
+++ b/src/pages/RepoPage/RepoPageTabs.tsx
@@ -86,7 +86,7 @@ export const useRepoTabs = ({ refetchEnabled }: UseRepoTabsArgs) => {
 
   if (onboardingFailedTests) {
     tabs.push({
-      pageName: 'failedTestsTab',
+      pageName: 'failedTestsOnboarding',
       children: (
         <>
           Tests <Badge>beta</Badge>{' '}

--- a/src/services/navigation/useNavLinks/useNavLinks.js
+++ b/src/services/navigation/useNavLinks/useNavLinks.js
@@ -777,7 +777,7 @@ export function useNavLinks() {
       text: 'Team plan feedback survey',
       isExternalLink: true,
     },
-    failedTestsTab: {
+    failedTestsOnboarding: {
       path: (
         { provider = p, owner = o, repo = r } = {
           provider: p,
@@ -785,7 +785,7 @@ export function useNavLinks() {
           repo: r,
         }
       ) => {
-        return `/${provider}/${owner}/${repo}/tests`
+        return `/${provider}/${owner}/${repo}/tests/new`
       },
       isExternalLink: false,
       text: 'Tests',
@@ -798,7 +798,7 @@ export function useNavLinks() {
           repo: r,
         }
       ) => {
-        return `/${provider}/${owner}/${repo}/tests/codecov-cli`
+        return `/${provider}/${owner}/${repo}/tests/new/codecov-cli`
       },
       text: 'Codecov CLI',
       isExternalLink: false,

--- a/src/services/navigation/useNavLinks/useNavLinks.spec.js
+++ b/src/services/navigation/useNavLinks/useNavLinks.spec.js
@@ -1923,8 +1923,8 @@ describe('useNavLinks', () => {
         wrapper: wrapper('/gl/codecov/cool-repo'),
       })
 
-      const path = result.current.failedTestsTab.path()
-      expect(path).toBe('/gl/codecov/cool-repo/tests')
+      const path = result.current.failedTestsOnboarding.path()
+      expect(path).toBe('/gl/codecov/cool-repo/tests/new')
     })
 
     it('can override the params', () => {
@@ -1932,12 +1932,12 @@ describe('useNavLinks', () => {
         wrapper: wrapper('/gl/codecov/cool-repo'),
       })
 
-      const path = result.current.failedTestsTab.path({
+      const path = result.current.failedTestsOnboarding.path({
         provider: 'bb',
         owner: 'test-owner',
         repo: 'test-repo',
       })
-      expect(path).toBe('/bb/test-owner/test-repo/tests')
+      expect(path).toBe('/bb/test-owner/test-repo/tests/new')
     })
   })
 
@@ -1948,7 +1948,7 @@ describe('useNavLinks', () => {
       })
 
       const path = result.current.failedTestsCodecovCLI.path()
-      expect(path).toBe('/gl/codecov/cool-repo/tests/codecov-cli')
+      expect(path).toBe('/gl/codecov/cool-repo/tests/new/codecov-cli')
     })
 
     it('can override the params', () => {
@@ -1961,7 +1961,7 @@ describe('useNavLinks', () => {
         owner: 'test-owner',
         repo: 'test-repo',
       })
-      expect(path).toBe('/bb/test-owner/test-repo/tests/codecov-cli')
+      expect(path).toBe('/bb/test-owner/test-repo/tests/new/codecov-cli')
     })
   })
 })


### PR DESCRIPTION
# Description
Instead of `/tests` use `/tests/new` and `/tests/new/codecov-cli`, reflecting other onboarding routes experience and making the development of `/tests` in dashboard easier  

Routes:

https://github.com/codecov/gazebo/assets/91732700/1cfe5731-ad10-49f2-993e-14de090c2d8b



<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.