### PR TITLE
fix: Move err checks to repo content results

### DIFF
--- a/src/pages/RepoPage/CoverageTab/subroute/FileExplorer/CodeTreeTable/CodeTreeTable.tsx
+++ b/src/pages/RepoPage/CoverageTab/subroute/FileExplorer/CodeTreeTable/CodeTreeTable.tsx
@@ -111,18 +111,6 @@ function CodeTreeTable() {
     manualSorting: true,
   })
 
-  if (pathContentsType === 'UnknownPath') {
-    return (
-      <p className="m-4">
-        Unknown filepath. Please ensure that files/directories exist and are not
-        empty.
-      </p>
-    )
-  }
-
-  if (pathContentsType === 'MissingCoverage') {
-    return <p className="m-4">No coverage data available.</p>
-  }
   return (
     <div className="flex flex-col gap-4">
       <div className="tableui">
@@ -207,6 +195,8 @@ function CodeTreeTable() {
           isMissingHeadReport={isMissingHeadReport}
           hasFlagsSelected={hasFlagsSelected}
           hasComponentsSelected={hasComponentsSelected}
+          isMissingCoverage={pathContentsType === 'MissingCoverage'}
+          isUnknownPath={pathContentsType === 'UnknownPath'}
         />
       ) : null}
     </div>

--- a/src/pages/RepoPage/CoverageTab/subroute/FileExplorer/FileListTable/FileListTable.tsx
+++ b/src/pages/RepoPage/CoverageTab/subroute/FileExplorer/FileListTable/FileListTable.tsx
@@ -111,18 +111,6 @@ function FileListTable() {
     manualSorting: true,
   })
 
-  if (pathContentsType === 'UnknownPath') {
-    return (
-      <p className="m-4">
-        Unknown filepath. Please ensure that files/directories exist and are not
-        empty.
-      </p>
-    )
-  }
-
-  if (pathContentsType === 'MissingCoverage') {
-    return <p className="m-4">No coverage data available.</p>
-  }
   return (
     <div className="flex flex-col gap-4">
       <div className="tableui">
@@ -207,6 +195,8 @@ function FileListTable() {
           isMissingHeadReport={isMissingHeadReport}
           hasFlagsSelected={hasFlagsSelected}
           hasComponentsSelected={hasComponentsSelected}
+          isMissingCoverage={pathContentsType === 'MissingCoverage'}
+          isUnknownPath={pathContentsType === 'UnknownPath'}
         />
       ) : null}
     </div>

