### PR TITLE
fix: Clean up select styling

### DIFF
--- a/src/ui/MultiSelect/MultiSelect.jsx
+++ b/src/ui/MultiSelect/MultiSelect.jsx
@@ -89,7 +89,7 @@ function DropdownList({
       className={cs(
         SelectClasses.listContainer,
         {
-          'border border-gray-ds-tertiary max-h-72 overflow-y-scroll': isOpen,
+          'border border-gray-ds-tertiary max-h-72 overflow-y-auto': isOpen,
         },
         onSearch ? 'top-16' : 'top-8'
       )}

--- a/src/ui/Select/Select.jsx
+++ b/src/ui/Select/Select.jsx
@@ -193,7 +193,7 @@ const Select = forwardRef(
               SelectClasses.ul,
               UlVariantClass[variant],
               {
-                'border overflow-scroll': isOpen,
+                'border overflow-y-auto': isOpen,
               },
               !!onSearch ? 'top-16' : 'top-8 rounded'
             )}


### PR DESCRIPTION
# Description

Small style tweak to the selects to clean up the scroll bars

# Screenshots

![Screenshot 2024-06-07 at 10 55 34](https://github.com/codecov/gazebo/assets/105234307/e906da8c-c4b1-4125-9779-edb844d1f015)
