### PR TITLE
feat: Create BundleTrendChart

### DIFF
--- a/src/shared/utils/bundleAnalysis.spec.ts
+++ b/src/shared/utils/bundleAnalysis.spec.ts
@@ -1,4 +1,8 @@
-import { formatSizeToString, formatTimeToString } from './bundleAnalysis'
+import {
+  formatSizeToString,
+  formatTimeToString,
+  localizeBundleSize,
+} from './bundleAnalysis'
 
 describe('formatSizeToString', () => {
   describe('size is less then one kilobyte', () => {
@@ -94,6 +98,72 @@ describe('formatTimeToString', () => {
     it('returns unit in milliseconds', () => {
       const time = formatTimeToString(123)
       expect(time).toBe('123ms')
+    })
+  })
+})
+
+describe('localizeBundleSize', () => {
+  describe('size is less then one kilobyte', () => {
+    describe('size is a positive number', () => {
+      it('returns size in bytes', () => {
+        const result = localizeBundleSize(900)
+        expect(result).toBe(900)
+      })
+    })
+
+    describe('size is a negative number', () => {
+      it('returns size in bytes', () => {
+        const result = localizeBundleSize(-900)
+        expect(result).toBe(-900)
+      })
+    })
+  })
+
+  describe('size is greater then one kilobyte and smaller then one megabyte', () => {
+    describe('size is a positive number', () => {
+      it('returns size in kilobytes', () => {
+        const result = localizeBundleSize(10000)
+        expect(result).toBe(10)
+      })
+    })
+
+    describe('size is a negative number', () => {
+      it('returns size in kilobytes', () => {
+        const result = localizeBundleSize(-10000)
+        expect(result).toBe(-10)
+      })
+    })
+  })
+
+  describe('size is greater then one megabyte and smaller then gigabyte', () => {
+    describe('size is a positive number', () => {
+      it('returns size in megabytes', () => {
+        const result = localizeBundleSize(1000000)
+        expect(result).toBe(1)
+      })
+    })
+
+    describe('size is a negative number', () => {
+      it('returns size in megabytes', () => {
+        const result = localizeBundleSize(-1000000)
+        expect(result).toBe(-1)
+      })
+    })
+  })
+
+  describe('size is greater then gigabyte', () => {
+    describe('size is a positive number', () => {
+      it('returns size in gigabytes', () => {
+        const result = localizeBundleSize(1000000000)
+        expect(result).toBe(1)
+      })
+    })
+
+    describe('size is a negative number', () => {
+      it('returns size in gigabytes', () => {
+        const result = localizeBundleSize(-1000000000)
+        expect(result).toBe(-1)
+      })
     })
   })
 })

--- a/src/shared/utils/bundleAnalysis.ts
+++ b/src/shared/utils/bundleAnalysis.ts
@@ -57,3 +57,21 @@ export const formatTimeToString = (milliseconds: number) => {
     unit: 'millisecond',
   }).format(milliseconds)
 }
+
+export const localizeBundleSize = (bytes: number) => {
+  const positiveBytes = Math.abs(bytes)
+
+  if (positiveBytes < KILOBYTE) {
+    return bytes
+  }
+
+  if (positiveBytes >= KILOBYTE && positiveBytes < MEGABYTE) {
+    return bytes / KILOBYTE
+  }
+
+  if (positiveBytes >= MEGABYTE && positiveBytes < GIGABYTE) {
+    return bytes / MEGABYTE
+  }
+
+  return bytes / GIGABYTE
+}

