### PR TITLE
feat: Show tests onboarding if it's not enabled yet

### DIFF
--- a/src/pages/CommitDetailPage/CommitBundleAnalysis/CommitBundleAnalysis.spec.tsx
+++ b/src/pages/CommitDetailPage/CommitBundleAnalysis/CommitBundleAnalysis.spec.tsx
@@ -111,6 +111,7 @@ const mockRepoOverview = ({
       oldestCommitAt: '2022-10-10T11:59:59',
       coverageEnabled,
       bundleAnalysisEnabled,
+      testAnalyticsEnabled: false,
       languages: ['javascript'],
     },
   },

--- a/src/pages/CommitDetailPage/CommitCoverage/CommitCoverage.spec.jsx
+++ b/src/pages/CommitDetailPage/CommitCoverage/CommitCoverage.spec.jsx
@@ -305,6 +305,7 @@ const mockRepoOverview = ({
       oldestCommitAt: '2022-10-10T11:59:59',
       coverageEnabled,
       bundleAnalysisEnabled,
+      testAnalyticsEnabled: false,
       languages: ['javascript'],
     },
   },

--- a/src/pages/CommitDetailPage/CommitCoverage/UploadsCard/useUploads/useUploads.spec.js
+++ b/src/pages/CommitDetailPage/CommitCoverage/UploadsCard/useUploads/useUploads.spec.js
@@ -28,6 +28,7 @@ const mockOverview = {
       coverageEnabled: true,
       bundleAnalysisEnabled: true,
       languages: ['typescript'],
+      testAnalyticsEnabled: false,
     },
   },
 }

--- a/src/pages/CommitDetailPage/CommitCoverage/routes/CommitDetailFileExplorer/CommitDetailFileExplorerTable.spec.tsx
+++ b/src/pages/CommitDetailPage/CommitCoverage/routes/CommitDetailFileExplorer/CommitDetailFileExplorerTable.spec.tsx
@@ -149,6 +149,7 @@ const mockOverview = {
       coverageEnabled: true,
       bundleAnalysisEnabled: true,
       languages: ['typescript'],
+      testAnalyticsEnabled: true,
     },
   },
 }

--- a/src/pages/CommitDetailPage/CommitCoverage/routes/FilesChangedTab/shared/CommitFileDiff/CommitFileDiff.spec.jsx
+++ b/src/pages/CommitDetailPage/CommitCoverage/routes/FilesChangedTab/shared/CommitFileDiff/CommitFileDiff.spec.jsx
@@ -112,6 +112,7 @@ const mockOverview = (bundleAnalysisEnabled = false) => {
         coverageEnabled: true,
         bundleAnalysisEnabled,
         languages: ['javascript'],
+        testAnalyticsEnabled: false,
       },
     },
   }

--- a/src/pages/CommitDetailPage/CommitCoverage/routes/IndirectChangesTab/IndirectChangesTable/CommitFileDiff/CommitFileDiff.spec.jsx
+++ b/src/pages/CommitDetailPage/CommitCoverage/routes/IndirectChangesTab/IndirectChangesTable/CommitFileDiff/CommitFileDiff.spec.jsx
@@ -101,6 +101,7 @@ const mockOverview = (bundleAnalysisEnabled = false) => {
         coverageEnabled: true,
         bundleAnalysisEnabled,
         languages: ['javascript'],
+        testAnalyticsEnabled: false,
       },
     },
   }

--- a/src/pages/PullRequestPage/PullBundleAnalysis/PullBundleAnalysis.spec.tsx
+++ b/src/pages/PullRequestPage/PullBundleAnalysis/PullBundleAnalysis.spec.tsx
@@ -93,6 +93,7 @@ const mockRepoOverview = ({
       coverageEnabled,
       bundleAnalysisEnabled,
       languages: ['javascript'],
+      testAnalyticsEnabled: false,
     },
   },
 })

--- a/src/pages/PullRequestPage/PullBundleAnalysis/PullBundleHeadTable/PullBundleHeadTable.spec.tsx
+++ b/src/pages/PullRequestPage/PullBundleAnalysis/PullBundleHeadTable/PullBundleHeadTable.spec.tsx
@@ -18,6 +18,7 @@ const mockRepoOverview = {
       coverageEnabled: true,
       bundleAnalysisEnabled: true,
       languages: ['javascript'],
+      testAnalyticsEnabled: true,
     },
   },
 }

--- a/src/pages/PullRequestPage/PullCoverage/PullCoverage.spec.jsx
+++ b/src/pages/PullRequestPage/PullCoverage/PullCoverage.spec.jsx
@@ -131,6 +131,7 @@ const mockRepoOverview = ({
       coverageEnabled,
       bundleAnalysisEnabled,
       languages: ['typescript'],
+      testAnalyticsEnabled: false,
     },
   },
 })

