### PR TITLE
[feat] Add user onboarding metrics tracking + mutation 

### DIFF
--- a/src/pages/DefaultOrgSelector/DefaultOrgSelector.jsx
+++ b/src/pages/DefaultOrgSelector/DefaultOrgSelector.jsx
@@ -5,6 +5,7 @@ import { Redirect, useHistory, useParams } from 'react-router-dom'
 import { z } from 'zod'
 
 import { TrialStatuses, usePlanData } from 'services/account'
+import { useStoreCodecovEventMetric } from 'services/codecovEventMetrics'
 import { useUpdateDefaultOrganization } from 'services/defaultOrganization'
 import { useStaticNavLinks } from 'services/navigation'
 import { useStartTrial } from 'services/trial'
@@ -63,6 +64,7 @@ function DefaultOrgSelector() {
 
   const { data: currentUser, isLoading: userIsLoading } = useUser()
   const { mutate: updateDefaultOrg } = useUpdateDefaultOrganization()
+  const { mutate: storeEventMetric } = useStoreCodecovEventMetric()
 
   const selectedOrg = orgValue?.org?.username ?? currentUser?.user?.username
 
@@ -100,7 +102,11 @@ function DefaultOrgSelector() {
 
   const onSubmit = () => {
     updateDefaultOrg({ username: selectedOrg })
-
+    storeEventMetric({
+      owner: selectedOrg,
+      event: 'CLICKED_BUTTON',
+      jsonPayload: { action: 'Selected Default Org' },
+    })
     if (
       isBasicPlan(planData?.plan?.value) &&
       selectedOrg !== currentUser?.user?.username &&

--- a/src/pages/RepoPage/BundlesTab/BundleOnboarding/BundleOnboarding.tsx
+++ b/src/pages/RepoPage/BundlesTab/BundleOnboarding/BundleOnboarding.tsx
@@ -1,9 +1,10 @@
-import { Suspense } from 'react'
+import { Suspense, useEffect } from 'react'
 import { Switch, useHistory, useLocation, useParams } from 'react-router-dom'
 
 import { SentryRoute } from 'sentry'
 
 import NotFound from 'pages/NotFound'
+import { useStoreCodecovEventMetric } from 'services/codecovEventMetrics'
 import { useNavLinks } from 'services/navigation'
 import { useRepo } from 'services/repo'
 import { useRedirect } from 'shared/useRedirect'
@@ -121,6 +122,15 @@ const BundleOnboarding: React.FC = () => {
   const { provider, owner, repo } = useParams<URLParams>()
   const { data } = useRepo({ provider, owner, repo })
   const { hardRedirect } = useRedirect({ href: `/${provider}` })
+  const { mutate: storeEventMetric } = useStoreCodecovEventMetric()
+
+  useEffect(() => {
+    storeEventMetric({
+      owner,
+      event: 'VISITED_PAGE',
+      jsonPayload: { page: 'Bundle Onboarding' },
+    })
+  }, [storeEventMetric, owner])
 
   // if no upload token redirect
   if (!data?.repository?.uploadToken) {

--- a/src/pages/RepoPage/CoverageOnboarding/CircleCI/CircleCI.tsx
+++ b/src/pages/RepoPage/CoverageOnboarding/CircleCI/CircleCI.tsx
@@ -1,5 +1,6 @@
 import { useParams } from 'react-router-dom'
 
+import { useStoreCodecovEventMetric } from 'services/codecovEventMetrics'
 import { useOrgUploadToken } from 'services/orgUploadToken'
 import { useRepo } from 'services/repo'
 import { useFlags } from 'shared/featureFlags'
@@ -64,6 +65,8 @@ interface Step1Props {
 }
 
 function Step1({ tokenCopy, uploadToken, providerName }: Step1Props) {
+  const { mutate: storeEventMetric } = useStoreCodecovEventMetric()
+  const { owner } = useParams<URLParams>()
   return (
     <Card>
       <Card.Header>
@@ -89,7 +92,17 @@ function Step1({ tokenCopy, uploadToken, providerName }: Step1Props) {
           <CodeSnippet className="basis-1/3" clipboard="CODECOV_TOKEN">
             CODECOV_TOKEN
           </CodeSnippet>
-          <CodeSnippet className="basis-2/3" clipboard={uploadToken}>
+          <CodeSnippet
+            className="basis-2/3"
+            clipboard={uploadToken}
+            clipboardOnClick={() =>
+              storeEventMetric({
+                owner,
+                event: 'COPIED_TEXT',
+                jsonPayload: { text: 'Step 1 CircleCI' },
+              })
+            }
+          >
             {uploadToken}
           </CodeSnippet>
         </div>
@@ -103,6 +116,8 @@ interface Step2Props {
 }
 
 function Step2({ defaultBranch }: Step2Props) {
+  const { mutate: storeEventMetric } = useStoreCodecovEventMetric()
+  const { owner } = useParams<URLParams>()
   return (
     <Card>
       <Card.Header>
@@ -125,7 +140,18 @@ function Step2({ defaultBranch }: Step2Props) {
           Add the following to your .circleci/config.yaml and push changes to
           repository.
         </p>
-        <CodeSnippet clipboard={orbsString}>{orbsString}</CodeSnippet>
+        <CodeSnippet
+          clipboard={orbsString}
+          clipboardOnClick={() =>
+            storeEventMetric({
+              owner,
+              event: 'COPIED_TEXT',
+              jsonPayload: { text: 'Step 2 CircleCI' },
+            })
+          }
+        >
+          {orbsString}
+        </CodeSnippet>
         <ExampleBlurb />
       </Card.Content>
     </Card>

--- a/src/pages/RepoPage/CoverageOnboarding/GitHubActions/GitHubActions.spec.tsx
+++ b/src/pages/RepoPage/CoverageOnboarding/GitHubActions/GitHubActions.spec.tsx
@@ -1,5 +1,6 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { graphql } from 'msw'
 import { setupServer } from 'msw/node'
 import { Suspense } from 'react'
@@ -83,14 +84,24 @@ describe('GitHubActions', () => {
     mockedUseFlags.mockReturnValue({
       newRepoFlag: hasOrgUploadToken,
     })
+
+    const mockMetricMutationVariables = jest.fn()
+    const mockGetItem = jest.spyOn(window.localStorage.__proto__, 'getItem')
+    mockGetItem.mockReturnValue(null)
+
     server.use(
       graphql.query('GetRepo', (req, res, ctx) =>
         res(ctx.status(200), ctx.data(mockGetRepo))
       ),
       graphql.query('GetOrgUploadToken', (req, res, ctx) => {
         return res(ctx.status(200), ctx.data(mockGetOrgUploadToken))
+      }),
+      graphql.mutation('storeEventMetric', (req, res, ctx) => {
+        mockMetricMutationVariables(req?.variables)
+        return res(ctx.status(200), ctx.data({ storeEventMetric: null }))
       })
     )
+    return { mockMetricMutationVariables }
   }
 
   describe('step one', () => {
@@ -258,6 +269,26 @@ describe('GitHubActions', () => {
       expect(bodyLink).toHaveAttribute(
         'href',
         'https://github.com/codecov/Codecov-user-feedback/issues/18'
+      )
+    })
+  })
+
+  describe('user copies text', () => {
+    it('stores codecov metric', async () => {
+      const { mockMetricMutationVariables } = setup({})
+      const user = userEvent.setup()
+      render(<GitHubActions />, { wrapper })
+
+      const copyCommands = await screen.findAllByTestId(
+        'clipboard-code-snippet'
+      )
+      expect(copyCommands.length).toEqual(3)
+
+      await user.click(copyCommands[1] as HTMLElement)
+
+      await user.click(copyCommands[2] as HTMLElement)
+      await waitFor(() =>
+        expect(mockMetricMutationVariables).toHaveBeenCalledTimes(2)
       )
     })
   })

--- a/src/pages/RepoPage/CoverageOnboarding/GitHubActions/GitHubActions.tsx
+++ b/src/pages/RepoPage/CoverageOnboarding/GitHubActions/GitHubActions.tsx
@@ -1,5 +1,6 @@
 import { useParams } from 'react-router-dom'
 
+import { useStoreCodecovEventMetric } from 'services/codecovEventMetrics'
 import { useOrgUploadToken } from 'services/orgUploadToken'
 import { useRepo } from 'services/repo'
 import { useFlags } from 'shared/featureFlags'
@@ -60,6 +61,8 @@ interface Step1Props {
 }
 
 function Step1({ tokenCopy, uploadToken }: Step1Props) {
+  const { mutate: storeEventMetric } = useStoreCodecovEventMetric()
+  const { owner } = useParams<URLParams>()
   return (
     <Card>
       <Card.Header>
@@ -87,7 +90,17 @@ function Step1({ tokenCopy, uploadToken }: Step1Props) {
           >
             CODECOV_TOKEN
           </CodeSnippet>
-          <CodeSnippet className="basis-2/3" clipboard={uploadToken}>
+          <CodeSnippet
+            className="basis-2/3"
+            clipboard={uploadToken}
+            clipboardOnClick={() =>
+              storeEventMetric({
+                owner,
+                event: 'COPIED_TEXT',
+                jsonPayload: { text: 'Step 1 GHA' },
+              })
+            }
+          >
             {uploadToken}
           </CodeSnippet>
         </div>
@@ -102,6 +115,8 @@ interface Step2Props {
 }
 
 function Step2({ defaultBranch, actionString }: Step2Props) {
+  const { mutate: storeEventMetric } = useStoreCodecovEventMetric()
+  const { owner } = useParams<URLParams>()
   return (
     <Card>
       <Card.Header>
@@ -124,7 +139,18 @@ function Step2({ defaultBranch, actionString }: Step2Props) {
           After tests run, this will upload your coverage report to Codecov:
         </p>
 
-        <CodeSnippet clipboard={actionString}>{actionString}</CodeSnippet>
+        <CodeSnippet
+          clipboard={actionString}
+          clipboardOnClick={() =>
+            storeEventMetric({
+              owner,
+              event: 'COPIED_TEXT',
+              jsonPayload: { text: 'Step 2 GHA' },
+            })
+          }
+        >
+          {actionString}
+        </CodeSnippet>
         <ExampleBlurb />
       </Card.Content>
     </Card>

--- a/src/pages/RepoPage/CoverageOnboarding/NewRepoTab.tsx
+++ b/src/pages/RepoPage/CoverageOnboarding/NewRepoTab.tsx
@@ -1,4 +1,4 @@
-import { lazy , Suspense, useEffect } from 'react'
+import { lazy, Suspense, useEffect } from 'react'
 import { Switch, useHistory, useLocation, useParams } from 'react-router-dom'
 
 import { SentryRoute } from 'sentry'

--- a/src/pages/RepoPage/CoverageOnboarding/NewRepoTab.tsx
+++ b/src/pages/RepoPage/CoverageOnboarding/NewRepoTab.tsx
@@ -1,9 +1,10 @@
-import { lazy, Suspense } from 'react'
+import { lazy , Suspense, useEffect } from 'react'
 import { Switch, useHistory, useLocation, useParams } from 'react-router-dom'
 
 import { SentryRoute } from 'sentry'
 
 import NotFound from 'pages/NotFound'
+import { useStoreCodecovEventMetric } from 'services/codecovEventMetrics'
 import { useNavLinks } from 'services/navigation'
 import { useRepo } from 'services/repo'
 import { useRedirect } from 'shared/useRedirect'
@@ -127,6 +128,15 @@ function NewRepoTab() {
   const { provider, owner, repo } = useParams<URLParams>()
   const { data } = useRepo({ provider, owner, repo })
   const { hardRedirect } = useRedirect({ href: `/${provider}` })
+  const { mutate: storeEventMetric } = useStoreCodecovEventMetric()
+
+  useEffect(() => {
+    storeEventMetric({
+      owner,
+      event: 'VISITED_PAGE',
+      jsonPayload: { page: 'Coverage Onboarding' },
+    })
+  }, [storeEventMetric, owner])
 
   // if no upload token redirect
   // also have a component render incase redirect isn't fast enough

--- a/src/services/codecovEventMetrics/index.ts
+++ b/src/services/codecovEventMetrics/index.ts
@@ -1,0 +1,1 @@
+export * from './useStoreCodecovEventMetric'

--- a/src/services/codecovEventMetrics/useStoreCodecovEventMetric.spec.tsx
+++ b/src/services/codecovEventMetrics/useStoreCodecovEventMetric.spec.tsx
@@ -1,0 +1,129 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { renderHook, waitFor } from '@testing-library/react'
+import { graphql } from 'msw'
+import { setupServer } from 'msw/node'
+import { MemoryRouter, Route } from 'react-router-dom'
+
+import { useStoreCodecovEventMetric } from './useStoreCodecovEventMetric'
+
+const server = setupServer()
+
+const wrapper: React.FC<React.PropsWithChildren> = ({ children }) => (
+  <QueryClientProvider client={queryClient}>
+    <MemoryRouter initialEntries={['/gh']}>
+      <Route path="/:provider">{children}</Route>
+    </MemoryRouter>
+  </QueryClientProvider>
+)
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    mutations: {
+      retry: false,
+    },
+    queries: {
+      retry: false,
+    },
+  },
+  logger: {
+    error: () => null,
+    warn: () => null,
+    log: () => null,
+  },
+})
+
+beforeAll(() => {
+  server.listen({ onUnhandledRequest: 'warn' })
+})
+afterEach(() => {
+  queryClient.clear()
+  server.resetHandlers()
+})
+afterAll(() => {
+  server.close()
+})
+
+describe('useStoreCodecovEventMetric', () => {
+  function setup() {
+    const mockSetItem = jest.spyOn(window.localStorage.__proto__, 'setItem')
+    const mockGetItem = jest.spyOn(window.localStorage.__proto__, 'getItem')
+
+    server.use(
+      graphql.mutation('storeEventMetric', (req, res, ctx) => {
+        return res(ctx.status(200), ctx.data({ storeEventMetric: null }))
+      })
+    )
+
+    return { mockSetItem, mockGetItem }
+  }
+
+  afterEach(() => jest.resetAllMocks)
+
+  describe('when called', () => {
+    describe('when successful', () => {
+      it('calls the mutation fn', async () => {
+        setup()
+        const { result } = renderHook(() => useStoreCodecovEventMetric(), {
+          wrapper,
+        })
+
+        result.current.mutate({
+          owner: 'codecov',
+          event: 'CLICKED_BUTTON',
+          jsonPayload: {},
+        })
+
+        await waitFor(() =>
+          expect(result.current.data).toEqual({
+            data: {
+              storeEventMetric: null,
+            },
+          })
+        )
+      })
+
+      it('sets metric in local storage', async () => {
+        const { mockSetItem, mockGetItem } = setup()
+        const { result } = renderHook(() => useStoreCodecovEventMetric(), {
+          wrapper,
+        })
+
+        result.current.mutate({
+          owner: 'codecov',
+          event: 'CLICKED_BUTTON',
+          jsonPayload: {},
+        })
+
+        await waitFor(() => expect(mockGetItem).toHaveBeenCalled())
+        await waitFor(() =>
+          expect(mockSetItem).toHaveBeenCalledWith(
+            'UserOnboardingMetricsStored',
+            '["codecov|CLICKED_BUTTON|{}"]'
+          )
+        )
+      })
+    })
+
+    describe('metric exists in localstorage', () => {
+      it('does not fire mutation', async () => {
+        const { mockSetItem, mockGetItem } = setup()
+
+        const { result } = renderHook(() => useStoreCodecovEventMetric(), {
+          wrapper,
+        })
+
+        const metric = {
+          owner: 'codecov',
+          event: 'CLICKED_BUTTON',
+          jsonPayload: {},
+        }
+        mockGetItem.mockReturnValue(JSON.stringify(metric))
+
+        result.current.mutate(metric)
+
+        await waitFor(() => expect(mockGetItem).toHaveBeenCalled())
+        await waitFor(() => expect(mockSetItem).not.toHaveBeenCalled())
+      })
+    })
+  })
+})

--- a/src/services/codecovEventMetrics/useStoreCodecovEventMetric.tsx
+++ b/src/services/codecovEventMetrics/useStoreCodecovEventMetric.tsx
@@ -33,7 +33,7 @@ interface StoreEventMetricMutationArgs {
 }
 
 const LOCAL_STORAGE_KEY = 'UserOnboardingMetricsStored'
-const MAX_ENTRIES = 50
+const MAX_ENTRIES = 30
 
 const generateMetricString = (
   owner: string,

--- a/src/services/codecovEventMetrics/useStoreCodecovEventMetric.tsx
+++ b/src/services/codecovEventMetrics/useStoreCodecovEventMetric.tsx
@@ -1,0 +1,103 @@
+import { useMutation } from '@tanstack/react-query'
+import { useParams } from 'react-router-dom'
+
+import Api from 'shared/api'
+
+const mutationQuery = `
+  mutation storeEventMetric(
+    $input: StoreEventMetricsInput!
+  ) {
+    storeEventMetric(
+      input: $input
+    ) {
+      error {
+        ... on UnauthenticatedError {
+          message
+        }
+        ... on ValidationError {
+          message
+        }
+      }
+    }
+  }
+`
+
+interface Params {
+  provider: string
+}
+
+interface StoreEventMetricMutationArgs {
+  owner: string
+  event: string
+  jsonPayload: object
+}
+
+const LOCAL_STORAGE_KEY = 'UserOnboardingMetricsStored'
+const MAX_ENTRIES = 50
+
+const generateMetricString = (
+  owner: string,
+  event: string,
+  jsonPayload: string
+) => {
+  return `${owner}|${event}|${jsonPayload}`
+}
+
+const getStoredMetrics = (): string[] => {
+  const storedMetrics = localStorage.getItem(LOCAL_STORAGE_KEY)
+  return storedMetrics ? JSON.parse(storedMetrics) : []
+}
+
+const isMetricInLocalStorage = (metricString: string) => {
+  const storedMetrics = getStoredMetrics()
+  return storedMetrics.includes(metricString)
+}
+
+const addMetricToLocalStorage = (metricString: string) => {
+  let storedMetrics = getStoredMetrics()
+
+  // limit size of metrics stored to ensure we are in reasonable localstorage limits
+  if (storedMetrics.length >= MAX_ENTRIES) {
+    storedMetrics = storedMetrics.slice(1)
+  }
+
+  storedMetrics.push(metricString)
+  localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(storedMetrics))
+}
+
+export const useStoreCodecovEventMetric = () => {
+  const { provider } = useParams<Params>()
+
+  const mutation = useMutation({
+    mutationFn: async ({
+      owner,
+      event,
+      jsonPayload,
+    }: StoreEventMetricMutationArgs) => {
+      const jsonPayloadString = JSON.stringify(jsonPayload)
+      const metricString = generateMetricString(owner, event, jsonPayloadString)
+      if (isMetricInLocalStorage(metricString)) {
+        return
+      }
+
+      const variables = {
+        input: {
+          orgUsername: owner,
+          eventName: event,
+          jsonPayload: jsonPayloadString,
+        },
+      }
+
+      addMetricToLocalStorage(metricString)
+
+      return Api.graphqlMutation({
+        provider,
+        query: mutationQuery,
+        variables,
+        mutationPath: 'storeEventMetric',
+      })
+    },
+  })
+
+  return mutation
+}


### PR DESCRIPTION
# Description

This closes https://github.com/codecov/engineering-team/issues/1830. 

Notion: https://www.notion.so/sentry/Eng-Design-Tracking-Codecov-user-signup-to-first-commit-conversion-rate-6097411516f84563820276aafe3436ea

The useStoreCodecovMetric hook calls the storeCodecovMetric mutation [defined in API
](https://github.com/codecov/engineering-team/issues/1829) There are already a few layers of validation to sanitize input and prevent duplicate entries. In this PR, another check is added so as not to overcrowd the number of client network requests. 

We store all added metrics in `localstorage` and do not make a request if the client sees that we have already added that metric. The size of what can go into the `localstorage` object is also restricted to 30 entires to be reasonable with space constraints. 

![image](https://github.com/codecov/gazebo/assets/148245014/17aa2243-60a1-4ae0-bf87-c1954e524349)


<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.