--- a/src/ui/BundleTrendChart/BundleTrendChart.spec.tsx
+++ b/src/ui/BundleTrendChart/BundleTrendChart.spec.tsx
@@ -1,0 +1,114 @@
+import { render, screen } from '@testing-library/react'
+
+import { BundleTrendChart } from './BundleTrendChart'
+
+describe('Coverage Area Chart', () => {
+  beforeEach(() => {
+    jest.useFakeTimers().setSystemTime(new Date('2020-04-01'))
+  })
+
+  afterAll(() => {
+    jest.useRealTimers()
+  })
+
+  describe('Chart with data', () => {
+    it('renders victory', () => {
+      render(
+        <BundleTrendChart
+          data={{
+            maxY: 70,
+            multiplier: 1,
+            measurements: [
+              { date: new Date('2020-01-15T20:18:39.413Z'), size: 20 },
+              { date: new Date('2020-01-17T20:18:39.413Z'), size: 50 },
+            ],
+          }}
+          desc="Chart desc"
+          title="Chart title"
+        />
+      )
+
+      const victory = screen.getByRole('img')
+      expect(victory).toBeInTheDocument()
+    })
+
+    it('renders a screen reader description', () => {
+      render(
+        <BundleTrendChart
+          data={{
+            maxY: 70,
+            multiplier: 1,
+            measurements: [
+              { date: new Date('2020-01-15T20:18:39.413Z'), size: 20 },
+              { date: new Date('2020-01-17T20:18:39.413Z'), size: 50 },
+            ],
+          }}
+          desc="Chart desc"
+          title="Chart title"
+        />
+      )
+
+      const chartDescription = screen.getByText('Chart desc')
+      expect(chartDescription).toBeInTheDocument()
+    })
+
+    it('renders a screen reader title', () => {
+      render(
+        <BundleTrendChart
+          data={{
+            maxY: 70,
+            multiplier: 1,
+            measurements: [
+              { date: new Date('2020-01-15T20:18:39.413Z'), size: 20 },
+              { date: new Date('2020-01-17T20:18:39.413Z'), size: 50 },
+            ],
+          }}
+          desc="Chart desc"
+          title="Chart title"
+        />
+      )
+
+      const chartTitle = screen.getByText('Chart title')
+      expect(chartTitle).toBeInTheDocument()
+    })
+  })
+
+  describe('Not enough data to render', () => {
+    it('renders victory', () => {
+      render(
+        <BundleTrendChart
+          data={{
+            maxY: 10,
+            multiplier: 1,
+            measurements: [
+              { date: new Date('2020-01-15T20:18:39.413Z'), size: 20 },
+            ],
+          }}
+          desc="Chart desc"
+          title="Chart title"
+        />
+      )
+      const victory = screen.getByRole('img')
+      expect(victory).toBeInTheDocument()
+    })
+
+    it('renders not enough data', () => {
+      render(
+        <BundleTrendChart
+          data={{
+            maxY: 10,
+            multiplier: 1,
+            measurements: [
+              { date: new Date('2020-01-15T20:18:39.413Z'), size: 20 },
+            ],
+          }}
+          desc="Chart desc"
+          title="Chart title"
+        />
+      )
+
+      const noData = screen.getByText('Not enough data to render')
+      expect(noData).toBeInTheDocument()
+    })
+  })
+})

--- a/src/ui/BundleTrendChart/BundleTrendChart.stories.tsx
+++ b/src/ui/BundleTrendChart/BundleTrendChart.stories.tsx
@@ -1,0 +1,51 @@
+import { Meta, StoryObj } from '@storybook/react'
+
+import { BundleTrendChart } from './BundleTrendChart'
+
+type BundleTrendChartStory = React.ComponentProps<typeof BundleTrendChart> & {}
+
+const meta: Meta<AbortController> = {
+  title: 'Components/BundleTrendChart',
+}
+
+export default meta
+
+type Story = StoryObj<BundleTrendChartStory>
+
+const trendData = {
+  maxY: 90,
+  multiplier: 1,
+  measurements: [
+    { date: new Date('December 10, 2022'), size: 17 },
+    { date: new Date('December 12, 2022'), size: 10 },
+    { date: new Date('December 17, 2022'), size: 6 },
+    { date: new Date('December 22, 2022'), size: 45 },
+    { date: new Date('December 25, 2022'), size: 74 },
+  ],
+}
+
+export const Default: Story = {
+  render: () => (
+    <BundleTrendChart
+      data={trendData}
+      title="Example with data"
+      desc="Bundle trend chart with data"
+    />
+  ),
+}
+
+const noTrendData = {
+  maxY: 2,
+  multiplier: 1,
+  measurements: [],
+}
+
+export const NoData: Story = {
+  render: () => (
+    <BundleTrendChart
+      data={noTrendData}
+      title="Example with no data"
+      desc="Bundle trend chart with no data"
+    />
+  ),
+}

