### PR TITLE
fix: Remove Cookie Session Expiry cookie when expired and redirect

### DIFF
--- a/src/layouts/EnterpriseLoginLayout/EnterpriseLoginLayout.tsx
+++ b/src/layouts/EnterpriseLoginLayout/EnterpriseLoginLayout.tsx
@@ -1,4 +1,5 @@
 import { Suspense } from 'react'
+import { useLocation } from 'react-router-dom'
 
 import { LOCAL_STORAGE_SESSION_EXPIRED_KEY } from 'config'
 
@@ -19,13 +20,17 @@ const FullPageLoader = () => (
 )
 
 function EnterpriseLoginLayout({ children }: { children: React.ReactNode }) {
+  const location = useLocation()
+
   const showExpiryBanner = localStorage.getItem(
     LOCAL_STORAGE_SESSION_EXPIRED_KEY
   )
   return (
     <>
       <Header />
-      {showExpiryBanner && <SessionExpiredBanner />}
+      {(location.search.includes('expired') || showExpiryBanner) && (
+        <SessionExpiredBanner />
+      )}
       <Suspense fallback={<FullPageLoader />}>
         <ErrorBoundary sentryScopes={[['layout', 'base']]}>
           <NetworkErrorBoundary>

--- a/src/layouts/LoginLayout/LoginLayout.tsx
+++ b/src/layouts/LoginLayout/LoginLayout.tsx
@@ -1,4 +1,5 @@
 import { Suspense } from 'react'
+import { useLocation } from 'react-router-dom'
 
 import { LOCAL_STORAGE_SESSION_EXPIRED_KEY } from 'config'
 
@@ -14,12 +15,16 @@ const FullPageLoader = () => (
 )
 
 const LoginLayout: React.FC<React.PropsWithChildren> = ({ children }) => {
+  const location = useLocation()
+
   const showExpiryBanner = localStorage.getItem(
     LOCAL_STORAGE_SESSION_EXPIRED_KEY
   )
   return (
     <>
-      {showExpiryBanner && <SessionExpiredBanner />}
+      {(location.search.includes('expired') || showExpiryBanner) && (
+        <SessionExpiredBanner />
+      )}
       <Header />
       <Suspense fallback={<FullPageLoader />}>
         <main className="container mb-8 mt-2 flex grow flex-col gap-2 md:p-0">

--- a/src/ui/SessionExpiryTracker/SessionExpiryTracker.spec.tsx
+++ b/src/ui/SessionExpiryTracker/SessionExpiryTracker.spec.tsx
@@ -25,6 +25,7 @@ describe('SessionExpiryTracker', () => {
   beforeEach(() => {
     jest.useFakeTimers()
     jest.setSystemTime(new Date())
+    global.fetch = jest.fn()
   })
 
   afterEach(() => {
@@ -36,6 +37,7 @@ describe('SessionExpiryTracker', () => {
     const expiryTime = new Date()
     expiryTime.setMinutes(expiryTime.getMinutes() + 15)
     Cookies.get = jest.fn().mockImplementation(() => expiryTime.toString())
+    const removeCookieSpy = jest.spyOn(Cookies, 'remove')
     const { mockSetItem, mockRemoveItem } = setup()
     render(<SessionExpiryTracker />, { wrapper })
 
@@ -51,6 +53,9 @@ describe('SessionExpiryTracker', () => {
       expect(screen.getByText(/Your session has expired/)).toBeInTheDocument()
     })
     expect(mockSetItem).toHaveBeenCalled()
+    expect(mockRemoveItem).toHaveBeenCalled()
+    expect(removeCookieSpy).toHaveBeenCalled()
+    expect(global.fetch).toHaveBeenCalled()
   })
 
   it('using real timers', async () => {

--- a/src/ui/SessionExpiryTracker/SessionExpiryTracker.tsx
+++ b/src/ui/SessionExpiryTracker/SessionExpiryTracker.tsx
@@ -3,6 +3,7 @@ import React, { useCallback, useEffect, useState } from 'react'
 import { Redirect } from 'react-router-dom'
 
 import config, {
+  COOKIE_SESSION_EXPIRY,
   COOKIE_SESSION_ID,
   LOCAL_STORAGE_SESSION_EXPIRED_KEY,
   LOCAL_STORAGE_SESSION_TRACKING_KEY,
@@ -17,7 +18,7 @@ const SessionExpiryTracker: React.FC = () => {
   localStorage.removeItem(LOCAL_STORAGE_SESSION_EXPIRED_KEY)
 
   const [redirectToLogout, setRedirectToLogout] = useState(false)
-  const sessionExpiryTimeString = Cookies.get('session_expiry')
+  const sessionExpiryTimeString = Cookies.get(COOKIE_SESSION_EXPIRY)
   const getCheckDelay = (sessionExpiryTime: Date) => {
     const timeLeft = sessionExpiryTime.getTime() - new Date().getTime()
     return timeLeft > THIRTY_MINUTES_MILLIS
@@ -69,6 +70,7 @@ const SessionExpiryTracker: React.FC = () => {
   }
 
   Cookies.remove(COOKIE_SESSION_ID, { path: '' })
+  Cookies.remove(COOKIE_SESSION_EXPIRY)
   localStorage.setItem(LOCAL_STORAGE_SESSION_EXPIRED_KEY, 'true')
   localStorage.removeItem(LOCAL_STORAGE_SESSION_TRACKING_KEY)
 

--- a/src/ui/SessionExpiryTracker/SessionExpiryTracker.tsx
+++ b/src/ui/SessionExpiryTracker/SessionExpiryTracker.tsx
@@ -8,8 +8,8 @@ import config, {
   LOCAL_STORAGE_SESSION_TRACKING_KEY,
 } from 'config'
 
-const ONE_MINUTE_MILLIS = 6 * 1000
-const TWO_MINUTES_MILLIS = 2 * 60 * 1000 // ONE_MINUTE_MILLIS
+const ONE_MINUTE_MILLIS = 60 * 1000
+const TWO_MINUTES_MILLIS = 2 * ONE_MINUTE_MILLIS
 const THIRTY_MINUTES_MILLIS = 30 * ONE_MINUTE_MILLIS
 
 const SessionExpiryTracker: React.FC = () => {
@@ -29,7 +29,6 @@ const SessionExpiryTracker: React.FC = () => {
     (sessionExpiryTime: Date) => {
       const currentTime = new Date()
       const timeLeft = sessionExpiryTime.getTime() - currentTime.getTime()
-      console.log('CHECKING SESSION', timeLeft, sessionExpiryTime)
       if (timeLeft <= TWO_MINUTES_MILLIS && !redirectToLogout) {
         setRedirectToLogout(true)
       }
@@ -87,7 +86,11 @@ const SessionExpiryTracker: React.FC = () => {
     return null
   }
 
-  return <Redirect to={'/login'} />
+  return config.IS_SELF_HOSTED ? (
+    <Redirect to={'/?session=expired'} />
+  ) : (
+    <Redirect to={'/login?session=expired'} />
+  )
 }
 
 export default SessionExpiryTracker


### PR DESCRIPTION
# Description

This stemmed from thinking through what is causing the redirect, which is the presence of the expiration cookie timestamp.

That cookie is added on login here: https://github.com/codecov/codecov-api/blob/c3f5e7f903c63f8a5eadc5a69a2846df57e65a0a/codecov_auth/views/github.py#L169-L171 in API on login, and only for Github

Because we're already setting a "session expired" key here: https://github.com/codecov/gazebo/blob/902fa2fcff89b96d1fc0ab470a22b7088b21fc61/src/ui/SessionExpiryTracker/SessionExpiryTracker.tsx#L74 and that key is removed and reset only when the user logs in, since Session Expiry Tracker is only present on the BaseLayout here: https://github.com/codecov/gazebo/blob/5d142294fee83428c92ca4f33a8861a7e15b4dde/src/layouts/BaseLayout/BaseLayout.jsx#L72

My hunch is that we shouldn't face any regression here since the Login page uses a different layout: 

https://github.com/codecov/gazebo/blob/b07fcc7bae68f7a015dac9804f8649a97b6b5859/src/App.tsx#L72-L74

Closes https://github.com/codecov/engineering-team/issues/1994


**THE FIX:**

This ultimate fix calls is to call the logout API to clear the user's session, as well as removing the session-expiry cookie at the same time. This also fixes the issue where users who had logged in prior had to login again to view other user's codecov orgs. Now they will see the guest header and navigate freely without logging in

# Screenshots

Couple videos prior to adding query param stuff (but showing the logic works)


https://github.com/codecov/gazebo/assets/159853603/2d5264ac-c678-45a5-a6fe-cff7d73721d2


https://github.com/codecov/gazebo/assets/159853603/e76d2373-c21f-4ff1-9fea-611c747952d8



**NON-ENTERPRISE**
**QUERY PARAM**
![Screenshot 2024-06-21 at 9 45 46 AM](https://github.com/codecov/gazebo/assets/159853603/3e826648-8261-40e7-a6d0-ff4422bd367b)
**NO QUERY PARAM**
![Screenshot 2024-06-21 at 9 45 57 AM](https://github.com/codecov/gazebo/assets/159853603/547673e1-5b9d-4677-8d4c-24c5f6c2f0c8)
**ENTERPRISE**
**QUERY PARAM**
![Screenshot 2024-06-21 at 9 52 11 AM](https://github.com/codecov/gazebo/assets/159853603/1b797f7a-f57e-405c-85a5-5bae9feab9f3)
**NO QUERY PARAM**
![Screenshot 2024-06-21 at 9 52 20 AM](https://github.com/codecov/gazebo/assets/159853603/7d17c7e5-7742-4360-bdbf-36cdf81a1ad0)


# Link to Sample Entry

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.