--- a/src/pages/PullRequestPage/PullCoverage/PullCoverageTabs/PullCoverageTabs.spec.jsx
+++ b/src/pages/PullRequestPage/PullCoverage/PullCoverageTabs/PullCoverageTabs.spec.jsx
@@ -20,6 +20,7 @@ const mockOverview = (privateRepo = false) => ({
       oldestCommitAt: '2022-10-10T11:59:59',
       coverageEnabled: true,
       bundleAnalysisEnabled: true,
+      testAnalyticsEnabled: true,
       languages: ['typescript'],
     },
   },

--- a/src/pages/PullRequestPage/PullCoverage/routes/CommitsTab/CommitsTable/CommitsTable.spec.tsx
+++ b/src/pages/PullRequestPage/PullCoverage/routes/CommitsTab/CommitsTable/CommitsTable.spec.tsx
@@ -21,6 +21,7 @@ const mockRepoOverview = (bundleAnalysisEnabled = false) => ({
       coverageEnabled: false,
       bundleAnalysisEnabled,
       languages: ['javascript'],
+      testAnalyticsEnabled: true,
     },
   },
 })

--- a/src/pages/PullRequestPage/PullCoverage/routes/CommitsTab/CommitsTableTeam/CommitsTableTeam.spec.tsx
+++ b/src/pages/PullRequestPage/PullCoverage/routes/CommitsTab/CommitsTableTeam/CommitsTableTeam.spec.tsx
@@ -21,6 +21,7 @@ const mockRepoOverview = (bundleAnalysisEnabled = false) => ({
       coverageEnabled: false,
       bundleAnalysisEnabled,
       languages: ['javascript'],
+      testAnalyticsEnabled: true,
     },
   },
 })

--- a/src/pages/PullRequestPage/PullCoverage/routes/FileExplorer/FileExplorer.spec.tsx
+++ b/src/pages/PullRequestPage/PullCoverage/routes/FileExplorer/FileExplorer.spec.tsx
@@ -328,6 +328,7 @@ describe('FileExplorer', () => {
                 coverageEnabled: true,
                 bundleAnalysisEnabled: true,
                 languages: [],
+                testAnalyticsEnabled: true,
               },
             },
           })

--- a/src/pages/PullRequestPage/PullCoverage/routes/FilesChangedTab/FilesChangedTab.spec.tsx
+++ b/src/pages/PullRequestPage/PullCoverage/routes/FilesChangedTab/FilesChangedTab.spec.tsx
@@ -71,6 +71,7 @@ const mockOverview = {
       coverageEnabled: true,
       bundleAnalysisEnabled: false,
       languages: ['javascript'],
+      testAnalyticsEnabled: true,
     },
   },
 }

--- a/src/pages/PullRequestPage/PullCoverage/routes/FilesChangedTab/shared/FileDiff/FileDiff.spec.jsx
+++ b/src/pages/PullRequestPage/PullCoverage/routes/FilesChangedTab/shared/FileDiff/FileDiff.spec.jsx
@@ -75,6 +75,7 @@ const mockOverview = (bundleAnalysisEnabled = false) => {
         coverageEnabled: true,
         bundleAnalysisEnabled,
         languages: ['javascript'],
+        testAnalyticsEnabled: false,
       },
     },
   }

--- a/src/pages/PullRequestPage/PullCoverage/routes/IndirectChangesTab/FileDiff/FileDiff.spec.jsx
+++ b/src/pages/PullRequestPage/PullCoverage/routes/IndirectChangesTab/FileDiff/FileDiff.spec.jsx
@@ -75,6 +75,7 @@ const mockOverview = (bundleAnalysisEnabled = false) => {
         coverageEnabled: true,
         bundleAnalysisEnabled,
         languages: ['javascript'],
+        testAnalyticsEnabled: false,
       },
     },
   }

--- a/src/pages/PullRequestPage/PullCoverage/routes/IndirectChangesTab/IndirectChangedFiles/IndirectChangedFiles.spec.tsx
+++ b/src/pages/PullRequestPage/PullCoverage/routes/IndirectChangesTab/IndirectChangedFiles/IndirectChangedFiles.spec.tsx
@@ -162,6 +162,7 @@ const mockOverview = {
       coverageEnabled: true,
       bundleAnalysisEnabled: false,
       languages: ['javascript'],
+      testAnalyticsEnabled: true,
     },
   },
 }

--- a/src/pages/PullRequestPage/PullRequestPage.spec.tsx
+++ b/src/pages/PullRequestPage/PullRequestPage.spec.tsx
@@ -137,6 +137,7 @@ const mockOverview = (privateRepo = false) => ({
       coverageEnabled: true,
       bundleAnalysisEnabled: true,
       languages: ['typescript'],
+      testAnalyticsEnabled: true,
     },
   },
 })

