### PR TITLE
fix: Disable SessionExpiryTracker

### DIFF
--- a/src/layouts/BaseLayout/BaseLayout.jsx
+++ b/src/layouts/BaseLayout/BaseLayout.jsx
@@ -11,7 +11,6 @@ import { useTracking } from 'services/tracking'
 import GlobalBanners from 'shared/GlobalBanners'
 import GlobalTopBanners from 'shared/GlobalTopBanners'
 import LoadingLogo from 'ui/LoadingLogo'
-import SessionExpiryTracker from 'ui/SessionExpiryTracker'
 
 import { useUserAccessGate } from './hooks/useUserAccessGate'
 
@@ -69,7 +68,6 @@ function BaseLayout({ children }) {
 
   return (
     <>
-      <SessionExpiryTracker />
       {isFullExperience ? (
         <>
           <Header />


### PR DESCRIPTION
The current SessionExpiryTracker implementation makes every user reauth with GitHub every 8 hours. This has been a pain point for users. We will revisit our session expiry code in [issue].

Closes https://github.com/codecov/engineering-team/issues/1892
