### PR TITLE
feat: Add Prettier check to ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,6 +103,35 @@ jobs:
         run: |
           npm run type-check
 
+  prettier:
+    name: Run Prettier Check
+    runs-on: ubuntu-latest
+    needs: install
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Cache node_modules
+        id: cache-node-modules
+        uses: actions/cache@v4
+        env:
+          cache-name: cache-gazebo-node-modules
+        with:
+          path: |
+            node_modules
+          key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ env.cache-name }}-
+
+      - name: Run Prettier
+        run: |
+          npm run type-check
+
   codecovstartup:
     name: Codecov Startup
     needs: install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,7 @@ jobs:
         run: |
           npm run type-check
 
-  prettier:
+  format-check:
     name: Run Prettier Check
     runs-on: ubuntu-latest
     needs: install
@@ -130,7 +130,7 @@ jobs:
 
       - name: Run Prettier
         run: |
-          npm run type-check
+          npm run format-check
 
   codecovstartup:
     name: Codecov Startup

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "postinstall": "husky install",
     "generate-icons": "node ./scripts/icons.js",
     "analyze": "source-map-explorer 'build/static/js/*.js'",
-    "type-check": "tsc --noEmit"
+    "type-check": "tsc --noEmit",
+    "format-check": "prettier --check 'src/**/*.{js,jsx,ts,tsx,css,md}'"
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx,json,css,scss,md,json}": [

--- a/src/pages/RepoPage/FailedTestsTab/GitHubActions/GitHubActions.spec.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/GitHubActions/GitHubActions.spec.tsx
@@ -5,7 +5,6 @@ import { MemoryRouter, Route } from 'react-router-dom'
 
 import GitHubActions from './GitHubActions'
 
-
 jest.mock('./FrameworkTabs', () => ({
   __esModule: true,
   FrameworkTabs: () => 'FrameworkTabs',


### PR DESCRIPTION
Adds a check to the CI run that will fail if Prettier check fails. This should only happen if you commit with `--no-verify` as we run Prettier formatting in a commit hook. That said, the reason for adding this is because some way or another it seems we do get non-pretty stuff merged from time to time.