### PR TITLE
feat: Okta access new tab

### DIFF
--- a/src/pages/AccountSettings/AccountSettings.jsx
+++ b/src/pages/AccountSettings/AccountSettings.jsx
@@ -6,7 +6,10 @@ import config from 'config'
 import { SentryRoute } from 'sentry'
 
 import SidebarLayout from 'layouts/SidebarLayout'
+import { usePlanData } from 'services/account'
 import { useIsCurrentUserAnAdmin, useUser } from 'services/user'
+import { useFlags } from 'shared/featureFlags'
+import { isEnterprisePlan } from 'shared/utils/billing'
 import LoadingLogo from 'ui/LoadingLogo'
 
 import AccountSettingsSideMenu from './AccountSettingsSideMenu'
@@ -18,9 +21,10 @@ const NotFound = lazy(() => import('../NotFound'))
 const OrgUploadToken = lazy(() => import('./tabs/OrgUploadToken'))
 const Profile = lazy(() => import('./tabs/Profile'))
 const YAMLTab = lazy(() => import('./tabs/YAML'))
+const OktaAccess = lazy(() => import('./tabs/OktaAccess'))
 
 const Loader = () => (
-  <div className="flex size-full items-center justify-center">
+  <div className="flex items-center justify-center">
     <LoadingLogo />
   </div>
 )
@@ -29,6 +33,12 @@ function AccountSettings() {
   const { provider, owner } = useParams()
   const isAdmin = useIsCurrentUserAnAdmin({ owner })
   const { data: currentUser } = useUser()
+
+  const { data } = usePlanData({ provider, owner })
+  const { oktaSettings } = useFlags({
+    oktaSettings: false,
+  })
+  const viewOktaAccess = oktaSettings && isEnterprisePlan(data?.plan?.value)
 
   const isViewingPersonalSettings =
     currentUser?.user?.username?.toLowerCase() === owner?.toLowerCase()
@@ -48,6 +58,11 @@ function AccountSettings() {
                 <Redirect to={`/account/${provider}/${owner}/yaml/`} />
               )}
             </SentryRoute>
+            {viewOktaAccess ? (
+              <SentryRoute path="/account/:provider/:owner/okta-access/" exact>
+                <OktaAccess />
+              </SentryRoute>
+            ) : null}
             <SentryRoute path="/account/:provider/:owner/yaml/" exact>
               <YAMLTab provider={provider} owner={owner} />
             </SentryRoute>

--- a/src/pages/AccountSettings/AccountSettingsSideMenu.jsx
+++ b/src/pages/AccountSettings/AccountSettingsSideMenu.jsx
@@ -2,11 +2,15 @@ import { useParams } from 'react-router-dom'
 
 import config from 'config'
 
+import { usePlanData } from 'services/account'
 import { useIsCurrentUserAnAdmin, useUser } from 'services/user'
+import { useFlags } from 'shared/featureFlags'
+import { isEnterprisePlan } from 'shared/utils/billing'
 import Sidemenu from 'ui/Sidemenu'
 