--- a/src/pages/RepoPage/BundlesTab/BundleContent/BundleContent.spec.tsx
+++ b/src/pages/RepoPage/BundlesTab/BundleContent/BundleContent.spec.tsx
@@ -20,6 +20,7 @@ const mockRepoOverview = {
       coverageEnabled: true,
       bundleAnalysisEnabled: true,
       languages: ['javascript'],
+      testAnalyticsEnabled: true,
     },
   },
 }

--- a/src/pages/RepoPage/BundlesTab/BundleContent/BundleSummary/BranchSelector.spec.tsx
+++ b/src/pages/RepoPage/BundlesTab/BundleContent/BundleSummary/BranchSelector.spec.tsx
@@ -22,6 +22,7 @@ const mockRepoOverview = {
   coverageEnabled: true,
   bundleAnalysisEnabled: true,
   languages: [],
+  testAnalyticsEnabled: true,
 }
 
 const mockMainBranchSearch = {

--- a/src/pages/RepoPage/BundlesTab/BundleContent/BundleSummary/BundleDetails.spec.tsx
+++ b/src/pages/RepoPage/BundlesTab/BundleContent/BundleSummary/BundleDetails.spec.tsx
@@ -17,6 +17,7 @@ const mockRepoOverview = {
       coverageEnabled: false,
       bundleAnalysisEnabled: false,
       languages: ['javascript'],
+      testAnalyticsEnabled: true,
     },
   },
 }

--- a/src/pages/RepoPage/BundlesTab/BundleContent/BundleSummary/BundleSelector.spec.tsx
+++ b/src/pages/RepoPage/BundlesTab/BundleContent/BundleSummary/BundleSelector.spec.tsx
@@ -16,6 +16,7 @@ const mockRepoOverview = {
   coverageEnabled: true,
   bundleAnalysisEnabled: true,
   languages: [],
+  testAnalyticsEnabled: true,
 }
 
 const mockBundles = {

--- a/src/pages/RepoPage/BundlesTab/BundleContent/BundleSummary/BundleSummary.spec.tsx
+++ b/src/pages/RepoPage/BundlesTab/BundleContent/BundleSummary/BundleSummary.spec.tsx
@@ -16,6 +16,7 @@ const mockRepoOverview = {
   coverageEnabled: true,
   bundleAnalysisEnabled: true,
   languages: [],
+  testAnalyticsEnabled: true,
 }
 
 const mockBundleSummary = {

--- a/src/pages/RepoPage/BundlesTab/BundlesTab.spec.tsx
+++ b/src/pages/RepoPage/BundlesTab/BundlesTab.spec.tsx
@@ -35,6 +35,7 @@ const mockRepoOverview = ({
         coverageEnabled,
         bundleAnalysisEnabled,
         languages,
+        testAnalyticsEnabled: true,
       },
     },
   }

--- a/src/pages/RepoPage/CommitsTab/CommitsTab.spec.jsx
+++ b/src/pages/RepoPage/CommitsTab/CommitsTab.spec.jsx
@@ -117,6 +117,7 @@ const mockOverview = {
       coverageEnabled: true,
       bundleAnalysisEnabled: true,
       languages: [],
+      testAnalyticsEnabled: false,
     },
   },
 }

--- a/src/pages/RepoPage/CommitsTab/CommitsTable/CommitsTable.spec.tsx
+++ b/src/pages/RepoPage/CommitsTab/CommitsTable/CommitsTable.spec.tsx
@@ -21,6 +21,7 @@ const mockRepoOverview = (bundleAnalysisEnabled = false) => ({
       coverageEnabled: false,
       bundleAnalysisEnabled,
       languages: ['javascript'],
+      testAnalyticsEnabled: true,
     },
   },
 })

--- a/src/pages/RepoPage/CommitsTab/CommitsTableTeam/CommitsTableTeam.spec.tsx
+++ b/src/pages/RepoPage/CommitsTab/CommitsTableTeam/CommitsTableTeam.spec.tsx
@@ -21,6 +21,7 @@ const mockRepoOverview = (bundleAnalysisEnabled = false) => ({
       coverageEnabled: false,
       bundleAnalysisEnabled,
       languages: ['javascript'],
+      testAnalyticsEnabled: true,
     },
   },
 })

