### PR TITLE
feat: Add Address Form, View, and E2E Glue

### DIFF
--- a/src/pages/PlanPage/subRoutes/CurrentOrgPlan/BillingDetails/Address/AddressCard.spec.tsx
+++ b/src/pages/PlanPage/subRoutes/CurrentOrgPlan/BillingDetails/Address/AddressCard.spec.tsx
@@ -1,0 +1,323 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { z } from 'zod'
+
+import { SubscriptionDetailSchema } from 'services/account'
+import { useUpdateBillingAddress } from 'services/account/useUpdateBillingAddress'
+
+import AddressCard from './AddressCard'
+
+jest.mock('services/account/useUpdateBillingAddress')
+
+const subscriptionDetail = {
+  defaultPaymentMethod: {
+    card: {
+      brand: 'visa',
+      expMonth: 12,
+      expYear: 2021,
+      last4: '1234',
+    },
+    billingDetails: {
+      name: 'Bob Smith',
+      address: {
+        line1: '123 Sesame St.',
+        line2: '',
+        city: 'San Francisco',
+        country: 'US',
+        state: 'CA',
+        postalCode: '12345',
+      },
+    },
+  },
+  currentPeriodEnd: 1606851492,
+  cancelAtPeriodEnd: false,
+} as z.infer<typeof SubscriptionDetailSchema>
+
+// mocking stripe components
+jest.mock('@stripe/react-stripe-js', () => {
+  function makeFakeComponent(name: string) {
+    // mocking onReady to be called after a bit of time
+    return function Component({ onReady }: { onReady?: any }) {
+      return name
+    }
+  }
+  return {
+    useElements: () => ({
+      getElement: jest.fn().mockReturnValue({
+        getValue: jest.fn().mockResolvedValue({
+          complete: true,
+          value: {
+            address: {},
+          },
+        }),
+      }),
+    }),
+    useStripe: () => ({}),
+    AddressElement: makeFakeComponent('AddressElement'),
+  }
+})
+
+const mockUseUpdateBillingAddress = useUpdateBillingAddress as jest.Mock
+
+describe('AddressCard', () => {
+  function setup() {
+    const user = userEvent.setup()
+
+    return { user }
+  }
+
+  describe(`when the user doesn't have any subscriptionDetail`, () => {
+    // NOTE: This test is misleading because we hide this component from a higher level in
+    // BillingDetails.tsx if there is no subscriptionDetail
+    it('renders the set card message', () => {
+      render(
+        <AddressCard subscriptionDetail={null} provider="gh" owner="codecov" />
+      )
+
+      expect(
+        screen.getByText(
+          /No address has been set. Please contact support if you think it’s an error or set it yourself./
+        )
+      ).toBeInTheDocument()
+    })
+  })
+
+  describe(`when the user doesn't have billing details`, () => {
+    it('renders an error message', () => {
+      render(
+        <AddressCard
+          // @ts-expect-error weird param funkiness
+          subscriptionDetail={{
+            ...subscriptionDetail,
+            defaultPaymentMethod: null,
+          }}
+          provider="gh"
+          owner="codecov"
+        />
+      )
+
+      expect(
+        screen.getByText(
+          /No address has been set. Please contact support if you think it’s an error or set it yourself./
+        )
+      ).toBeInTheDocument()
+    })
+
+    describe('when the user clicks on "Set Address"', () => {
+      it(`doesn't render address info stuff anymore`, async () => {
+        const { user } = setup()
+        render(
+          <AddressCard
+            // @ts-expect-error weird param funkiness
+            subscriptionDetail={{
+              ...subscriptionDetail,
+              defaultPaymentMethod: null,
+            }}
+            provider="gh"
+            owner="codecov"
+          />
+        )
+
+        mockUseUpdateBillingAddress.mockReturnValue({
+          mutate: () => null,
+          isLoading: false,
+        })
+        await user.click(screen.getByTestId('open-modal'))
+
+        expect(screen.queryByText(/123 Sesame St./)).not.toBeInTheDocument()
+      })
+
+      it('renders the address form component', async () => {
+        const { user } = setup()
+        render(
+          <AddressCard
+            // @ts-expect-error weird param funkiness
+            subscriptionDetail={{
+              ...subscriptionDetail,
+              defaultPaymentMethod: null,
+            }}
+            provider="gh"
+            owner="codecov"
+          />
+        )
+
+        mockUseUpdateBillingAddress.mockReturnValue({
+          mutate: () => null,
+          isLoading: false,
+        })
+        await user.click(screen.getByTestId('open-modal'))
+
+        expect(
+          screen.getByRole('button', { name: /update/i })
+        ).toBeInTheDocument()
+      })
+    })
+  })
+
+  describe('when the user has an address', () => {
+    it('renders the address information', () => {
+      render(
+        <AddressCard
+          subscriptionDetail={subscriptionDetail}
+          provider="gh"
+          owner="codecov"
+        />
+      )
+
+      expect(screen.getByText(/Billing address/)).toBeInTheDocument()
+      expect(screen.getByText(/123 Sesame St./)).toBeInTheDocument()
+      expect(screen.getByText(/San Francisco, CA 12345/)).toBeInTheDocument()
+    })
+
+    it('renders the card holder information', () => {
+      render(
+        <AddressCard
+          subscriptionDetail={subscriptionDetail}
+          provider="gh"
+          owner="codecov"
+        />
+      )
+
+      expect(screen.getByText(/Cardholder name/)).toBeInTheDocument()
+      expect(screen.getByText(/Bob Smith/)).toBeInTheDocument()
+    })
+  })
+
+  describe('when the user clicks on Edit', () => {
+    it(`doesn't render the card anymore`, async () => {
+      const { user } = setup()
+      const updateAddress = jest.fn()
+      mockUseUpdateBillingAddress.mockReturnValue({
+        mutate: updateAddress,
+        isLoading: false,
+      })
+
+      render(
+        <AddressCard
+          subscriptionDetail={subscriptionDetail}
+          provider="gh"
+          owner="codecov"
+        />
+      )
+      await user.click(screen.getByTestId('edit-address'))
+
+      expect(screen.queryByText(/Cardholder name/)).not.toBeInTheDocument()
+      expect(screen.queryByText(/Bob Smith/)).not.toBeInTheDocument()
+      expect(screen.queryByText(/Billing address/)).not.toBeInTheDocument()
+      expect(screen.queryByText(/123 Sesame St./)).not.toBeInTheDocument()
+      expect(
+        screen.queryByText(/San Francisco, CA 12345/)
+      ).not.toBeInTheDocument()
+    })
+
+    it('renders the form', async () => {
+      const { user } = setup()
+      const updateAddress = jest.fn()
+      mockUseUpdateBillingAddress.mockReturnValue({
+        mutate: updateAddress,
+        isLoading: false,
+      })
+      render(
+        <AddressCard
+          subscriptionDetail={subscriptionDetail}
+          provider="gh"
+          owner="codecov"
+        />
+      )
+      await user.click(screen.getByTestId('edit-address'))
+
+      expect(
+        screen.getByRole('button', { name: /update/i })
+      ).toBeInTheDocument()
+    })
+
+    describe('when submitting', () => {
+      it('calls the service to update the address', async () => {
+        const { user } = setup()
+        const updateAddress = jest.fn()
+        mockUseUpdateBillingAddress.mockReturnValue({
+          mutate: updateAddress,
+          isLoading: false,
+        })
+        render(
+          <AddressCard
+            subscriptionDetail={subscriptionDetail}
+            provider="gh"
+            owner="codecov"
+          />
+        )
+        await user.click(screen.getByTestId('edit-address'))
+        await user.click(screen.queryByRole('button', { name: /update/i })!)
+
+        expect(updateAddress).toHaveBeenCalled()
+      })
+    })
+
+    describe('when the user clicks on cancel', () => {
+      it(`doesn't render the form anymore`, async () => {
+        const { user } = setup()
+        mockUseUpdateBillingAddress.mockReturnValue({
+          mutate: jest.fn(),
+          isLoading: false,
+        })
+        render(
+          <AddressCard
+            subscriptionDetail={subscriptionDetail}
+            provider="gh"
+            owner="codecov"
+          />
+        )
+
+        await user.click(screen.getByTestId('edit-address'))
+        await user.click(screen.getByRole('button', { name: /Cancel/ }))
+
+        expect(
+          screen.queryByRole('button', { name: /save/i })
+        ).not.toBeInTheDocument()
+      })
+    })
+  })
+
+  describe('when there is an error in the form', () => {
+    it('renders the error', async () => {
+      const { user } = setup()
+      const randomError = 'not a valid address'
+      mockUseUpdateBillingAddress.mockReturnValue({
+        mutate: jest.fn(),
+        error: randomError,
+      })
+      render(
+        <AddressCard
+          subscriptionDetail={subscriptionDetail}
+          provider="gh"
+          owner="codecov"
+        />
+      )
+
+      await user.click(screen.getByTestId('edit-address'))
+
+      expect(screen.getByText(randomError)).toBeInTheDocument()
+    })
+  })
+
+  describe('when the form is loading', () => {
+    it('has the error and save button disabled', async () => {
+      const { user } = setup()
+      mockUseUpdateBillingAddress.mockReturnValue({
+        mutate: jest.fn(),
+        isLoading: true,
+      })
+      render(
+        <AddressCard
+          subscriptionDetail={subscriptionDetail}
+          provider="gh"
+          owner="codecov"
+        />
+      )
+      await user.click(screen.getByTestId('edit-address'))
+
+      expect(screen.queryByRole('button', { name: /update/i })).toBeDisabled()
+      expect(screen.queryByRole('button', { name: /cancel/i })).toBeDisabled()
+    })
+  })
+})