--- a/src/ui/BundleTrendChart/BundleTrendChart.tsx
+++ b/src/ui/BundleTrendChart/BundleTrendChart.tsx
@@ -1,0 +1,228 @@
+import { format } from 'date-fns'
+import {
+  createContainer,
+  VictoryAccessibleGroup,
+  VictoryArea,
+  VictoryAxis,
+  VictoryChart,
+  VictoryClipContainer,
+  VictoryTooltip,
+} from 'victory'
+
+import {
+  formatSizeToString,
+  localizeBundleSize,
+} from 'shared/utils/bundleAnalysis'
+
+import './chart.css'
+import NoBundleData from './NoBundleData'
+
+const defaultStyles = {
+  tooltip: {
+    style: { fontSize: 4 },
+    flyout: { top: 4, bottom: 3, left: 5, right: 5 },
+  },
+  chartPadding: {
+    top: 2,
+    bottom: 10,
+    left: 0,
+    right: 15,
+  },
+  bundleAxisLabels: { fontSize: 4, padding: 1 },
+  dateAxisLabels: { fontSize: 4, padding: 0 },
+}
+
+// @ts-expect-error - This function wants two args, however we have only ever provided it one, see CoverageAreaChart.
+const VictoryVoronoiContainer = createContainer('voronoi')
+
+interface BundleTrendChartProps {
+  /**
+   * Title of the chart
+   * @example `${bundle} size chart`
+   */
+  title: string
+
+  /**
+   * Description of the chart
+   * @example
+   * ```typescript
+   * function makeDesc({ first, last, repo, data }) {
+   *  if (!data || !first || !last) return ''
+   *    const firstDate = format(new Date(first.date), 'MMM dd, yyy')
+   *    const lastDate = format(new Date(last.date), 'MMM dd, yyy')
+   *    const sizeDiff = Math.abs(first.size, last.size)
+   *    const change = first.size < last.size ? '+' : '-'
+
+   *    return `${repo} size chart from ${firstDate} to ${lastDate}, size change is ${change}${sizeDiff}%`
+   *  }
+   *  ```
+   */
+  desc: string
+
+  /**
+   * Data for the chart
+   * @param maxY - Maximum Y value
+   * @param multiplier - Multiplier for the Y axis
+   * @param measurements - Array of measurements
+   * @example
+   * ```typescript
+   * const data = {
+   *   maxY: 10,
+   *   multiplier: 1,
+   *   measurements: [
+   *     { date: new Date('2021-01-01'), size: 1 },
+   *   ]
+   * }
+   * ```
+   */
+  data: {
+    maxY: number
+    multiplier: number
+    measurements: { date: Date; size: number }[]
+  }
+}
+
+export function BundleTrendChart({ title, desc, data }: BundleTrendChartProps) {
+  return (
+    <>
+      <svg data-testid="bundle-trend-chart" style={{ height: 0 }}>
+        <defs>
+          <filter
+            id="toLinearRGB"
+            filterUnits="objectBoundingBox"
+            x="0"
+            y="0"
+            width="1"
+            height="1"
+          >
+            <feComponentTransfer colorInterpolationFilters="sRGB">
+              <feFuncR
+                type="gamma"
+                amplitude="1"
+                exponent="0.454545454545"
+                offset="0"
+              />
+              <feFuncG
+                type="gamma"
+                amplitude="1"
+                exponent="0.454545454545"
+                offset="0"
+              />
+              <feFuncB
+                type="gamma"
+                amplitude="1"
+                exponent="0.454545454545"
+                offset="0"
+              />
+              <feFuncA
+                type="gamma"
+                amplitude="1"
+                exponent="0.454545454545"
+                offset="0"
+              />
+            </feComponentTransfer>
+          </filter>
+        </defs>
+      </svg>
+      <VictoryChart
+        width={340}
+        height={80}
+        domain={{ y: [0, data.maxY] }}
+        scale={{ x: 'time', y: 'linear' }}
+        singleQuadrantDomainPadding={{ x: false }}
+        // Custom padding tightens the whitespace around the chart.
+        padding={defaultStyles.chartPadding}
+        containerComponent={
+          // Voronoi is a algorithm that defines invisible mouse hover regions for data points.
+          // For line charts this is a better tooltip then using a normal hover target
+          // which is hard/tiny to hit.
+          // Reference: https://en.wikipedia.org/wiki/Voronoi_diagram
+          // @ts-expect-error - VictoryVoronoiContainer is not typed as JSX ... but it really is.
+          <VictoryVoronoiContainer
+            className="bundleTrendChart"
+            title={title}
+            desc={desc}
+            voronoiDimension="x"
+            /* labels not testable. */
+            labels={({ datum }: any) => `Size: ${formatSizeToString(
+              datum.size * data.multiplier
+            )}
+                ${format(new Date(datum.date), 'MMM dd, yyy')}`}
+            labelComponent={
+              <VictoryTooltip
+                groupComponent={
+                  <VictoryAccessibleGroup
+                    className="chart-tooltip"
+                    aria-label="size tooltip"
+                  />
+                }
+                flyoutPadding={defaultStyles.tooltip.flyout}
+                style={defaultStyles.tooltip.style}
+                constrainToVisibleArea
+                cornerRadius={0}
+                pointerLength={0}
+              />
+            }
+          />
+        }
+      >
+        <NoBundleData dataPointCount={data?.measurements.length} />
+        <VictoryAxis
+          // Dates (x)
+          orientation="bottom"
+          domainPadding={{ x: [10, 10] }}
+          groupComponent={
+            <VictoryAccessibleGroup
+              className="date-axis"
+              aria-label="date axis"
+            />
+          }
+          tickFormat={(t: Date) => format(t, 'MMM dd')}
+          style={{
+            tickLabels: defaultStyles.dateAxisLabels,
+            axis: { stroke: 'transparent', strokeWidth: 0 },
+          }}
+        />
+        <VictoryAxis
+          // Bundle size (y)
+          orientation="right"
+          groupComponent={
+            <VictoryAccessibleGroup
+              className="size-axis"
+              aria-label="size axis"
+            />
+          }
+          crossAxis={false}
+          offsetX={5}
+          dependentAxis
+          domain={[0, data.measurements.length]}
+          tickFormat={(t: number) => formatSizeToString(t * data.multiplier)}
+          style={{
+            tickLabels: defaultStyles.bundleAxisLabels,
+            axis: { stroke: 'transparent', strokeWidth: 0 },
+          }}
+        />
+        <VictoryArea
+          animate={{
+            onLoad: { duration: 1000 },
+          }}
+          groupComponent={<VictoryClipContainer />}
+          x="date"
+          y="size"
+          data={data.measurements.map(({ size, date }) => ({
+            date,
+            size: localizeBundleSize(size),
+          }))}
+          style={{
+            data: {
+              fill: '#0071C220',
+              cursor: 'pointer',
+              stroke: 'rgb(var(--color-ds-gray-octonary))',
+              strokeWidth: '0.25px',
+            },
+          }}
+        />
+      </VictoryChart>
+    </>
+  )
+}

