### PR TITLE
feat: Update useBundleAssets service to grab asset measurements

### DIFF
--- a/src/pages/RepoPage/BundlesTab/BundleContent/AssetsTable/AssetsTable.spec.tsx
+++ b/src/pages/RepoPage/BundlesTab/BundleContent/AssetsTable/AssetsTable.spec.tsx
@@ -18,6 +18,11 @@ const mockAssets = {
           bundleAnalysisReport: {
             __typename: 'BundleAnalysisReport',
             bundle: {
+              bundleData: {
+                size: {
+                  uncompress: 12,
+                },
+              },
               assets: [
                 {
                   name: 'asset-1',
@@ -31,6 +36,16 @@ const mockAssets = {
                       uncompress: 3000,
                       gzip: 4000,
                     },
+                  },
+                  measurements: {
+                    change: {
+                      size: {
+                        uncompress: 5,
+                      },
+                    },
+                    measurements: [
+                      { timestamp: '2022-10-10T11:59:59', avg: 6 },
+                    ],
                   },
                 },
               ],
@@ -51,6 +66,11 @@ const mockBundleAssetModules = {
           bundleAnalysisReport: {
             __typename: 'BundleAnalysisReport',
             bundle: {
+              bundleData: {
+                size: {
+                  uncompress: 12,
+                },
+              },
               asset: {
                 modules: [],
               },
@@ -71,6 +91,11 @@ const mockEmptyAssets = {
           bundleAnalysisReport: {
             __typename: 'BundleAnalysisReport',
             bundle: {
+              bundleData: {
+                size: {
+                  uncompress: 12,
+                },
+              },
               assets: [],
             },
           },

--- a/src/pages/RepoPage/BundlesTab/BundleContent/BundleContent.spec.tsx
+++ b/src/pages/RepoPage/BundlesTab/BundleContent/BundleContent.spec.tsx
@@ -89,6 +89,11 @@ const mockAssets = {
           bundleAnalysisReport: {
             __typename: 'BundleAnalysisReport',
             bundle: {
+              bundleData: {
+                size: {
+                  uncompress: 12,
+                },
+              },
               assets: [
                 {
                   name: 'asset-1',
@@ -102,6 +107,16 @@ const mockAssets = {
                       uncompress: 3000,
                       gzip: 4000,
                     },
+                  },
+                  measurements: {
+                    change: {
+                      size: {
+                        uncompress: 5,
+                      },
+                    },
+                    measurements: [
+                      { timestamp: '2022-10-10T11:59:59', avg: 6 },
+                    ],
                   },
                 },
               ],

--- a/src/services/bundleAnalysis/useBundleAssets.spec.tsx
+++ b/src/services/bundleAnalysis/useBundleAssets.spec.tsx
@@ -29,6 +29,11 @@ const mockBranchBundles = {
           bundleAnalysisReport: {
             __typename: 'BundleAnalysisReport',
             bundle: {
+              bundleData: {
+                size: {
+                  uncompress: 12,
+                },
+              },
               assets: [
                 {
                   name: 'asset-1',
@@ -42,6 +47,16 @@ const mockBranchBundles = {
                       uncompress: 3,
                       gzip: 4,
                     },
+                  },
+                  measurements: {
+                    change: {
+                      size: {
+                        uncompress: 5,
+                      },
+                    },
+                    measurements: [
+                      { timestamp: '2022-10-10T11:59:59', avg: 6 },
+                    ],
                   },
                 },
               ],
@@ -224,6 +239,7 @@ describe('useBundleAssets', () => {
         )
 
         const expectedResponse = {
+          bundleUncompressSize: 12,
           assets: [
             {
               name: 'asset-1',
@@ -237,6 +253,14 @@ describe('useBundleAssets', () => {
                   uncompress: 3,
                   gzip: 4,
                 },
+              },
+              measurements: {
+                change: {
+                  size: {
+                    uncompress: 5,
+                  },
+                },
+                measurements: [{ timestamp: '2022-10-10T11:59:59', avg: 6 }],
               },
             },
           ],
@@ -264,6 +288,7 @@ describe('useBundleAssets', () => {
         )
 
         const expectedResponse = {
+          bundleUncompressSize: null,
           assets: [],
         }
 
@@ -291,6 +316,7 @@ describe('useBundleAssets', () => {
 
       const expectedResponse = {
         assets: [],
+        bundleUncompressSize: null,
       }
 
       await waitFor(() =>


### PR DESCRIPTION
# Description

This PR updates the `useBundleAssets` hook to grab a bit more data including the total bundle size, and the measurements for each possible asset. I have temporarily provided place holder values for the interval and dates for the measurements until we have the rest of the page hooked up with the trend chart and time frame selector.

Closes codecov/engineering-team#1803

# Notable Changes

- Update `useBundleAssets` to grab total bundle size, and asset measurements
- Update tests