-function defaultLinks({ internalAccessTab }) {
+function defaultLinks({ internalAccessTab, viewOktaAccess }) {
   return [
+    ...(viewOktaAccess ? [{ pageName: 'oktaAccess' }] : []),
     ...(internalAccessTab ? [{ pageName: internalAccessTab }] : []),
     { pageName: 'yamlTab' },
   ]
@@ -26,19 +30,20 @@ function selfHostedOverrideLinks({ isPersonalSettings, isAdmin }) {
   ]
 }
 
-function adminOverrideLinks({ internalAccessTab }) {
+function adminOverrideLinks({ internalAccessTab, viewOktaAccess }) {
   return [
     {
       pageName: 'accountAdmin',
       exact: true,
     },
+    ...(viewOktaAccess ? [{ pageName: 'oktaAccess' }] : []),
     ...(internalAccessTab ? [{ pageName: internalAccessTab }] : []),
     { pageName: 'yamlTab' },
     { pageName: 'orgUploadToken' },
   ]
 }
 
-const generateLinks = ({ isAdmin, isPersonalSettings }) => {
+const generateLinks = ({ isAdmin, isPersonalSettings, viewOktaAccess }) => {
   const internalAccessTab = isPersonalSettings ? 'internalAccessTab' : ''
 
   if (config.IS_SELF_HOSTED) {
@@ -46,14 +51,14 @@ const generateLinks = ({ isAdmin, isPersonalSettings }) => {
   }
 
   if (isAdmin) {
-    return adminOverrideLinks({ internalAccessTab })
+    return adminOverrideLinks({ internalAccessTab, viewOktaAccess })
   }
 
-  return defaultLinks({ internalAccessTab })
+  return defaultLinks({ internalAccessTab, viewOktaAccess })
 }
 
 function AccountSettingsSideMenu() {
-  const { owner } = useParams()
+  const { provider, owner } = useParams()
 
   const { data: currentUser } = useUser()
   const isAdmin = useIsCurrentUserAnAdmin({ owner })
@@ -61,9 +66,16 @@ function AccountSettingsSideMenu() {
   const isPersonalSettings =
     currentUser?.user?.username?.toLowerCase() === owner?.toLowerCase()
 
+  const { data } = usePlanData({ provider, owner })
+  const { oktaSettings } = useFlags({
+    oktaSettings: false,
+  })
+  const viewOktaAccess = oktaSettings && isEnterprisePlan(data?.plan?.value)
+
   const links = generateLinks({
     isAdmin,
     isPersonalSettings,
+    viewOktaAccess,
   })
 
   return <Sidemenu links={links} />

--- a/src/pages/AccountSettings/tabs/OktaAccess/AdminAuthorizationBanner/AdminAuthorizationBanner.spec.tsx
+++ b/src/pages/AccountSettings/tabs/OktaAccess/AdminAuthorizationBanner/AdminAuthorizationBanner.spec.tsx
@@ -1,0 +1,21 @@
+import { render, screen } from '@testing-library/react'
+
+import { AdminAuthorizationBanner } from './AdminAuthorizationBanner'
+
+describe('AdminAuthorizationBanner', () => {
+  it('should render heading', () => {
+    render(<AdminAuthorizationBanner />)
+    const header = screen.getByRole('heading', {
+      name: /Admin authorization required/,
+    })
+    expect(header).toBeInTheDocument()
+  })
+
+  it('should render content', () => {
+    render(<AdminAuthorizationBanner />)
+    const content = screen.getByText(
+      /Requires organization administrator privileges. Please contact your GitHub administrator if you need access to configure Okta integration./
+    )
+    expect(content).toBeInTheDocument()
+  })
+})

--- a/src/pages/AccountSettings/tabs/OktaAccess/AdminAuthorizationBanner/AdminAuthorizationBanner.tsx
+++ b/src/pages/AccountSettings/tabs/OktaAccess/AdminAuthorizationBanner/AdminAuthorizationBanner.tsx
@@ -1,0 +1,17 @@
+import Banner from 'ui/Banner'
+import BannerContent from 'ui/Banner/BannerContent'
+import BannerHeading from 'ui/Banner/BannerHeading'
+
+export function AdminAuthorizationBanner() {
+  return (
+    <Banner>
+      <BannerHeading>
+        <h3 className="font-semibold">Admin authorization required</h3>
+      </BannerHeading>
+      <BannerContent>
+        Requires organization administrator privileges. Please contact your
+        GitHub administrator if you need access to configure Okta integration.
+      </BannerContent>
+    </Banner>
+  )
+}

--- a/src/pages/AccountSettings/tabs/OktaAccess/AdminAuthorizationBanner/index.ts
+++ b/src/pages/AccountSettings/tabs/OktaAccess/AdminAuthorizationBanner/index.ts
@@ -1,0 +1,1 @@
+export { AdminAuthorizationBanner } from './AdminAuthorizationBanner'

--- a/src/pages/AccountSettings/tabs/OktaAccess/OktaAccess.spec.tsx
+++ b/src/pages/AccountSettings/tabs/OktaAccess/OktaAccess.spec.tsx
@@ -1,0 +1,83 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { render, screen } from '@testing-library/react'
+import { graphql } from 'msw'
+import { setupServer } from 'msw/node'
+import { Suspense } from 'react'
+import { MemoryRouter, Route } from 'react-router-dom'
+
+import OktaAccess from './OktaAccess'
+
+const server = setupServer()
+const queryClient = new QueryClient({
+  defaultOptions: { queries: { suspense: true, retry: false } },
+})
+
+const wrapper: React.FC<React.PropsWithChildren> = ({ children }) => (
+  <QueryClientProvider client={queryClient}>
+    <MemoryRouter initialEntries={['/account/gh/codecov/okta-access/']}>
+      <Route path="/account/:provider/:owner/okta-access/">
+        <Suspense fallback={null}>{children}</Suspense>
+      </Route>
+    </MemoryRouter>
+  </QueryClientProvider>
+)
+
+beforeAll(() => {
+  server.listen({ onUnhandledRequest: 'warn' })
+})
+
+afterEach(() => {
+  queryClient.clear()
+  server.resetHandlers()
+})
+
+afterAll(() => {
+  server.close()
+})
+
+describe('OktaAccess', () => {
+  function setup({ isAdmin = false } = {}) {
+    server.use(
+      graphql.query('DetailOwner', (req, res, ctx) =>
+        res(
+          ctx.status(200),
+          ctx.data({ owner: { username: 'codecov', isAdmin } })
+        )
+      )
+    )
+  }
+
+  it('should render okta access header', async () => {
+    setup()
+    render(<OktaAccess />, { wrapper })
+
+    const header = await screen.findByText(/Okta access/)
+    expect(header).toBeInTheDocument()
+  })
+
+  it('should render okta access description', async () => {
+    setup()
+    render(<OktaAccess />, { wrapper })
+
+    const description = await screen.findByText(
+      /Configure your Okta integration to enable single sign-on \(SSO\) for your Codecov account./
+    )
+    expect(description).toBeInTheDocument()
+  })
+
+  it('should render Okta access form when user is admin', async () => {
+    setup({ isAdmin: true })
+    render(<OktaAccess />, { wrapper })
+
+    const form = await screen.findByText(/Okta access form/)
+    expect(form).toBeInTheDocument()
+  })
+
+  it('should render AdminAuthorizationBanner when user is not admin', async () => {
+    setup({ isAdmin: false })
+    render(<OktaAccess />, { wrapper })
+
+    const banner = await screen.findByText(/Admin authorization required/)
+    expect(banner).toBeInTheDocument()
+  })
+})

--- a/src/pages/AccountSettings/tabs/OktaAccess/OktaAccess.tsx
+++ b/src/pages/AccountSettings/tabs/OktaAccess/OktaAccess.tsx
@@ -1,0 +1,30 @@
+import { useParams } from 'react-router-dom'
+
+import { useIsCurrentUserAnAdmin } from 'services/user'
+
+import { AdminAuthorizationBanner } from './AdminAuthorizationBanner'
+
+interface URLParams {
+  owner: string
+}
+
+function OktaAccess() {
+  const { owner } = useParams<URLParams>()
+  const isAdmin = useIsCurrentUserAnAdmin({ owner })
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div>
+        <h1 className="text-lg font-semibold">Okta access</h1>
+        <p>
+          Configure your Okta integration to enable single sign-on &#40;SSO&#41;
+          for your Codecov account.
+        </p>
+      </div>
+      <hr />
+      {isAdmin ? <>Okta access form</> : <AdminAuthorizationBanner />}
+    </div>
+  )
+}
+
+export default OktaAccess

--- a/src/pages/AccountSettings/tabs/OktaAccess/index.ts
+++ b/src/pages/AccountSettings/tabs/OktaAccess/index.ts
@@ -1,0 +1,1 @@
+export { default } from './OktaAccess'

--- a/src/services/navigation/useNavLinks/useNavLinks.js
+++ b/src/services/navigation/useNavLinks/useNavLinks.js
@@ -803,5 +803,17 @@ export function useNavLinks() {
       text: 'Codecov CLI',
       isExternalLink: false,
     },
+    oktaAccess: {
+      path: (
+        { provider = p, owner = o } = {
+          provider: p,
+          owner: o,
+        }
+      ) => {
+        return `/account/${provider}/${owner}/okta-access`
+      },
+      text: 'Okta access',
+      isExternalLink: false,
+    },
   }
 }


### PR DESCRIPTION
# Description
We're supporting OKTA login for cloud enterprise users! This PR is meant to setup initial route and users view of okta settings page. (form is blocked by some API and Design work)  

# Notable Changes
- New okta route 
- New page under account settings 

# Screenshots
<img width="1501" alt="Screenshot 2024-06-24 at 6 12 24 PM" src="https://github.com/codecov/gazebo/assets/91732700/bb3a51d1-f0d7-4666-adb9-8fe4664a8688">
<img width="1501" alt="Screenshot 2024-06-24 at 6 13 36 PM" src="https://github.com/codecov/gazebo/assets/91732700/019152e2-a8f8-4d0d-a3c8-5c53c0f6e661">

closes: https://github.com/codecov/engineering-team/issues/1984
<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.