### PR TITLE
feat: Show new guest header on Login page

### DIFF
--- a/src/layouts/Header/Header.tsx
+++ b/src/layouts/Header/Header.tsx
@@ -15,7 +15,7 @@ function Header() {
   return (
     <header
       className={cs('text-white', {
-        'bg-ds-default  border-b-2': !isImpersonating && !currentUser,
+        'bg-white  border-b-2': !isImpersonating && !currentUser,
         'bg-ds-primary-base': !isImpersonating && !!currentUser,
         'bg-ds-pink-tertiary': isImpersonating,
       })}

--- a/src/layouts/LoginLayout/LoginLayout.spec.tsx
+++ b/src/layouts/LoginLayout/LoginLayout.spec.tsx
@@ -59,7 +59,7 @@ describe('LoginLayout', () => {
       expect(link).toHaveAttribute('href', 'https://about.codecov.io')
     })
 
-    it('renders new to codecov link', () => {
+    it('renders guest header', () => {
       setup()
 
       render(<LoginLayout>child content</LoginLayout>, {
@@ -69,12 +69,8 @@ describe('LoginLayout', () => {
         }),
       })
 
-      const text = screen.getByText(/New to Codecov\?/)
+      const text = screen.getByText(/Why Test Code\?/)
       expect(text).toBeInTheDocument()
-
-      const link = screen.getByRole('link', { name: /Learn more/ })
-      expect(link).toBeInTheDocument()
-      expect(link).toHaveAttribute('href', 'https://about.codecov.io')
     })
 
     it('renders children', () => {

--- a/src/layouts/LoginLayout/LoginLayout.tsx
+++ b/src/layouts/LoginLayout/LoginLayout.tsx
@@ -2,27 +2,10 @@ import { Suspense } from 'react'
 
 import { LOCAL_STORAGE_SESSION_EXPIRED_KEY } from 'config'
 
-import { CodecovIcon } from 'assets/svg/codecov'
 import Footer from 'layouts/Footer'
+import Header from 'layouts/Header'
 import SessionExpiredBanner from 'pages/LoginPage/SessionExpiredBanner'
-import A from 'ui/A'
 import LoadingLogo from 'ui/LoadingLogo'
-
-const LogoButton = () => {
-  return (
-    // @ts-expect-error
-    <A
-      to={{
-        pageName: 'root',
-      }}
-      variant="header"
-      data-testid="homepage-link"
-    >
-      <span className="sr-only">Link to Homepage</span>
-      <CodecovIcon />
-    </A>
-  )
-}
 
 const FullPageLoader = () => (
   <div className="mt-16 flex flex-1 items-center justify-center">
@@ -37,17 +20,7 @@ const LoginLayout: React.FC<React.PropsWithChildren> = ({ children }) => {
   return (
     <>
       {showExpiryBanner && <SessionExpiredBanner />}
-      <header className="bg-ds-primary-base text-white">
-        <nav className="container mx-auto flex flex-wrap items-center justify-between gap-2 px-3 py-4 sm:px-0">
-          <LogoButton />
-          <div className="text-ds-gray-tertiary">
-            New to Codecov? {/* @ts-expect-error */}
-            <A to={{ pageName: 'root' }} variant="header">
-              Learn more
-            </A>
-          </div>
-        </nav>
-      </header>
+      <Header />
       <Suspense fallback={<FullPageLoader />}>
         <main className="container mb-8 mt-2 flex grow flex-col gap-2 md:p-0">
           {children}


### PR DESCRIPTION
Shows the new guest header on the Login page. Previously, we had a special header for this page, but we've decided to replace this with the guest header. 

Had some ideas to clean up the code here a bit more, but decided to leave as is because I'll be making big changes to our header over the next couple weeks.

Closes https://github.com/codecov/engineering-team/issues/1819

## Screenshots 
Before:

![Screenshot 2024-06-10 at 15 23 38](https://github.com/codecov/gazebo/assets/159931558/e7f93209-3ef6-44f3-9421-32ebad51acb3)

After:

![Screenshot 2024-06-10 at 15 23 17](https://github.com/codecov/gazebo/assets/159931558/4606edbd-eed8-4ac5-9caf-618a7f6c8267)
