### PR TITLE
chore: Update to latest version of victory for charts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -53,7 +53,7 @@
         "react-router-dom-v5-compat": "^6.15.0",
         "react-use": "^17.2.4",
         "tailwind-merge": "^2.3.0",
-        "victory": "^36.6.11",
+        "victory": "^37.0.2",
         "yup": "^0.32.11",
         "zod": "^3.21.4"
       },
@@ -8883,58 +8883,58 @@
       }
     },
     "node_modules/@types/d3-array": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.0.tgz",
-      "integrity": "sha512-tjU8juPSfhMnu6mJZPOCVVGba4rZoE0tjHDPb81PYwA8CzbaFscGjgkUM7juUJu6iWA1cCVWNEVwxZ5HN9Jj8Q=="
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.1.tgz",
+      "integrity": "sha512-Y2Jn2idRrLzUfAKV2LyRImR+y4oa2AntrgID95SHJxuMUrkNXmanDSed71sRNZysveJVt1hLLemQZIady0FpEg=="
     },
     "node_modules/@types/d3-color": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.2.tgz",
-      "integrity": "sha512-At+Ski7dL8Bs58E8g8vPcFJc8tGcaC12Z4m07+p41+DRqnZQcAlp3NfYjLrhNYv+zEyQitU1CUxXNjqUyf+c0g=="
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A=="
     },
     "node_modules/@types/d3-ease": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.1.tgz",
-      "integrity": "sha512-VZofjpEt8HWv3nxUAosj5o/+4JflnJ7Bbv07k17VO3T2WRuzGdZeookfaF60iVh5RdhVG49LE5w6LIshVUC6rg=="
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA=="
     },
     "node_modules/@types/d3-interpolate": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.3.tgz",
-      "integrity": "sha512-6OZ2EIB4lLj+8cUY7I/Cgn9Q+hLdA4DjJHYOQDiHL0SzqS1K9DL5xIOVBSIHgF+tiuO9MU1D36qvdIvRDRPh+Q==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
       "dependencies": {
         "@types/d3-color": "*"
       }
     },
     "node_modules/@types/d3-path": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.0.1.tgz",
-      "integrity": "sha512-blRhp7ki7pVznM8k6lk5iUU9paDbVRVq+/xpf0RRgSJn5gr6SE7RcFtxooYGMBOc1RZiGyqRpVdu5AD0z0ooMA=="
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-P2dlU/q51fkOc/Gfl3Ul9kicV7l+ra934qBFXCFhrZMOL6du1TM0pm1ThYvENukyOn5h9v+yMJ9Fn5JK4QozrQ=="
     },
     "node_modules/@types/d3-scale": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.6.tgz",
-      "integrity": "sha512-lo3oMLSiqsQUovv8j15X4BNEDOsnHuGjeVg7GRbAuB2PUa1prK5BNSOu6xixgNf3nqxPl4I1BqJWrPvFGlQoGQ==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.8.tgz",
+      "integrity": "sha512-gkK1VVTr5iNiYJ7vWDI+yUFFlszhNMtVeneJ6lUTKPjprsvLLI9/tgEGiXJOnlINJA8FyA88gfnQsHbybVZrYQ==",
       "dependencies": {
         "@types/d3-time": "*"
       }
     },
     "node_modules/@types/d3-shape": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.4.tgz",
-      "integrity": "sha512-M2/xsWPsjaZc5ifMKp1EBp0gqJG0eO/zlldJNOC85Y/5DGsBQ49gDkRJ2h5GY7ZVD6KUumvZWsylSbvTaJTqKg==",
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.6.tgz",
+      "integrity": "sha512-5KKk5aKGu2I+O6SONMYSNflgiP0WfZIQvVUMan50wHsLG1G94JlxEVnCpQARfTtzytuY0p/9PXXZb3I7giofIA==",
       "dependencies": {
         "@types/d3-path": "*"
       }
     },
     "node_modules/@types/d3-time": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.2.tgz",
-      "integrity": "sha512-kbdRXTmUgNfw5OTE3KZnFQn6XdIc4QGroN5UixgdrXATmYsdlPQS6pEut9tVlIojtzuFD4txs/L+Rq41AHtLpg=="
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.3.tgz",
+      "integrity": "sha512-2p6olUZ4w3s+07q3Tm2dbiMZy5pCDfYwtLXXHUnVzXgQlZ/OyPtUz6OL382BkOuGlLXqfT+wqv8Fw2v8/0geBw=="
     },
     "node_modules/@types/d3-timer": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.1.tgz",