--- a/src/pages/PlanPage/subRoutes/CurrentOrgPlan/BillingDetails/Address/AddressCard.tsx
+++ b/src/pages/PlanPage/subRoutes/CurrentOrgPlan/BillingDetails/Address/AddressCard.tsx
@@ -26,18 +26,20 @@ function AddressCard({
   return (
     <div className="flex flex-col gap-2 border-t p-4">
       <div className="flex justify-between">
-        <h4 className="font-semibold">Billing address</h4>
-        {!isFormOpen && (
-          <A
-            variant="semibold"
-            onClick={() => setIsFormOpen(true)}
-            hook="edit-address"
-            isExternal={false}
-            to={''}
-          >
-            Edit <Icon name="chevronRight" size="sm" variant="solid" />
-          </A>
-        )}
+        {!isFormOpen ? (
+          <>
+            <h4 className="font-semibold">Cardholder name</h4>
+            <A
+              variant="semibold"
+              onClick={() => setIsFormOpen(true)}
+              hook="edit-address"
+              isExternal={false}
+              to={undefined}
+            >
+              Edit <Icon name="chevronRight" size="sm" variant="solid" />
+            </A>
+          </>
+        ) : null}
       </div>
       {isFormOpen ? (
         <AddressForm
@@ -49,6 +51,9 @@ function AddressCard({
         />
       ) : billingDetails ? (
         <div>
+          <p>{`${billingDetails.name}`}</p>
+          <br />
+          <h4 className="mb-2 font-semibold">Billing address</h4>
           <p>{`${billingDetails.address?.line1}`}</p>
           <p>{`${billingDetails.address?.city}, ${billingDetails.address?.state} ${billingDetails.address?.postalCode}`}</p>
         </div>
@@ -63,7 +68,7 @@ function AddressCard({
               hook="open-modal"
               variant="primary"
               onClick={() => setIsFormOpen(true)}
-              to={''}
+              to={undefined}
               disabled={false}
             >
               Set address

--- a/src/pages/PlanPage/subRoutes/CurrentOrgPlan/BillingDetails/Address/AddressCard.tsx
+++ b/src/pages/PlanPage/subRoutes/CurrentOrgPlan/BillingDetails/Address/AddressCard.tsx
@@ -1,0 +1,78 @@
+import { useState } from 'react'
+import { z } from 'zod'
+
+import { SubscriptionDetailSchema } from 'services/account'
+import A from 'ui/A'
+import Button from 'ui/Button'
+import Icon from 'ui/Icon'
+
+import AddressForm from './AddressForm'
+
+interface AddressCardProps {
+  subscriptionDetail: z.infer<typeof SubscriptionDetailSchema>
+  provider: string
+  owner: string
+}
+
+function AddressCard({
+  subscriptionDetail,
+  provider,
+  owner,
+}: AddressCardProps) {
+  const [isFormOpen, setIsFormOpen] = useState(false)
+  const billingDetails =
+    subscriptionDetail?.defaultPaymentMethod?.billingDetails
+
+  return (
+    <div className="flex flex-col gap-2 border-t p-4">
+      <div className="flex justify-between">
+        <h4 className="font-semibold">Billing address</h4>
+        {!isFormOpen && (
+          <A
+            variant="semibold"
+            onClick={() => setIsFormOpen(true)}
+            hook="edit-address"
+            isExternal={false}
+            to={''}
+          >
+            Edit <Icon name="chevronRight" size="sm" variant="solid" />
+          </A>
+        )}
+      </div>
+      {isFormOpen ? (
+        <AddressForm
+          name={billingDetails?.name || ''}
+          address={billingDetails?.address}
+          provider={provider}
+          owner={owner}
+          closeForm={() => setIsFormOpen(false)}
+        />
+      ) : billingDetails ? (
+        <div>
+          <p>{`${billingDetails.address?.line1}`}</p>
+          <p>{`${billingDetails.address?.city}, ${billingDetails.address?.state} ${billingDetails.address?.postalCode}`}</p>
+        </div>
+      ) : (
+        <div className="flex flex-col gap-4 text-ds-gray-quinary">
+          <p className="mt-4">
+            No address has been set. Please contact support if you think it’s an
+            error or set it yourself.
+          </p>
+          <div className="flex self-start">
+            <Button
+              hook="open-modal"
+              variant="primary"
+              onClick={() => setIsFormOpen(true)}
+              to={''}
+              disabled={false}
+            >
+              Set address
+            </Button>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default AddressCard

--- a/src/pages/PlanPage/subRoutes/CurrentOrgPlan/BillingDetails/Address/AddressForm.tsx
+++ b/src/pages/PlanPage/subRoutes/CurrentOrgPlan/BillingDetails/Address/AddressForm.tsx
@@ -1,0 +1,102 @@
+import { AddressElement, useElements } from '@stripe/react-stripe-js'
+import cs from 'classnames'
+import { useState } from 'react'
+import { z } from 'zod'
+
+import { AddressSchema } from 'services/account'
+import { useUpdateBillingAddress } from 'services/account/useUpdateBillingAddress'
+import Button from 'ui/Button'
+
+interface AddressFormProps {
+  address?: z.infer<typeof AddressSchema>
+  name?: string
+  closeForm: () => void
+  provider: string
+  owner: string
+}
+
+function AddressForm({
+  address,
+  name,
+  closeForm,
+  provider,
+  owner,
+}: AddressFormProps) {
+  const [errorState, setErrorState] = useState('')
+
+  const elements = useElements()
+  const {
+    // mutate: updateAddress,
+    isLoading,
+    error,
+    reset,
+  } = useUpdateBillingAddress({
+    provider,
+    owner,
+  })
+
+  function submit(e: React.FormEvent) {
+    e.preventDefault()
+
+    if (!elements) {
+      return null
+    }
+
+    // updateAddress(elements.getElement(AddressElement), { onSuccess: closeForm })
+  }
+
+  const showError = (error && !reset) || errorState
+
+  return (
+    <form onSubmit={submit} aria-label="form">
+      <div className={cs('flex flex-col gap-3')}>
+        <div className="mt-2 flex flex-col gap-2">
+          <AddressElement
+            onChange={(e) => setErrorState('')}
+            options={{
+              mode: 'billing',
+              autocomplete: { mode: 'automatic' },
+              fields: { phone: 'never' },
+              defaultValues: {
+                name: name,
+                address: {
+                  line1: address?.line1,
+                  line2: address?.line2,
+                  city: address?.city,
+                  state: address?.state,
+                  // eslint-disable-next-line camelcase
+                  postal_code: address?.postalCode,
+                  country: address?.country || '',
+                },
+              },
+            }}
+          />
+          <p className="mt-1 text-ds-primary-red">{showError && errorState}</p>
+        </div>
+        <div className="flex gap-1">
+          <Button
+            hook="update-address"
+            type="submit"
+            variant="primary"
+            disabled={isLoading}
+            to={''}
+          >
+            Update
+          </Button>
+          <Button
+            type="button"
+            hook="cancel-address-update"
+            variant="plain"
+            disabled={isLoading}
+            onClick={closeForm}
+            to={''}
+          >
+            Cancel
+          </Button>
+        </div>
+      </div>
+    </form>
+  )
+}
+
+export default AddressForm

--- a/src/pages/PlanPage/subRoutes/CurrentOrgPlan/BillingDetails/Address/AddressForm.tsx
+++ b/src/pages/PlanPage/subRoutes/CurrentOrgPlan/BillingDetails/Address/AddressForm.tsx
@@ -1,6 +1,5 @@
 import { AddressElement, useElements } from '@stripe/react-stripe-js'
 import cs from 'classnames'
-import { useState } from 'react'
 import { z } from 'zod'
 
 import { AddressSchema } from 'services/account'
@@ -22,11 +21,9 @@ function AddressForm({
   provider,
   owner,
 }: AddressFormProps) {
-  const [errorState, setErrorState] = useState('')
-
   const elements = useElements()
   const {
-    // mutate: updateAddress,
+    mutate: updateAddress,
     isLoading,
     error,
     reset,
@@ -35,24 +32,28 @@ function AddressForm({
     owner,
   })
 
-  function submit(e: React.FormEvent) {
+  async function submit(e: React.FormEvent) {
     e.preventDefault()
 
     if (!elements) {
       return null
     }
 
-    // updateAddress(elements.getElement(AddressElement), { onSuccess: closeForm })
+    const newAddressObj = await elements.getElement('address')?.getValue()
+
+    if (newAddressObj?.complete) {
+      updateAddress(newAddressObj.value.address, { onSuccess: closeForm })
+    }
   }
 
-  const showError = (error && !reset) || errorState
+  const showError = error && !reset
 
   return (
     <form onSubmit={submit} aria-label="form">
       <div className={cs('flex flex-col gap-3')}>
         <div className="mt-2 flex flex-col gap-2">
           <AddressElement
-            onChange={(e) => setErrorState('')}
+            className={'font-semibold'}
             options={{
               mode: 'billing',
               autocomplete: { mode: 'automatic' },
@@ -71,15 +72,15 @@ function AddressForm({
               },
             }}
           />
-          <p className="mt-1 text-ds-primary-red">{showError && errorState}</p>
+          <p className="mt-1 text-ds-primary-red">{showError && error}</p>
         </div>
         <div className="flex gap-1">
           <Button
-            hook="update-address"
+            hook="submit-address-update"
             type="submit"
             variant="primary"
             disabled={isLoading}
-            to={''}
+            to={undefined}
           >
             Update
           </Button>
@@ -89,7 +90,7 @@ function AddressForm({
             variant="plain"
             disabled={isLoading}
             onClick={closeForm}
-            to={''}
+            to={undefined}
           >
             Cancel
           </Button>

--- a/src/pages/PlanPage/subRoutes/CurrentOrgPlan/BillingDetails/BillingDetails.tsx
+++ b/src/pages/PlanPage/subRoutes/CurrentOrgPlan/BillingDetails/BillingDetails.tsx
@@ -2,6 +2,7 @@ import { useParams } from 'react-router-dom'
 
 import { useAccountDetails } from 'services/account'
 
+import AddressCard from './Address/AddressCard'
 import EmailAddress from './EmailAddress'
 import PaymentCard from './PaymentCard'
 
@@ -28,7 +29,12 @@ function BillingDetails() {
       <EmailAddress />
       <PaymentCard
         // @ts-expect-error - TODO fix this once we update PaymentCard to TS
-        subscriptionDetail={accountDetails?.subscriptionDetail}
+        subscriptionDetail={subscriptionDetail}
+        provider={provider}
+        owner={owner}
+      />
+      <AddressCard
+        subscriptionDetail={subscriptionDetail}
         provider={provider}
         owner={owner}
       />

--- a/src/pages/PlanPage/subRoutes/CurrentOrgPlan/BillingDetails/EmailAddress/EmailAddress.tsx
+++ b/src/pages/PlanPage/subRoutes/CurrentOrgPlan/BillingDetails/EmailAddress/EmailAddress.tsx
@@ -67,7 +67,7 @@ function EmailAddress() {
             onClick={() => setIsFormOpen(true)}
             hook="edit-email"
           >
-            Edit email <Icon name="chevronRight" size="sm" variant="solid" />
+            Edit <Icon name="chevronRight" size="sm" variant="solid" />
           </A>
         )}
       </div>

--- a/src/pages/PlanPage/subRoutes/CurrentOrgPlan/BillingDetails/PaymentCard/CreditCardForm.tsx
+++ b/src/pages/PlanPage/subRoutes/CurrentOrgPlan/BillingDetails/PaymentCard/CreditCardForm.tsx
@@ -66,7 +66,7 @@ function CreditCardForm({ closeForm, provider, owner }: CreditCardFormProps) {
             type="submit"
             variant="primary"
             disabled={isLoading}
-            to={''}
+            to={undefined}
           >
             Update
           </Button>
@@ -76,7 +76,7 @@ function CreditCardForm({ closeForm, provider, owner }: CreditCardFormProps) {
             variant="plain"
             disabled={isLoading}
             onClick={closeForm}
-            to={''}
+            to={undefined}
           >
             Cancel
           </Button>

--- a/src/pages/PlanPage/subRoutes/CurrentOrgPlan/BillingDetails/PaymentCard/CreditCardForm.tsx
+++ b/src/pages/PlanPage/subRoutes/CurrentOrgPlan/BillingDetails/PaymentCard/CreditCardForm.tsx
@@ -66,7 +66,7 @@ function CreditCardForm({ closeForm, provider, owner }: CreditCardFormProps) {
             type="submit"
             variant="primary"
             disabled={isLoading}
-            to=""
+            to={''}
           >
             Update
           </Button>
@@ -76,7 +76,7 @@ function CreditCardForm({ closeForm, provider, owner }: CreditCardFormProps) {
             variant="plain"
             disabled={isLoading}
             onClick={closeForm}
-            to=""
+            to={''}
           >
             Cancel
           </Button>

--- a/src/pages/PlanPage/subRoutes/CurrentOrgPlan/BillingDetails/PaymentCard/PaymentCard.jsx
+++ b/src/pages/PlanPage/subRoutes/CurrentOrgPlan/BillingDetails/PaymentCard/PaymentCard.jsx
@@ -22,7 +22,7 @@ function PaymentCard({ subscriptionDetail, provider, owner }) {
             onClick={() => setIsFormOpen(true)}
             hook="edit-card"
           >
-            Edit card <Icon name="chevronRight" size="sm" variant="solid" />
+            Edit <Icon name="chevronRight" size="sm" variant="solid" />
           </A>
         )}
       </div>

--- a/src/services/account/useAccountDetails.ts
+++ b/src/services/account/useAccountDetails.ts
@@ -45,6 +45,17 @@ const InvoiceSchema = z
   })
   .nullable()
 
+export const AddressSchema = z
+  .object({
+    city: z.string().nullable(),
+    country: z.string().nullable(),
+    line1: z.string().nullable(),
+    line2: z.string().nullable(),
+    postalCode: z.string().nullable(),
+    state: z.string().nullable(),
+  })
+  .nullable()
+
 export const PaymentMethodSchema = z
   .object({
     card: z.object({
@@ -55,16 +66,7 @@ export const PaymentMethodSchema = z
     }),
     billingDetails: z
       .object({
-        address: z
-          .object({
-            city: z.string().nullable(),
-            country: z.string().nullable(),
-            line1: z.string().nullable(),
-            line2: z.string().nullable(),
-            postalCode: z.string().nullable(),
-            state: z.string().nullable(),
-          })
-          .nullable(),
+        address: AddressSchema,
         email: z.string().nullable(),
         name: z.string().nullable(),
         phone: z.string().nullable(),

--- a/src/services/account/useUpdateBillingAddress.spec.tsx
+++ b/src/services/account/useUpdateBillingAddress.spec.tsx
@@ -92,14 +92,17 @@ describe('useUpdateBillingAddress', () => {
         }
       )
 
-      result.current.mutate({
-        line1: '45 Fremont St.',
-        line2: '',
-        city: 'San Francisco',
-        state: 'CA',
-        country: 'US',
-        postalCode: '94105',
-      })
+      result.current.mutate(
+        {
+          line1: '45 Fremont St.',
+          line2: '',
+          city: 'San Francisco',
+          state: 'CA',
+          country: 'US',
+          postal_code: '94105',
+        },
+        {}
+      )
 
       await waitFor(() => result.current.isLoading)
       await waitFor(() => !result.current.isLoading)

--- a/src/services/account/useUpdateBillingAddress.ts
+++ b/src/services/account/useUpdateBillingAddress.ts
@@ -1,19 +1,13 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { z } from 'zod'
 
 import Api from 'shared/api'
+
+import { AddressSchema } from './useAccountDetails'
 
 interface useUpdateBillingAddressParams {
   provider: string
   owner: string
-}
-
-interface AddressInfo {
-  line1: string
-  line2: string
-  city: string
-  state: string
-  country: string
-  postalCode: string
 }
 
 export function useUpdateBillingAddress({
@@ -23,10 +17,11 @@ export function useUpdateBillingAddress({
   const queryClient = useQueryClient()
 
   return useMutation({
-    mutationFn: (addressInfo: AddressInfo) => {
+    mutationFn: (addressInfo: z.infer<typeof AddressSchema>) => {
       const path = `/${provider}/${owner}/account-details/update_billing_address`
 
       // NOTE: Hardcoded for now until we link up to address form
+
       const body = {
         /* eslint-disable camelcase */
         billing_address: {
@@ -41,7 +36,7 @@ export function useUpdateBillingAddress({
       return Api.patch({ path, provider, body })
     },
     onSuccess: (data) => {
-      queryClient.invalidateQueries(['accountDetails'])
+      queryClient.invalidateQueries(['accountDetails', provider, owner], data)
     },
   })
 }

--- a/src/services/account/useUpdateBillingAddress.ts
+++ b/src/services/account/useUpdateBillingAddress.ts
@@ -1,37 +1,42 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query'
-import { z } from 'zod'
 
 import Api from 'shared/api'
-
-import { AddressSchema } from './useAccountDetails'
 
 interface useUpdateBillingAddressParams {
   provider: string
   owner: string
 }
 
+interface useUpdateBillingAddressReturn {
+  reset: () => void
+  error: null | Error
+  isLoading: boolean
+  mutate: (variables: any, data: any) => void
+  data: undefined | unknown
+}
+
+interface AddressInfo {
+  line1: string
+  line2: string | null
+  city: string
+  country: string
+  postal_code: string
+  state: string
+}
+
 export function useUpdateBillingAddress({
   provider,
   owner,
-}: useUpdateBillingAddressParams) {
+}: useUpdateBillingAddressParams): useUpdateBillingAddressReturn {
   const queryClient = useQueryClient()
 
   return useMutation({
-    mutationFn: (addressInfo: z.infer<typeof AddressSchema>) => {
+    mutationFn: (addressInfo: AddressInfo) => {
       const path = `/${provider}/${owner}/account-details/update_billing_address`
-
-      // NOTE: Hardcoded for now until we link up to address form
 
       const body = {
         /* eslint-disable camelcase */
-        billing_address: {
-          line1: '45 Fremont St.',
-          line2: '',
-          city: 'San Francisco',
-          state: 'CA',
-          country: 'US',
-          postal_code: '94105',
-        },
+        billing_address: addressInfo,
       }
       return Api.patch({ path, provider, body })
     },


### PR DESCRIPTION
# Description

Aside from the title of this PR rhyming, I also hoped to accomplish a few things with this PR. Those are as follows:

- New Address Form component
- View component when address form is not clicked
- Updating the useUpdateBillingAddress hook to actually call our address update endpoint
- Minor UI tweaks for buttons: Edit email etc -> Edit

Many of these changes, and the unit tests were modeled after useUpdateCard.tsx, and PaymentCard.tsx, so shoutout @adrian-codecov for building those components initially in a very easy to follow way!

# Screenshots

# Link to Sample Entry

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.