--- a/src/pages/RepoPage/CoverageTab/subroute/FileExplorer/shared/RepoContentsResult.spec.tsx
+++ b/src/pages/RepoPage/CoverageTab/subroute/FileExplorer/shared/RepoContentsResult.spec.tsx
@@ -18,6 +18,8 @@ describe('RepoContentsResult', () => {
       isMissingHeadReport: false,
       hasFlagsSelected: false,
       hasComponentsSelected: false,
+      isMissingCoverage: false,
+      isUnknownPath: false,
     }
 
     render(<RepoContentsResult {...props} />)
@@ -32,6 +34,8 @@ describe('RepoContentsResult', () => {
       isMissingHeadReport: true,
       hasFlagsSelected: false,
       hasComponentsSelected: false,
+      isMissingCoverage: false,
+      isUnknownPath: false,
     }
 
     render(<RepoContentsResult {...props} />)
@@ -48,6 +52,8 @@ describe('RepoContentsResult', () => {
       isMissingHeadReport: false,
       hasFlagsSelected: true,
       hasComponentsSelected: false,
+      isMissingCoverage: false,
+      isUnknownPath: false,
     }
 
     render(<RepoContentsResult {...props} />)
@@ -64,6 +70,8 @@ describe('RepoContentsResult', () => {
       isMissingHeadReport: false,
       hasFlagsSelected: false,
       hasComponentsSelected: false,
+      isMissingCoverage: false,
+      isUnknownPath: false,
     }
 
     const queryClient = new QueryClient({
@@ -109,6 +117,8 @@ describe('RepoContentsResult', () => {
       isMissingHeadReport: false,
       hasFlagsSelected: false,
       hasComponentsSelected: true,
+      isMissingCoverage: false,
+      isUnknownPath: false,
     }
 
     render(<RepoContentsResult {...props} />)
@@ -125,6 +135,8 @@ describe('RepoContentsResult', () => {
       isMissingHeadReport: false,
       hasFlagsSelected: true,
       hasComponentsSelected: true,
+      isMissingCoverage: false,
+      isUnknownPath: false,
     }
 
     render(<RepoContentsResult {...props} />)
@@ -133,5 +145,39 @@ describe('RepoContentsResult', () => {
       /No coverage reported for the selected flag\/component combination in this branch's head commit/
     )
     expect(noCoverageForFlags).toBeInTheDocument()
+  })
+
+  it('renders no coverage message if there is no coverage data', async () => {
+    const props = {
+      isSearching: false,
+      isMissingHeadReport: false,
+      hasFlagsSelected: false,
+      hasComponentsSelected: false,
+      isMissingCoverage: true,
+      isUnknownPath: false,
+    }
+
+    render(<RepoContentsResult {...props} />)
+
+    const noCoverage = await screen.findByText(/No coverage data available./)
+    expect(noCoverage).toBeInTheDocument()
+  })
+
+  it('renders unknown path message if path does not exist', async () => {
+    const props = {
+      isSearching: false,
+      isMissingHeadReport: false,
+      hasFlagsSelected: false,
+      hasComponentsSelected: false,
+      isMissingCoverage: false,
+      isUnknownPath: true,
+    }
+
+    render(<RepoContentsResult {...props} />)
+
+    const unknownPath = await screen.findByText(
+      /Unknown filepath. Please ensure that files\/directories exist and are not empty./
+    )
+    expect(unknownPath).toBeInTheDocument()
   })
 })

--- a/src/pages/RepoPage/CoverageTab/subroute/FileExplorer/shared/RepoContentsResult.tsx
+++ b/src/pages/RepoPage/CoverageTab/subroute/FileExplorer/shared/RepoContentsResult.tsx
@@ -1,12 +1,11 @@
 import A from 'ui/A'
-import Banner from 'ui/Banner'
-import BannerContent from 'ui/Banner/BannerContent'
-
 interface RepoContentsProps {
   isSearching: boolean
   isMissingHeadReport: boolean
   hasFlagsSelected: boolean
   hasComponentsSelected: boolean
+  isMissingCoverage: boolean
+  isUnknownPath: boolean
 }
 
 const RepoContentsResult: React.FC<RepoContentsProps> = ({
@@ -14,6 +13,8 @@ const RepoContentsResult: React.FC<RepoContentsProps> = ({
   isMissingHeadReport,
   hasFlagsSelected,
   hasComponentsSelected,
+  isMissingCoverage,
+  isUnknownPath,
 }) => {
   let copy: JSX.Element | string = ''
 
@@ -21,6 +22,11 @@ const RepoContentsResult: React.FC<RepoContentsProps> = ({
     copy = 'No results found'
   } else if (isMissingHeadReport) {
     copy = 'No coverage report uploaded for this branch head commit'
+  } else if (isMissingCoverage) {
+    copy = 'No coverage data available.'
+  } else if (isUnknownPath) {
+    copy =
+      'Unknown filepath. Please ensure that files/directories exist and are not empty.'
   } else if (hasComponentsSelected && hasFlagsSelected) {
     copy = `
         No coverage reported for the selected flag/component combination in this
@@ -54,11 +60,7 @@ const RepoContentsResult: React.FC<RepoContentsProps> = ({
     )
   }
 
-  return (
-    <Banner>
-      <BannerContent>{copy}</BannerContent>
-    </Banner>
-  )
+  return <p className="m-4">{copy}</p>
 }
 
 export default RepoContentsResult


### PR DESCRIPTION
# Description
Moving all err checks to RepoContentResults, and remove banner for consistency. 

# Screenshots
<img width="1501" alt="Screenshot 2024-06-05 at 4 47 16 PM" src="https://github.com/codecov/gazebo/assets/91732700/41d718d5-b14a-4fb9-b6b9-3ad0868686e8">

# Link to Sample Entry

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.