### PR TITLE
feat: Create "dumb" useUpdateBillingAddress hook

### DIFF
--- a/src/services/account/useUpdateBillingAddress.spec.tsx
+++ b/src/services/account/useUpdateBillingAddress.spec.tsx
@@ -1,0 +1,122 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { renderHook, waitFor } from '@testing-library/react'
+import { rest } from 'msw'
+import { setupServer } from 'msw/node'
+
+import { useUpdateBillingAddress } from './useUpdateBillingAddress'
+
+const queryClient = new QueryClient({
+  defaultOptions: { queries: { retry: false } },
+})
+const server = setupServer()
+
+const wrapper: React.FC<React.PropsWithChildren> = ({ children }) => (
+  <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+)
+
+beforeAll(() => {
+  server.listen()
+})
+
+afterEach(() => {
+  queryClient.clear()
+  server.resetHandlers()
+})
+
+afterAll(() => {
+  server.close()
+})
+
+const provider = 'gh'
+const owner = 'codecov'
+
+const accountDetails = {
+  plan: {
+    marketingName: 'Pro Team',
+    baseUnitPrice: 12,
+    benefits: ['Configurable # of users', 'Unlimited repos'],
+    quantity: 5,
+    value: 'users-inappm',
+  },
+  subscription_detail: {
+    latest_invoice: {
+      id: 'in_1JnNyfGlVGuVgOrkkdkCYayW',
+    },
+    default_payment_method: {
+      card: {
+        brand: 'mastercard',
+        exp_month: 4,
+        exp_year: 2023,
+        last4: '8091',
+      },
+      billing_details: {
+        email: null,
+        name: null,
+        phone: null,
+      },
+    },
+    cancel_at_period_end: false,
+    current_period_end: 1636479475,
+  },
+  activatedUserCount: 2,
+  inactiveUserCount: 1,
+}
+
+describe('useUpdateBillingAddress', () => {
+  const mockBody = jest.fn()
+
+  function setup() {
+    server.use(
+      rest.patch(
+        `/internal/${provider}/${owner}/account-details/update_billing_address`,
+        async (req, res, ctx) => {
+          const body = await req.json()
+          mockBody(body)
+
+          return res(ctx.status(200), ctx.json(accountDetails))
+        }
+      )
+    )
+  }
+
+  describe('when called', () => {
+    beforeEach(() => {
+      setup()
+    })
+
+    it('calls with the correct body', async () => {
+      const { result } = renderHook(
+        () => useUpdateBillingAddress({ provider, owner }),
+        {
+          wrapper,
+        }
+      )
+
+      result.current.mutate({
+        line1: '45 Fremont St.',
+        line2: '',
+        city: 'San Francisco',
+        state: 'CA',
+        country: 'US',
+        postalCode: '94105',
+      })
+
+      await waitFor(() => result.current.isLoading)
+      await waitFor(() => !result.current.isLoading)
+
+      await waitFor(() => expect(mockBody).toHaveBeenCalled())
+      await waitFor(() =>
+        expect(mockBody).toHaveBeenCalledWith({
+          billing_address: {
+            line_1: '45 Fremont St.',
+            line_2: '',
+            city: 'San Francisco',
+            state: 'CA',
+            country: 'US',
+            postal_code: '94105',
+          },
+        })
+      )
+    })
+  })
+})

--- a/src/services/account/useUpdateBillingAddress.ts
+++ b/src/services/account/useUpdateBillingAddress.ts
@@ -1,0 +1,47 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+
+import Api from 'shared/api'
+
+interface useUpdateBillingAddressParams {
+  provider: string
+  owner: string
+}
+
+interface AddressInfo {
+  line1: string
+  line2: string
+  city: string
+  state: string
+  country: string
+  postalCode: string
+}
+
+export function useUpdateBillingAddress({
+  provider,
+  owner,
+}: useUpdateBillingAddressParams) {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: (addressInfo: AddressInfo) => {
+      const path = `/${provider}/${owner}/account-details/update_billing_address`
+
+      // NOTE: Hardcoded for now until we link up to address form
+      const body = {
+        /* eslint-disable camelcase */
+        billing_address: {
+          line1: '45 Fremont St.',
+          line2: '',
+          city: 'San Francisco',
+          state: 'CA',
+          country: 'US',
+          postal_code: '94105',
+        },
+      }
+      return Api.patch({ path, provider, body })
+    },
+    onSuccess: (data) => {
+      queryClient.invalidateQueries(['accountDetails'])
+    },
+  })
+}


### PR DESCRIPTION
# Description

Part of the Q2 billing epic, particularly around updates for edit billing details, this PR aims to add a a new hook for updating the user's billing address that will be used when we add the stripe address component to the plan page.

For now, the hook is hardcoded to use Sentry's address, and isn't being used anywhere just yet. I wanted to try and isolate gazebo PR's to small chunks to make it easier to review. Directly relates to https://github.com/codecov/codecov-api/pull/611 which adds the service function in API

Closes https://github.com/codecov/engineering-team/issues/1864

# Screenshots

N/A

# Link to Sample Entry

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.