--- a/src/pages/RepoPage/ComponentsTab/Header/BranchSelector/BranchSelector.spec.tsx
+++ b/src/pages/RepoPage/ComponentsTab/Header/BranchSelector/BranchSelector.spec.tsx
@@ -22,6 +22,7 @@ const mockRepoOverview = {
   coverageEnabled: true,
   bundleAnalysisEnabled: true,
   languages: [],
+  testAnalyticsEnabled: true,
 }
 
 const mockMainBranchSearch = {

--- a/src/pages/RepoPage/CoverageTab/CoverageTab.spec.tsx
+++ b/src/pages/RepoPage/CoverageTab/CoverageTab.spec.tsx
@@ -95,6 +95,7 @@ const overviewMock = {
       coverageEnabled: true,
       bundleAnalysisEnabled: true,
       languages: [],
+      testAnalyticsEnabled: true,
     },
   },
 }
@@ -219,6 +220,7 @@ const mockOverview = {
       coverageEnabled: true,
       bundleAnalysisEnabled: true,
       languages: ['JavaScript'],
+      testAnalyticsEnabled: true,
     },
   },
 }

--- a/src/pages/RepoPage/CoverageTab/Summary/Summary.spec.jsx
+++ b/src/pages/RepoPage/CoverageTab/Summary/Summary.spec.jsx
@@ -23,6 +23,7 @@ const mockRepoOverview = {
   coverageEnabled: true,
   bundleAnalysisEnabled: true,
   languages: [],
+  testAnalyticsEnabled: false,
 }
 
 const mockMainBranchSearch = {

--- a/src/pages/RepoPage/CoverageTab/SummaryTeamPlan/SummaryTeamPlan.spec.tsx
+++ b/src/pages/RepoPage/CoverageTab/SummaryTeamPlan/SummaryTeamPlan.spec.tsx
@@ -22,6 +22,7 @@ const mockRepoOverview = {
   coverageEnabled: true,
   bundleAnalysisEnabled: true,
   languages: [],
+  testAnalyticsEnabled: true,
 }
 
 const mockMainBranchSearch = {

--- a/src/pages/RepoPage/CoverageTab/hooks/useCoverageTabData.spec.tsx
+++ b/src/pages/RepoPage/CoverageTab/hooks/useCoverageTabData.spec.tsx
@@ -16,6 +16,7 @@ const mockOverview = {
       coverageEnabled: true,
       bundleAnalysisEnabled: true,
       languages: ['JavaScript'],
+      testAnalyticsEnabled: true,
     },
   },
 }

--- a/src/pages/RepoPage/CoverageTab/hooks/useRepoCoverageTimeseries.spec.js
+++ b/src/pages/RepoPage/CoverageTab/hooks/useRepoCoverageTimeseries.spec.js
@@ -18,6 +18,7 @@ const mockRepoOverview = {
       coverageEnabled: true,
       bundleAnalysisEnabled: true,
       languages: [],
+      testAnalyticsEnabled: false,
     },
   },
 }

--- a/src/pages/RepoPage/CoverageTab/subroute/ComponentsMultiSelect/ComponentsMultiSelect.spec.tsx
+++ b/src/pages/RepoPage/CoverageTab/subroute/ComponentsMultiSelect/ComponentsMultiSelect.spec.tsx
@@ -36,6 +36,7 @@ const mockRepoOverview = {
   coverageEnabled: true,
   bundleAnalysisEnabled: true,
   languages: [],
+  testAnalyticsEnabled: true,
 }
 
 const mockBranch = {

--- a/src/pages/RepoPage/CoverageTab/subroute/CoverageChart/CoverageChart.spec.jsx
+++ b/src/pages/RepoPage/CoverageTab/subroute/CoverageChart/CoverageChart.spec.jsx
@@ -47,6 +47,7 @@ const overviewMock = {
       coverageEnabled: true,
       bundleAnalysisEnabled: true,
       languages: [],
+      testAnalyticsEnabled: false,
     },
   },
 }

--- a/src/pages/RepoPage/CoverageTab/subroute/FileExplorer/CodeTreeTable/CodeTreeTable.spec.tsx
+++ b/src/pages/RepoPage/CoverageTab/subroute/FileExplorer/CodeTreeTable/CodeTreeTable.spec.tsx
@@ -139,6 +139,7 @@ const mockOverview = {
       coverageEnabled: true,
       bundleAnalysisEnabled: true,
       languages: [],
+      testAnalyticsEnabled: true,
     },
   },
 }

--- a/src/pages/RepoPage/CoverageTab/subroute/FileExplorer/FileExplorer.spec.jsx
+++ b/src/pages/RepoPage/CoverageTab/subroute/FileExplorer/FileExplorer.spec.jsx
@@ -124,6 +124,7 @@ const mockOverview = {
       coverageEnabled: true,
       bundleAnalysisEnabled: true,
       languages: [],
+      testAnalyticsEnabled: false,
     },
   },
 }

