### PR TITLE
fix: Update self hosted link on login page

### DIFF
--- a/src/pages/LoginPage/LoginPage.jsx
+++ b/src/pages/LoginPage/LoginPage.jsx
@@ -37,8 +37,11 @@ function LoginPage() {
           <hr />
         </div>
         <p>
-          If you are using GitHub Enterprise, GitLab EE/CE, or Bitbucket Server
-          please view our <A to={{ pageName: 'enterprise' }}>self hosted</A>{' '}
+          If you are using GitHub Enterprise Server, GitLab EE/CE, or Bitbucket
+          Server please view our{' '}
+          <A to={{ pageName: 'dedicatedEnterpriseCloudGuide' }}>
+            Dedicated Enterprise Cloud
+          </A>{' '}
           option.
         </p>
       </div>

--- a/src/pages/LoginPage/LoginPage.spec.jsx
+++ b/src/pages/LoginPage/LoginPage.spec.jsx
@@ -25,6 +25,30 @@ describe('LoginPage', () => {
 
   afterEach(() => jest.resetAllMocks())
 
+  describe('rendering DEC message', () => {
+    it('renders the message', () => {
+      setup()
+      render(<LoginPage />, { wrapper: wrapper('/login') })
+
+      const message = screen.getByText(/If you are using GitHub/)
+      expect(message).toBeInTheDocument()
+    })
+
+    it('renders the docs link', () => {
+      setup()
+      render(<LoginPage />, { wrapper: wrapper('/login') })
+
+      const link = screen.getByRole('link', {
+        name: /dedicated enterprise cloud/i,
+      })
+      expect(link).toBeInTheDocument()
+      expect(link).toHaveAttribute(
+        'href',
+        'https://docs.codecov.com/docs/codecov-dedicated-enterprise-cloud-install-steps'
+      )
+    })
+  })
+
   describe('when the url is /login', () => {
     it('renders github login button', () => {
       render(<LoginPage />, { wrapper: wrapper('/login') })


### PR DESCRIPTION
# Description

Update link to point to new dedicated cloud docs.

Just an updated version of #2527

# Notable Changes

- Update link on login page
- Update tests