-      "integrity": "sha512-GGTvzKccVEhxmRfJEB6zhY9ieT4UhGVUIQaBzFpUO9OXy2ycAlnPCSJLzmGGgqt3KVjqN3QCQB4g1rsZnHsWhg=="
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw=="
     },
     "node_modules/@types/debug": {
       "version": "4.1.10",
@@ -32506,384 +32506,361 @@
       }
     },
     "node_modules/victory": {
-      "version": "36.6.12",
-      "resolved": "https://registry.npmjs.org/victory/-/victory-36.6.12.tgz",
-      "integrity": "sha512-3CBOC++Bh0iGFWzY0lwqeirvzQxdxIYAFh4+ieJ+ghrfs8Uj5ReSpI+OKVPpvag8Vug5b16own2sWVVa6Lve+Q==",
+      "version": "37.0.2",
+      "resolved": "https://registry.npmjs.org/victory/-/victory-37.0.2.tgz",
+      "integrity": "sha512-/8qsoIJWMu11CYula+HBgjva6fu5ZO/0zJO14ZRXlI71vpMf7ga8Siakd7YIvFjWrlXPX2IFWM6jXe7bK0EKdg==",
       "dependencies": {
-        "victory-area": "^36.6.12",
-        "victory-axis": "^36.6.12",
-        "victory-bar": "^36.6.12",
-        "victory-box-plot": "^36.6.12",
-        "victory-brush-container": "^36.6.12",
-        "victory-brush-line": "^36.6.12",
-        "victory-candlestick": "^36.6.12",
-        "victory-canvas": "^36.6.12",
-        "victory-chart": "^36.6.12",
-        "victory-core": "^36.6.12",
-        "victory-create-container": "^36.6.12",
-        "victory-cursor-container": "^36.6.12",
-        "victory-errorbar": "^36.6.12",
-        "victory-group": "^36.6.12",
-        "victory-histogram": "^36.6.12",
-        "victory-legend": "^36.6.12",
-        "victory-line": "^36.6.12",
-        "victory-pie": "^36.6.12",
-        "victory-polar-axis": "^36.6.12",
-        "victory-scatter": "^36.6.12",
-        "victory-selection-container": "^36.6.12",
-        "victory-shared-events": "^36.6.12",
-        "victory-stack": "^36.6.12",
-        "victory-tooltip": "^36.6.12",
-        "victory-voronoi": "^36.6.12",
-        "victory-voronoi-container": "^36.6.12",
-        "victory-zoom-container": "^36.6.12"
+        "victory-area": "^37.0.2",
+        "victory-axis": "^37.0.2",
+        "victory-bar": "^37.0.2",
+        "victory-box-plot": "^37.0.2",
+        "victory-brush-container": "^37.0.2",
+        "victory-brush-line": "^37.0.2",
+        "victory-candlestick": "^37.0.2",
+        "victory-canvas": "^37.0.2",
+        "victory-chart": "^37.0.2",
+        "victory-core": "^37.0.2",
+        "victory-create-container": "^37.0.2",
+        "victory-cursor-container": "^37.0.2",
+        "victory-errorbar": "^37.0.2",
+        "victory-group": "^37.0.2",
+        "victory-histogram": "^37.0.2",
+        "victory-legend": "^37.0.2",
+        "victory-line": "^37.0.2",
+        "victory-pie": "^37.0.2",
+        "victory-polar-axis": "^37.0.2",
+        "victory-scatter": "^37.0.2",
+        "victory-selection-container": "^37.0.2",
+        "victory-shared-events": "^37.0.2",
+        "victory-stack": "^37.0.2",
+        "victory-tooltip": "^37.0.2",
+        "victory-voronoi": "^37.0.2",
+        "victory-voronoi-container": "^37.0.2",
+        "victory-zoom-container": "^37.0.2"
       },
       "peerDependencies": {
         "react": ">=16.6.0"
       }
     },
     "node_modules/victory-area": {
-      "version": "36.6.12",
-      "resolved": "https://registry.npmjs.org/victory-area/-/victory-area-36.6.12.tgz",
-      "integrity": "sha512-9v/+c22J0ryVKunU/7OuLFd/Wdty9d3RC0qzH86k0pfYqD4t5c+xa1rRQDiVTkdixrO9K1Ef0fvkOrABhGCIfg==",
+      "version": "37.0.2",
+      "resolved": "https://registry.npmjs.org/victory-area/-/victory-area-37.0.2.tgz",
+      "integrity": "sha512-KEuJiBg/VQq1CSQe8U1Gk1eI/sMm+Y4WGveKkx9lXvgPHqxXog2Of+j+q1ZY0bXVrb9vAlIuJHPg4Oq+UQRUYw==",
       "dependencies": {
         "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
-        "victory-core": "^36.6.12",
-        "victory-vendor": "^36.6.12"
+        "victory-core": "^37.0.2",
+        "victory-vendor": "^37.0.2"
       },
       "peerDependencies": {
         "react": ">=16.6.0"
       }
     },
     "node_modules/victory-axis": {
-      "version": "36.6.12",
-      "resolved": "https://registry.npmjs.org/victory-axis/-/victory-axis-36.6.12.tgz",
-      "integrity": "sha512-z5g/rPS20GbORYn08F8py+hvYZ//sLU1OxX8A76KTJwKpICS6bxvvOb/RD23WB6SPlOm3Nrp/9WHvD0KB0anAA==",
+      "version": "37.0.2",
+      "resolved": "https://registry.npmjs.org/victory-axis/-/victory-axis-37.0.2.tgz",
+      "integrity": "sha512-tmjq43m7hto7NblaJwPiSloilFIlmZ4UMt91yv0dBUlM8sexRTE8g/fAvnioTblVEec/t91sqQBoLta5VZnWIQ==",
       "dependencies": {
         "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
-        "victory-core": "^36.6.12"
+        "victory-core": "^37.0.2"
       },
       "peerDependencies": {
         "react": ">=16.6.0"
       }
     },
     "node_modules/victory-bar": {
-      "version": "36.6.12",
-      "resolved": "https://registry.npmjs.org/victory-bar/-/victory-bar-36.6.12.tgz",
-      "integrity": "sha512-0vwivPCfj73kaL9Oe2oyGTArXUyqwf4W41NVSv8EvjzDrYFBh7C5FGGuUJJZqUQYHjl+4G8ftnKYfhRbTIajtg==",
+      "version": "37.0.2",
+      "resolved": "https://registry.npmjs.org/victory-bar/-/victory-bar-37.0.2.tgz",
+      "integrity": "sha512-ofezvu4NYkxaQZuLJSnQVsgQKO+869IEYZQuIvc7EtiLrVSznNygqcDrZzLJ+0q6ZxGRIJ/1cdEgaz2dS40ukQ==",
       "dependencies": {
         "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
-        "victory-core": "^36.6.12",
-        "victory-vendor": "^36.6.12"
+        "victory-core": "^37.0.2",
+        "victory-vendor": "^37.0.2"
       },
       "peerDependencies": {
         "react": ">=16.6.0"
       }
     },
     "node_modules/victory-box-plot": {
-      "version": "36.6.12",
-      "resolved": "https://registry.npmjs.org/victory-box-plot/-/victory-box-plot-36.6.12.tgz",
-      "integrity": "sha512-4x3Ju9XBAaXeDp4WUUYX6vMrVEQGWmLcLQSXsEGjXlAGVM2YF/339XtsoL5W41F8MxrlB63riIBdFCQ28W0gxA==",
+      "version": "37.0.2",
+      "resolved": "https://registry.npmjs.org/victory-box-plot/-/victory-box-plot-37.0.2.tgz",
+      "integrity": "sha512-NzhxPRXues5F3Ay3JRLAnDBGrSC3940KmFHtc14F0Y+KDmwMDa15c2MBME9Rhg6SOvKL/o+jGzYX8ohE3k94kA==",
       "dependencies": {
         "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
-        "victory-core": "^36.6.12",
-        "victory-vendor": "^36.6.12"
+        "victory-core": "^37.0.2",
+        "victory-vendor": "^37.0.2"
       },
       "peerDependencies": {
         "react": ">=16.6.0"
       }
     },
     "node_modules/victory-brush-container": {
-      "version": "36.6.12",
-      "resolved": "https://registry.npmjs.org/victory-brush-container/-/victory-brush-container-36.6.12.tgz",
-      "integrity": "sha512-sCx+q3X5EeqxVME3KZRLeHYVbdX5R3U9RSncOucTUwXrHsebrwsl+F9LKJ1l+Ohl73CmhStyD9Ap6zamKwfkbg==",
+      "version": "37.0.2",
+      "resolved": "https://registry.npmjs.org/victory-brush-container/-/victory-brush-container-37.0.2.tgz",
+      "integrity": "sha512-eZBarKzkGw1fM3n1FSGo5MAE7o4ZM3a87aSSRuIK4aMgGxaZkxKV4y219WCIIDeYw6U4l7T+tDXSw71XbXGG3g==",
       "dependencies": {
         "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
         "react-fast-compare": "^3.2.0",
-        "victory-core": "^36.6.12"
+        "victory-core": "^37.0.2"
       },
       "peerDependencies": {
         "react": ">=16.6.0"
       }
     },
     "node_modules/victory-brush-line": {
-      "version": "36.6.12",
-      "resolved": "https://registry.npmjs.org/victory-brush-line/-/victory-brush-line-36.6.12.tgz",
-      "integrity": "sha512-Nb2zi1iNvt/LpKazLJslTpViTuM65gykg4JiBkNL7yJlFMFAceX4Pe8PdKSlV3YnhNwPzt+Kwo+cT5HBuXB5dA==",
+      "version": "37.0.2",
+      "resolved": "https://registry.npmjs.org/victory-brush-line/-/victory-brush-line-37.0.2.tgz",
+      "integrity": "sha512-pPo5XiiNj33s1jdqnzs88W7B6DBI0RhUFRT4Ce5ciWpHw11aW/CvM4wa3OQhI2fiwCqmKv7v9lBiIWEKBcKgMQ==",
       "dependencies": {
         "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
         "react-fast-compare": "^3.2.0",
-        "victory-core": "^36.6.12"
+        "victory-core": "^37.0.2"
       },
       "peerDependencies": {
         "react": ">=16.6.0"
       }
     },
     "node_modules/victory-candlestick": {
-      "version": "36.6.12",
-      "resolved": "https://registry.npmjs.org/victory-candlestick/-/victory-candlestick-36.6.12.tgz",
-      "integrity": "sha512-xpA3hREbLLyy6kul681R0E2k0ZoqDh5UV8jq4F48G3jMxbd3wWvrPGdvJyQO1T+ptvdesdGGvXFVHRyRHV+Plw==",
+      "version": "37.0.2",
+      "resolved": "https://registry.npmjs.org/victory-candlestick/-/victory-candlestick-37.0.2.tgz",
+      "integrity": "sha512-Whaw1aRfWO11TGamwyonOcFHOtCxMggYEe8S+IFV8C4jrstucHEAr9BiTpqqsYjohv499bY8MfOaHEyBtETrfA==",
       "dependencies": {
         "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
-        "victory-core": "^36.6.12"
+        "victory-core": "^37.0.2"
       },
       "peerDependencies": {
         "react": ">=16.6.0"
       }
     },
     "node_modules/victory-canvas": {
-      "version": "36.6.12",
-      "resolved": "https://registry.npmjs.org/victory-canvas/-/victory-canvas-36.6.12.tgz",
-      "integrity": "sha512-ojNpfANjr/DGcJLRQD/uj6uxiLlFbBRGTKZTYj+AJeYml7t+g87uMzDwHbRw9MVn2UsA3ShFsFFF3/fyPZhs2w==",
+      "version": "37.0.2",
+      "resolved": "https://registry.npmjs.org/victory-canvas/-/victory-canvas-37.0.2.tgz",
+      "integrity": "sha512-jHOvcnoqboi9kkZw2dDObje1f5Mz4Om1xb9iGjEvNXO5n0epGgv3NXiBY7gmzTHlv3gj19AdGIsI7jaakQulOg==",
       "dependencies": {
         "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
-        "victory-bar": "^36.6.12",
-        "victory-core": "^36.6.12"
+        "victory-bar": "^37.0.2",
+        "victory-core": "^37.0.2"
       },
       "peerDependencies": {
         "react": ">=16.6.0"
       }
     },
     "node_modules/victory-chart": {
-      "version": "36.6.12",
-      "resolved": "https://registry.npmjs.org/victory-chart/-/victory-chart-36.6.12.tgz",
-      "integrity": "sha512-ySYjcZBzkTEZt5mWlUoCbQrXRZRw6lMOEd0HnC7FI6lJKgkFV3rYr39Qdl9KJ59reHwRW7NoJ4BOXpxXuCzq5g==",
+      "version": "37.0.2",
+      "resolved": "https://registry.npmjs.org/victory-chart/-/victory-chart-37.0.2.tgz",
+      "integrity": "sha512-OpNvSzypQyhyJtBYAcx+9vJZTry2HssBJVT5Yui1NrT4IcHTuw02z5Zg/RYFgADloqraA+TsVzZbJQcfD/j6MA==",
       "dependencies": {
         "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
         "react-fast-compare": "^3.2.0",
-        "victory-axis": "^36.6.12",
-        "victory-core": "^36.6.12",
-        "victory-polar-axis": "^36.6.12",
-        "victory-shared-events": "^36.6.12"
+        "victory-axis": "^37.0.2",
+        "victory-core": "^37.0.2",
+        "victory-polar-axis": "^37.0.2",
+        "victory-shared-events": "^37.0.2"
       },
       "peerDependencies": {
         "react": ">=16.6.0"
       }
     },
     "node_modules/victory-core": {
-      "version": "36.6.12",
-      "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-36.6.12.tgz",
-      "integrity": "sha512-9zWemm6JYRkxDcvpQntkOLFZL3T3XbIDeZsqfhv/30+SLak/H59QfYj6nhyJUZuWQVTUtbAHKjAAQh5wfqgVPw==",
+      "version": "37.0.2",
+      "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-37.0.2.tgz",
+      "integrity": "sha512-B3A3yCanjskShZTFtA1Bp8BLXniaTtjzaKHOChjCkay8oRkWjGMy0aZdCL7ezfUWVHAaFUIw248PgqApMn1K/w==",
       "dependencies": {
         "lodash": "^4.17.21",
-        "prop-types": "^15.8.1",
         "react-fast-compare": "^3.2.0",
-        "victory-vendor": "^36.6.12"
+        "victory-vendor": "^37.0.2"
       },
       "peerDependencies": {
         "react": ">=16.6.0"
       }
     },
     "node_modules/victory-create-container": {
-      "version": "36.6.12",
-      "resolved": "https://registry.npmjs.org/victory-create-container/-/victory-create-container-36.6.12.tgz",
-      "integrity": "sha512-TEwjWUevRm+JOh3SozuahGebo4xBBSfoHPxCA0CgxtmhxInPBCkYGtm7k6IJWQ8a4kVzvMTaR1qit3653JiZhQ==",
+      "version": "37.0.2",
+      "resolved": "https://registry.npmjs.org/victory-create-container/-/victory-create-container-37.0.2.tgz",
+      "integrity": "sha512-cojSUT/TWunznM3rMlchlYZ+QdTLKHQE519ZQdomA04rKdU+rK/X+XaeMHDWZVRZHp4YrfUmR7OfOb4AHBTm7w==",
       "dependencies": {
         "lodash": "^4.17.19",
-        "victory-brush-container": "^36.6.12",
-        "victory-core": "^36.6.12",
-        "victory-cursor-container": "^36.6.12",
-        "victory-selection-container": "^36.6.12",
-        "victory-voronoi-container": "^36.6.12",
-        "victory-zoom-container": "^36.6.12"
+        "victory-brush-container": "^37.0.2",
+        "victory-core": "^37.0.2",
+        "victory-cursor-container": "^37.0.2",
+        "victory-selection-container": "^37.0.2",
+        "victory-voronoi-container": "^37.0.2",
+        "victory-zoom-container": "^37.0.2"
       },
       "peerDependencies": {
         "react": ">=16.6.0"
       }
     },
     "node_modules/victory-cursor-container": {
-      "version": "36.6.12",
-      "resolved": "https://registry.npmjs.org/victory-cursor-container/-/victory-cursor-container-36.6.12.tgz",
-      "integrity": "sha512-MJAILAw+DMtDTN3fz7K7iAXnV0EEHezwBqS4JS0URoffZPwZZr0rKawQLFfJRh+TS9BO6bf0X3UtVRb4/TxlZA==",
+      "version": "37.0.2",
+      "resolved": "https://registry.npmjs.org/victory-cursor-container/-/victory-cursor-container-37.0.2.tgz",
+      "integrity": "sha512-07PB8XNYi9AqnwZjCxQ6gKcJip6p2fwUT1+aHYDUAy/ncL6xBZD4t3sXErPHT3ha/itx7I861OsehDLZCjnkHA==",
       "dependencies": {
         "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
-        "victory-core": "^36.6.12"
+        "victory-core": "^37.0.2"
       },
       "peerDependencies": {
         "react": ">=16.6.0"
       }
     },
     "node_modules/victory-errorbar": {
-      "version": "36.6.12",
-      "resolved": "https://registry.npmjs.org/victory-errorbar/-/victory-errorbar-36.6.12.tgz",
-      "integrity": "sha512-8EbVGsP9ZSWw+YVjKuB1LnEFQDpEmyRcet5p1WnsrnWSOZAlSAnv/oVdUcVP1suwW93B6S1Dy7DowR7njeKC6g==",
+      "version": "37.0.2",
+      "resolved": "https://registry.npmjs.org/victory-errorbar/-/victory-errorbar-37.0.2.tgz",
+      "integrity": "sha512-yA4IN1Scn9de8g4q1hL9S60BzRzyG2FqrjAOpgvUaVEzkWcxIiPLLOZFdwC0/8KCnPsGFJHHnL0OMQpbq2O1nA==",
       "dependencies": {
         "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
-        "victory-core": "^36.6.12"
+        "victory-core": "^37.0.2"
       },
       "peerDependencies": {
         "react": ">=16.6.0"
       }
     },
     "node_modules/victory-group": {
-      "version": "36.6.12",
-      "resolved": "https://registry.npmjs.org/victory-group/-/victory-group-36.6.12.tgz",
-      "integrity": "sha512-bN5M/+AWDTzb3ooTLxmVg8F63Ibbw5gqmLPUy6qFF7zDdDqMrmd9WG2JP/G88+pHlWHs+Phnce/r22y2oAojgQ==",
+      "version": "37.0.2",
+      "resolved": "https://registry.npmjs.org/victory-group/-/victory-group-37.0.2.tgz",
+      "integrity": "sha512-uBU3PdndeOxE5E+LVoVnT3ciJNwlTj99Deh178AARJ3jKuuH3hJ7Fnw+tgQjQNMdRuKKxILJdddd9ouktLTJJA==",
       "dependencies": {
         "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
         "react-fast-compare": "^3.2.0",
-        "victory-core": "^36.6.12",
-        "victory-shared-events": "^36.6.12"
+        "victory-core": "^37.0.2",
+        "victory-shared-events": "^37.0.2"
       },
       "peerDependencies": {
         "react": ">=16.6.0"
       }
     },
     "node_modules/victory-histogram": {
-      "version": "36.6.12",
-      "resolved": "https://registry.npmjs.org/victory-histogram/-/victory-histogram-36.6.12.tgz",
-      "integrity": "sha512-4vuOGFrUWdtMPGHxzIvrAuKyy6HIyzsCz7nKo55kL/deF9m+T8iqnnXWOVWaUpZGQ4xQrzb01AshQu/7ryhbGQ==",
+      "version": "37.0.2",
+      "resolved": "https://registry.npmjs.org/victory-histogram/-/victory-histogram-37.0.2.tgz",
+      "integrity": "sha512-9y6DU2Pw1XHlNAZJCrMCxGT3++55a8KwNDgzeXePetW1pUrpa3HPDJqo8ctLu9sRP6Lkk3DAplP0SpaS948AhA==",
       "dependencies": {
         "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
         "react-fast-compare": "^3.2.0",
-        "victory-bar": "^36.6.12",
-        "victory-core": "^36.6.12",
-        "victory-vendor": "^36.6.12"
+        "victory-bar": "^37.0.2",
+        "victory-core": "^37.0.2",
+        "victory-vendor": "^37.0.2"
       },
       "peerDependencies": {
         "react": ">=16.6.0"
       }
     },
     "node_modules/victory-legend": {
-      "version": "36.6.12",
-      "resolved": "https://registry.npmjs.org/victory-legend/-/victory-legend-36.6.12.tgz",
-      "integrity": "sha512-ssZM4/yarYDbIhz96n6wlCBNOHT8u/0oQNE6F5y45iDBJzJUVWuIQ+aKnr1+eIbylUp1hIopBtj4oN4N/RWtvA==",
+      "version": "37.0.2",
+      "resolved": "https://registry.npmjs.org/victory-legend/-/victory-legend-37.0.2.tgz",
+      "integrity": "sha512-mbScaQepyvLVghyRSxsccZwpf3LTz434GuWIh5aFQcP8pTrGT+9V8Wtw6N6W/4MxHBznh1sGZbI755k+IM2oNQ==",
       "dependencies": {
         "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
-        "victory-core": "^36.6.12"
+        "victory-core": "^37.0.2"
       },
       "peerDependencies": {
         "react": ">=16.6.0"
       }
     },
     "node_modules/victory-line": {
-      "version": "36.6.12",
-      "resolved": "https://registry.npmjs.org/victory-line/-/victory-line-36.6.12.tgz",
-      "integrity": "sha512-2wS8N9z+O+JhzYE4CczR+uWXYudhF3aWbYOzI5Jjf2XoQdjaeDEeawli3y0g76OE/sxPet4+sPzkn/f1tEFxGQ==",
+      "version": "37.0.2",
+      "resolved": "https://registry.npmjs.org/victory-line/-/victory-line-37.0.2.tgz",
+      "integrity": "sha512-b0Jj9uYGzWhA3KCbzjvraxKfP3gB+sqzaU/r2JQdICug0isGQHnng3vW40RNveEjE6CfIEHGZdylSCAbjAFhzQ==",
       "dependencies": {
         "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
-        "victory-core": "^36.6.12",
-        "victory-vendor": "^36.6.12"
+        "victory-core": "^37.0.2",
+        "victory-vendor": "^37.0.2"
       },
       "peerDependencies": {
         "react": ">=16.6.0"
       }
     },
     "node_modules/victory-pie": {
-      "version": "36.6.12",
-      "resolved": "https://registry.npmjs.org/victory-pie/-/victory-pie-36.6.12.tgz",
-      "integrity": "sha512-MOVcraD+aQungIS3HdjzukFzznFV2tDvsmhsSjFyONs3h4d18Vsc0tOTlnCuMmBb7Pih4Un4eGZRlHnyzwsqKA==",
+      "version": "37.0.2",
+      "resolved": "https://registry.npmjs.org/victory-pie/-/victory-pie-37.0.2.tgz",
+      "integrity": "sha512-rdaL7Or5BU/368xLoe8FThekxx9ICgwmtaUc2Lt1w8uklt6S3SBMbAoL2lmr5IutZf55HYRX64vM3TGqWjD3+w==",
       "dependencies": {
         "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
-        "victory-core": "^36.6.12",
-        "victory-vendor": "^36.6.12"
+        "victory-core": "^37.0.2",
+        "victory-vendor": "^37.0.2"
       },
       "peerDependencies": {
         "react": ">=16.6.0"
       }
     },
     "node_modules/victory-polar-axis": {
-      "version": "36.6.12",
-      "resolved": "https://registry.npmjs.org/victory-polar-axis/-/victory-polar-axis-36.6.12.tgz",
-      "integrity": "sha512-VL3lgzNcUupGXCdE+jPWFS5+621l4OL5/vR1pdINpzXHT2pEA/0CxQAw13a9NLtQyf+E05TxM6bEnJA/JEEVZQ==",
+      "version": "37.0.2",
+      "resolved": "https://registry.npmjs.org/victory-polar-axis/-/victory-polar-axis-37.0.2.tgz",
+      "integrity": "sha512-qqIk9fFYuL9G/RzHoXB/9ZI6DkKHdfdczI2vdl2rl0KdzAcfd9Eosa9EHmnTh/9ijPJvYi++1ul1WQNRWXBVSg==",
       "dependencies": {
         "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
-        "victory-core": "^36.6.12"
+        "victory-core": "^37.0.2"
       },
       "peerDependencies": {
         "react": ">=16.6.0"
       }
     },
     "node_modules/victory-scatter": {
-      "version": "36.6.12",
-      "resolved": "https://registry.npmjs.org/victory-scatter/-/victory-scatter-36.6.12.tgz",
-      "integrity": "sha512-wGf/eHzKOkpi/eceBRcJHghOmFo4u08duedUGREoAHpNAh4yUEsYhF75ttcOCwMidxaScxcmXFmh5eE4FlckwA==",
+      "version": "37.0.2",
+      "resolved": "https://registry.npmjs.org/victory-scatter/-/victory-scatter-37.0.2.tgz",
+      "integrity": "sha512-BY83Y+D3enHqPvHAt3HrEaT5ckmcj3vq3QJ28e1b6DhlbGWoS/DEmhf5OiHF+wCBSSDBOkAyq1uTXSbcHKyLXQ==",
       "dependencies": {
         "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
-        "victory-core": "^36.6.12"
+        "victory-core": "^37.0.2"
       },
       "peerDependencies": {
         "react": ">=16.6.0"
       }
     },
     "node_modules/victory-selection-container": {
-      "version": "36.6.12",
-      "resolved": "https://registry.npmjs.org/victory-selection-container/-/victory-selection-container-36.6.12.tgz",
-      "integrity": "sha512-jFNvS0lBrRPhNs7lN1hZ5kn/WEPDo1E7NU8a3pDCH4o9jm5EesBHt+KPb0DOUPMPhnjs5nglBDOlNhdDwEC6PQ==",
+      "version": "37.0.2",
+      "resolved": "https://registry.npmjs.org/victory-selection-container/-/victory-selection-container-37.0.2.tgz",
+      "integrity": "sha512-HgLmGTIZNdlpZ081ZowJAoUYE69q4p9sB0h8FBKbM7xPDXfH9Eh6MZ5RIfoen9GdB4Hz0He4vQZIU5OOK3TNDQ==",
       "dependencies": {
         "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
-        "victory-core": "^36.6.12"
+        "victory-core": "^37.0.2"
       },
       "peerDependencies": {
         "react": ">=16.6.0"
       }
     },
     "node_modules/victory-shared-events": {
-      "version": "36.6.12",
-      "resolved": "https://registry.npmjs.org/victory-shared-events/-/victory-shared-events-36.6.12.tgz",
-      "integrity": "sha512-pbM7ApTe81rVhzdmcGGVbU6I0zDgCFfyiItutHakxL7oypTNu5QtC/pkNza4IFVDDF10KX/eymOcAxkke3V/gg==",
+      "version": "37.0.2",
+      "resolved": "https://registry.npmjs.org/victory-shared-events/-/victory-shared-events-37.0.2.tgz",
+      "integrity": "sha512-1U1yljfsFs3fGJmoSZt1j/ZgdV4tf2hWhue2Xixn71ZEYFBlsF6hY3gXI5EzRji1QhHa3mnar17wrgr++H+CWQ==",
       "dependencies": {
         "json-stringify-safe": "^5.0.1",
         "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
         "react-fast-compare": "^3.2.0",
-        "victory-core": "^36.6.12"
+        "victory-core": "^37.0.2"
       },
       "peerDependencies": {
         "react": ">=16.6.0"
       }
     },
     "node_modules/victory-stack": {
-      "version": "36.6.12",
-      "resolved": "https://registry.npmjs.org/victory-stack/-/victory-stack-36.6.12.tgz",
-      "integrity": "sha512-dhukj84UGXEOO7yAtMgXwKFZAgc+GvgLSFcYFeHlygEZR7B1Mivd88PNNOeOMaJeRp22jC9yu6Z/54LbRm8YlA==",
+      "version": "37.0.2",
+      "resolved": "https://registry.npmjs.org/victory-stack/-/victory-stack-37.0.2.tgz",
+      "integrity": "sha512-CbinJJxkN7WT6XJ8EWZLXiibqHGU++rKqyh95jo01U+FZ7QOu5l0qf7OxfEnmEWGLF3J5hcMEOSX22lrdtxl+A==",
       "dependencies": {
         "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
         "react-fast-compare": "^3.2.0",
-        "victory-core": "^36.6.12",
-        "victory-shared-events": "^36.6.12"
+        "victory-core": "^37.0.2",
+        "victory-shared-events": "^37.0.2"
       },
       "peerDependencies": {
         "react": ">=16.6.0"
       }
     },
     "node_modules/victory-tooltip": {
-      "version": "36.6.12",
-      "resolved": "https://registry.npmjs.org/victory-tooltip/-/victory-tooltip-36.6.12.tgz",
-      "integrity": "sha512-i9Q+51yQr3PBlAx81tJRLlyM/b+6z/EyYyWgrB1rdnq3VaKLdx0RSj8y2fqNXafdoGPh2mQAWYrxqBTNGxBMJg==",
+      "version": "37.0.2",
+      "resolved": "https://registry.npmjs.org/victory-tooltip/-/victory-tooltip-37.0.2.tgz",
+      "integrity": "sha512-UYne2i9in8bwxz0z6+kknvZbKVbMdfapQnISDBBWfmqWVHirsxNGJUFaSrHMqEBdNtTCXLd0vNhADJxIUKGtqA==",
       "dependencies": {
         "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
-        "victory-core": "^36.6.12"
+        "victory-core": "^37.0.2"
       },
       "peerDependencies": {
         "react": ">=16.6.0"
       }
     },
     "node_modules/victory-vendor": {
-      "version": "36.6.12",
-      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-36.6.12.tgz",
-      "integrity": "sha512-pJrTkNHln+D83vDCCSUf0ZfxBvIaVrFHmrBOsnnLAbdqfudRACAj51He2zU94/IWq9464oTADcPVkmWAfNMwgA==",
+      "version": "37.0.2",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.0.2.tgz",
+      "integrity": "sha512-Mjs+00QR256itUM/jVqGJkAw5OADpwjQj7sOEqLqJQfnj9uuf7cPto1KCjrS5d+E6lb0mE5kYwUfzBq0BrMa8Q==",
       "dependencies": {
         "@types/d3-array": "^3.0.3",
         "@types/d3-ease": "^3.0.0",
@@ -32902,43 +32879,40 @@
       }
     },
     "node_modules/victory-voronoi": {
-      "version": "36.6.12",
-      "resolved": "https://registry.npmjs.org/victory-voronoi/-/victory-voronoi-36.6.12.tgz",
-      "integrity": "sha512-8mxoIs8N6s7ZV+j+oPZ/ver3o2PqutyJ4sZMiw93XS7MxedVolFrhlIJed2Sn2x7mUTCjfcDN4Fk+KfSlBtmWg==",
+      "version": "37.0.2",
+      "resolved": "https://registry.npmjs.org/victory-voronoi/-/victory-voronoi-37.0.2.tgz",
+      "integrity": "sha512-YdM5Ywsj4gv5DGl52BIJEffO+ROIVUufXXjdgHRZX0adXcWVyM36sHzXmDrD4WhPH7Wiz0cX/uzYMCBhKGkU0Q==",
       "dependencies": {
         "d3-voronoi": "^1.1.4",
         "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
-        "victory-core": "^36.6.12"
+        "victory-core": "^37.0.2"
       },
       "peerDependencies": {
         "react": ">=16.6.0"
       }
     },
     "node_modules/victory-voronoi-container": {
-      "version": "36.6.12",
-      "resolved": "https://registry.npmjs.org/victory-voronoi-container/-/victory-voronoi-container-36.6.12.tgz",
-      "integrity": "sha512-j9QjqkijWy6wqBcJMO7PG7+B6Q3vsfbdW1eQ5GyowLI1sPLI8kt7NnHt8SweN4QHWj3E8bMQkj31qwIDCR9FeQ==",
+      "version": "37.0.2",
+      "resolved": "https://registry.npmjs.org/victory-voronoi-container/-/victory-voronoi-container-37.0.2.tgz",
+      "integrity": "sha512-iqx/35Rx9vMDKkHw+2xibAF8OT4MTHZk9GG7sPxnlYWoZqDSuuaqR5SmrHosDmw2oqXbj7AqG2wqfxmbMp7ZhA==",
       "dependencies": {
         "delaunay-find": "0.0.6",
         "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
         "react-fast-compare": "^3.2.0",
-        "victory-core": "^36.6.12",
-        "victory-tooltip": "^36.6.12"
+        "victory-core": "^37.0.2",
+        "victory-tooltip": "^37.0.2"
       },
       "peerDependencies": {
         "react": ">=16.6.0"
       }
     },
     "node_modules/victory-zoom-container": {
-      "version": "36.6.12",
-      "resolved": "https://registry.npmjs.org/victory-zoom-container/-/victory-zoom-container-36.6.12.tgz",
-      "integrity": "sha512-KfZNjth6QoIAb8tB6ctCQRCE3SAyE2vAHyK3FgfTzhTJg825F9MfM5KTWNU/mGiyHnwuZxVGxWNK4vQAJUc7cA==",
+      "version": "37.0.2",
+      "resolved": "https://registry.npmjs.org/victory-zoom-container/-/victory-zoom-container-37.0.2.tgz",
+      "integrity": "sha512-CCTm7EgCtFKBduEgJjYTokC13sy0LmLC3Eczb967n7IZUUrIaNQsyGajW3gH5wbof4zeHSpuZghRGPUB2DVQ1Q==",
       "dependencies": {
         "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
-        "victory-core": "^36.6.12"
+        "victory-core": "^37.0.2"
       },
       "peerDependencies": {
         "react": ">=16.6.0"
@@ -40165,58 +40139,58 @@
       }
     },
     "@types/d3-array": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.0.tgz",
