### PR TITLE
fix: Branch selector redirect broken after info architecture update

### DIFF
--- a/src/pages/RepoPage/CoverageTab/CoverageTab.tsx
+++ b/src/pages/RepoPage/CoverageTab/CoverageTab.tsx
@@ -13,6 +13,8 @@ import OverviewTab from './OverviewTab'
 const FlagsTab = lazy(() => import('./FlagsTab'))
 const ComponentsTab = lazy(() => import('./ComponentsTab'))
 
+const path = '/:provider/:owner/:repo'
+
 const Loader = () => (
   <div className="flex flex-1 items-center justify-center pt-16">
     <LoadingLogo />
@@ -46,7 +48,15 @@ function CoverageTab() {
           <SentryRoute path="/:provider/:owner/:repo/components" exact>
             <ComponentsTab />
           </SentryRoute>
-          <SentryRoute path="/:provider/:owner/:repo">
+          <SentryRoute
+            path={[
+              path,
+              `${path}/blob/:ref/:path+`,
+              `${path}/tree/:branch`,
+              `${path}/tree/:branch/:path+`,
+            ]}
+            exact
+          >
             <OverviewTab />
           </SentryRoute>
         </Switch>


### PR DESCRIPTION
Fixes bug with branch selector introduced in new information architecture update. 

Issue is as pictured below, branch was not getting pulled out of the url by useParams as it was before. Problem was that the route matcher at the CoverageTab level needed explicit param definitions instead of a catch-all matcher.

![Recording 2024-06-10 at 14 24 57](https://github.com/codecov/gazebo/assets/159931558/7de6adb0-c96b-49a5-9360-0d7a823bb273)

