### PR TITLE
ref: convert billing hooks to TS

### DIFF
--- a/src/services/account/useUpdateCard.spec.tsx
+++ b/src/services/account/useUpdateCard.spec.tsx
@@ -3,6 +3,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { renderHook, waitFor } from '@testing-library/react'
 import { rest } from 'msw'
 import { setupServer } from 'msw/node'
+import React from 'react'
 import { MemoryRouter, Route } from 'react-router-dom'
 
 import { useUpdateCard } from './useUpdateCard'
@@ -13,7 +14,7 @@ const queryClient = new QueryClient({
   defaultOptions: { queries: { retry: false } },
 })
 const wrapper =
-  (initialEntries = '/gh') =>
+  (initialEntries = '/gh'): React.FC<React.PropsWithChildren> =>
   ({ children }) =>
     (
       <QueryClientProvider client={queryClient}>
@@ -52,8 +53,13 @@ describe('useUpdateCard', () => {
     last4: '1234',
   }
 
-  function setupStripe({ createPaymentMethod }) {
-    useStripe.mockReturnValue({
+  function setupStripe({
+    createPaymentMethod,
+  }: {
+    createPaymentMethod: jest.Mock
+  }) {
+    const mockedUseStripe = useStripe as jest.Mock
+    mockedUseStripe.mockReturnValue({
       createPaymentMethod,
     })
   }
@@ -92,6 +98,7 @@ describe('useUpdateCard', () => {
           }
         )
 
+        // @ts-expect-error mutation mock
         result.current.mutate(card)
 
         await waitFor(() => expect(result.current.data).toEqual(accountDetails))
@@ -133,12 +140,12 @@ describe('useUpdateCard', () => {
           }
         )
 
+        // @ts-expect-error mutation mock
         result.current.mutate(card)
 
         await waitFor(() => result.current.error)
 
-        // await waitFor(() => expect(result.current.error).toEqual(error))
-        expect(result.current.error).toEqual(error)
+        await waitFor(() => expect(result.current.error).toEqual(error))
       })
     })
   })

--- a/src/services/account/useUpdateCard.ts
+++ b/src/services/account/useUpdateCard.ts
@@ -1,19 +1,25 @@
 import { useStripe } from '@stripe/react-stripe-js'
+import { StripeCardElement } from '@stripe/stripe-js'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 
 import Api from 'shared/api'
 
-function getPathAccountDetails({ provider, owner }) {
+interface useUpdateCardParams {
+  provider: string
+  owner: string
+}
+
+function getPathAccountDetails({ provider, owner }: useUpdateCardParams) {
   return `/${provider}/${owner}/account-details/`
 }
 
-export function useUpdateCard({ provider, owner }) {
+export function useUpdateCard({ provider, owner }: useUpdateCardParams) {
   const stripe = useStripe()
   const queryClient = useQueryClient()
 
   return useMutation({
-    mutationFn: (card) => {
-      return stripe
+    mutationFn: (card: StripeCardElement) => {
+      return stripe!
         .createPaymentMethod({
           type: 'card',
           card,
@@ -28,9 +34,8 @@ export function useUpdateCard({ provider, owner }) {
             provider,
             path,
             body: {
-              /* eslint-disable camelcase */
+              /* eslint-disable-next-line camelcase */
               payment_method: result.paymentMethod.id,
-              /* eslint-enable camelcase */
             },
           })
         })

--- a/src/services/account/useUpgradePlan.spec.tsx
+++ b/src/services/account/useUpgradePlan.spec.tsx
@@ -13,7 +13,7 @@ const queryClient = new QueryClient({
   defaultOptions: { queries: { retry: false } },
 })
 const wrapper =
-  (initialEntries = '/gh') =>
+  (initialEntries = '/gh'): React.FC<React.PropsWithChildren> =>
   ({ children }) =>
     (
       <QueryClientProvider client={queryClient}>
@@ -45,16 +45,17 @@ afterEach(() => server.resetHandlers())
 afterAll(() => server.close())
 
 describe('useUpgradePlan', () => {
-  let redirectToCheckout
+  let redirectToCheckout: any
 
   function setupStripe() {
-    redirectToCheckout = jest.fn().mockResolvedValue()
-    useStripe.mockReturnValue({
+    redirectToCheckout = jest.fn().mockResolvedValue(undefined)
+    const mockedUseStripe = useStripe as jest.Mock
+    mockedUseStripe.mockReturnValue({
       redirectToCheckout,
     })
   }
 
-  function setup(currentUrl) {
+  function setup() {
     setupStripe()
   }
 

--- a/src/services/account/useUpgradePlan.ts
+++ b/src/services/account/useUpgradePlan.ts
@@ -3,23 +3,28 @@ import { useMutation, useQueryClient } from '@tanstack/react-query'
 
 import Api from 'shared/api'
 
-function getPathAccountDetails({ provider, owner }) {
+interface useUpgradePlanParams {
+  provider: string
+  owner: string
+}
+
+function getPathAccountDetails({ provider, owner }: useUpgradePlanParams) {
   return `/${provider}/${owner}/account-details/`
 }
 
-export function useUpgradePlan({ provider, owner }) {
+export function useUpgradePlan({ provider, owner }: useUpgradePlanParams) {
   const stripe = useStripe()
   const queryClient = useQueryClient()
 
-  function redirectToStripe(sessionId) {
-    return stripe.redirectToCheckout({ sessionId }).then((e) => {
+  function redirectToStripe(sessionId: string) {
+    return stripe!.redirectToCheckout({ sessionId }).then((e) => {
       // error from Stripe SDK
-      return Promise.reject(new Error(e))
+      return Promise.reject(new Error(e.error.message))
     })
   }
 
   return useMutation({
-    mutationFn: (formData) => {
+    mutationFn: (formData: { seats: number; newPlan: string }) => {
       const path = getPathAccountDetails({ provider, owner })
       const body = {
         plan: {


### PR DESCRIPTION
# Description

Just converting a couple hooks over to TS and adding related types

- useUpgradePlan
- useUpdateCard

Closes https://github.com/codecov/engineering-team/issues/1861
Closes https://github.com/codecov/engineering-team/issues/1862

# Screenshots

Example of updating a credit card:

https://github.com/codecov/gazebo/assets/159853603/2c26863b-b0a1-4943-8b6f-532a305e1bbd

Example of changing a plan:

https://github.com/codecov/gazebo/assets/159853603/3e89173b-f140-409d-8d15-d09df8ba7fd1


# Link to Sample Entry

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.