### PR TITLE
feat: Select first bundle on bundles tab

### DIFF
--- a/src/pages/RepoPage/BundlesTab/BundleContent/BundleSummary/BundleSelector.spec.tsx
+++ b/src/pages/RepoPage/BundlesTab/BundleContent/BundleSummary/BundleSelector.spec.tsx
@@ -27,7 +27,7 @@ const mockBundles = {
         head: {
           bundleAnalysisReport: {
             __typename: 'BundleAnalysisReport',
-            bundles: [{ name: 'bundle1' }],
+            bundles: [{ name: 'bundle1' }, { name: 'bundle2' }],
           },
         },
       },
@@ -162,24 +162,35 @@ describe('BundleSelector', () => {
       expect(select).not.toBeDisabled()
     })
 
-    it('renders select bundle in button', async () => {
-      setup({})
-      render(<BundleSelector />, { wrapper: wrapper() })
+    describe('selector loads first bundle', () => {
+      it('renders selected bundle in button', async () => {
+        setup({})
+        render(<BundleSelector />, { wrapper: wrapper() })
 
-      const select = await screen.findByRole('button', {
-        name: 'bundle tab bundle selector',
+        const select = await screen.findByRole('button', {
+          name: 'bundle tab bundle selector',
+        })
+        expect(select).toBeInTheDocument()
+        expect(select).toHaveTextContent('bundle1')
       })
-      expect(select).toBeInTheDocument()
-      expect(select).toHaveTextContent('Select bundle')
+
+      it('puts the bundle in the url', async () => {
+        setup({})
+        render(<BundleSelector />, { wrapper: wrapper() })
+
+        await waitFor(() => {
+          expect(testLocation.pathname).toBe(
+            '/gh/codecov/test-repo/bundles/test-branch/bundle1'
+          )
+        })
+      })
     })
 
     describe('bundle is set in the url', () => {
       it('sets the button to that bundle', async () => {
         setup({})
         render(<BundleSelector />, {
-          wrapper: wrapper(
-            '/gh/codecov/test-repo/bundles/test-branch/test-bundle'
-          ),
+          wrapper: wrapper('/gh/codecov/test-repo/bundles/test-branch/bundle2'),
         })
 
         const select = await screen.findByRole('button', {
@@ -187,7 +198,7 @@ describe('BundleSelector', () => {
         })
         expect(select).toBeInTheDocument()
         expect(select).not.toBeDisabled()
-        expect(select).toHaveTextContent(/test-bundle/)
+        expect(select).toHaveTextContent(/bundle2/)
       })
     })
 
@@ -202,12 +213,12 @@ describe('BundleSelector', () => {
           })
           await user.click(select)
 
-          const bundle = await screen.findByText('bundle1')
+          const bundle = await screen.findByText('bundle2')
           await user.click(bundle)
 
           await waitFor(() => {
             expect(testLocation.pathname).toBe(
-              '/gh/codecov/test-repo/bundles/test-branch/bundle1'
+              '/gh/codecov/test-repo/bundles/test-branch/bundle2'
             )
           })
         })
@@ -228,9 +239,9 @@ describe('BundleSelector', () => {
           await user.click(select)
 
           const input = await screen.findByRole('combobox')
-          await user.type(input, 'bundle1')
+          await user.type(input, 'bundle2')
 
-          const foundBundle = await screen.findByText('bundle1')
+          const foundBundle = await screen.findByText('bundle2')
           expect(foundBundle).toBeInTheDocument()
         })
       })

--- a/src/pages/RepoPage/BundlesTab/BundleContent/BundleSummary/BundleSelector.tsx
+++ b/src/pages/RepoPage/BundlesTab/BundleContent/BundleSummary/BundleSelector.tsx
@@ -6,31 +6,6 @@ import { useNavLinks } from 'services/navigation'
 import { useRepoOverview } from 'services/repo'
 import Select from 'ui/Select'
 
-export const BundleSelectorSkeleton: React.FC = () => {
-  return (
-    <div className="md:w-64">
-      <h3 className="flex items-center gap-1 text-sm font-semibold text-ds-gray-octonary">
-        Bundle
-      </h3>
-      <span className="max-w-64 text-sm">
-        <Select
-          // @ts-expect-error
-          disabled={true}
-          resourceName="bundle"
-          placeholder="Select bundle"
-          dataMarketing="bundle-selector-bundle-tab"
-          ariaName="bundle tab bundle selector"
-          variant="gray"
-          isLoading={false}
-          items={[]}
-          value={'Select bundle'}
-          onChange={() => {}}
-        />
-      </span>
-    </div>
-  )
-}
-
 interface URLParams {
   provider: string
   owner: string

--- a/src/pages/RepoPage/BundlesTab/BundleContent/BundleSummary/BundleSelector.tsx
+++ b/src/pages/RepoPage/BundlesTab/BundleContent/BundleSummary/BundleSelector.tsx
@@ -53,12 +53,7 @@ const BundleSelector = forwardRef(({}, ref) => {
   } = useParams<URLParams>()
 
   const [selectedBundle, setSelectedBundle] = useState<string | undefined>(
-    () => {
-      if (bundle) {
-        return decodeURIComponent(bundle)
-      }
-      return undefined
-    }
+    bundle ? decodeURIComponent(bundle) : undefined
   )
 
   const { data: overviewData } = useRepoOverview({
@@ -84,6 +79,18 @@ const BundleSelector = forwardRef(({}, ref) => {
     [bundleData?.bundles]
   )
   const [filteredBundles, setFilteredBundles] = useState<Array<string>>([])
+
+  if (selectedBundle === undefined && bundles.length > 0) {
+    history.push(
+      bundlesLink.path({
+        // @ts-expect-error - useNavLinks needs to be typed
+        branch,
+        // @ts-expect-error - useNavLinks needs to be typed
+        bundle: encodeURIComponent(bundles[0]),
+      })
+    )
+    setSelectedBundle(bundles[0])
+  }
 
   return (
     <div className="md:w-64">

--- a/src/pages/RepoPage/BundlesTab/BundleContent/BundleSummary/BundleSummary.tsx
+++ b/src/pages/RepoPage/BundlesTab/BundleContent/BundleSummary/BundleSummary.tsx
@@ -2,7 +2,6 @@ import { lazy, Suspense, useCallback, useRef } from 'react'
 
 import BranchSelector from './BranchSelector'
 import { NoDetails } from './BundleDetails'
-import { BundleSelectorSkeleton } from './BundleSelector'
 
 const BundleDetails = lazy(() => import('./BundleDetails'))
 const BundleSelector = lazy(() => import('./BundleSelector'))
@@ -18,9 +17,7 @@ const BundleSummary: React.FC = () => {
     <div className="flex flex-col gap-8 py-4 md:flex-row md:justify-between">
       <div className="flex flex-col gap-4 md:flex-row">
         <BranchSelector resetBundleSelect={resetBundleSelect} />
-        <Suspense fallback={<BundleSelectorSkeleton />}>
-          <BundleSelector ref={bundleSelectRef} />
-        </Suspense>
+        <BundleSelector ref={bundleSelectRef} />
       </div>
       <Suspense fallback={<NoDetails />}>
         <BundleDetails />


### PR DESCRIPTION
# Description

This PR updates the `BundleSelector` component by having it default to the first bundle in the returned list of bundles and select it for the user.

Closes #1783

# Notable Changes

- Update `BundleSelector` to set bundle to first one from list
- Update tests

# Screenshots

https://github.com/codecov/gazebo/assets/105234307/71cca61f-db93-46db-bc46-fb60cf5d4891