### PR TITLE
feat: Create hook to fetch bundle trend data

### DIFF
--- a/src/services/bundleAnalysis/index.ts
+++ b/src/services/bundleAnalysis/index.ts
@@ -1,5 +1,9 @@
-export * from './useBranchBundleSummary'
-export * from './useBranchBundlesNames'
-export * from './useBundleAssetModules'
-export * from './useBundleAssets'
-export * from './useBundleSummary'
+export {
+  useBranchBundleSummary,
+  type UseBranchBundleSummaryArgs,
+} from './useBranchBundleSummary'
+export { useBranchBundlesNames } from './useBranchBundlesNames'
+export { useBundleAssetModules } from './useBundleAssetModules'
+export { useBundleAssets } from './useBundleAssets'
+export { useBundleSummary } from './useBundleSummary'
+export { useBundleTrendData } from './useBundleTrendData'

--- a/src/services/bundleAnalysis/useBundleTrendData.spec.tsx
+++ b/src/services/bundleAnalysis/useBundleTrendData.spec.tsx
@@ -1,0 +1,366 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { renderHook, waitFor } from '@testing-library/react'
+import { graphql } from 'msw'
+import { setupServer } from 'msw/node'
+
+import { useBundleTrendData } from './useBundleTrendData'
+
+const mockBundleTrendData = {
+  owner: {
+    repository: {
+      __typename: 'Repository',
+      branch: {
+        head: {
+          bundleAnalysisReport: {
+            __typename: 'BundleAnalysisReport',
+            bundle: {
+              measurements: [
+                {
+                  __typename: 'BundleAnalysisMeasurements',
+                  assetType: 'REPORT_SIZE',
+                  measurements: [
+                    {
+                      timestamp: '2024-06-15T00:00:00+00:00',
+                      avg: null,
+                    },
+                    {
+                      timestamp: '2024-06-16T00:00:00+00:00',
+                      avg: null,
+                    },
+                    {
+                      timestamp: '2024-06-17T00:00:00+00:00',
+                      avg: 6834699.8,
+                    },
+                    {
+                      timestamp: '2024-06-18T00:00:00+00:00',
+                      avg: 6822037.27273,
+                    },
+                    {
+                      timestamp: '2024-06-19T00:00:00+00:00',
+                      avg: 6824833.33333,
+                    },
+                    {
+                      timestamp: '2024-06-20T00:00:00+00:00',
+                      avg: 6812341,
+                    },
+                  ],
+                },
+              ],
+            },
+          },
+        },
+      },
+    },
+  },
+}
+
+const mockMissingHeadReport = {
+  owner: {
+    repository: {
+      __typename: 'Repository',
+      branch: {
+        head: {
+          bundleAnalysisReport: {
+            __typename: 'MissingHeadReport',
+            message: 'Missing head report',
+          },
+        },
+      },
+    },
+  },
+}
+
+const mockUnsuccessfulParseError = {}
+
+const mockNullOwner = { owner: null }
+
+const mockRepoNotFound = {
+  owner: {
+    repository: {
+      __typename: 'NotFoundError',
+      message: 'Repository not found',
+    },
+  },
+}
+
+const mockOwnerNotActivated = {
+  owner: {
+    repository: {
+      __typename: 'OwnerNotActivatedError',
+      message: 'Owner not activated',
+    },
+  },
+}
+
+const server = setupServer()
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      retry: false,
+    },
+  },
+})
+
+const wrapper: React.FC<React.PropsWithChildren> = ({ children }) => (
+  <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+)
+
+beforeAll(() => {
+  server.listen()
+})
+
+afterEach(() => {
+  queryClient.clear()
+  server.resetHandlers()
+})
+
+afterAll(() => {
+  server.close()
+})
+
+interface SetupArgs {
+  isNotFoundError?: boolean
+  isOwnerNotActivatedError?: boolean
+  isUnsuccessfulParseError?: boolean
+  isNullOwner?: boolean
+  isMissingHeadReport?: boolean
+}
+
+describe('useBundleTrendData', () => {
+  function setup({
+    isMissingHeadReport,
+    isNotFoundError,
+    isNullOwner,
+    isOwnerNotActivatedError,
+    isUnsuccessfulParseError,
+  }: SetupArgs) {
+    server.use(
+      graphql.query('GetBundleTrend', (req, res, ctx) => {
+        if (isNotFoundError) {
+          return res(ctx.status(200), ctx.data(mockRepoNotFound))
+        } else if (isOwnerNotActivatedError) {
+          return res(ctx.status(200), ctx.data(mockOwnerNotActivated))
+        } else if (isUnsuccessfulParseError) {
+          return res(ctx.status(200), ctx.data(mockUnsuccessfulParseError))
+        } else if (isNullOwner) {
+          return res(ctx.status(200), ctx.data(mockNullOwner))
+        } else if (isMissingHeadReport) {
+          return res(ctx.status(200), ctx.data(mockMissingHeadReport))
+        }
+
+        return res(ctx.status(200), ctx.data(mockBundleTrendData))
+      })
+    )
+  }
+
+  describe('there is valid data', () => {
+    it('returns list of measurements', async () => {
+      setup({})
+      const { result } = renderHook(
+        () =>
+          useBundleTrendData({
+            provider: 'gh',
+            owner: 'codecov',
+            repo: 'codecov',
+            branch: 'main',
+            bundle: 'test-bundle',
+            interval: 'INTERVAL_1_DAY',
+            after: '2024-06-15T03:00:00.000Z',
+            before: '2024-06-20T03:00:00.000Z',
+            filters: {
+              assetTypes: ['REPORT_SIZE'],
+            },
+          }),
+        { wrapper }
+      )
+
+      const expectedResponse = [
+        {
+          __typename: 'BundleAnalysisMeasurements',
+          assetType: 'REPORT_SIZE',
+          measurements: [
+            {
+              timestamp: '2024-06-15T00:00:00+00:00',
+              avg: null,
+            },
+            {
+              timestamp: '2024-06-16T00:00:00+00:00',
+              avg: null,
+            },
+            {
+              timestamp: '2024-06-17T00:00:00+00:00',
+              avg: 6834699.8,
+            },
+            {
+              timestamp: '2024-06-18T00:00:00+00:00',
+              avg: 6822037.27273,
+            },
+            {
+              timestamp: '2024-06-19T00:00:00+00:00',
+              avg: 6824833.33333,
+            },
+            {
+              timestamp: '2024-06-20T00:00:00+00:00',
+              avg: 6812341,
+            },
+          ],
+        },
+      ]
+
+      await waitFor(() =>
+        expect(result.current.data).toStrictEqual(expectedResponse)
+      )
+    })
+  })
+
+  describe('there is invalid data', () => {
+    it('returns an empty array', async () => {
+      setup({ isNullOwner: true })
+      const { result } = renderHook(
+        () =>
+          useBundleTrendData({
+            provider: 'gh',
+            owner: 'codecov',
+            repo: 'codecov',
+            branch: 'main',
+            bundle: 'test-bundle',
+            interval: 'INTERVAL_1_DAY',
+            after: '2024-06-15T03:00:00.000Z',
+            before: '2024-06-20T03:00:00.000Z',
+            filters: {
+              assetTypes: ['REPORT_SIZE'],
+            },
+          }),
+        { wrapper }
+      )
+
+      await waitFor(() => expect(result.current.data).toStrictEqual([]))
+    })
+  })
+
+  describe('returns NotFoundError __typename', () => {
+    let oldConsoleError = console.error
+
+    beforeEach(() => {
+      console.error = () => null
+    })
+
+    afterEach(() => {
+      console.error = oldConsoleError
+    })
+
+    it('throws a 404', async () => {
+      setup({ isNotFoundError: true })
+      const { result } = renderHook(
+        () =>
+          useBundleTrendData({
+            provider: 'gh',
+            owner: 'codecov',
+            repo: 'codecov',
+            branch: 'main',
+            bundle: 'test-bundle',
+            interval: 'INTERVAL_1_DAY',
+            after: '2024-06-15T03:00:00.000Z',
+            before: '2024-06-20T03:00:00.000Z',
+            filters: {
+              assetTypes: ['REPORT_SIZE'],
+            },
+          }),
+        { wrapper }
+      )
+
+      await waitFor(() => expect(result.current.isError).toBeTruthy())
+      await waitFor(() =>
+        expect(result.current.error).toEqual(
+          expect.objectContaining({
+            status: 404,
+          })
+        )
+      )
+    })
+  })
+
+  describe('returns OwnerNotActivatedError __typename', () => {
+    let oldConsoleError = console.error
+
+    beforeEach(() => {
+      console.error = () => null
+    })
+
+    afterEach(() => {
+      console.error = oldConsoleError
+    })
+
+    it('throws a 403', async () => {
+      setup({ isOwnerNotActivatedError: true })
+      const { result } = renderHook(
+        () =>
+          useBundleTrendData({
+            provider: 'gh',
+            owner: 'codecov',
+            repo: 'codecov',
+            branch: 'main',
+            bundle: 'test-bundle',
+            interval: 'INTERVAL_1_DAY',
+            after: '2024-06-15T03:00:00.000Z',
+            before: '2024-06-20T03:00:00.000Z',
+            filters: {
+              assetTypes: ['REPORT_SIZE'],
+            },
+          }),
+        { wrapper }
+      )
+
+      await waitFor(() => expect(result.current.isError).toBeTruthy())
+      await waitFor(() =>
+        expect(result.current.error).toEqual(
+          expect.objectContaining({
+            status: 403,
+          })
+        )
+      )
+    })
+  })
+
+  describe('unsuccessful parse of zod schema', () => {
+    let oldConsoleError = console.error
+
+    beforeEach(() => {
+      console.error = () => null
+    })
+
+    afterEach(() => {
+      console.error = oldConsoleError
+    })
+
+    it('throws a 404', async () => {
+      setup({ isUnsuccessfulParseError: true })
+      const { result } = renderHook(
+        () =>
+          useBundleTrendData({
+            provider: 'gh',
+            owner: 'codecov',
+            repo: 'codecov',
+            branch: 'main',
+            bundle: 'test-bundle',
+            interval: 'INTERVAL_1_DAY',
+            after: '2024-06-15T03:00:00.000Z',
+            before: '2024-06-20T03:00:00.000Z',
+            filters: {
+              assetTypes: ['REPORT_SIZE'],
+            },
+          }),
+        { wrapper }
+      )
+
+      await waitFor(() => expect(result.current.isError).toBeTruthy())
+      await waitFor(() =>
+        expect(result.current.error).toEqual(
+          expect.objectContaining({
+            status: 404,
+          })
+        )
+      )
+    })
+  })
+})

