### PR TITLE
Other CLI New repo onboarding text changes

### DIFF
--- a/src/pages/RepoPage/CoverageOnboarding/CircleCI/CircleCI.tsx
+++ b/src/pages/RepoPage/CoverageOnboarding/CircleCI/CircleCI.tsx
@@ -170,7 +170,7 @@ function Step3() {
         <p>
           Once merged to your default branch, subsequent pull requests will have
           Codecov checks and comments. Additionally, you’ll find your repo
-          coverage dashboard here. If you have merged try reloading the page.
+          coverage dashboard here. If you have merged, try reloading the page.
         </p>
       </Card.Content>
     </Card>

--- a/src/pages/RepoPage/CoverageOnboarding/GitHubActions/GitHubActions.tsx
+++ b/src/pages/RepoPage/CoverageOnboarding/GitHubActions/GitHubActions.tsx
@@ -169,7 +169,7 @@ function Step3() {
         <p>
           Once merged to your default branch, subsequent pull requests will have
           Codecov checks and comments. Additionally, you’ll find your repo
-          coverage dashboard here. If you have merged try reloading the page.
+          coverage dashboard here. If you have merged, try reloading the page.
         </p>
       </Card.Content>
     </Card>

--- a/src/pages/RepoPage/CoverageOnboarding/NewRepoTab.spec.tsx
+++ b/src/pages/RepoPage/CoverageOnboarding/NewRepoTab.spec.tsx
@@ -160,15 +160,15 @@ describe('NewRepoTab', () => {
       setup({})
       render(<NewRepoTab />, { wrapper: wrapper() })
 
-      const selectorHeader = await screen.findByText('Select your CI')
+      const selectorHeader = await screen.findByText('Select a setup option')
       expect(selectorHeader).toBeInTheDocument()
 
       const githubActions = await screen.findByText('Using GitHub Actions')
       const circleCI = await screen.findByText('Using Circle CI')
-      const otherCI = await screen.findByText('Other')
+      const codecovCLI = await screen.findByText("Using Codecov's CLI")
       expect(githubActions).toBeInTheDocument()
       expect(circleCI).toBeInTheDocument()
-      expect(otherCI).toBeInTheDocument()
+      expect(codecovCLI).toBeInTheDocument()
     })
 
     describe('initial selection', () => {

--- a/src/pages/RepoPage/CoverageOnboarding/NewRepoTab.tsx
+++ b/src/pages/RepoPage/CoverageOnboarding/NewRepoTab.tsx
@@ -67,7 +67,7 @@ function CISelector({ provider, owner, repo }: CISelectorProps) {
   return (
     <Card>
       <Card.Header>
-        <Card.Title size="base">Select your CI</Card.Title>
+        <Card.Title size="base">Select a setup option</Card.Title>
       </Card.Header>
       <Card.Content>
         <RadioTileGroup
@@ -92,7 +92,9 @@ function CISelector({ provider, owner, repo }: CISelectorProps) {
             value={CI_PROVIDERS.OtherCI}
             data-testid="other-ci-radio"
           >
-            <RadioTileGroup.Label>Other</RadioTileGroup.Label>
+            <RadioTileGroup.Label>
+              Using Codecov&apos;s CLI
+            </RadioTileGroup.Label>
           </RadioTileGroup.Item>
         </RadioTileGroup>
       </Card.Content>

--- a/src/pages/RepoPage/CoverageOnboarding/OtherCI/OtherCI.spec.tsx
+++ b/src/pages/RepoPage/CoverageOnboarding/OtherCI/OtherCI.spec.tsx
@@ -155,7 +155,7 @@ describe('OtherCI', () => {
       expect(header).toBeInTheDocument()
 
       const headerLink = await screen.findByRole('link', {
-        name: /uploader to your/,
+        name: /Codecov CLI/,
       })
       expect(headerLink).toBeInTheDocument()
       expect(headerLink).toHaveAttribute(
@@ -193,7 +193,7 @@ describe('OtherCI', () => {
       setup({})
       render(<OtherCI />, { wrapper })
 
-      const box = await screen.findByText(/codecovcli upload-process/)
+      const box = await screen.findByText(/upload-process/)
       expect(box).toBeInTheDocument()
     })
 

--- a/src/pages/RepoPage/CoverageOnboarding/OtherCI/OtherCI.tsx
+++ b/src/pages/RepoPage/CoverageOnboarding/OtherCI/OtherCI.tsx
@@ -132,7 +132,7 @@ function Step4() {
         <p>
           Once merged to your default branch, subsequent pull requests will have
           Codecov checks and comments. Additionally, you’ll find your repo
-          coverage dashboard here. If you have merged try reloading the page.
+          coverage dashboard here. If you have merged, try reloading the page.
         </p>
       </Card.Content>
     </Card>

--- a/src/pages/RepoPage/CoverageOnboarding/OtherCI/OtherCI.tsx
+++ b/src/pages/RepoPage/CoverageOnboarding/OtherCI/OtherCI.tsx
@@ -32,7 +32,7 @@ function OtherCI() {
   const uploadToken = orgUploadToken ?? data?.repository?.uploadToken ?? ''
   const tokenCopy = orgUploadToken ? 'global' : 'repository'
 
-  const uploadCommand = `codecovcli upload-process -t ${uploadToken}${
+  const uploadCommand = `./codecov -u https://qa.codecov.dev upload-process -t ${uploadToken}${
     orgUploadToken ? `-r ${repo}` : ''
   }`
 
@@ -81,15 +81,16 @@ function Step2() {
     <Card>
       <Card.Header>
         <Card.Title size="base">
-          Step 2: add Codecov{' '}
+          Step 2: add the{' '}
           <A
             to={{ pageName: 'uploader' }}
             data-testid="uploader"
             isExternal
             hook="uploaderLink"
           >
-            uploader to your CI workflow
-          </A>
+            Codecov CLI
+          </A>{' '}
+          to your CI environment
         </Card.Title>
       </Card.Header>
       <Card.Content className="flex flex-col gap-4">

--- a/src/pages/RepoPage/CoverageOnboarding/OtherCI/OtherCI.tsx
+++ b/src/pages/RepoPage/CoverageOnboarding/OtherCI/OtherCI.tsx
@@ -1,5 +1,7 @@
 import { useParams } from 'react-router-dom'
 
+import config from 'config'
+
 import { useOrgUploadToken } from 'services/orgUploadToken'
 import { useRepo } from 'services/repo'
 import { useFlags } from 'shared/featureFlags'
@@ -32,9 +34,9 @@ function OtherCI() {
   const uploadToken = orgUploadToken ?? data?.repository?.uploadToken ?? ''
   const tokenCopy = orgUploadToken ? 'global' : 'repository'
 
-  const uploadCommand = `./codecov -u https://qa.codecov.dev upload-process -t ${uploadToken}${
-    orgUploadToken ? `-r ${repo}` : ''
-  }`
+  const uploadCommand = `./codecov -u ${
+    config.API_URL
+  } upload-process -t ${uploadToken}${orgUploadToken ? `-r ${repo}` : ''}`
 
   return (
     <div className="flex flex-col gap-6">

--- a/src/pages/RepoPage/CoverageOnboarding/OtherCI/OtherCI.tsx
+++ b/src/pages/RepoPage/CoverageOnboarding/OtherCI/OtherCI.tsx
@@ -34,9 +34,9 @@ function OtherCI() {
   const uploadToken = orgUploadToken ?? data?.repository?.uploadToken ?? ''
   const tokenCopy = orgUploadToken ? 'global' : 'repository'
 
-  const apiUrlCopy = config.IS_SELF_HOSTED ? ` ${config.API_URL}` : ''
-  const uploadCommand = `./codecov -u${apiUrlCopy} upload-process -t ${uploadToken}${
-    orgUploadToken ? `-r ${repo}` : ''
+  const apiUrlCopy = config.IS_SELF_HOSTED ? ` -u ${config.API_URL}` : ''
+  const uploadCommand = `./codecov${apiUrlCopy} upload-process -t ${uploadToken}${
+    orgUploadToken ? ` -r ${repo}` : ''
   }`
 
   return (

--- a/src/pages/RepoPage/CoverageOnboarding/OtherCI/OtherCI.tsx
+++ b/src/pages/RepoPage/CoverageOnboarding/OtherCI/OtherCI.tsx
@@ -34,9 +34,10 @@ function OtherCI() {
   const uploadToken = orgUploadToken ?? data?.repository?.uploadToken ?? ''
   const tokenCopy = orgUploadToken ? 'global' : 'repository'
 
-  const uploadCommand = `./codecov -u ${
-    config.API_URL
-  } upload-process -t ${uploadToken}${orgUploadToken ? `-r ${repo}` : ''}`
+  const apiUrlCopy = config.IS_SELF_HOSTED ? ` ${config.API_URL}` : ''
+  const uploadCommand = `./codecov -u${apiUrlCopy} upload-process -t ${uploadToken}${
+    orgUploadToken ? `-r ${repo}` : ''
+  }`
 
   return (
     <div className="flex flex-col gap-6">
@@ -111,7 +112,8 @@ function Step3({ uploadCommand }: Step3Props) {
     <Card>
       <Card.Header>
         <Card.Title size="base">
-          Step 3: upload coverage to Codecov via CLI after your tests have run
+          Step 3: upload coverage to Codecov via the CLI after your tests have
+          run
         </Card.Title>
       </Card.Header>
       <Card.Content className="flex flex-col gap-4">
@@ -133,7 +135,7 @@ function Step4() {
       <Card.Content className="flex flex-col gap-4">
         <p>
           Once merged to your default branch, subsequent pull requests will have
-          Codecov checks and comments. Additionally, you’ll find your repo
+          Codecov checks and comments. Additionally, you&apos;ll find your repo
           coverage dashboard here. If you have merged, try reloading the page.
         </p>
       </Card.Content>

--- a/src/pages/RepoPage/CoverageOnboarding/OtherCI/TerminalInstructions/InstructionBox.spec.tsx
+++ b/src/pages/RepoPage/CoverageOnboarding/OtherCI/TerminalInstructions/InstructionBox.spec.tsx
@@ -101,17 +101,4 @@ describe('InstructionBox', () => {
       expect(instruction).toBeInTheDocument()
     })
   })
-
-  describe('when user is a self hosted user', () => {
-    it('renders windows specific instruction', async () => {
-      const { user } = setup({ isSelfHosted: true })
-      render(<InstructionBox />)
-
-      const WindowsButton = screen.getByRole('button', { name: 'Windows' })
-      await user.click(WindowsButton)
-
-      const instruction = screen.getByText(/--verbose --enterprise-url/)
-      expect(instruction).toBeInTheDocument()
-    })
-  })
 })

--- a/src/pages/RepoPage/CoverageOnboarding/OtherCI/TerminalInstructions/InstructionBox.tsx
+++ b/src/pages/RepoPage/CoverageOnboarding/OtherCI/TerminalInstructions/InstructionBox.tsx
@@ -1,15 +1,12 @@
 import cs from 'classnames'
 import { type MouseEvent, useState } from 'react'
 
-import config from 'config'
-
 import { CopyClipboard } from 'ui/CopyClipboard'
 
 import {
-  aplineLinuxSystemInstructions,
+  alpineLinuxSystemInstructions,
   linuxSystemInstructions,
   macOSSystemInstructions,
-  selfHostedSystemInstructions,
   windowsSystemInstructions,
 } from './instructions'
 
@@ -22,7 +19,7 @@ const systemsEnum = Object.freeze({
 
 const systemsMapper = Object.freeze({
   Linux: linuxSystemInstructions,
-  'Alpine Linux': aplineLinuxSystemInstructions,
+  'Alpine Linux': alpineLinuxSystemInstructions,
   macOS: macOSSystemInstructions,
   Windows: windowsSystemInstructions,
 })
@@ -43,9 +40,7 @@ export function InstructionBox() {
     setCurSystem(name)
   }
 
-  const systemContent = config.IS_SELF_HOSTED
-    ? selfHostedSystemInstructions
-    : systemsMapper[curSystem as keyof typeof systemsMapper]
+  const systemContent = systemsMapper[curSystem as keyof typeof systemsMapper]
 
   return (
     <div

--- a/src/pages/RepoPage/CoverageOnboarding/OtherCI/TerminalInstructions/instructions.ts
+++ b/src/pages/RepoPage/CoverageOnboarding/OtherCI/TerminalInstructions/instructions.ts
@@ -60,12 +60,3 @@ shasum -a 256 -c codecov.SHA256SUM
 sudo chmod +x codecov
 ./codecov --help
 `
-
-export const selfHostedSystemInstructions = `# here we'll upload the test report called  coverage-service.xml, we are passing 
-# in the flag called "service" and a dyncamic name  to specify a specifc test run
-# we are using some options params like --verbose and --fail-on-error
-# the most important that you must pass in this case is the actual upload token
-# NOTE: we're adding a parameter for the self-hosted URL
-
-./codecov --verbose --enterprise-url https://<your-codecov-self-hosted-url> upload-process --fail-on-error -t \${{ secrets.CODECOV_TOKEN }}
--n 'service'-\${{ github.run_id }} -F service -f coverage-service.xml`

--- a/src/pages/RepoPage/CoverageOnboarding/OtherCI/TerminalInstructions/instructions.ts
+++ b/src/pages/RepoPage/CoverageOnboarding/OtherCI/TerminalInstructions/instructions.ts
@@ -46,7 +46,7 @@ sudo chmod +x codecov
 ./codecov --help
 `
 
-export const aplineLinuxSystemInstructions = `# download Codecov CLI
+export const alpineLinuxSystemInstructions = `# download Codecov CLI
 curl -Os https://cli.codecov.io/latest/alpine/codecov
 
 # integrity check


### PR DESCRIPTION
# Description

Closes https://github.com/codecov/engineering-team/issues/1812

Figma: https://www.figma.com/design/oSgW7AFOXDr1TGrkWh79kV/GH-1812?node-id=1-488&t=H7qE1Ij99oPCP235-1

# Code Example

# Notable Changes

# Screenshots

Cloud:
<img width="1062" alt="cloud" src="https://github.com/user-attachments/assets/02eea0e4-c1eb-47b7-b520-7226e40a111a">
OLD Self-Hosted (step 3): <img width="1045" alt="old_enterprise_step_2" src="https://github.com/user-attachments/assets/1ad22652-1fc2-428a-9cfb-7f0fad95136f">
NEW Self-Hosted (step 3 now same as cloud):<img width="1027" alt="new_enterprise" src="https://github.com/user-attachments/assets/fecb1f44-fabc-4c5c-a173-1e4e5a60e88c">


<img width="993" alt="Screenshot 2024-06-18 at 4 22 04 PM" src="https://github.com/codecov/gazebo/assets/170470397/2d35e1a2-6003-4198-9939-0902c41278fd">


# Link to Sample Entry

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.