### PR TITLE
Fix alignment of elements on ReposTable

### DIFF
--- a/src/shared/ListRepo/RepoTitleLink/RepoTitleLink.jsx
+++ b/src/shared/ListRepo/RepoTitleLink/RepoTitleLink.jsx
@@ -5,7 +5,7 @@ import Icon from 'ui/Icon'
 
 function Badge({ children }) {
   return (
-    <span className="ml-2 rounded border border-ds-gray-tertiary px-1 py-0.5 text-xs text-ds-gray-senary">
+    <span className="ml-2 h-min rounded border border-ds-gray-tertiary px-1 py-0.5 text-xs text-ds-gray-senary">
       {children}
     </span>
   )
@@ -24,7 +24,7 @@ function RepoTitleLink({ repo, showRepoOwner, pageName, disabledLink }) {
 
   if (disabledLink) {
     return (
-      <div className="flex">
+      <div className="flex items-center">
         <div className="flex cursor-default items-center text-ds-gray-quinary">
           <Icon
             size="sm"
@@ -43,7 +43,7 @@ function RepoTitleLink({ repo, showRepoOwner, pageName, disabledLink }) {
   }
 
   return (
-    <div className="flex">
+    <div className="flex items-center">
       <AppLink
         pageName={pageName}
         options={options}

--- a/src/shared/ListRepo/ReposTable/ReposTable.tsx
+++ b/src/shared/ListRepo/ReposTable/ReposTable.tsx
@@ -218,7 +218,7 @@ const ReposTable = ({
                     <td
                       key={cell.id}
                       className={cs({
-                        'flex justify-end':
+                        'text-right':
                           cell.column.id === 'coverage' ||
                           cell.column.id === 'inactiveRepo',
                       })}

--- a/src/shared/ListRepo/ReposTableTeam/ReposTableTeam.tsx
+++ b/src/shared/ListRepo/ReposTableTeam/ReposTableTeam.tsx
@@ -250,7 +250,7 @@ const ReposTableTeam = ({ searchValue }: ReposTableTeamProps) => {
                 <td
                   key={cell.id}
                   className={cs({
-                    'flex justify-end': cell.column.id === 'lines',
+                    'text-right': cell.column.id === 'lines',
                   })}
                 >
                   {flexRender(cell.column.columnDef.cell, cell.getContext())}


### PR DESCRIPTION
Fixes vertical alignment of a few elements on the repos table for small screen sizes and/or long repo names.

Closes https://github.com/codecov/engineering-team/issues/1883

# Before:
Pro view:
![Screenshot 2024-06-10 at 10 28 32](https://github.com/codecov/gazebo/assets/159931558/dc47204f-0ecb-418a-8b30-103c31684617)

Team view:
![Screenshot 2024-06-10 at 10 29 22](https://github.com/codecov/gazebo/assets/159931558/f677f5b5-c80a-42b4-b305-39463dde15c1)


Unconfigured repo:
![Screenshot 2024-06-10 at 10 29 02](https://github.com/codecov/gazebo/assets/159931558/714eda62-0d30-4ca4-85d6-890a034375a2)

# After:
Pro view:
![Screenshot 2024-06-10 at 10 25 43](https://github.com/codecov/gazebo/assets/159931558/605c2863-979f-4b8f-983c-273adc22f455)

Team view:
![Screenshot 2024-06-10 at 10 26 06](https://github.com/codecov/gazebo/assets/159931558/9632dc9e-4504-4cba-868c-a5f7fe82b119)

Unconfigured repo:
![Screenshot 2024-06-10 at 10 26 54](https://github.com/codecov/gazebo/assets/159931558/ab21ff01-1a98-41ed-95e5-237ae981a299)