-      "integrity": "sha512-tjU8juPSfhMnu6mJZPOCVVGba4rZoE0tjHDPb81PYwA8CzbaFscGjgkUM7juUJu6iWA1cCVWNEVwxZ5HN9Jj8Q=="
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.1.tgz",
+      "integrity": "sha512-Y2Jn2idRrLzUfAKV2LyRImR+y4oa2AntrgID95SHJxuMUrkNXmanDSed71sRNZysveJVt1hLLemQZIady0FpEg=="
     },
     "@types/d3-color": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.2.tgz",
-      "integrity": "sha512-At+Ski7dL8Bs58E8g8vPcFJc8tGcaC12Z4m07+p41+DRqnZQcAlp3NfYjLrhNYv+zEyQitU1CUxXNjqUyf+c0g=="
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A=="
     },
     "@types/d3-ease": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.1.tgz",
-      "integrity": "sha512-VZofjpEt8HWv3nxUAosj5o/+4JflnJ7Bbv07k17VO3T2WRuzGdZeookfaF60iVh5RdhVG49LE5w6LIshVUC6rg=="
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA=="
     },
     "@types/d3-interpolate": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.3.tgz",
-      "integrity": "sha512-6OZ2EIB4lLj+8cUY7I/Cgn9Q+hLdA4DjJHYOQDiHL0SzqS1K9DL5xIOVBSIHgF+tiuO9MU1D36qvdIvRDRPh+Q==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
       "requires": {
         "@types/d3-color": "*"
       }
     },
     "@types/d3-path": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.0.1.tgz",
