### PR TITLE
fix: clarify components text for enabling analytics

### DIFF
--- a/src/pages/RepoPage/ComponentsTab/BackfillBanners/TriggerSyncBanner/TriggerSyncBanner.spec.tsx
+++ b/src/pages/RepoPage/ComponentsTab/BackfillBanners/TriggerSyncBanner/TriggerSyncBanner.spec.tsx
@@ -60,13 +60,19 @@ describe('TriggerSyncBanner', () => {
     it('renders heading and content components', () => {
       setup()
       render(<TriggerSyncBanner />, { wrapper })
-
+      expect(screen.getByText('No data to display')).toBeInTheDocument()
       const enableAnalyticsText = screen.getByText(
-        'You will need to enable components to see related coverage data.'
+        'To view related coverage data',
+        { exact: false }
       )
       expect(enableAnalyticsText).toBeInTheDocument()
-      expect(screen.getByText('No data to display')).toBeInTheDocument()
-      expect(screen.getByText('Enable component analytics')).toBeInTheDocument()
+      expect(enableAnalyticsText.textContent).toEqual(
+        'To view related coverage data, please click the Enable component analytics button below.'
+      )
+      const enableComponentButton = screen.getByRole('button', {
+        name: 'Enable component analytics',
+      })
+      expect(enableComponentButton).toBeInTheDocument()
     })
 
     describe('when clicking on the button to upgrade', () => {

--- a/src/pages/RepoPage/ComponentsTab/BackfillBanners/TriggerSyncBanner/TriggerSyncBanner.tsx
+++ b/src/pages/RepoPage/ComponentsTab/BackfillBanners/TriggerSyncBanner/TriggerSyncBanner.tsx
@@ -25,7 +25,13 @@ function TriggerSyncBanner() {
       <LoadingTable />
       <div className="flex flex-col items-center gap-1">
         <p>No data to display</p>
-        <p>You will need to enable components to see related coverage data.</p>
+        <p>
+          To view related coverage data, please click the{' '}
+          <b>
+            <i>Enable component analytics</i>
+          </b>{' '}
+          button below.
+        </p>
       </div>
       <div className="flex flex-col items-center">
         <Button


### PR DESCRIPTION
# Description
This PR changes the text as the ticket designates. "Enable component analytics" text is now bolded and italicized.

https://github.com/codecov/engineering-team/issues/1843

# Code Example

# Notable Changes

# Screenshots
<img width="1662" alt="Screenshot 2024-06-05 at 5 04 18 PM" src="https://github.com/codecov/gazebo/assets/170470397/be35ba50-c195-48b9-8c64-65aa615e74c6">


# Link to Sample Entry

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.