--- a/src/pages/RepoPage/CoverageTab/subroute/FileExplorer/FileListTable/FileListTable.spec.tsx
+++ b/src/pages/RepoPage/CoverageTab/subroute/FileExplorer/FileListTable/FileListTable.spec.tsx
@@ -114,6 +114,7 @@ const mockOverview = {
       coverageEnabled: true,
       bundleAnalysisEnabled: true,
       languages: [],
+      testAnalyticsEnabled: true,
     },
   },
 }

--- a/src/pages/RepoPage/CoverageTab/subroute/FileExplorer/hooks/useRepoBranchContentsTable.spec.tsx
+++ b/src/pages/RepoPage/CoverageTab/subroute/FileExplorer/hooks/useRepoBranchContentsTable.spec.tsx
@@ -118,6 +118,7 @@ const mockOverview = {
       coverageEnabled: true,
       bundleAnalysisEnabled: true,
       languages: [],
+      testAnalyticsEnabled: true,
     },
   },
 }

--- a/src/pages/RepoPage/CoverageTab/subroute/Fileviewer/Fileviewer.spec.jsx
+++ b/src/pages/RepoPage/CoverageTab/subroute/Fileviewer/Fileviewer.spec.jsx
@@ -42,6 +42,7 @@ const mockOverview = {
       coverageEnabled: true,
       bundleAnalysisEnabled: true,
       languages: [],
+      testAnalyticsEnabled: false,
     },
   },
 }

--- a/src/pages/RepoPage/CoverageTab/subroute/Sunburst/Sunburst.spec.jsx
+++ b/src/pages/RepoPage/CoverageTab/subroute/Sunburst/Sunburst.spec.jsx
@@ -47,6 +47,7 @@ const overviewMock = {
       coverageEnabled: true,
       bundleAnalysisEnabled: true,
       languages: [],
+      testAnalyticsEnabled: false,
     },
   },
 }

--- a/src/pages/RepoPage/CoverageTab/subroute/Sunburst/hooks/useConvertD3ToBreadcrumbs.spec.js
+++ b/src/pages/RepoPage/CoverageTab/subroute/Sunburst/hooks/useConvertD3ToBreadcrumbs.spec.js
@@ -50,6 +50,7 @@ const overviewMock = {
       coverageEnabled: true,
       bundleAnalysisEnabled: true,
       languages: [],
+      testAnalyticsEnabled: false,
     },
   },
 }

--- a/src/pages/RepoPage/CoverageTab/subroute/Sunburst/hooks/useSunburstChart.spec.js
+++ b/src/pages/RepoPage/CoverageTab/subroute/Sunburst/hooks/useSunburstChart.spec.js
@@ -50,6 +50,7 @@ const overviewMock = {
       coverageEnabled: true,
       bundleAnalysisEnabled: true,
       languages: [],
+      testAnalyticsEnabled: false,
     },
   },
 }

--- a/src/pages/RepoPage/CoverageTab/summaryHooks/useSummary.spec.tsx
+++ b/src/pages/RepoPage/CoverageTab/summaryHooks/useSummary.spec.tsx
@@ -15,6 +15,7 @@ const mockRepoOverview = {
   coverageEnabled: true,
   bundleAnalysisEnabled: true,
   languages: [],
+  testAnalyticsEnabled: true,
 }
 
 const mockMainBranchSearch = {

--- a/src/pages/RepoPage/PullsTab/PullsTable/PullsTable.spec.tsx
+++ b/src/pages/RepoPage/PullsTab/PullsTable/PullsTable.spec.tsx
@@ -21,6 +21,7 @@ const mockRepoOverview = (bundleAnalysisEnabled = false) => ({
       coverageEnabled: false,
       bundleAnalysisEnabled,
       languages: ['javascript'],
+      testAnalyticsEnabled: true,
     },
   },
 })

--- a/src/pages/RepoPage/PullsTab/PullsTableTeam/PullsTableTeam.spec.tsx
+++ b/src/pages/RepoPage/PullsTab/PullsTableTeam/PullsTableTeam.spec.tsx
@@ -21,6 +21,7 @@ const mockRepoOverview = (bundleAnalysisEnabled = false) => ({
       coverageEnabled: false,
       bundleAnalysisEnabled,
       languages: ['javascript'],
+      testAnalyticsEnabled: true,
     },
   },
 })

