### PR TITLE
fix: Hide Address 2 if null

### DIFF
--- a/src/pages/PlanPage/subRoutes/CurrentOrgPlan/BillingDetails/Address/AddressCard.tsx
+++ b/src/pages/PlanPage/subRoutes/CurrentOrgPlan/BillingDetails/Address/AddressCard.tsx
@@ -73,7 +73,9 @@ function BillingInner({ billingDetails, setIsFormOpen }: BillingInnerProps) {
         <p>{`${billingDetails.name}`}</p>
         <br />
         <h4 className="mb-2 font-semibold">Billing address</h4>
-        <p>{`${billingDetails.address?.line1} ${billingDetails.address?.line2}`}</p>
+        <p>{`${billingDetails.address?.line1} ${
+          billingDetails.address?.line2 ?? ''
+        }`}</p>
         <p>{`${billingDetails.address?.city}, ${billingDetails.address?.state} ${billingDetails.address?.postalCode}`}</p>
       </div>
     )


### PR DESCRIPTION
# Description

Saw address 2 was coming back as null and showing on the UI, we want to hide it.

# Screenshots

**BEFORE**
![Screenshot 2024-06-20 at 1 48 16 PM](https://github.com/codecov/gazebo/assets/159853603/57a4f8db-feb0-4005-991b-f9ea0cd94cd3)

**AFTER**
![Screenshot 2024-06-20 at 1 48 02 PM](https://github.com/codecov/gazebo/assets/159853603/f8f46694-eddb-4915-a896-6446e22993ff)


# Link to Sample Entry

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.