### PR TITLE
fix: User unable to update card if no default payment method

### DIFF
--- a/src/pages/PlanPage/subRoutes/CurrentOrgPlan/BillingDetails/PaymentCard/PaymentCard.jsx
+++ b/src/pages/PlanPage/subRoutes/CurrentOrgPlan/BillingDetails/PaymentCard/PaymentCard.jsx
@@ -8,23 +8,9 @@ import Icon from 'ui/Icon'
 
 import CardInformation from './CardInformation'
 import CreditCardForm from './CreditCardForm'
-import { useEnterpriseCloudPlanSupport } from './hooks'
-
-const defaultProPlans = [
-  'users-pr-inappm',
-  'users-pr-inappy',
-  'users-inappm',
-  'users-inappy',
-]
 function PaymentCard({ subscriptionDetail, provider, owner }) {
-  const { plans: proPlans } = useEnterpriseCloudPlanSupport({
-    plans: defaultProPlans,
-  })
-  const isPayingCustomer = proPlans.includes(subscriptionDetail?.plan?.value)
   const [isFormOpen, setIsFormOpen] = useState(false)
   const card = subscriptionDetail?.defaultPaymentMethod?.card
-
-  if (!card && !isPayingCustomer) return null
 
   return (
     <div className="flex flex-col gap-2 border-t p-4">
@@ -50,7 +36,7 @@ function PaymentCard({ subscriptionDetail, provider, owner }) {
         <CardInformation card={card} subscriptionDetail={subscriptionDetail} />
       ) : (
         <div className="flex flex-col gap-4 text-ds-gray-quinary">
-          <p>
+          <p className="mt-4">
             No credit card set. Please contact support if you think it’s an
             error or set it yourself.
           </p>

--- a/src/pages/PlanPage/subRoutes/CurrentOrgPlan/BillingDetails/PaymentCard/PaymentCard.spec.jsx
+++ b/src/pages/PlanPage/subRoutes/CurrentOrgPlan/BillingDetails/PaymentCard/PaymentCard.spec.jsx
@@ -48,36 +48,22 @@ describe('PaymentCard', () => {
   }
 
   describe(`when the user doesn't have any subscriptionDetail`, () => {
-    it('renders nothing', () => {
-      const { container } = render(
+    // NOTE: This test is misleading because we hide this component from a higher level in
+    // BillingDetails.tsx if there is no subscriptionDetail
+    it('renders the set card message', () => {
+      render(
         <PaymentCard subscriptionDetail={null} provider="gh" owner="codecov" />
       )
 
-      expect(container).toBeEmptyDOMElement()
+      expect(
+        screen.getByText(
+          /No credit card set. Please contact support if you think it’s an error or set it yourself./
+        )
+      ).toBeInTheDocument()
     })
   })
 
-  describe(`when the user doesn't have a card but is on a free plan`, () => {
-    it('renders nothing', () => {
-      const { container } = render(
-        <PaymentCard
-          subscriptionDetail={{
-            ...subscriptionDetail,
-            defaultPaymentMethod: null,
-            plan: {
-              value: 'users-free',
-            },
-          }}
-          provider="gh"
-          owner="codecov"
-        />
-      )
-
-      expect(container).toBeEmptyDOMElement()
-    })
-  })
-
-  describe(`when the user doesn't have any cards but has a paid plan`, () => {
+  describe(`when the user doesn't have any card`, () => {
     it('renders an error message', () => {
       render(
         <PaymentCard


### PR DESCRIPTION
# Description

This PR aims to fix situations where a user doesn't have a default payment method but does have a stripe subscription, and is unable to update their card.

Originally, we were checking to see if the user didn't have a card, but was a paying customer, and then showing the "no card set message," but looking at the serializer and data we were keying off of, [plan has never existed on a subscriptionDetail](https://github.com/codecov/codecov-api/blob/83a55770400f5693bac483d0de68a0593b39ad27/api/internal/owner/serializers.py#L184-L193) and so that condition was always returning false.

Because a user without a default payment method also didn't have a card (referring to the condition !card && !payingCustomer), we were essentially always hiding the billing update screen from the user when they didn't have a default payment method set... which is really bad! Not sure how much this has contributed to churn, but def a non-zero amount

As for why I removed the payingCustomer null check altogether, well... 
- In BillingDetails.tsx we already have a condition to hide the higher component if there is no subscriptionDetail
  - Free users won't have a subscriptionDetail
  - Enterprise users won't have a subscriptionDetail
  - This means we were getting the "paidCustomer" check stuff for free already!

Closes https://github.com/codecov/engineering-team/issues/1811
Closes https://github.com/codecov/internal-issues/issues/518

# Screenshots

![Screenshot 2024-06-07 at 3 46 23 PM](https://github.com/codecov/gazebo/assets/159853603/afff5d0f-b94b-406a-8890-a3e8895d7f41)


# Link to Sample Entry

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.