### PR TITLE
fix: usePullCompareTotalsTeam pullId int type

### DIFF
--- a/src/services/pull/usePullCompareTotalsTeam.tsx
+++ b/src/services/pull/usePullCompareTotalsTeam.tsx
@@ -81,7 +81,7 @@ const query = `
 query GetPullCompareTotalsTeam(
   $owner: String!
   $repo: String!
-  $pullId: String!
+  $pullId: Int!
   $filters: ImpactedFilesFilters
 ) {
   owner(username: $owner) {
@@ -171,7 +171,7 @@ export function usePullCompareTotalsTeam({
         variables: {
           owner,
           repo,
-          pullId,
+          pullId: parseInt(pullId, 10),
           filters,
         },
       }).then((res) => {


### PR DESCRIPTION
Updates query to cast pullId to an integer, which is what the API expects.

Closes https://github.com/codecov/engineering-team/issues/1693
Fixes https://codecov.sentry.io/issues/4797243800/?project=5215654