--- a/src/services/bundleAnalysis/useBundleTrendData.spec.tsx
+++ b/src/services/bundleAnalysis/useBundleTrendData.spec.tsx
@@ -16,7 +16,6 @@ const mockBundleTrendData = {
             bundle: {
               measurements: [
                 {
-                  __typename: 'BundleAnalysisMeasurements',
                   assetType: 'REPORT_SIZE',
                   measurements: [
                     {
@@ -176,7 +175,6 @@ describe('useBundleTrendData', () => {
 
       const expectedResponse = [
         {
-          __typename: 'BundleAnalysisMeasurements',
           assetType: 'REPORT_SIZE',
           measurements: [
             {

--- a/src/services/bundleAnalysis/useBundleTrendData.tsx
+++ b/src/services/bundleAnalysis/useBundleTrendData.tsx
@@ -34,7 +34,6 @@ const BundleSchema = z.object({
   measurements: z
     .array(
       z.object({
-        __typename: z.literal('BundleAnalysisMeasurements'),
         assetType: z.enum(BUNDLE_TREND_REPORT_TYPES),
         measurements: z.array(MeasurementSchema).nullable(),
       })
@@ -102,13 +101,10 @@ query GetBundleTrend(
                     after: $after
                     filters: $filters
                   ) {
-                    __typename
-                    ... on BundleAnalysisMeasurements {
-                      assetType
-                      measurements {
-                        timestamp
-                        avg
-                      }
+                    assetType
+                    measurements {
+                      timestamp
+                      avg
                     }
                   }
                 }

--- a/src/services/bundleAnalysis/useBundleTrendData.tsx
+++ b/src/services/bundleAnalysis/useBundleTrendData.tsx
@@ -1,0 +1,234 @@
+import { useQuery } from '@tanstack/react-query'
+import { z } from 'zod'
+
+import { MissingHeadReportSchema } from 'services/comparison'
+import {
+  RepoNotFoundErrorSchema,
+  RepoOwnerNotActivatedErrorSchema,
+} from 'services/repo'
+import Api from 'shared/api'
+import { NetworkErrorObject } from 'shared/api/helpers'
+import A from 'ui/A'
+
+export const BUNDLE_TREND_INTERVALS = [
+  'INTERVAL_1_DAY',
+  'INTERVAL_7_DAY',
+  'INTERVAL_30_DAY',
+] as const
+
+export const BUNDLE_TREND_REPORT_TYPES = [
+  'REPORT_SIZE',
+  'JAVASCRIPT_SIZE',
+  'STYLESHEET_SIZE',
+  'FONT_SIZE',
+  'IMAGE_SIZE',
+  'ASSET_SIZE',
+] as const
+
+const MeasurementSchema = z.object({
+  timestamp: z.string(),
+  avg: z.number().nullable(),
+})
+
+const BundleSchema = z.object({
+  measurements: z
+    .array(
+      z.object({
+        __typename: z.literal('BundleAnalysisMeasurements'),
+        assetType: z.enum(BUNDLE_TREND_REPORT_TYPES),
+        measurements: z.array(MeasurementSchema).nullable(),
+      })
+    )
+    .nullable(),
+})
+
+const BundleReportSchema = z.object({
+  __typename: z.literal('BundleAnalysisReport'),
+  bundle: BundleSchema.nullable(),
+})
+
+const BranchSchema = z.object({
+  head: z
+    .object({
+      bundleAnalysisReport: z.discriminatedUnion('__typename', [
+        BundleReportSchema,
+        MissingHeadReportSchema,
+      ]),
+    })
+    .nullable(),
+})
+
+const RepositorySchema = z.object({
+  __typename: z.literal('Repository'),
+  branch: BranchSchema.nullable(),
+})
+
+const RequestSchema = z.object({
+  owner: z
+    .object({
+      repository: z.discriminatedUnion('__typename', [
+        RepositorySchema,
+        RepoNotFoundErrorSchema,
+        RepoOwnerNotActivatedErrorSchema,
+      ]),
+    })
+    .nullable(),
+})
+
+const query = `
+query GetBundleTrend(
+  $owner: String!
+  $repo: String!
+  $branch: String!
+  $bundle: String!
+  $interval: MeasurementInterval!
+  $before: DateTime!
+  $after: DateTime!
+  $filters: BundleAnalysisMeasurementsSetFilters
+) {
+  owner(username: $owner) {
+    repository(name: $repo) {
+      __typename
+      ... on Repository {
+        branch(name: $branch) {
+          head {
+            bundleAnalysisReport {
+              __typename
+              ... on BundleAnalysisReport {
+                bundle(name: $bundle) {
+                  measurements(
+                    interval: $interval
+                    before: $before
+                    after: $after
+                    filters: $filters
+                  ) {
+                    __typename
+                    ... on BundleAnalysisMeasurements {
+                      assetType
+                      measurements {
+                        timestamp
+                        avg
+                      }
+                    }
+                  }
+                }
+              }
+              ... on MissingHeadReport {
+                message
+              }
+            }
+          }
+        }
+      }
+      ... on NotFoundError {
+        message
+      }
+      ... on OwnerNotActivatedError {
+        message
+      }
+    }
+  }
+}`
+
+interface UseBundleTrendDataArgs {
+  provider: string
+  owner: string
+  repo: string
+  branch: string
+  bundle: string
+  interval: (typeof BUNDLE_TREND_INTERVALS)[number]
+  before: string
+  after: string
+  filters: {
+    assetTypes: Array<(typeof BUNDLE_TREND_REPORT_TYPES)[number]>
+  }
+}
+
+export const useBundleTrendData = ({
+  provider,
+  owner,
+  repo,
+  branch,
+  bundle,
+  interval,
+  before,
+  after,
+  filters,
+}: UseBundleTrendDataArgs) => {
+  return useQuery({
+    queryKey: [
+      'GetBundleTrend',
+      provider,
+      owner,
+      repo,
+      branch,
+      bundle,
+      interval,
+      before,
+      after,
+      filters,
+    ],
+    queryFn: ({ signal }) =>
+      Api.graphql({
+        query,
+        provider,
+        signal,
+        variables: {
+          owner,
+          repo,
+          branch,
+          bundle,
+          interval,
+          before,
+          after,
+          filters,
+        },
+      }).then((res) => {
+        const parsedData = RequestSchema.safeParse(res?.data)
+
+        if (!parsedData.success) {
+          return Promise.reject({
+            status: 404,
+            data: {},
+            dev: 'useBundleTrendData - 404 Failed to parse schema',
+          } satisfies NetworkErrorObject)
+        }
+
+        const data = parsedData.data
+
+        if (data?.owner?.repository?.__typename === 'NotFoundError') {
+          return Promise.reject({
+            status: 404,
+            data: {},
+            dev: 'useBundleTrendData - 404 Not found error',
+          } satisfies NetworkErrorObject)
+        }
+
+        if (data?.owner?.repository?.__typename === 'OwnerNotActivatedError') {
+          return Promise.reject({
+            status: 403,
+            data: {
+              detail: (
+                <p>
+                  Activation is required to view this repo, please{' '}
+                  {/* @ts-expect-error */}
+                  <A to={{ pageName: 'membersTab' }}>click here </A> to activate
+                  your account.
+                </p>
+              ),
+            },
+            dev: 'useBundleTrendData - 403 Owner not activated',
+          } satisfies NetworkErrorObject)
+        }
+
+        const bundleReport =
+          data.owner?.repository?.branch?.head?.bundleAnalysisReport
+
+        if (bundleReport?.__typename === 'BundleAnalysisReport') {
+          return bundleReport?.bundle?.measurements
+        }
+
+        return []
+      }),
+  })
+}


### PR DESCRIPTION
# Description

This PR adds in a hook to fetch the trend data for a given branch + bundle, with additional options for time range, data interval, and report type filters.

Closes #1800

# Code Example

```ts
const { data, /* ... */ } = useBundleTrendData({
  provider: 'gh',
  owner: 'codecov',
  repo: 'codecov',
  branch: 'main',
  bundle: 'test-bundle',
  interval: 'INTERVAL_1_DAY',
  after: '2024-06-15T03:00:00.000Z',
  before: '2024-06-20T03:00:00.000Z',
  filters: {
    assetTypes: ['REPORT_SIZE'],
  },
})
```

# Notable Changes

- Add in new `useBundleTrendData` hook
- Add in tests