-      "integrity": "sha512-blRhp7ki7pVznM8k6lk5iUU9paDbVRVq+/xpf0RRgSJn5gr6SE7RcFtxooYGMBOc1RZiGyqRpVdu5AD0z0ooMA=="
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-P2dlU/q51fkOc/Gfl3Ul9kicV7l+ra934qBFXCFhrZMOL6du1TM0pm1ThYvENukyOn5h9v+yMJ9Fn5JK4QozrQ=="
     },
     "@types/d3-scale": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.6.tgz",
-      "integrity": "sha512-lo3oMLSiqsQUovv8j15X4BNEDOsnHuGjeVg7GRbAuB2PUa1prK5BNSOu6xixgNf3nqxPl4I1BqJWrPvFGlQoGQ==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.8.tgz",
+      "integrity": "sha512-gkK1VVTr5iNiYJ7vWDI+yUFFlszhNMtVeneJ6lUTKPjprsvLLI9/tgEGiXJOnlINJA8FyA88gfnQsHbybVZrYQ==",
       "requires": {
         "@types/d3-time": "*"
       }
     },
     "@types/d3-shape": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.4.tgz",
-      "integrity": "sha512-M2/xsWPsjaZc5ifMKp1EBp0gqJG0eO/zlldJNOC85Y/5DGsBQ49gDkRJ2h5GY7ZVD6KUumvZWsylSbvTaJTqKg==",
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.6.tgz",
+      "integrity": "sha512-5KKk5aKGu2I+O6SONMYSNflgiP0WfZIQvVUMan50wHsLG1G94JlxEVnCpQARfTtzytuY0p/9PXXZb3I7giofIA==",
       "requires": {
         "@types/d3-path": "*"
       }
     },
     "@types/d3-time": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.2.tgz",
