### PR TITLE
Setup IP address tracking for sentry user

### DIFF
--- a/src/services/tracking/useTracking.js
+++ b/src/services/tracking/useTracking.js
@@ -42,16 +42,17 @@ export function useTracking() {
   useTrackFeatureFlags(user) // TODO: Can probably delete
   useUpdatePendoWithOwner(user)
 
-  const maybeSentryUser = {}
+  const sentryUser = {}
   if (user?.email) {
-    maybeSentryUser.email = user?.email
+    sentryUser.email = user?.email
   }
   if (user?.user?.username) {
-    maybeSentryUser.username = user?.user?.username
+    sentryUser.username = user?.user?.username
   }
 
-  const sentryUser =
-    Object.keys(maybeSentryUser).length === 0 ? null : maybeSentryUser
+  // https://docs.sentry.io/platforms/javascript/enriching-events/identify-user/#ip_address
+  // eslint-disable-next-line
+  sentryUser.ip_address = '{{auto}}'
   Sentry.setUser(sentryUser)
 
   return { data: user, ...all }


### PR DESCRIPTION
# Description

This PR closes https://github.com/codecov/engineering-team/issues/1663.

It should update the sentry user object to store IP as per https://docs.sentry.io/platforms/javascript/enriching-events/identify-user/#ip_address.

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.