### PR TITLE
feat: Hide old header stuff when new header flag is true

### DIFF
--- a/src/layouts/BaseLayout/BaseLayout.jsx
+++ b/src/layouts/BaseLayout/BaseLayout.jsx
@@ -2,12 +2,14 @@ import { lazy, Suspense } from 'react'
 import { Redirect } from 'react-router-dom'
 
 import Footer from 'layouts/Footer'
-import Header from 'layouts/OldHeader'
+import Header from 'layouts/Header'
+import OldHeader from 'layouts/OldHeader'
 import ErrorBoundary from 'layouts/shared/ErrorBoundary'
 import NetworkErrorBoundary from 'layouts/shared/NetworkErrorBoundary'
 import ToastNotifications from 'layouts/ToastNotifications'
 import { useImpersonate } from 'services/impersonate'
 import { useTracking } from 'services/tracking'
+import { useFlags } from 'shared/featureFlags'
 import GlobalBanners from 'shared/GlobalBanners'
 import GlobalTopBanners from 'shared/GlobalTopBanners'
 import LoadingLogo from 'ui/LoadingLogo'
@@ -63,6 +65,10 @@ function BaseLayout({ children }) {
     useUserAccessGate()
   useTracking()
 
+  const { newHeader } = useFlags({
+    newHeader: false,
+  })
+
   // Pause rendering of a page till we know if the user is logged in or not
   if (isLoading) return <FullPageLoader />
 
@@ -71,7 +77,7 @@ function BaseLayout({ children }) {
       <SessionExpiryTracker />
       {isFullExperience ? (
         <>
-          <Header />
+          {newHeader ? <Header /> : <OldHeader />}
           <GlobalTopBanners />
         </>
       ) : (

--- a/src/layouts/BaseLayout/BaseLayout.spec.jsx
+++ b/src/layouts/BaseLayout/BaseLayout.spec.jsx
@@ -77,10 +77,10 @@ const mockMe = {
 
 const userHasDefaultOrg = {
   me: {
+    ...mockMe,
     owner: {
       defaultOrgUsername: 'codecov',
     },
-    ...mockMe,
   },
 }
 
@@ -393,7 +393,7 @@ describe('BaseLayout', () => {
     })
 
     it('renders new header when feature flag is true', async () => {
-      setup({ currentUser: userHasDefaultOrg, newHeaderFlag: true })
+      setup({ currentUser: userHasDefaultOrg })
       useFlags.mockReturnValue({
         newHeader: true,
       })

--- a/src/layouts/BaseLayout/BaseLayout.spec.jsx
+++ b/src/layouts/BaseLayout/BaseLayout.spec.jsx
@@ -380,7 +380,7 @@ describe('BaseLayout', () => {
     })
   })
 
-  describe('header feature flaging', () => {
+  describe('header feature flagging', () => {
     it('renders old header when feature flag is false', async () => {
       setup({ currentUser: userHasDefaultOrg })
 

--- a/src/layouts/Header/Header.spec.tsx
+++ b/src/layouts/Header/Header.spec.tsx
@@ -1,0 +1,12 @@
+import { render, screen } from '@testing-library/react'
+
+import Header from './Header'
+
+describe('placeholder new header', () => {
+  it('renders', async () => {
+    render(<Header />)
+
+    const header = await screen.findByText('New header')
+    expect(header).toBeInTheDocument()
+  })
+})

--- a/src/layouts/Header/Header.tsx
+++ b/src/layouts/Header/Header.tsx
@@ -1,0 +1,5 @@
+function Header() {
+  return <h1>New header</h1>
+}
+
+export default Header

--- a/src/layouts/Header/index.ts
+++ b/src/layouts/Header/index.ts
@@ -1,0 +1,1 @@
+export { default } from './Header'

--- a/src/layouts/LoginLayout/LoginLayout.spec.tsx
+++ b/src/layouts/LoginLayout/LoginLayout.spec.tsx
@@ -5,14 +5,18 @@ import { setupServer } from 'msw/node'
 import { MemoryRouter, Route } from 'react-router'
 import { useLocation } from 'react-router-dom'
 
+import { useFlags } from 'shared/featureFlags'
+
 import LoginLayout from './LoginLayout'
 
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
   useLocation: jest.fn(),
 }))
+jest.mock('shared/featureFlags')
 
 const mockedUseLocation = useLocation as jest.Mock
+const mockedUseFlags = useFlags as jest.Mock
 
 const server = setupServer()
 const queryClient = new QueryClient()
@@ -54,6 +58,7 @@ describe('LoginLayout', () => {
       graphql.query('CurrentUser', (req, res, ctx) => res(ctx.status(200)))
     )
     mockedUseLocation.mockReturnValue({ search: [] })
+    mockedUseFlags.mockReturnValue({ newHeader: false })
   }
 
   describe('rendering component', () => {
@@ -115,6 +120,27 @@ describe('LoginLayout', () => {
       await waitFor(() => {
         expect(screen.getByText(/Your session has expired/)).toBeInTheDocument()
       })
+    })
+  })
+
+  describe('header feature flaging', () => {
+    it('renders old header when feature flag is false', async () => {
+      setup()
+
+      render(<LoginLayout>child content</LoginLayout>, { wrapper: wrapper() })
+
+      const blogLink = await screen.findByText('Why Test Code?')
+      expect(blogLink).toBeInTheDocument()
+    })
+
+    it('renders new header when feature flag is true', async () => {
+      setup()
+      mockedUseFlags.mockReturnValue({ newHeader: true })
+
+      render(<LoginLayout>child content</LoginLayout>, { wrapper: wrapper() })
+
+      const newHeader = await screen.findByText('New header')
+      expect(newHeader).toBeInTheDocument()
     })
   })
 })

--- a/src/layouts/LoginLayout/LoginLayout.spec.tsx
+++ b/src/layouts/LoginLayout/LoginLayout.spec.tsx
@@ -123,7 +123,7 @@ describe('LoginLayout', () => {
     })
   })
 
-  describe('header feature flaging', () => {
+  describe('header feature flagging', () => {
     it('renders old header when feature flag is false', async () => {
       setup()
 

--- a/src/layouts/LoginLayout/LoginLayout.tsx
+++ b/src/layouts/LoginLayout/LoginLayout.tsx
@@ -4,8 +4,10 @@ import { useLocation } from 'react-router-dom'
 import { LOCAL_STORAGE_SESSION_EXPIRED_KEY } from 'config'
 
 import Footer from 'layouts/Footer'
-import Header from 'layouts/OldHeader'
+import Header from 'layouts/Header'
+import OldHeader from 'layouts/OldHeader'
 import SessionExpiredBanner from 'pages/LoginPage/SessionExpiredBanner'
+import { useFlags } from 'shared/featureFlags'
 import LoadingLogo from 'ui/LoadingLogo'
 
 const FullPageLoader = () => (
@@ -17,6 +19,10 @@ const FullPageLoader = () => (
 const LoginLayout: React.FC<React.PropsWithChildren> = ({ children }) => {
   const location = useLocation()
 
+  const { newHeader } = useFlags({
+    newHeader: false,
+  })
+
   const showExpiryBanner = localStorage.getItem(
     LOCAL_STORAGE_SESSION_EXPIRED_KEY
   )
@@ -25,7 +31,7 @@ const LoginLayout: React.FC<React.PropsWithChildren> = ({ children }) => {
       {(location.search.includes('expired') || showExpiryBanner) && (
         <SessionExpiredBanner />
       )}
-      <Header />
+      {newHeader ? <Header /> : <OldHeader />}
       <Suspense fallback={<FullPageLoader />}>
         <main className="container mb-8 mt-2 flex grow flex-col gap-2 md:p-0">
           {children}

--- a/src/pages/AccountSettings/shared/Header/Header.jsx
+++ b/src/pages/AccountSettings/shared/Header/Header.jsx
@@ -1,12 +1,17 @@
 import config from 'config'
 
 import MyContextSwitcher from 'layouts/MyContextSwitcher'
+import { useFlags } from 'shared/featureFlags'
 import TabNavigation from 'ui/TabNavigation'
 
 function Header() {
+  const { newHeader } = useFlags({
+    newHeader: false,
+  })
+
   return (
     <>
-      <MyContextSwitcher pageName="accountAdmin" />
+      {newHeader ? null : <MyContextSwitcher pageName="accountAdmin" />}
       <TabNavigation
         tabs={[
           { pageName: 'owner', children: 'Repos' },

--- a/src/pages/AdminSettings/AdminSettingsHeader/AdminSettingsHeader.jsx
+++ b/src/pages/AdminSettings/AdminSettingsHeader/AdminSettingsHeader.jsx
@@ -1,10 +1,19 @@
 import { useUser } from 'services/user'
+import { useFlags } from 'shared/featureFlags'
 import Breadcrumb from 'ui/Breadcrumb'
 
 function AdminSettingsHeader() {
   const { data: currentUser } = useUser()
   const defaultOrg =
     currentUser?.owner?.defaultOrgUsername ?? currentUser?.user?.username
+
+  const { newHeader } = useFlags({
+    newHeader: false,
+  })
+
+  if (newHeader) {
+    return null
+  }
 
   return (
     <div className="my-4">

--- a/src/pages/AnalyticsPage/AnalyticsPage.jsx
+++ b/src/pages/AnalyticsPage/AnalyticsPage.jsx
@@ -5,6 +5,7 @@ import NotFound from 'pages/NotFound'
 import { useLocationParams } from 'services/navigation'
 import { orderingOptions } from 'services/repos'
 import { useOwner } from 'services/user'
+import { useFlags } from 'shared/featureFlags'
 import ReposTable from 'shared/ListRepo/ReposTable'
 import LoadingLogo from 'ui/LoadingLogo'
 
@@ -37,6 +38,10 @@ function AnalyticsPage() {
   const { owner } = useParams()
   const { data: ownerData } = useOwner({ username: owner })
 
+  const { newHeader } = useFlags({
+    newHeader: false,
+  })
+
   const orderOptions = orderingOptions
 
   const sortItem =
@@ -52,7 +57,7 @@ function AnalyticsPage() {
 
   return (
     <div className="mt-2 flex flex-col gap-4">
-      <Header />
+      {newHeader ? null : <Header />}
       <div>{ownerData?.isCurrentUserPartOfOrg && <Tabs />}</div>
       <ChartSelectors
         params={params}

--- a/src/pages/CommitDetailPage/CommitDetailPage.spec.tsx
+++ b/src/pages/CommitDetailPage/CommitDetailPage.spec.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { render, screen } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
 import { graphql } from 'msw'
 import { setupServer } from 'msw/node'
 import { Suspense } from 'react'
@@ -324,6 +324,12 @@ describe('CommitDetailPage', () => {
         newHeader: true,
       })
       render(<CommitPage />, { wrapper: wrapper() })
+
+      await waitFor(() =>
+        expect(mockedUseFlags).toHaveReturnedWith(
+          expect.objectContaining({ newHeader: true })
+        )
+      )
 
       const breadcrumb = screen.queryByText(/test-repo/)
       expect(breadcrumb).not.toBeInTheDocument()

--- a/src/pages/CommitDetailPage/CommitDetailPage.spec.tsx
+++ b/src/pages/CommitDetailPage/CommitDetailPage.spec.tsx
@@ -331,6 +331,9 @@ describe('CommitDetailPage', () => {
         )
       )
 
+      const CommitCoverage = await screen.findByText(/CommitCoverage/)
+      expect(CommitCoverage).toBeInTheDocument()
+
       const breadcrumb = screen.queryByText(/test-repo/)
       expect(breadcrumb).not.toBeInTheDocument()
     })

--- a/src/pages/CommitDetailPage/CommitDetailPage.tsx
+++ b/src/pages/CommitDetailPage/CommitDetailPage.tsx
@@ -4,6 +4,7 @@ import { lazy, Suspense } from 'react'
 import { useLocation, useParams } from 'react-router-dom'
 
 import NotFound from 'pages/NotFound'
+import { useFlags } from 'shared/featureFlags'
 import Breadcrumb from 'ui/Breadcrumb'
 import Spinner from 'ui/Spinner'
 import SummaryDropdown from 'ui/SummaryDropdown'
@@ -41,6 +42,10 @@ const CommitDetailPage: React.FC = () => {
   const location = useLocation()
   const { provider, owner, repo, commit: commitSha } = useParams<URLParams>()
   const shortSHA = commitSha?.slice(0, 7)
+
+  const { newHeader } = useFlags({
+    newHeader: false,
+  })
 
   // reset cache when user navigates to the commit detail page
   const queryClient = useQueryClient()
@@ -86,19 +91,21 @@ const CommitDetailPage: React.FC = () => {
 
   return (
     <div className="flex flex-col gap-4 px-3 sm:px-0">
-      <Breadcrumb
-        paths={[
-          { pageName: 'owner', text: owner },
-          { pageName: 'repo', text: repo },
-          { pageName: 'commits', text: 'commits' },
-          {
-            pageName: 'commit',
-            options: { commitSha },
-            readOnly: true,
-            text: shortSHA,
-          },
-        ]}
-      />
+      {newHeader ? null : (
+        <Breadcrumb
+          paths={[
+            { pageName: 'owner', text: owner },
+            { pageName: 'repo', text: repo },
+            { pageName: 'commits', text: 'commits' },
+            {
+              pageName: 'commit',
+              options: { commitSha },
+              readOnly: true,
+              text: shortSHA,
+            },
+          ]}
+        />
+      )}
       <Header />
       {displayMode === DISPLAY_MODE.BOTH ? (
         <SummaryDropdown type="multiple" defaultValue={defaultDropdown}>

--- a/src/pages/MembersPage/MembersPage.jsx
+++ b/src/pages/MembersPage/MembersPage.jsx
@@ -3,6 +3,7 @@ import { Redirect, useParams } from 'react-router-dom'
 import config from 'config'
 
 import { useOwner } from 'services/user'
+import { useFlags } from 'shared/featureFlags'
 
 import Header from './Header'
 import MemberActivation from './MembersActivation'
@@ -14,13 +15,17 @@ function MembersPage() {
   const { owner, provider } = useParams()
   const { data: ownerData } = useOwner({ username: owner })
 
+  const { newHeader } = useFlags({
+    newHeader: false,
+  })
+
   if (config.IS_SELF_HOSTED) {
     return <Redirect to={`/${provider}/${owner}`} />
   }
 
   return (
     <div className="mt-2 flex flex-col gap-4">
-      <Header />
+      {newHeader ? null : <Header />}
       {ownerData?.isCurrentUserPartOfOrg && <Tabs />}
       <h2 className="mx-4 text-lg font-semibold sm:mx-0">Manage members</h2>
       <hr className="lg:w-10/12" />

--- a/src/pages/MembersPage/MembersPage.spec.jsx
+++ b/src/pages/MembersPage/MembersPage.spec.jsx
@@ -5,6 +5,7 @@ import { MemoryRouter, Route } from 'react-router-dom'
 import config from 'config'
 
 import { useOwner } from 'services/user'
+import { useFlags } from 'shared/featureFlags'
 
 import MembersPage from './MembersPage'
 
@@ -16,6 +17,9 @@ jest.mock('./MissingMemberBanner', () => () => 'MissingMemberBanner')
 jest.mock('./MembersList', () => () => 'MembersList')
 jest.mock('config')
 
+// temp, for new header work
+jest.mock('shared/featureFlags')
+
 const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
@@ -26,11 +30,14 @@ const queryClient = new QueryClient({
 
 let testLocation
 describe('MembersPage', () => {
-  function setup({ owner = null, isSelfHosted = false }) {
+  function setup({ owner = null, isSelfHosted = false, newHeader = false }) {
     config.IS_SELF_HOSTED = isSelfHosted
 
     useOwner.mockReturnValue({
       data: owner,
+    })
+    useFlags.mockReturnValue({
+      newHeader,
     })
     render(
       <MemoryRouter initialEntries={['/members/gh/codecov']}>
@@ -111,6 +118,21 @@ describe('MembersPage', () => {
 
     it('redirects to owner page', () => {
       expect(testLocation.pathname).toBe('/gh/codecov')
+    })
+  })
+
+  describe('header feature flagging', () => {
+    it('renders header when flag is false', async () => {
+      setup({})
+
+      const header = await screen.findByText(/Header/)
+      expect(header).toBeInTheDocument()
+    })
+
+    it('does not render header when flag is true', async () => {
+      setup({ newHeader: true })
+      const header = screen.queryByText(/Header/)
+      expect(header).not.toBeInTheDocument()
     })
   })
 })

--- a/src/pages/OwnerPage/OwnerPage.jsx
+++ b/src/pages/OwnerPage/OwnerPage.jsx
@@ -7,6 +7,7 @@ import { useSentryToken } from 'services/account'
 import { useLocationParams } from 'services/navigation'
 import { renderToast } from 'services/toast'
 import { ActiveContext } from 'shared/context'
+import { useFlags } from 'shared/featureFlags'
 import ListRepo from 'shared/ListRepo'
 
 import Header from './Header'
@@ -41,6 +42,10 @@ function OwnerPage() {
     repoDisplay: 'All',
   })
 
+  const { newHeader } = useFlags({
+    newHeader: false,
+  })
+
   useSentryTokenRedirect({ ownerData })
   const userStartedTrial = localStorage.getItem(
     LOCAL_STORAGE_USER_STARTED_TRIAL_KEY
@@ -68,7 +73,7 @@ function OwnerPage() {
   return (
     // mt-2 temporary till we stick this header
     <div className="mt-2 flex flex-col gap-4">
-      <Header />
+      {newHeader ? null : <Header />}
       <div>
         {ownerData?.isCurrentUserPartOfOrg && (
           <Tabs owner={ownerData} provider={provider} />

--- a/src/pages/PlanPage/PlanPage.jsx
+++ b/src/pages/PlanPage/PlanPage.jsx
@@ -8,6 +8,7 @@ import config from 'config'
 import { SentryRoute } from 'sentry'
 
 import { usePlanPageData } from 'pages/PlanPage/hooks'
+import { useFlags } from 'shared/featureFlags'
 import LoadingLogo from 'ui/LoadingLogo'
 
 import { PlanBreadcrumbProvider } from './context'
@@ -36,13 +37,17 @@ function PlanPage() {
   const { owner, provider } = useParams()
   const { data: ownerData } = usePlanPageData({ owner, provider })
 
+  const { newHeader } = useFlags({
+    newHeader: false,
+  })
+
   if (config.IS_SELF_HOSTED || !ownerData?.isCurrentUserPartOfOrg) {
     return <Redirect to={`/${provider}/${owner}`} />
   }
 
   return (
     <div className="mt-2 flex flex-col gap-4">
-      <Header />
+      {newHeader ? null : <Header />}
       <Tabs />
       <Elements stripe={stripePromise}>
         <PlanBreadcrumbProvider>

--- a/src/pages/PullRequestPage/PullRequestPage.spec.tsx
+++ b/src/pages/PullRequestPage/PullRequestPage.spec.tsx
@@ -19,7 +19,6 @@ const mockedUseFlags = useFlags as jest.Mock<{
 jest.mock('./Header', () => () => 'Header')
 jest.mock('./PullCoverage', () => () => 'PullCoverage')
 jest.mock('./PullBundleAnalysis', () => () => 'PullBundleAnalysis')
-jest.mock('shared/featureFlags')
 
 const mockPullHeadData = {
   owner: {

--- a/src/pages/PullRequestPage/PullRequestPage.spec.tsx
+++ b/src/pages/PullRequestPage/PullRequestPage.spec.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from 'custom-testing-library'
+import { render, screen, waitFor } from 'custom-testing-library'
 
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { graphql } from 'msw'
@@ -395,6 +395,12 @@ describe('PullRequestPage', () => {
         newHeader: true,
       })
       render(<PullRequestPage />, { wrapper: wrapper() })
+
+      await waitFor(() =>
+        expect(mockedUseFlags).toHaveReturnedWith(
+          expect.objectContaining({ newHeader: true })
+        )
+      )
 
       const breadcrumb = screen.queryByText(/test-repo/)
       expect(breadcrumb).not.toBeInTheDocument()

--- a/src/pages/PullRequestPage/PullRequestPage.spec.tsx
+++ b/src/pages/PullRequestPage/PullRequestPage.spec.tsx
@@ -402,6 +402,9 @@ describe('PullRequestPage', () => {
         )
       )
 
+      const PullCoverage = await screen.findByText(/PullCoverage/)
+      expect(PullCoverage).toBeInTheDocument()
+
       const breadcrumb = screen.queryByText(/test-repo/)
       expect(breadcrumb).not.toBeInTheDocument()
     })

--- a/src/pages/PullRequestPage/PullRequestPage.spec.tsx
+++ b/src/pages/PullRequestPage/PullRequestPage.spec.tsx
@@ -13,6 +13,7 @@ import PullRequestPage from './PullRequestPage'
 jest.mock('shared/featureFlags')
 const mockedUseFlags = useFlags as jest.Mock<{
   multipleTiers: boolean
+  newHeader: boolean
 }>
 
 jest.mock('./Header', () => () => 'Header')
@@ -189,6 +190,7 @@ describe('PullRequestPage', () => {
   }: SetupArgs) {
     mockedUseFlags.mockReturnValue({
       multipleTiers: true,
+      newHeader: false,
     })
 
     server.use(
@@ -375,6 +377,28 @@ describe('PullRequestPage', () => {
         const PullBundleAnalysis = await screen.findByText(/PullBundleAnalysis/)
         expect(PullBundleAnalysis).toBeInTheDocument()
       })
+    })
+  })
+
+  describe('header feature flagging', () => {
+    it('renders breadcrumb when flag is false', async () => {
+      setup({})
+      render(<PullRequestPage />, { wrapper: wrapper() })
+
+      const breadcrumb = await screen.findByText(/test-repo/)
+      expect(breadcrumb).toBeInTheDocument()
+    })
+
+    it('does not render breadcrumb when flag is true', async () => {
+      setup({})
+      mockedUseFlags.mockReturnValue({
+        multipleTiers: false,
+        newHeader: true,
+      })
+      render(<PullRequestPage />, { wrapper: wrapper() })
+
+      const breadcrumb = screen.queryByText(/test-repo/)
+      expect(breadcrumb).not.toBeInTheDocument()
     })
   })
 })

--- a/src/pages/PullRequestPage/PullRequestPage.tsx
+++ b/src/pages/PullRequestPage/PullRequestPage.tsx
@@ -42,8 +42,9 @@ const Loader = () => (
 function PullRequestPage() {
   const location = useLocation()
   const { provider, owner, repo, pullId } = useParams<URLParams>()
-  const { multipleTiers } = useFlags({
+  const { multipleTiers, newHeader } = useFlags({
     multipleTiers: false,
+    newHeader: false,
   })
 
   const { data: overview } = useRepoOverview({ provider, owner, repo })
@@ -86,19 +87,21 @@ function PullRequestPage() {
 
   return (
     <div className="mx-4 flex flex-col gap-4 md:mx-0">
-      <Breadcrumb
-        paths={[
-          { pageName: 'owner', text: owner },
-          { pageName: 'repo', text: repo },
-          { pageName: 'pulls', text: 'Pulls' },
-          {
-            pageName: 'pullDetail',
-            options: { pullId },
-            readOnly: true,
-            text: pullId,
-          },
-        ]}
-      />
+      {newHeader ? null : (
+        <Breadcrumb
+          paths={[
+            { pageName: 'owner', text: owner },
+            { pageName: 'repo', text: repo },
+            { pageName: 'pulls', text: 'Pulls' },
+            {
+              pageName: 'pullDetail',
+              options: { pullId },
+              readOnly: true,
+              text: pullId,
+            },
+          ]}
+        />
+      )}
       <Header />
       {displayMode === DISPLAY_MODE.BOTH ? (
         <SummaryDropdown type="multiple" defaultValue={defaultDropdown}>

--- a/src/pages/RepoPage/RepoBreadcrumb.jsx
+++ b/src/pages/RepoPage/RepoBreadcrumb.jsx
@@ -1,9 +1,18 @@
+import { useFlags } from 'shared/featureFlags'
 import Breadcrumb from 'ui/Breadcrumb'
 
 import { useCrumbs } from './context'
 
 export default function RepoBreadcrumb() {
   const crumbs = useCrumbs()
+
+  const { newHeader } = useFlags({
+    newHeader: false,
+  })
+
+  if (newHeader) {
+    return null
+  }
 
   return (
     <div className="sticky top-0 z-10 flex flex-row bg-white px-6 py-2 sm:px-0">

--- a/src/pages/RepoPage/RepoPage.spec.tsx
+++ b/src/pages/RepoPage/RepoPage.spec.tsx
@@ -940,6 +940,12 @@ describe('RepoPage', () => {
       })
       render(<RepoPage />, { wrapper: wrapper({ queryClient }) })
 
+      await waitFor(() =>
+        expect(mockedUseFlags).toHaveReturnedWith(
+          expect.objectContaining({ newHeader: true })
+        )
+      )
+
       const repoCrumb = screen.queryByText('cool-repo')
       expect(repoCrumb).not.toBeInTheDocument()
     })

--- a/src/pages/RepoPage/RepoPage.spec.tsx
+++ b/src/pages/RepoPage/RepoPage.spec.tsx
@@ -936,7 +936,7 @@ describe('RepoPage', () => {
       mockedUseFlags.mockReturnValue({
         componentTab: true,
         onboardingFailedTests: false,
-        newHeader: false,
+        newHeader: true,
       })
       render(<RepoPage />, { wrapper: wrapper({ queryClient }) })
 

--- a/src/pages/RepoPage/RepoPage.spec.tsx
+++ b/src/pages/RepoPage/RepoPage.spec.tsx
@@ -28,6 +28,7 @@ jest.mock('shared/featureFlags')
 const mockedUseFlags = useFlags as jest.Mock<{
   componentTab: boolean
   onboardingFailedTests: boolean
+  newHeader: boolean
 }>
 
 const mockGetRepo = ({
@@ -193,6 +194,7 @@ describe('RepoPage', () => {
     mockedUseFlags.mockReturnValue({
       componentTab: true,
       onboardingFailedTests,
+      newHeader: false,
     })
 
     const user = userEvent.setup()
@@ -917,6 +919,29 @@ describe('RepoPage', () => {
         const error = await screen.findByText('ActivationAlert')
         expect(error).toBeInTheDocument()
       })
+    })
+  })
+
+  describe('header feature flagging', () => {
+    it('renders header when flag is false', async () => {
+      const { queryClient } = setup({ hasRepoData: true, isRepoActive: true })
+      render(<RepoPage />, { wrapper: wrapper({ queryClient }) })
+
+      const repoCrumb = await screen.findByText('cool-repo')
+      expect(repoCrumb).toBeInTheDocument()
+    })
+
+    it('does not render header when flag is true', async () => {
+      const { queryClient } = setup({ hasRepoData: true, isRepoActive: true })
+      mockedUseFlags.mockReturnValue({
+        componentTab: true,
+        onboardingFailedTests: false,
+        newHeader: false,
+      })
+      render(<RepoPage />, { wrapper: wrapper({ queryClient }) })
+
+      const repoCrumb = screen.queryByText('cool-repo')
+      expect(repoCrumb).not.toBeInTheDocument()
     })
   })
 })


### PR DESCRIPTION
Hides all primary and secondary Navs along with old header whenever the `newHeader` feature flag is `true`. This is prep for implementing the new header/nav and will not affect any users until the proper rollout of the feature.

Closes https://github.com/codecov/engineering-team/issues/1935
Closes https://github.com/codecov/engineering-team/issues/1951