--- a/src/pages/RepoPage/RepoPage.spec.tsx
+++ b/src/pages/RepoPage/RepoPage.spec.tsx
@@ -63,6 +63,7 @@ const mockGetRepo = ({
 const mockRepoOverview = ({
   coverageEnabled = true,
   bundleAnalysisEnabled = true,
+  testAnalyticsEnabled = false,
   language = '',
 }) => {
   const languages = ['python']
@@ -79,6 +80,7 @@ const mockRepoOverview = ({
         oldestCommitAt: '2022-10-10T11:59:59',
         coverageEnabled,
         bundleAnalysisEnabled,
+        testAnalyticsEnabled,
         languages,
       },
     },
@@ -158,6 +160,7 @@ interface SetupArgs {
   bundleAnalysisEnabled?: boolean
   language?: string
   onboardingFailedTests?: boolean
+  testAnalyticsEnabled?: boolean
 }
 
 describe('RepoPage', () => {
@@ -175,6 +178,7 @@ describe('RepoPage', () => {
       bundleAnalysisEnabled = true,
       onboardingFailedTests = true,
       language,
+      testAnalyticsEnabled = false,
     }: SetupArgs = {
       noUploadToken: false,
       isCurrentUserPartOfOrg: true,
@@ -242,6 +246,7 @@ describe('RepoPage', () => {
             mockRepoOverview({
               coverageEnabled,
               bundleAnalysisEnabled,
+              testAnalyticsEnabled,
               language,
             })
           )
@@ -724,6 +729,7 @@ describe('RepoPage', () => {
             isRepoActive: true,
             hasRepoData: true,
             isRepoActivated: true,
+            onboardingFailedTests: true,
           })
           render(<RepoPage />, {
             wrapper: wrapper({
@@ -789,6 +795,27 @@ describe('RepoPage', () => {
             'CoverageOnboarding'
           )
           expect(coverageOnboarding).toBeInTheDocument()
+        })
+
+        it('does not render tab when feature flag is on and test analytics is already enabled', async () => {
+          const { queryClient } = setup({
+            isRepoActive: true,
+            hasRepoData: true,
+            isRepoActivated: true,
+            testAnalyticsEnabled: true,
+          })
+          render(<RepoPage />, {
+            wrapper: wrapper({
+              queryClient,
+              initialEntries: '/gh/codecov/cool-repo/tests',
+            }),
+          })
+
+          const failedTests = screen.queryByText('FailedTestsTab')
+          expect(failedTests).not.toBeInTheDocument()
+
+          const coverage = await screen.findByText('CoverageTab')
+          expect(coverage).toBeInTheDocument()
         })
       })
 

--- a/src/pages/RepoPage/RepoPage.tsx
+++ b/src/pages/RepoPage/RepoPage.tsx
@@ -209,7 +209,7 @@ function Routes({
       >
         <NewRepoTab />
       </SentryRoute>
-      {onboardingFailedTests ? (
+      {onboardingFailedTests && !testAnalyticsEnabled ? (
         <SentryRoute
           path={[`${path}/tests/new`, `${path}/tests/new/codecov-cli`]}
           exact

--- a/src/pages/RepoPage/RepoPage.tsx
+++ b/src/pages/RepoPage/RepoPage.tsx
@@ -47,6 +47,7 @@ interface RoutesProps {
   jsOrTsPresent?: boolean
   isRepoPrivate: boolean
   isCurrentUserActivated?: boolean | null
+  testAnalyticsEnabled?: boolean
 }
 
 function Routes({
@@ -57,6 +58,7 @@ function Routes({
   jsOrTsPresent,
   isRepoPrivate,
   isCurrentUserActivated,
+  testAnalyticsEnabled,
 }: RoutesProps) {
   const { componentTab, onboardingFailedTests } = useFlags({
     bundleAnalysisPrAndCommitPages: false,
@@ -129,7 +131,7 @@ function Routes({
             <BundleOnboarding />
           </SentryRoute>
         ) : null}
-        {onboardingFailedTests ? (
+        {onboardingFailedTests && !testAnalyticsEnabled ? (
           <SentryRoute
             path={[`${path}/tests/new`, `${path}/tests/new/codecov-cli`]}
             exact
@@ -280,6 +282,7 @@ function RepoPage() {
             jsOrTsPresent={jsOrTsPresent}
             isRepoPrivate={isRepoPrivate}
             isCurrentUserActivated={isCurrentUserActivated}
+            testAnalyticsEnabled={repoOverview?.testAnalyticsEnabled}
           />
         </Suspense>
       </div>

--- a/src/pages/RepoPage/RepoPage.tsx
+++ b/src/pages/RepoPage/RepoPage.tsx
@@ -172,6 +172,9 @@ function Routes({
         {!bundleAnalysisEnabled && jsOrTsPresent ? (
           <Redirect from={`${path}/bundles/*`} to={`${path}/bundles/new`} />
         ) : null}
+        {onboardingFailedTests && !testAnalyticsEnabled ? (
+          <Redirect from={`${path}/tests`} to={`${path}/tests/new`} />
+        ) : null}
         {!coverageEnabled ? <Redirect from={path} to={`${path}/new`} /> : null}
         {!coverageEnabled ? (
           <Redirect from={`${path}/*`} to={`${path}/new`} />
@@ -231,7 +234,7 @@ function Routes({
       </SentryRoute>
       <Redirect from={`${path}/bundles`} to={`${path}/bundles/new`} />
       <Redirect from={`${path}/bundles/*`} to={`${path}/bundles/new`} />
-      {onboardingFailedTests ? (
+      {onboardingFailedTests && !testAnalyticsEnabled ? (
         <Redirect from={`${path}/tests`} to={`${path}/tests/new`} />
       ) : null}
       <Redirect from={path} to={`${path}/new`} />

--- a/src/pages/RepoPage/RepoPageTabs.spec.tsx
+++ b/src/pages/RepoPage/RepoPageTabs.spec.tsx
@@ -490,6 +490,23 @@ describe('RepoPageTabs', () => {
       const betaBadge = await screen.findByText('beta')
       expect(betaBadge).toBeInTheDocument()
     })
+
+    it('does not render failed tests tab if test analytics is disabled', async () => {
+      setup({
+        coverageEnabled: false,
+        onboardingFailedTests: false,
+        testAnalyticsEnabled: false,
+      })
+      render(<RepoPageTabs refetchEnabled={false} />, {
+        wrapper: wrapper('/gh/codecov/test-repo/tests/new'),
+      })
+
+      await waitFor(() => queryClient.isFetching)
+      await waitFor(() => !queryClient.isFetching)
+
+      const tab = screen.queryByText('Tests')
+      expect(tab).not.toBeInTheDocument()
+    })
   })
 })
 

--- a/src/pages/RepoPage/RepoPageTabs.spec.tsx
+++ b/src/pages/RepoPage/RepoPageTabs.spec.tsx
@@ -27,6 +27,7 @@ const mockRepoOverview = ({
   isRepoPrivate = false,
   coverageEnabled = false,
   bundleAnalysisEnabled = false,
+  testAnalyticsEnabled = false,
 }) => {
   let languages = null
   if (language !== '') {
@@ -43,6 +44,7 @@ const mockRepoOverview = ({
         coverageEnabled,
         bundleAnalysisEnabled,
         languages,
+        testAnalyticsEnabled,
       },
     },
   }
@@ -128,6 +130,7 @@ interface SetupArgs {
   isCurrentUserPartOfOrg?: boolean
   componentTab?: boolean
   onboardingFailedTests?: boolean
+  testAnalyticsEnabled?: boolean
 }
 
 describe('RepoPageTabs', () => {
@@ -140,6 +143,7 @@ describe('RepoPageTabs', () => {
     isCurrentUserPartOfOrg = true,
     componentTab = true,
     onboardingFailedTests = false,
+    testAnalyticsEnabled = false,
   }: SetupArgs) {
     mockedUseFlags.mockReturnValue({
       componentTab,
@@ -156,6 +160,7 @@ describe('RepoPageTabs', () => {
               isRepoPrivate,
               coverageEnabled,
               bundleAnalysisEnabled,
+              testAnalyticsEnabled,
             })
           )
         )
@@ -493,6 +498,7 @@ describe('useRepoTabs', () => {
     language,
     bundleAnalysisEnabled,
     coverageEnabled,
+    testAnalyticsEnabled = false,
     isRepoPrivate,
     tierName = TierNames.PRO,
     isCurrentUserPartOfOrg = true,
@@ -511,6 +517,7 @@ describe('useRepoTabs', () => {
               isRepoPrivate,
               coverageEnabled,
               bundleAnalysisEnabled,
+              testAnalyticsEnabled,
             })
           )
         )

--- a/src/pages/RepoPage/RepoPageTabs.tsx
+++ b/src/pages/RepoPage/RepoPageTabs.tsx
@@ -84,7 +84,7 @@ export const useRepoTabs = ({ refetchEnabled }: UseRepoTabsArgs) => {
     })
   }
 
-  if (onboardingFailedTests) {
+  if (onboardingFailedTests && !repoOverview?.testAnalyticsEnabled) {
     tabs.push({
       pageName: 'failedTestsOnboarding',
       children: (

--- a/src/services/bundleAnalysis/useBranchBundleSummary.spec.tsx
+++ b/src/services/bundleAnalysis/useBranchBundleSummary.spec.tsx
@@ -15,6 +15,7 @@ const mockRepoOverview = {
       coverageEnabled: false,
       bundleAnalysisEnabled: false,
       languages: ['javascript'],
+      testAnalyticsEnabled: true,
     },
   },
 }

--- a/src/services/bundleAnalysis/useBranchBundlesNames.spec.tsx
+++ b/src/services/bundleAnalysis/useBranchBundlesNames.spec.tsx
@@ -15,6 +15,7 @@ const mockRepoOverview = {
       coverageEnabled: false,
       bundleAnalysisEnabled: false,
       languages: ['javascript'],
+      testAnalyticsEnabled: true,
     },
   },
 }

--- a/src/services/bundleAnalysis/useBundleAssets.spec.tsx
+++ b/src/services/bundleAnalysis/useBundleAssets.spec.tsx
@@ -15,6 +15,7 @@ const mockRepoOverview = {
       coverageEnabled: false,
       bundleAnalysisEnabled: false,
       languages: ['javascript'],
+      testAnalyticsEnabled: true,
     },
   },
 }

--- a/src/services/bundleAnalysis/useBundleSummary.spec.tsx
+++ b/src/services/bundleAnalysis/useBundleSummary.spec.tsx
@@ -15,6 +15,7 @@ const mockRepoOverview = {
       coverageEnabled: false,
       bundleAnalysisEnabled: false,
       languages: ['javascript'],
+      testAnalyticsEnabled: true,
     },
   },
 }

--- a/src/services/pull/usePullBundleHeadList.spec.tsx
+++ b/src/services/pull/usePullBundleHeadList.spec.tsx
@@ -15,6 +15,7 @@ const mockRepoOverview = {
       coverageEnabled: false,
       bundleAnalysisEnabled: false,
       languages: ['javascript'],
+      testAnalyticsEnabled: true,
     },
   },
 }

--- a/src/services/repo/useRepoOverview.spec.tsx
+++ b/src/services/repo/useRepoOverview.spec.tsx
@@ -21,6 +21,7 @@ const mockOverview = (language?: string) => {
         coverageEnabled: true,
         bundleAnalysisEnabled: true,
         languages,
+        testAnalyticsEnabled: true,
       },
     },
   }
@@ -130,6 +131,7 @@ describe('useRepoOverview', () => {
             bundleAnalysisEnabled: true,
             languages: [],
             jsOrTsPresent: false,
+            testAnalyticsEnabled: true,
           })
         )
       })
@@ -157,6 +159,7 @@ describe('useRepoOverview', () => {
               bundleAnalysisEnabled: true,
               languages: ['javascript'],
               jsOrTsPresent: true,
+              testAnalyticsEnabled: true,
             })
           )
         })
@@ -185,6 +188,7 @@ describe('useRepoOverview', () => {
               bundleAnalysisEnabled: true,
               languages: ['typescript'],
               jsOrTsPresent: true,
+              testAnalyticsEnabled: true,
             })
           )
         })

--- a/src/services/repo/useRepoOverview.tsx
+++ b/src/services/repo/useRepoOverview.tsx
@@ -15,6 +15,7 @@ const RepositorySchema = z.object({
   oldestCommitAt: z.string().nullable(),
   coverageEnabled: z.boolean().nullable(),
   bundleAnalysisEnabled: z.boolean().nullable(),
+  testAnalyticsEnabled: z.boolean().nullable(),
   languages: z.array(z.string()).nullable(),
 })
 
@@ -40,6 +41,7 @@ const query = `query GetRepoOverview($owner: String!, $repo: String!) {
         oldestCommitAt
         coverageEnabled
         bundleAnalysisEnabled
+        testAnalyticsEnabled
         languages
       }
       ... on NotFoundError {
@@ -122,12 +124,15 @@ export function useRepoOverview({
         const coverageEnabled = data.owner.repository.coverageEnabled ?? false
         const bundleAnalysisEnabled =
           data.owner.repository.bundleAnalysisEnabled ?? false
+        const testAnalyticsEnabled =
+          data.owner.repository.testAnalyticsEnabled ?? false
 
         return {
           ...data.owner.repository,
           coverageEnabled,
           bundleAnalysisEnabled,
           jsOrTsPresent,
+          testAnalyticsEnabled,
         }
       })
     },

--- a/src/shared/treePaths/useTreePaths.spec.js
+++ b/src/shared/treePaths/useTreePaths.spec.js
@@ -64,6 +64,7 @@ const overviewMock = {
       coverageEnabled: true,
       bundleAnalysisEnabled: true,
       languages: [],
+      testAnalyticsEnabled: false,
     },
   },
 }
@@ -223,6 +224,7 @@ describe('useTreePaths', () => {
                 coverageEnabled: true,
                 bundleAnalysisEnabled: true,
                 languages: [],
+                testAnalyticsEnabled: false,
               },
             },
           },


### PR DESCRIPTION
# Description
Check if test analytics is disabled to view onboarding. 

# Notable Changes
- Update overview hook with testAnalyticsEnabled
- Update tests
- Use field to conditionally render the tab 

# Screenshots
Nothing visual changed.

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.