--- a/src/ui/BundleTrendChart/NoBundleData.tsx
+++ b/src/ui/BundleTrendChart/NoBundleData.tsx
@@ -1,0 +1,20 @@
+import { VictoryGroup } from 'victory'
+
+interface NoBundleDataProps {
+  dataPointCount: number
+}
+
+const NoBundleData: React.FC<NoBundleDataProps> = ({
+  dataPointCount,
+  ...props
+}) => {
+  return dataPointCount < 2 ? (
+    <VictoryGroup {...props}>
+      <text x="40%" y="45%" fontSize="4">
+        Not enough data to render
+      </text>
+    </VictoryGroup>
+  ) : null
+}
+
+export default NoBundleData

--- a/src/ui/BundleTrendChart/chart.css
+++ b/src/ui/BundleTrendChart/chart.css
@@ -1,0 +1,44 @@
+.bundleTrendChart title {
+  pointer-events: none;
+}
+
+.bundleTrendChart {
+  @apply max-h-[140px] md:max-h-[170px] lg:max-h-[210px] xl:max-h-[270px]  2xl:max-h-[350px] !important;
+}
+
+.bundleTrendChart .size-line path {
+  @apply text-ds-pink stroke-current !important;
+}
+
+.bundleTrendChart .chart-tooltip path {
+  @apply text-ds-gray-quinary stroke-current !important;
+  fill: white !important;
+}
+
+.bundleTrendChart .chart-tooltip tspan {
+  @apply font-sans !important;
+  @apply text-ds-gray-quinary font-extralight stroke-current;
+}
+
+.bundleTrendChart .date-axis tspan {
+  text-anchor: start !important;
+}
+
+.bundleTrendChart .date-axis:last-child tspan {
+  text-anchor: middle !important;
+}
+
+.bundleTrendChart .size-axis tspan {
+  text-anchor: end !important;
+}
+
+.bundleTrendChart .date-axis line,
+.bundleTrendChart .size-axis line {
+  @apply text-ds-gray-quinary stroke-current !important;
+}
+
+.bundleTrendChart .date-axis tspan,
+.bundleTrendChart .size-axis tspan {
+  @apply font-sans !important;
+  @apply text-ds-gray-quinary font-light stroke-current;
+}

--- a/src/ui/BundleTrendChart/index.ts
+++ b/src/ui/BundleTrendChart/index.ts
@@ -1,0 +1,1 @@
+export { BundleTrendChart } from './BundleTrendChart'


### PR DESCRIPTION
# Description

This PR adds in a new `ui/BundleTrendChart` component which will be added into the bundle tab shortly providing trend data for users and their bundles.

Closes codecov/engineering-team#1801

# Notable Changes

- Add in `ui/BundleTrendChart`, CSS, and `NoData` component
- Add in tests and stories
- Add in new helper function

# Screenshots

![Screenshot 2024-06-25 at 07 53 44](https://github.com/codecov/gazebo/assets/105234307/cff1a048-b032-43eb-89a4-502e54a31fa6)