-      "integrity": "sha512-kbdRXTmUgNfw5OTE3KZnFQn6XdIc4QGroN5UixgdrXATmYsdlPQS6pEut9tVlIojtzuFD4txs/L+Rq41AHtLpg=="
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.3.tgz",
+      "integrity": "sha512-2p6olUZ4w3s+07q3Tm2dbiMZy5pCDfYwtLXXHUnVzXgQlZ/OyPtUz6OL382BkOuGlLXqfT+wqv8Fw2v8/0geBw=="
     },
     "@types/d3-timer": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.1.tgz",
-      "integrity": "sha512-GGTvzKccVEhxmRfJEB6zhY9ieT4UhGVUIQaBzFpUO9OXy2ycAlnPCSJLzmGGgqt3KVjqN3QCQB4g1rsZnHsWhg=="
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw=="
     },
     "@types/debug": {
       "version": "4.1.10",
@@ -57713,309 +57687,286 @@
       }
     },
     "victory": {
-      "version": "36.6.12",
-      "resolved": "https://registry.npmjs.org/victory/-/victory-36.6.12.tgz",
-      "integrity": "sha512-3CBOC++Bh0iGFWzY0lwqeirvzQxdxIYAFh4+ieJ+ghrfs8Uj5ReSpI+OKVPpvag8Vug5b16own2sWVVa6Lve+Q==",
+      "version": "37.0.2",
+      "resolved": "https://registry.npmjs.org/victory/-/victory-37.0.2.tgz",
+      "integrity": "sha512-/8qsoIJWMu11CYula+HBgjva6fu5ZO/0zJO14ZRXlI71vpMf7ga8Siakd7YIvFjWrlXPX2IFWM6jXe7bK0EKdg==",
       "requires": {
-        "victory-area": "^36.6.12",
-        "victory-axis": "^36.6.12",
-        "victory-bar": "^36.6.12",
-        "victory-box-plot": "^36.6.12",
-        "victory-brush-container": "^36.6.12",
-        "victory-brush-line": "^36.6.12",
-        "victory-candlestick": "^36.6.12",
-        "victory-canvas": "^36.6.12",
-        "victory-chart": "^36.6.12",
-        "victory-core": "^36.6.12",
-        "victory-create-container": "^36.6.12",
-        "victory-cursor-container": "^36.6.12",
-        "victory-errorbar": "^36.6.12",
-        "victory-group": "^36.6.12",
-        "victory-histogram": "^36.6.12",
-        "victory-legend": "^36.6.12",
-        "victory-line": "^36.6.12",
-        "victory-pie": "^36.6.12",
-        "victory-polar-axis": "^36.6.12",
-        "victory-scatter": "^36.6.12",
-        "victory-selection-container": "^36.6.12",
-        "victory-shared-events": "^36.6.12",
-        "victory-stack": "^36.6.12",
-        "victory-tooltip": "^36.6.12",
-        "victory-voronoi": "^36.6.12",
-        "victory-voronoi-container": "^36.6.12",
-        "victory-zoom-container": "^36.6.12"
+        "victory-area": "^37.0.2",
+        "victory-axis": "^37.0.2",
+        "victory-bar": "^37.0.2",
+        "victory-box-plot": "^37.0.2",
+        "victory-brush-container": "^37.0.2",
+        "victory-brush-line": "^37.0.2",
+        "victory-candlestick": "^37.0.2",
+        "victory-canvas": "^37.0.2",
+        "victory-chart": "^37.0.2",
+        "victory-core": "^37.0.2",
+        "victory-create-container": "^37.0.2",
+        "victory-cursor-container": "^37.0.2",
+        "victory-errorbar": "^37.0.2",
+        "victory-group": "^37.0.2",
+        "victory-histogram": "^37.0.2",
+        "victory-legend": "^37.0.2",
+        "victory-line": "^37.0.2",
+        "victory-pie": "^37.0.2",
+        "victory-polar-axis": "^37.0.2",
+        "victory-scatter": "^37.0.2",
+        "victory-selection-container": "^37.0.2",
+        "victory-shared-events": "^37.0.2",
+        "victory-stack": "^37.0.2",
+        "victory-tooltip": "^37.0.2",
+        "victory-voronoi": "^37.0.2",
+        "victory-voronoi-container": "^37.0.2",
+        "victory-zoom-container": "^37.0.2"
       }
     },
     "victory-area": {
-      "version": "36.6.12",
-      "resolved": "https://registry.npmjs.org/victory-area/-/victory-area-36.6.12.tgz",
-      "integrity": "sha512-9v/+c22J0ryVKunU/7OuLFd/Wdty9d3RC0qzH86k0pfYqD4t5c+xa1rRQDiVTkdixrO9K1Ef0fvkOrABhGCIfg==",
+      "version": "37.0.2",
+      "resolved": "https://registry.npmjs.org/victory-area/-/victory-area-37.0.2.tgz",
+      "integrity": "sha512-KEuJiBg/VQq1CSQe8U1Gk1eI/sMm+Y4WGveKkx9lXvgPHqxXog2Of+j+q1ZY0bXVrb9vAlIuJHPg4Oq+UQRUYw==",
       "requires": {
         "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
-        "victory-core": "^36.6.12",
-        "victory-vendor": "^36.6.12"
+        "victory-core": "^37.0.2",
+        "victory-vendor": "^37.0.2"
       }
     },
     "victory-axis": {
-      "version": "36.6.12",
-      "resolved": "https://registry.npmjs.org/victory-axis/-/victory-axis-36.6.12.tgz",
-      "integrity": "sha512-z5g/rPS20GbORYn08F8py+hvYZ//sLU1OxX8A76KTJwKpICS6bxvvOb/RD23WB6SPlOm3Nrp/9WHvD0KB0anAA==",
+      "version": "37.0.2",
+      "resolved": "https://registry.npmjs.org/victory-axis/-/victory-axis-37.0.2.tgz",
+      "integrity": "sha512-tmjq43m7hto7NblaJwPiSloilFIlmZ4UMt91yv0dBUlM8sexRTE8g/fAvnioTblVEec/t91sqQBoLta5VZnWIQ==",
       "requires": {
         "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
-        "victory-core": "^36.6.12"
+        "victory-core": "^37.0.2"
       }
     },
     "victory-bar": {
-      "version": "36.6.12",
-      "resolved": "https://registry.npmjs.org/victory-bar/-/victory-bar-36.6.12.tgz",
-      "integrity": "sha512-0vwivPCfj73kaL9Oe2oyGTArXUyqwf4W41NVSv8EvjzDrYFBh7C5FGGuUJJZqUQYHjl+4G8ftnKYfhRbTIajtg==",
+      "version": "37.0.2",
+      "resolved": "https://registry.npmjs.org/victory-bar/-/victory-bar-37.0.2.tgz",
+      "integrity": "sha512-ofezvu4NYkxaQZuLJSnQVsgQKO+869IEYZQuIvc7EtiLrVSznNygqcDrZzLJ+0q6ZxGRIJ/1cdEgaz2dS40ukQ==",
       "requires": {
         "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
-        "victory-core": "^36.6.12",
-        "victory-vendor": "^36.6.12"
+        "victory-core": "^37.0.2",
+        "victory-vendor": "^37.0.2"
       }
     },
     "victory-box-plot": {
-      "version": "36.6.12",
-      "resolved": "https://registry.npmjs.org/victory-box-plot/-/victory-box-plot-36.6.12.tgz",
-      "integrity": "sha512-4x3Ju9XBAaXeDp4WUUYX6vMrVEQGWmLcLQSXsEGjXlAGVM2YF/339XtsoL5W41F8MxrlB63riIBdFCQ28W0gxA==",
+      "version": "37.0.2",
+      "resolved": "https://registry.npmjs.org/victory-box-plot/-/victory-box-plot-37.0.2.tgz",
+      "integrity": "sha512-NzhxPRXues5F3Ay3JRLAnDBGrSC3940KmFHtc14F0Y+KDmwMDa15c2MBME9Rhg6SOvKL/o+jGzYX8ohE3k94kA==",
       "requires": {
         "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
-        "victory-core": "^36.6.12",
-        "victory-vendor": "^36.6.12"
+        "victory-core": "^37.0.2",
+        "victory-vendor": "^37.0.2"
       }
     },
     "victory-brush-container": {
-      "version": "36.6.12",
-      "resolved": "https://registry.npmjs.org/victory-brush-container/-/victory-brush-container-36.6.12.tgz",
-      "integrity": "sha512-sCx+q3X5EeqxVME3KZRLeHYVbdX5R3U9RSncOucTUwXrHsebrwsl+F9LKJ1l+Ohl73CmhStyD9Ap6zamKwfkbg==",
+      "version": "37.0.2",
+      "resolved": "https://registry.npmjs.org/victory-brush-container/-/victory-brush-container-37.0.2.tgz",
+      "integrity": "sha512-eZBarKzkGw1fM3n1FSGo5MAE7o4ZM3a87aSSRuIK4aMgGxaZkxKV4y219WCIIDeYw6U4l7T+tDXSw71XbXGG3g==",
       "requires": {
         "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
         "react-fast-compare": "^3.2.0",
-        "victory-core": "^36.6.12"
+        "victory-core": "^37.0.2"
       }
     },
     "victory-brush-line": {
-      "version": "36.6.12",
-      "resolved": "https://registry.npmjs.org/victory-brush-line/-/victory-brush-line-36.6.12.tgz",
-      "integrity": "sha512-Nb2zi1iNvt/LpKazLJslTpViTuM65gykg4JiBkNL7yJlFMFAceX4Pe8PdKSlV3YnhNwPzt+Kwo+cT5HBuXB5dA==",
+      "version": "37.0.2",
+      "resolved": "https://registry.npmjs.org/victory-brush-line/-/victory-brush-line-37.0.2.tgz",
+      "integrity": "sha512-pPo5XiiNj33s1jdqnzs88W7B6DBI0RhUFRT4Ce5ciWpHw11aW/CvM4wa3OQhI2fiwCqmKv7v9lBiIWEKBcKgMQ==",
       "requires": {
         "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
         "react-fast-compare": "^3.2.0",
-        "victory-core": "^36.6.12"
+        "victory-core": "^37.0.2"
       }
     },
     "victory-candlestick": {
-      "version": "36.6.12",
-      "resolved": "https://registry.npmjs.org/victory-candlestick/-/victory-candlestick-36.6.12.tgz",
-      "integrity": "sha512-xpA3hREbLLyy6kul681R0E2k0ZoqDh5UV8jq4F48G3jMxbd3wWvrPGdvJyQO1T+ptvdesdGGvXFVHRyRHV+Plw==",
+      "version": "37.0.2",
+      "resolved": "https://registry.npmjs.org/victory-candlestick/-/victory-candlestick-37.0.2.tgz",
+      "integrity": "sha512-Whaw1aRfWO11TGamwyonOcFHOtCxMggYEe8S+IFV8C4jrstucHEAr9BiTpqqsYjohv499bY8MfOaHEyBtETrfA==",
       "requires": {
         "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
-        "victory-core": "^36.6.12"
+        "victory-core": "^37.0.2"
       }
     },
     "victory-canvas": {
-      "version": "36.6.12",
-      "resolved": "https://registry.npmjs.org/victory-canvas/-/victory-canvas-36.6.12.tgz",
-      "integrity": "sha512-ojNpfANjr/DGcJLRQD/uj6uxiLlFbBRGTKZTYj+AJeYml7t+g87uMzDwHbRw9MVn2UsA3ShFsFFF3/fyPZhs2w==",
+      "version": "37.0.2",
+      "resolved": "https://registry.npmjs.org/victory-canvas/-/victory-canvas-37.0.2.tgz",
+      "integrity": "sha512-jHOvcnoqboi9kkZw2dDObje1f5Mz4Om1xb9iGjEvNXO5n0epGgv3NXiBY7gmzTHlv3gj19AdGIsI7jaakQulOg==",
       "requires": {
         "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
-        "victory-bar": "^36.6.12",
-        "victory-core": "^36.6.12"
+        "victory-bar": "^37.0.2",
+        "victory-core": "^37.0.2"
       }
     },
     "victory-chart": {
-      "version": "36.6.12",
-      "resolved": "https://registry.npmjs.org/victory-chart/-/victory-chart-36.6.12.tgz",
-      "integrity": "sha512-ySYjcZBzkTEZt5mWlUoCbQrXRZRw6lMOEd0HnC7FI6lJKgkFV3rYr39Qdl9KJ59reHwRW7NoJ4BOXpxXuCzq5g==",
+      "version": "37.0.2",
+      "resolved": "https://registry.npmjs.org/victory-chart/-/victory-chart-37.0.2.tgz",
+      "integrity": "sha512-OpNvSzypQyhyJtBYAcx+9vJZTry2HssBJVT5Yui1NrT4IcHTuw02z5Zg/RYFgADloqraA+TsVzZbJQcfD/j6MA==",
       "requires": {
         "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
         "react-fast-compare": "^3.2.0",
-        "victory-axis": "^36.6.12",
-        "victory-core": "^36.6.12",
-        "victory-polar-axis": "^36.6.12",
-        "victory-shared-events": "^36.6.12"
+        "victory-axis": "^37.0.2",
+        "victory-core": "^37.0.2",
+        "victory-polar-axis": "^37.0.2",
+        "victory-shared-events": "^37.0.2"
       }
     },
     "victory-core": {
-      "version": "36.6.12",
-      "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-36.6.12.tgz",
-      "integrity": "sha512-9zWemm6JYRkxDcvpQntkOLFZL3T3XbIDeZsqfhv/30+SLak/H59QfYj6nhyJUZuWQVTUtbAHKjAAQh5wfqgVPw==",
+      "version": "37.0.2",
+      "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-37.0.2.tgz",
+      "integrity": "sha512-B3A3yCanjskShZTFtA1Bp8BLXniaTtjzaKHOChjCkay8oRkWjGMy0aZdCL7ezfUWVHAaFUIw248PgqApMn1K/w==",
       "requires": {
         "lodash": "^4.17.21",
-        "prop-types": "^15.8.1",
         "react-fast-compare": "^3.2.0",
-        "victory-vendor": "^36.6.12"
+        "victory-vendor": "^37.0.2"
       }
     },
     "victory-create-container": {
-      "version": "36.6.12",
-      "resolved": "https://registry.npmjs.org/victory-create-container/-/victory-create-container-36.6.12.tgz",
-      "integrity": "sha512-TEwjWUevRm+JOh3SozuahGebo4xBBSfoHPxCA0CgxtmhxInPBCkYGtm7k6IJWQ8a4kVzvMTaR1qit3653JiZhQ==",
+      "version": "37.0.2",
+      "resolved": "https://registry.npmjs.org/victory-create-container/-/victory-create-container-37.0.2.tgz",
+      "integrity": "sha512-cojSUT/TWunznM3rMlchlYZ+QdTLKHQE519ZQdomA04rKdU+rK/X+XaeMHDWZVRZHp4YrfUmR7OfOb4AHBTm7w==",
       "requires": {
         "lodash": "^4.17.19",
-        "victory-brush-container": "^36.6.12",
-        "victory-core": "^36.6.12",
-        "victory-cursor-container": "^36.6.12",
-        "victory-selection-container": "^36.6.12",
-        "victory-voronoi-container": "^36.6.12",
-        "victory-zoom-container": "^36.6.12"
+        "victory-brush-container": "^37.0.2",
+        "victory-core": "^37.0.2",
+        "victory-cursor-container": "^37.0.2",
+        "victory-selection-container": "^37.0.2",
+        "victory-voronoi-container": "^37.0.2",
+        "victory-zoom-container": "^37.0.2"
       }
     },
     "victory-cursor-container": {
-      "version": "36.6.12",
-      "resolved": "https://registry.npmjs.org/victory-cursor-container/-/victory-cursor-container-36.6.12.tgz",
-      "integrity": "sha512-MJAILAw+DMtDTN3fz7K7iAXnV0EEHezwBqS4JS0URoffZPwZZr0rKawQLFfJRh+TS9BO6bf0X3UtVRb4/TxlZA==",
+      "version": "37.0.2",
+      "resolved": "https://registry.npmjs.org/victory-cursor-container/-/victory-cursor-container-37.0.2.tgz",
+      "integrity": "sha512-07PB8XNYi9AqnwZjCxQ6gKcJip6p2fwUT1+aHYDUAy/ncL6xBZD4t3sXErPHT3ha/itx7I861OsehDLZCjnkHA==",
       "requires": {
         "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
-        "victory-core": "^36.6.12"
+        "victory-core": "^37.0.2"
       }
     },
     "victory-errorbar": {
-      "version": "36.6.12",
-      "resolved": "https://registry.npmjs.org/victory-errorbar/-/victory-errorbar-36.6.12.tgz",
-      "integrity": "sha512-8EbVGsP9ZSWw+YVjKuB1LnEFQDpEmyRcet5p1WnsrnWSOZAlSAnv/oVdUcVP1suwW93B6S1Dy7DowR7njeKC6g==",
+      "version": "37.0.2",
+      "resolved": "https://registry.npmjs.org/victory-errorbar/-/victory-errorbar-37.0.2.tgz",
+      "integrity": "sha512-yA4IN1Scn9de8g4q1hL9S60BzRzyG2FqrjAOpgvUaVEzkWcxIiPLLOZFdwC0/8KCnPsGFJHHnL0OMQpbq2O1nA==",
       "requires": {
         "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
-        "victory-core": "^36.6.12"
+        "victory-core": "^37.0.2"
       }
     },
     "victory-group": {
-      "version": "36.6.12",
-      "resolved": "https://registry.npmjs.org/victory-group/-/victory-group-36.6.12.tgz",
-      "integrity": "sha512-bN5M/+AWDTzb3ooTLxmVg8F63Ibbw5gqmLPUy6qFF7zDdDqMrmd9WG2JP/G88+pHlWHs+Phnce/r22y2oAojgQ==",
+      "version": "37.0.2",
+      "resolved": "https://registry.npmjs.org/victory-group/-/victory-group-37.0.2.tgz",
+      "integrity": "sha512-uBU3PdndeOxE5E+LVoVnT3ciJNwlTj99Deh178AARJ3jKuuH3hJ7Fnw+tgQjQNMdRuKKxILJdddd9ouktLTJJA==",
       "requires": {
         "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
         "react-fast-compare": "^3.2.0",
-        "victory-core": "^36.6.12",
-        "victory-shared-events": "^36.6.12"
+        "victory-core": "^37.0.2",
+        "victory-shared-events": "^37.0.2"
       }
     },
     "victory-histogram": {
-      "version": "36.6.12",
-      "resolved": "https://registry.npmjs.org/victory-histogram/-/victory-histogram-36.6.12.tgz",
-      "integrity": "sha512-4vuOGFrUWdtMPGHxzIvrAuKyy6HIyzsCz7nKo55kL/deF9m+T8iqnnXWOVWaUpZGQ4xQrzb01AshQu/7ryhbGQ==",
+      "version": "37.0.2",
+      "resolved": "https://registry.npmjs.org/victory-histogram/-/victory-histogram-37.0.2.tgz",
+      "integrity": "sha512-9y6DU2Pw1XHlNAZJCrMCxGT3++55a8KwNDgzeXePetW1pUrpa3HPDJqo8ctLu9sRP6Lkk3DAplP0SpaS948AhA==",
       "requires": {
         "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
         "react-fast-compare": "^3.2.0",
-        "victory-bar": "^36.6.12",
-        "victory-core": "^36.6.12",
-        "victory-vendor": "^36.6.12"
+        "victory-bar": "^37.0.2",
+        "victory-core": "^37.0.2",
+        "victory-vendor": "^37.0.2"
       }
     },
     "victory-legend": {
-      "version": "36.6.12",
-      "resolved": "https://registry.npmjs.org/victory-legend/-/victory-legend-36.6.12.tgz",
-      "integrity": "sha512-ssZM4/yarYDbIhz96n6wlCBNOHT8u/0oQNE6F5y45iDBJzJUVWuIQ+aKnr1+eIbylUp1hIopBtj4oN4N/RWtvA==",
+      "version": "37.0.2",
+      "resolved": "https://registry.npmjs.org/victory-legend/-/victory-legend-37.0.2.tgz",
+      "integrity": "sha512-mbScaQepyvLVghyRSxsccZwpf3LTz434GuWIh5aFQcP8pTrGT+9V8Wtw6N6W/4MxHBznh1sGZbI755k+IM2oNQ==",
       "requires": {
         "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
-        "victory-core": "^36.6.12"
+        "victory-core": "^37.0.2"
       }
     },
     "victory-line": {
-      "version": "36.6.12",
-      "resolved": "https://registry.npmjs.org/victory-line/-/victory-line-36.6.12.tgz",
-      "integrity": "sha512-2wS8N9z+O+JhzYE4CczR+uWXYudhF3aWbYOzI5Jjf2XoQdjaeDEeawli3y0g76OE/sxPet4+sPzkn/f1tEFxGQ==",
+      "version": "37.0.2",
+      "resolved": "https://registry.npmjs.org/victory-line/-/victory-line-37.0.2.tgz",
+      "integrity": "sha512-b0Jj9uYGzWhA3KCbzjvraxKfP3gB+sqzaU/r2JQdICug0isGQHnng3vW40RNveEjE6CfIEHGZdylSCAbjAFhzQ==",
       "requires": {
         "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
-        "victory-core": "^36.6.12",
-        "victory-vendor": "^36.6.12"
+        "victory-core": "^37.0.2",
+        "victory-vendor": "^37.0.2"
       }
     },
     "victory-pie": {
-      "version": "36.6.12",
-      "resolved": "https://registry.npmjs.org/victory-pie/-/victory-pie-36.6.12.tgz",
-      "integrity": "sha512-MOVcraD+aQungIS3HdjzukFzznFV2tDvsmhsSjFyONs3h4d18Vsc0tOTlnCuMmBb7Pih4Un4eGZRlHnyzwsqKA==",
+      "version": "37.0.2",
+      "resolved": "https://registry.npmjs.org/victory-pie/-/victory-pie-37.0.2.tgz",
+      "integrity": "sha512-rdaL7Or5BU/368xLoe8FThekxx9ICgwmtaUc2Lt1w8uklt6S3SBMbAoL2lmr5IutZf55HYRX64vM3TGqWjD3+w==",
       "requires": {
         "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
-        "victory-core": "^36.6.12",
-        "victory-vendor": "^36.6.12"
+        "victory-core": "^37.0.2",
+        "victory-vendor": "^37.0.2"
       }
     },
     "victory-polar-axis": {
-      "version": "36.6.12",
-      "resolved": "https://registry.npmjs.org/victory-polar-axis/-/victory-polar-axis-36.6.12.tgz",
-      "integrity": "sha512-VL3lgzNcUupGXCdE+jPWFS5+621l4OL5/vR1pdINpzXHT2pEA/0CxQAw13a9NLtQyf+E05TxM6bEnJA/JEEVZQ==",
+      "version": "37.0.2",
+      "resolved": "https://registry.npmjs.org/victory-polar-axis/-/victory-polar-axis-37.0.2.tgz",
+      "integrity": "sha512-qqIk9fFYuL9G/RzHoXB/9ZI6DkKHdfdczI2vdl2rl0KdzAcfd9Eosa9EHmnTh/9ijPJvYi++1ul1WQNRWXBVSg==",
       "requires": {
         "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
-        "victory-core": "^36.6.12"
+        "victory-core": "^37.0.2"
       }
     },
     "victory-scatter": {
-      "version": "36.6.12",
-      "resolved": "https://registry.npmjs.org/victory-scatter/-/victory-scatter-36.6.12.tgz",
-      "integrity": "sha512-wGf/eHzKOkpi/eceBRcJHghOmFo4u08duedUGREoAHpNAh4yUEsYhF75ttcOCwMidxaScxcmXFmh5eE4FlckwA==",
+      "version": "37.0.2",
+      "resolved": "https://registry.npmjs.org/victory-scatter/-/victory-scatter-37.0.2.tgz",
+      "integrity": "sha512-BY83Y+D3enHqPvHAt3HrEaT5ckmcj3vq3QJ28e1b6DhlbGWoS/DEmhf5OiHF+wCBSSDBOkAyq1uTXSbcHKyLXQ==",
       "requires": {
         "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
-        "victory-core": "^36.6.12"
+        "victory-core": "^37.0.2"
       }
     },
     "victory-selection-container": {
-      "version": "36.6.12",
-      "resolved": "https://registry.npmjs.org/victory-selection-container/-/victory-selection-container-36.6.12.tgz",
-      "integrity": "sha512-jFNvS0lBrRPhNs7lN1hZ5kn/WEPDo1E7NU8a3pDCH4o9jm5EesBHt+KPb0DOUPMPhnjs5nglBDOlNhdDwEC6PQ==",
+      "version": "37.0.2",
+      "resolved": "https://registry.npmjs.org/victory-selection-container/-/victory-selection-container-37.0.2.tgz",
+      "integrity": "sha512-HgLmGTIZNdlpZ081ZowJAoUYE69q4p9sB0h8FBKbM7xPDXfH9Eh6MZ5RIfoen9GdB4Hz0He4vQZIU5OOK3TNDQ==",
       "requires": {
         "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
-        "victory-core": "^36.6.12"
+        "victory-core": "^37.0.2"
       }
     },
     "victory-shared-events": {
-      "version": "36.6.12",
-      "resolved": "https://registry.npmjs.org/victory-shared-events/-/victory-shared-events-36.6.12.tgz",
-      "integrity": "sha512-pbM7ApTe81rVhzdmcGGVbU6I0zDgCFfyiItutHakxL7oypTNu5QtC/pkNza4IFVDDF10KX/eymOcAxkke3V/gg==",
+      "version": "37.0.2",
+      "resolved": "https://registry.npmjs.org/victory-shared-events/-/victory-shared-events-37.0.2.tgz",
+      "integrity": "sha512-1U1yljfsFs3fGJmoSZt1j/ZgdV4tf2hWhue2Xixn71ZEYFBlsF6hY3gXI5EzRji1QhHa3mnar17wrgr++H+CWQ==",
       "requires": {
         "json-stringify-safe": "^5.0.1",
         "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
         "react-fast-compare": "^3.2.0",
-        "victory-core": "^36.6.12"
+        "victory-core": "^37.0.2"
       }
     },
     "victory-stack": {
-      "version": "36.6.12",
-      "resolved": "https://registry.npmjs.org/victory-stack/-/victory-stack-36.6.12.tgz",
-      "integrity": "sha512-dhukj84UGXEOO7yAtMgXwKFZAgc+GvgLSFcYFeHlygEZR7B1Mivd88PNNOeOMaJeRp22jC9yu6Z/54LbRm8YlA==",
+      "version": "37.0.2",
+      "resolved": "https://registry.npmjs.org/victory-stack/-/victory-stack-37.0.2.tgz",
+      "integrity": "sha512-CbinJJxkN7WT6XJ8EWZLXiibqHGU++rKqyh95jo01U+FZ7QOu5l0qf7OxfEnmEWGLF3J5hcMEOSX22lrdtxl+A==",
       "requires": {
         "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
         "react-fast-compare": "^3.2.0",
-        "victory-core": "^36.6.12",
-        "victory-shared-events": "^36.6.12"
+        "victory-core": "^37.0.2",
+        "victory-shared-events": "^37.0.2"
       }
     },
     "victory-tooltip": {
-      "version": "36.6.12",
-      "resolved": "https://registry.npmjs.org/victory-tooltip/-/victory-tooltip-36.6.12.tgz",
-      "integrity": "sha512-i9Q+51yQr3PBlAx81tJRLlyM/b+6z/EyYyWgrB1rdnq3VaKLdx0RSj8y2fqNXafdoGPh2mQAWYrxqBTNGxBMJg==",
+      "version": "37.0.2",
+      "resolved": "https://registry.npmjs.org/victory-tooltip/-/victory-tooltip-37.0.2.tgz",
+      "integrity": "sha512-UYne2i9in8bwxz0z6+kknvZbKVbMdfapQnISDBBWfmqWVHirsxNGJUFaSrHMqEBdNtTCXLd0vNhADJxIUKGtqA==",
       "requires": {
         "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
-        "victory-core": "^36.6.12"
+        "victory-core": "^37.0.2"
       }
     },
     "victory-vendor": {
-      "version": "36.6.12",
-      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-36.6.12.tgz",
-      "integrity": "sha512-pJrTkNHln+D83vDCCSUf0ZfxBvIaVrFHmrBOsnnLAbdqfudRACAj51He2zU94/IWq9464oTADcPVkmWAfNMwgA==",
+      "version": "37.0.2",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.0.2.tgz",
+      "integrity": "sha512-Mjs+00QR256itUM/jVqGJkAw5OADpwjQj7sOEqLqJQfnj9uuf7cPto1KCjrS5d+E6lb0mE5kYwUfzBq0BrMa8Q==",
       "requires": {
         "@types/d3-array": "^3.0.3",
         "@types/d3-ease": "^3.0.0",
@@ -58034,37 +57985,34 @@
       }
     },
     "victory-voronoi": {
-      "version": "36.6.12",
-      "resolved": "https://registry.npmjs.org/victory-voronoi/-/victory-voronoi-36.6.12.tgz",
-      "integrity": "sha512-8mxoIs8N6s7ZV+j+oPZ/ver3o2PqutyJ4sZMiw93XS7MxedVolFrhlIJed2Sn2x7mUTCjfcDN4Fk+KfSlBtmWg==",
+      "version": "37.0.2",
+      "resolved": "https://registry.npmjs.org/victory-voronoi/-/victory-voronoi-37.0.2.tgz",
+      "integrity": "sha512-YdM5Ywsj4gv5DGl52BIJEffO+ROIVUufXXjdgHRZX0adXcWVyM36sHzXmDrD4WhPH7Wiz0cX/uzYMCBhKGkU0Q==",
       "requires": {
         "d3-voronoi": "^1.1.4",
         "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
-        "victory-core": "^36.6.12"
+        "victory-core": "^37.0.2"
       }
     },
     "victory-voronoi-container": {
-      "version": "36.6.12",
-      "resolved": "https://registry.npmjs.org/victory-voronoi-container/-/victory-voronoi-container-36.6.12.tgz",
-      "integrity": "sha512-j9QjqkijWy6wqBcJMO7PG7+B6Q3vsfbdW1eQ5GyowLI1sPLI8kt7NnHt8SweN4QHWj3E8bMQkj31qwIDCR9FeQ==",
+      "version": "37.0.2",
+      "resolved": "https://registry.npmjs.org/victory-voronoi-container/-/victory-voronoi-container-37.0.2.tgz",
+      "integrity": "sha512-iqx/35Rx9vMDKkHw+2xibAF8OT4MTHZk9GG7sPxnlYWoZqDSuuaqR5SmrHosDmw2oqXbj7AqG2wqfxmbMp7ZhA==",
       "requires": {
         "delaunay-find": "0.0.6",
         "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
         "react-fast-compare": "^3.2.0",
-        "victory-core": "^36.6.12",
-        "victory-tooltip": "^36.6.12"
+        "victory-core": "^37.0.2",
+        "victory-tooltip": "^37.0.2"
       }
     },
     "victory-zoom-container": {
-      "version": "36.6.12",
-      "resolved": "https://registry.npmjs.org/victory-zoom-container/-/victory-zoom-container-36.6.12.tgz",
-      "integrity": "sha512-KfZNjth6QoIAb8tB6ctCQRCE3SAyE2vAHyK3FgfTzhTJg825F9MfM5KTWNU/mGiyHnwuZxVGxWNK4vQAJUc7cA==",
+      "version": "37.0.2",
+      "resolved": "https://registry.npmjs.org/victory-zoom-container/-/victory-zoom-container-37.0.2.tgz",
+      "integrity": "sha512-CCTm7EgCtFKBduEgJjYTokC13sy0LmLC3Eczb967n7IZUUrIaNQsyGajW3gH5wbof4zeHSpuZghRGPUB2DVQ1Q==",
       "requires": {
         "lodash": "^4.17.19",
-        "prop-types": "^15.8.1",
-        "victory-core": "^36.6.12"
+        "victory-core": "^37.0.2"
       }
     },
     "w3c-hr-time": {

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "react-router-dom-v5-compat": "^6.15.0",
     "react-use": "^17.2.4",
     "tailwind-merge": "^2.3.0",
-    "victory": "^36.6.11",
+    "victory": "^37.0.2",
     "yup": "^0.32.11",
     "zod": "^3.21.4"
   },


### PR DESCRIPTION
# Description

As I'm closely working on adding in a new chart for bundle data I thought it fit to update our as FormidableLabs has released  [v37.0.0](https://github.com/FormidableLabs/victory/releases/tag/v37.0.0), there are no breaking changes, just dropping support for older browsers.

# Notable Changes

- Update version