### PR TITLE
feat: Implement new header's User dropdown

### DIFF
--- a/src/layouts/BaseLayout/BaseLayout.spec.jsx
+++ b/src/layouts/BaseLayout/BaseLayout.spec.jsx
@@ -402,7 +402,7 @@ describe('BaseLayout', () => {
         wrapper: wrapper(),
       })
 
-      const newHeader = await screen.findByText('New header')
+      const newHeader = await screen.findByText('Navigation')
       expect(newHeader).toBeInTheDocument()
     })
   })

--- a/src/layouts/Header/Header.spec.tsx
+++ b/src/layouts/Header/Header.spec.tsx
@@ -1,12 +1,114 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { render, screen } from '@testing-library/react'
+import { graphql } from 'msw'
+import { setupServer } from 'msw/node'
+import { MemoryRouter, Route } from 'react-router-dom'
+
+import { User } from 'services/user'
 
 import Header from './Header'
 
-describe('placeholder new header', () => {
-  it('renders', async () => {
-    render(<Header />)
+jest.mock(
+  'src/layouts/Header/components/UserDropdown',
+  () => () => 'User Dropdown'
+)
 
-    const header = await screen.findByText('New header')
-    expect(header).toBeInTheDocument()
+const mockUser = {
+  me: {
+    owner: {
+      defaultOrgUsername: 'codecov',
+    },
+    email: 'jane.doe@codecov.io',
+    privateAccess: true,
+    onboardingCompleted: true,
+    businessEmail: 'jane.doe@codecov.io',
+    termsAgreement: true,
+    user: {
+      name: 'Jane Doe',
+      username: 'janedoe',
+      avatarUrl: 'http://127.0.0.1/avatar-url',
+      avatar: 'http://127.0.0.1/avatar-url',
+      student: false,
+      studentCreatedAt: null,
+      studentUpdatedAt: null,
+      customerIntent: 'PERSONAL',
+    },
+    trackingMetadata: {
+      service: 'github',
+      ownerid: 123,
+      serviceId: '123',
+      plan: 'users-basic',
+      staff: false,
+      hasYaml: false,
+      bot: null,
+      delinquent: null,
+      didTrial: null,
+      planProvider: null,
+      planUserCount: 1,
+      createdAt: 'timestamp',
+      updatedAt: 'timestamp',
+      profile: {
+        createdAt: 'timestamp',
+        otherGoal: null,
+        typeProjects: [],
+        goals: [],
+      },
+    },
+  },
+}
+
+const mockNullUser = { me: null }
+
+const server = setupServer()
+const queryClient = new QueryClient({
+  defaultOptions: { queries: { retry: false } },
+})
+
+beforeAll(() => server.listen())
+afterEach(() => {
+  server.resetHandlers()
+  queryClient.clear()
+})
+afterAll(() => server.close())
+
+const wrapper: React.FC<React.PropsWithChildren> = ({ children }) => (
+  <MemoryRouter initialEntries={[`/gh/codecov/test-repo`]}>
+    <Route path="/:provider/:owner/:repo">
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    </Route>
+  </MemoryRouter>
+)
+
+type SetupArgs = {
+  user?: User
+}
+
+describe('Header', () => {
+  function setup({ user = mockUser }: SetupArgs) {
+    server.use(
+      graphql.query('CurrentUser', (req, res, ctx) =>
+        res(ctx.status(200), ctx.data(user))
+      )
+    )
+  }
+
+  describe('placeholder new header', () => {
+    it('shows when currentUser is defined', async () => {
+      setup({})
+      render(<Header />, { wrapper })
+
+      const text = await screen.findByText('Navigation')
+      expect(text).toBeInTheDocument()
+    })
+  })
+
+  describe('guest header', () => {
+    it('shows when currentUser is null', async () => {
+      setup({ user: mockNullUser })
+      render(<Header />, { wrapper })
+
+      const link = await screen.findByText('Guest header')
+      expect(link).toBeInTheDocument()
+    })
   })
 })

--- a/src/layouts/Header/Header.tsx
+++ b/src/layouts/Header/Header.tsx
@@ -1,5 +1,24 @@
+import { useUser } from 'services/user'
+
+import UserDropdown from './components/UserDropdown'
+
 function Header() {
-  return <h1>New header</h1>
+  const { data: currentUser } = useUser()
+
+  if (!currentUser) {
+    return <h1>Guest header</h1>
+  }
+
+  return (
+    <div className="container flex h-14 w-full items-center">
+      <div className="flex-1">Navigation</div>
+      <div className="flex items-center gap-2">
+        <div>Self hosted stuff</div>
+        <div>Help dropdown</div>
+        <UserDropdown />
+      </div>
+    </div>
+  )
 }
 
 export default Header

--- a/src/layouts/Header/components/UserDropdown/UserDropdown.spec.tsx
+++ b/src/layouts/Header/components/UserDropdown/UserDropdown.spec.tsx
@@ -1,0 +1,300 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import Cookies from 'js-cookie'
+import { graphql, rest } from 'msw'
+import { setupServer } from 'msw/node'
+import { MemoryRouter, Route, Switch } from 'react-router-dom'
+
+import config, {
+  COOKIE_SESSION_EXPIRY,
+  LOCAL_STORAGE_SESSION_TRACKING_KEY,
+} from 'config'
+
+import { useImage } from 'services/image'
+
+import UserDropdown from './UserDropdown'
+
+const mockUser = {
+  me: {
+    owner: {
+      defaultOrgUsername: 'codecov',
+    },
+    email: 'jane.doe@codecov.io',
+    privateAccess: true,
+    onboardingCompleted: true,
+    businessEmail: 'jane.doe@codecov.io',
+    termsAgreement: true,
+    user: {
+      name: 'Jane Doe',
+      username: 'janedoe',
+      avatarUrl: 'http://127.0.0.1/avatar-url',
+      avatar: 'http://127.0.0.1/avatar-url',
+      student: false,
+      studentCreatedAt: null,
+      studentUpdatedAt: null,
+      customerIntent: 'PERSONAL',
+    },
+    trackingMetadata: {
+      service: 'github',
+      ownerid: 123,
+      serviceId: '123',
+      plan: 'users-basic',
+      staff: false,
+      hasYaml: false,
+      bot: null,
+      delinquent: null,
+      didTrial: null,
+      planProvider: null,
+      planUserCount: 1,
+      createdAt: 'timestamp',
+      updatedAt: 'timestamp',
+      profile: {
+        createdAt: 'timestamp',
+        otherGoal: null,
+        typeProjects: [],
+        goals: [],
+      },
+    },
+  },
+}
+
+jest.mock('services/image')
+jest.mock('config')
+jest.mock('js-cookie')
+
+const queryClient = new QueryClient({
+  defaultOptions: { queries: { retry: false } },
+})
+const server = setupServer()
+
+const wrapper: (initialEntries?: string) => React.FC<React.PropsWithChildren> =
+  (initialEntries = '/gh') =>
+  ({ children }) =>
+    (
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter initialEntries={[initialEntries]}>
+          <Switch>
+            <Route path="/:provider" exact>
+              {children}
+            </Route>
+          </Switch>
+        </MemoryRouter>
+      </QueryClientProvider>
+    )
+
+beforeAll(() => {
+  server.listen()
+})
+afterEach(() => {
+  queryClient.clear()
+  server.resetHandlers()
+})
+afterAll(() => {
+  server.close()
+})
+
+describe('UserDropdown', () => {
+  function setup({ selfHosted } = { selfHosted: false }) {
+    const mockUseImage = useImage as jest.Mock
+    mockUseImage.mockReturnValue({
+      src: 'imageUrl',
+      isLoading: false,
+      error: null,
+    })
+    config.IS_SELF_HOSTED = selfHosted
+    config.API_URL = ''
+    const mockRemoveItem = jest.spyOn(
+      window.localStorage.__proto__,
+      'removeItem'
+    )
+
+    server.use(
+      rest.post('/logout', (req, res, ctx) => res(ctx.status(205))),
+      graphql.query('CurrentUser', (req, res, ctx) =>
+        res(ctx.status(200), ctx.data(mockUser))
+      )
+    )
+
+    return {
+      user: userEvent.setup(),
+      mockRemoveItem,
+    }
+  }
+
+  describe('when rendered', () => {
+    beforeEach(() => setup())
+
+    it('renders the users avatar', () => {
+      render(<UserDropdown />, {
+        wrapper: wrapper(),
+      })
+
+      const img = screen.getByRole('img')
+      expect(img).toHaveAttribute('alt', 'avatar')
+    })
+  })
+
+  describe('when on GitHub', () => {
+    afterEach(() => {
+      jest.resetAllMocks()
+    })
+    describe('when the avatar is clicked', () => {
+      it('shows settings link', async () => {
+        const { user } = setup()
+        render(<UserDropdown />, {
+          wrapper: wrapper(),
+        })
+
+        expect(screen.queryByText('Settings')).not.toBeInTheDocument()
+
+        const openSelect = screen.getByRole('combobox')
+        await user.click(openSelect)
+
+        const link = screen.getByText('Settings')
+        expect(link).toBeVisible()
+        expect(link).toHaveAttribute('href', '/account/gh/janedoe')
+      })
+
+      it('shows sign out button', async () => {
+        const { user } = setup()
+        render(<UserDropdown />, {
+          wrapper: wrapper(),
+        })
+
+        expect(screen.queryByText('Sign Out')).not.toBeInTheDocument()
+
+        const openSelect = screen.getByRole('combobox')
+        await user.click(openSelect)
+
+        const link = screen.getByText('Sign Out')
+        expect(link).toBeVisible()
+      })
+
+      it('handles sign out', async () => {
+        const { user, mockRemoveItem } = setup()
+
+        jest.spyOn(console, 'error').mockImplementation()
+        const removeSpy = jest.spyOn(Cookies, 'remove').mockReturnValue()
+        render(<UserDropdown />, {
+          wrapper: wrapper(),
+        })
+
+        const openSelect = screen.getByRole('combobox')
+        await user.click(openSelect)
+
+        const button = screen.getByText('Sign Out')
+        expect(button).toBeVisible()
+        await user.click(button)
+
+        await waitFor(() =>
+          expect(mockRemoveItem).toHaveBeenCalledWith(
+            LOCAL_STORAGE_SESSION_TRACKING_KEY
+          )
+        )
+        await waitFor(() =>
+          expect(removeSpy).toHaveBeenCalledWith(COOKIE_SESSION_EXPIRY)
+        )
+      })
+
+      it('shows manage app access link', async () => {
+        const { user } = setup()
+        render(<UserDropdown />, {
+          wrapper: wrapper(),
+        })
+
+        expect(
+          screen.queryByText('Install Codecov app')
+        ).not.toBeInTheDocument()
+
+        const openSelect = screen.getByRole('combobox')
+        await user.click(openSelect)
+
+        const link = screen.getByText('Install Codecov app')
+        expect(link).toBeVisible()
+        expect(link).toHaveAttribute(
+          'href',
+          'https://github.com/apps/codecov/installations/new'
+        )
+      })
+    })
+  })
+  describe('when not on GitHub', () => {
+    describe('when the avatar is clicked', () => {
+      it('shows settings link', async () => {
+        const { user } = setup()
+        render(<UserDropdown />, {
+          wrapper: wrapper('/gl'),
+        })
+
+        expect(screen.queryByText('Settings')).not.toBeInTheDocument()
+
+        const openSelect = screen.getByRole('combobox')
+        await user.click(openSelect)
+
+        const link = screen.getByText('Settings')
+        expect(link).toBeVisible()
+        expect(link).toHaveAttribute('href', '/account/gl/janedoe')
+      })
+
+      it('shows sign out button', async () => {
+        const { user } = setup()
+        render(<UserDropdown />, {
+          wrapper: wrapper('/gl'),
+        })
+
+        expect(screen.queryByText('Sign Out')).not.toBeInTheDocument()
+
+        const openSelect = screen.getByRole('combobox')
+        await user.click(openSelect)
+
+        const link = screen.getByText('Sign Out')
+        expect(link).toBeVisible()
+      })
+
+      it('handles sign out', async () => {
+        const { user, mockRemoveItem } = setup()
+
+        jest.spyOn(console, 'error').mockImplementation()
+        const removeSpy = jest.spyOn(Cookies, 'remove').mockReturnValue()
+        render(<UserDropdown />, {
+          wrapper: wrapper(),
+        })
+
+        const openSelect = screen.getByRole('combobox')
+        await user.click(openSelect)
+
+        const button = screen.getByText('Sign Out')
+        expect(button).toBeVisible()
+        await user.click(button)
+
+        await waitFor(() =>
+          expect(mockRemoveItem).toHaveBeenCalledWith(
+            LOCAL_STORAGE_SESSION_TRACKING_KEY
+          )
+        )
+        await waitFor(() =>
+          expect(removeSpy).toHaveBeenCalledWith(COOKIE_SESSION_EXPIRY)
+        )
+      })
+
+      it('does not show manage app access link', async () => {
+        const { user } = setup()
+        render(<UserDropdown />, {
+          wrapper: wrapper('/gl'),
+        })
+
+        expect(
+          screen.queryByText('Install Codecov app')
+        ).not.toBeInTheDocument()
+
+        const openSelect = screen.getByRole('combobox')
+        await user.click(openSelect)
+
+        expect(
+          screen.queryByText('Install Codecov app')
+        ).not.toBeInTheDocument()
+      })
+    })
+  })
+})

--- a/src/layouts/Header/components/UserDropdown/UserDropdown.tsx
+++ b/src/layouts/Header/components/UserDropdown/UserDropdown.tsx
@@ -104,7 +104,7 @@ function UserDropdown() {
         type="button"
         {...getToggleButtonProps()}
       >
-        <Avatar user={currentUser?.user} darkBordered />
+        <Avatar user={currentUser?.user} border="dark" />
         <span
           aria-hidden="true"
           className={cn('transition-transform', {

--- a/src/layouts/Header/components/UserDropdown/UserDropdown.tsx
+++ b/src/layouts/Header/components/UserDropdown/UserDropdown.tsx
@@ -31,7 +31,9 @@ type toProps = {
 
 function UserDropdown() {
   const { data: currentUser } = useUser({
-    suspense: false,
+    options: {
+      suspense: false,
+    },
   })
 
   const { provider } = useParams<URLParams>()

--- a/src/layouts/Header/components/UserDropdown/UserDropdown.tsx
+++ b/src/layouts/Header/components/UserDropdown/UserDropdown.tsx
@@ -1,4 +1,3 @@
-import cs from 'classnames'
 import { useSelect } from 'downshift'
 import Cookies from 'js-cookie'
 import { useHistory, useParams } from 'react-router-dom'
@@ -8,6 +7,8 @@ import config, {
   LOCAL_STORAGE_SESSION_TRACKING_KEY,
 } from 'config'
 
+import { useUser } from 'services/user'
+import { cn } from 'shared/utils/cn'
 import { providerToName } from 'shared/utils/provider'
 import Avatar from 'ui/Avatar'
 import Button from 'ui/Button'
@@ -15,13 +16,6 @@ import Icon from 'ui/Icon'
 
 interface URLParams {
   provider: string
-}
-
-type CurrentUser = {
-  user: {
-    avatarUrl: string
-    username: string
-  }
 }
 
 type itemProps = {
@@ -35,8 +29,11 @@ type toProps = {
   options?: object
 }
 
-// TODO: get types for free after converting useUser hook
-function Dropdown({ currentUser }: { currentUser: CurrentUser }) {
+function UserDropdown() {
+  const { data: currentUser } = useUser({
+    suspense: false,
+  })
+
   const { provider } = useParams<URLParams>()
   const isGh = providerToName(provider) === 'Github'
   const history = useHistory()
@@ -66,7 +63,7 @@ function Dropdown({ currentUser }: { currentUser: CurrentUser }) {
       props: {
         to: {
           pageName: 'account',
-          options: { owner: currentUser.user.username },
+          options: { owner: currentUser?.user?.username },
         },
       },
       children: 'Settings',
@@ -100,24 +97,24 @@ function Dropdown({ currentUser }: { currentUser: CurrentUser }) {
         Logged in user sub navigation
       </label>
       <button
-        className="flex flex-1 items-center justify-between whitespace-nowrap text-left focus:outline-1"
+        className="flex flex-1 items-center gap-1 whitespace-nowrap text-left focus:outline-1"
         data-marketing="user profile menu"
         type="button"
         {...getToggleButtonProps()}
       >
-        <Avatar user={currentUser.user} lightBordered />
+        <Avatar user={currentUser?.user} darkBordered />
         <span
           aria-hidden="true"
-          className={cs('transition-transform', {
+          className={cn('transition-transform', {
             'rotate-180': isOpen,
             'rotate-0': !isOpen,
           })}
         >
-          <Icon variant="solid" name="chevronDown" />
+          <Icon variant="solid" name="chevronDown" size="sm" />
         </span>
       </button>
       <ul
-        className={cs(
+        className={cn(
           'z-50 w-[15.5rem] border border-gray-ds-tertiary overflow-hidden rounded bg-white text-gray-900 border-ds-gray-tertiary absolute right-0 top-8 min-w-fit',
           { hidden: !isOpen }
         )}
@@ -142,4 +139,4 @@ function Dropdown({ currentUser }: { currentUser: CurrentUser }) {
   )
 }
 
-export default Dropdown
+export default UserDropdown

--- a/src/layouts/Header/components/UserDropdown/index.ts
+++ b/src/layouts/Header/components/UserDropdown/index.ts
@@ -1,0 +1,1 @@
+export { default } from './UserDropdown'

--- a/src/layouts/LoginLayout/LoginLayout.spec.tsx
+++ b/src/layouts/LoginLayout/LoginLayout.spec.tsx
@@ -55,7 +55,9 @@ afterAll(() => {
 describe('LoginLayout', () => {
   function setup() {
     server.use(
-      graphql.query('CurrentUser', (req, res, ctx) => res(ctx.status(200)))
+      graphql.query('CurrentUser', (req, res, ctx) =>
+        res(ctx.status(200), ctx.data({ me: null }))
+      )
     )
     mockedUseLocation.mockReturnValue({ search: [] })
     mockedUseFlags.mockReturnValue({ newHeader: false })
@@ -139,7 +141,7 @@ describe('LoginLayout', () => {
 
       render(<LoginLayout>child content</LoginLayout>, { wrapper: wrapper() })
 
-      const newHeader = await screen.findByText('New header')
+      const newHeader = await screen.findByText('Guest header')
       expect(newHeader).toBeInTheDocument()
     })
   })

--- a/src/layouts/OldHeader/Dropdown.tsx
+++ b/src/layouts/OldHeader/Dropdown.tsx
@@ -105,7 +105,7 @@ function Dropdown({ currentUser }: { currentUser: CurrentUser }) {
         type="button"
         {...getToggleButtonProps()}
       >
-        <Avatar user={currentUser.user} lightBordered />
+        <Avatar user={currentUser.user} border="light" />
         <span
           aria-hidden="true"
           className={cs('transition-transform', {

--- a/src/pages/OwnerPage/Header/Header.jsx
+++ b/src/pages/OwnerPage/Header/Header.jsx
@@ -21,7 +21,7 @@ function Header() {
 
   return (
     <div className="flex items-center">
-      <Avatar user={ownerData} bordered />
+      <Avatar user={ownerData} lightBordered />
       <h2 className="mx-2 text-xl font-semibold">{ownerData?.username}</h2>
     </div>
   )

--- a/src/pages/OwnerPage/Header/Header.jsx
+++ b/src/pages/OwnerPage/Header/Header.jsx
@@ -21,7 +21,7 @@ function Header() {
 
   return (
     <div className="flex items-center">
-      <Avatar user={ownerData} lightBordered />
+      <Avatar user={ownerData} border="light" />
       <h2 className="mx-2 text-xl font-semibold">{ownerData?.username}</h2>
     </div>
   )

--- a/src/pages/PullRequestPage/PullCoverage/routes/CommitsTab/CommitsTable/Title/Title.tsx
+++ b/src/pages/PullRequestPage/PullCoverage/routes/CommitsTab/CommitsTable/Title/Title.tsx
@@ -37,7 +37,7 @@ const Title = ({
 
   return (
     <div className="flex flex-1 flex-row items-center gap-4 lg:w-auto">
-      <Avatar user={user} bordered />
+      <Avatar user={user} lightBordered />
       <div className="flex flex-col">
         {/* @ts-ignore */}
         <A to={{ pageName: 'commit', options: { commit: commitid, flags } }}>

--- a/src/pages/PullRequestPage/PullCoverage/routes/CommitsTab/CommitsTable/Title/Title.tsx
+++ b/src/pages/PullRequestPage/PullCoverage/routes/CommitsTab/CommitsTable/Title/Title.tsx
@@ -37,7 +37,7 @@ const Title = ({
 
   return (
     <div className="flex flex-1 flex-row items-center gap-4 lg:w-auto">
-      <Avatar user={user} lightBordered />
+      <Avatar user={user} border="light" />
       <div className="flex flex-col">
         {/* @ts-ignore */}
         <A to={{ pageName: 'commit', options: { commit: commitid, flags } }}>

--- a/src/pages/RepoPage/CommitsTab/CommitsTable/Title/Title.tsx
+++ b/src/pages/RepoPage/CommitsTab/CommitsTable/Title/Title.tsx
@@ -37,7 +37,7 @@ const Title = ({
 
   return (
     <div className="flex flex-1 flex-row items-center gap-4 lg:w-auto">
-      <Avatar user={user} bordered />
+      <Avatar user={user} lightBordered />
       <div className="flex flex-col">
         {/* @ts-ignore */}
         <A to={{ pageName: 'commit', options: { commit: commitid, flags } }}>

--- a/src/pages/RepoPage/CommitsTab/CommitsTable/Title/Title.tsx
+++ b/src/pages/RepoPage/CommitsTab/CommitsTable/Title/Title.tsx
@@ -37,7 +37,7 @@ const Title = ({
 
   return (
     <div className="flex flex-1 flex-row items-center gap-4 lg:w-auto">
-      <Avatar user={user} lightBordered />
+      <Avatar user={user} border="light" />
       <div className="flex flex-col">
         {/* @ts-ignore */}
         <A to={{ pageName: 'commit', options: { commit: commitid, flags } }}>

--- a/src/pages/RepoPage/PullsTab/PullsTable/Title/Title.tsx
+++ b/src/pages/RepoPage/PullsTab/PullsTable/Title/Title.tsx
@@ -34,7 +34,7 @@ const Title: React.FC<TitleProps> = ({
   return (
     <div className="flex w-96 flex-row lg:w-auto">
       <span className="mr-5 flex items-center">
-        <Avatar user={user} lightBordered />
+        <Avatar user={user} border="light" />
       </span>
       <div className="flex w-5/6 flex-col lg:w-auto">
         {/* @ts-expect-error - disable because of non-ts component and type mismatch */}

--- a/src/pages/RepoPage/PullsTab/PullsTable/Title/Title.tsx
+++ b/src/pages/RepoPage/PullsTab/PullsTable/Title/Title.tsx
@@ -34,7 +34,7 @@ const Title: React.FC<TitleProps> = ({
   return (
     <div className="flex w-96 flex-row lg:w-auto">
       <span className="mr-5 flex items-center">
-        <Avatar user={user} bordered />
+        <Avatar user={user} lightBordered />
       </span>
       <div className="flex w-5/6 flex-col lg:w-auto">
         {/* @ts-expect-error - disable because of non-ts component and type mismatch */}

--- a/src/ui/Avatar/Avatar.jsx
+++ b/src/ui/Avatar/Avatar.jsx
@@ -1,16 +1,16 @@
-import cs from 'classnames'
 import PropTypes from 'prop-types'
 
 import { useImage } from 'services/image'
+import { cn } from 'shared/utils/cn'
 
 import AvatarSVG from './AvatarSVG'
 
 let baseClasses = 'rounded-full h-6 w-6 flex items-center justify-center'
-let lightBorderedClasses = 'border-ds-grey-secondary border-2'
-let darkBorderedClasses = 'border-ds-grey-octonary border-2'
+let lightBorderedClasses = 'border-ds-gray-secondary border-2'
+let darkBorderedClasses = 'border-ds-gray-octonary border-2'
 
 function Avatar({ user, lightBordered, darkBordered, ariaLabel }) {
-  const classes = cs(
+  const classes = cn(
     baseClasses,
     lightBordered ? lightBorderedClasses : '',
     darkBordered ? darkBorderedClasses : ''

--- a/src/ui/Avatar/Avatar.jsx
+++ b/src/ui/Avatar/Avatar.jsx
@@ -6,10 +6,15 @@ import { useImage } from 'services/image'
 import AvatarSVG from './AvatarSVG'
 
 let baseClasses = 'rounded-full h-6 w-6 flex items-center justify-center'
-let borderedClasses = 'border-ds-grey-secondary border-2'
+let lightBorderedClasses = 'border-ds-grey-secondary border-2'
+let darkBorderedClasses = 'border-ds-grey-octonary border-2'
 
-function Avatar({ user, bordered, ariaLabel }) {
-  const classes = cs(baseClasses, bordered ? borderedClasses : '')
+function Avatar({ user, lightBordered, darkBordered, ariaLabel }) {
+  const classes = cs(
+    baseClasses,
+    lightBordered ? lightBorderedClasses : '',
+    darkBordered ? darkBorderedClasses : ''
+  )
 
   const { src, error, isLoading } = useImage({
     src: user?.avatarUrl,
@@ -36,7 +41,8 @@ Avatar.propTypes = {
     username: PropTypes.string.isRequired,
     avatarUrl: PropTypes.string,
   }),
-  bordered: PropTypes.bool,
+  lightBordered: PropTypes.bool,
+  darkBordered: PropTypes.bool,
   ariaLabel: PropTypes.string,
 }
 

--- a/src/ui/Avatar/Avatar.jsx
+++ b/src/ui/Avatar/Avatar.jsx
@@ -5,16 +5,15 @@ import { cn } from 'shared/utils/cn'
 
 import AvatarSVG from './AvatarSVG'
 
-let baseClasses = 'rounded-full h-6 w-6 flex items-center justify-center'
-let lightBorderedClasses = 'border-ds-gray-secondary border-2'
-let darkBorderedClasses = 'border-ds-gray-octonary border-2'
+const baseClasses = 'rounded-full h-6 w-6 flex items-center justify-center'
+const borderClasses = {
+  none: '',
+  light: 'border-ds-gray-secondary border-2',
+  dark: 'border-ds-gray-octonary border-2',
+}
 
-function Avatar({ user, lightBordered, darkBordered, ariaLabel }) {
-  const classes = cn(
-    baseClasses,
-    lightBordered ? lightBorderedClasses : '',
-    darkBordered ? darkBorderedClasses : ''
-  )
+function Avatar({ user, border = 'none', ariaLabel }) {
+  const classes = cn(baseClasses, borderClasses[border])
 
   const { src, error, isLoading } = useImage({
     src: user?.avatarUrl,
@@ -41,8 +40,7 @@ Avatar.propTypes = {
     username: PropTypes.string.isRequired,
     avatarUrl: PropTypes.string,
   }),
-  lightBordered: PropTypes.bool,
-  darkBordered: PropTypes.bool,
+  border: PropTypes.oneOf(['light', 'dark', 'none']),
   ariaLabel: PropTypes.string,
 }
 

--- a/src/ui/ContextSwitcher/ContextSwitcher.jsx
+++ b/src/ui/ContextSwitcher/ContextSwitcher.jsx
@@ -53,7 +53,7 @@ function ContextItem({ context, defaultOrgUsername, setToggle, owner }) {
           mutate({ username: orgUsername })
         }}
       >
-        <Avatar user={contextOwner} bordered />
+        <Avatar user={contextOwner} lightBordered />
         <div className={cs('mx-1', { 'font-semibold': owner === orgUsername })}>
           {orgUsername}
         </div>
@@ -146,7 +146,7 @@ function ContextSwitcher({
         aria-expanded={toggle}
         onClick={() => setToggle((toggle) => !toggle)}
       >
-        <Avatar user={activeContext} bordered />
+        <Avatar user={activeContext} lightBordered />
         <p className="ml-1">{activeContext?.username}</p>
         <span
           aria-hidden="true"

--- a/src/ui/ContextSwitcher/ContextSwitcher.jsx
+++ b/src/ui/ContextSwitcher/ContextSwitcher.jsx
@@ -53,7 +53,7 @@ function ContextItem({ context, defaultOrgUsername, setToggle, owner }) {
           mutate({ username: orgUsername })
         }}
       >
-        <Avatar user={contextOwner} lightBordered />
+        <Avatar user={contextOwner} border="light" />
         <div className={cs('mx-1', { 'font-semibold': owner === orgUsername })}>
           {orgUsername}
         </div>
@@ -146,7 +146,7 @@ function ContextSwitcher({
         aria-expanded={toggle}
         onClick={() => setToggle((toggle) => !toggle)}
       >
-        <Avatar user={activeContext} lightBordered />
+        <Avatar user={activeContext} border="light" />
         <p className="ml-1">{activeContext?.username}</p>
         <span
           aria-hidden="true"

--- a/src/ui/List/List.stories.jsx
+++ b/src/ui/List/List.stories.jsx
@@ -39,7 +39,7 @@ const getListItems = () => {
     name: org.username,
     value: (
       <div className="flex items-center py-2">
-        <Avatar user={org} lightBordered />
+        <Avatar user={org} border="light" />
         <div className="mx-2 text-base">{org.username}</div>
       </div>
     ),

--- a/src/ui/List/List.stories.jsx
+++ b/src/ui/List/List.stories.jsx
@@ -39,7 +39,7 @@ const getListItems = () => {
     name: org.username,
     value: (
       <div className="flex items-center py-2">
-        <Avatar user={org} bordered />
+        <Avatar user={org} lightBordered />
         <div className="mx-2 text-base">{org.username}</div>
       </div>
     ),


### PR DESCRIPTION
Implements the UserDropdown for the new Header. For now, this is an almost exact copy the old user dropdown, but we'll move this over to the new Dropdown component once we implement that in https://github.com/codecov/engineering-team/issues/1942. The only difference between this and the old user dropdown is minor spacing change and dark border on the Avatar.

[Design](https://www.figma.com/design/kbJfmcDgAuptsJR5KB28O9/GH-293-(nav%2C-header%2C-and-related-elements)?node-id=322-1385&t=oCWsofSFCNg0QXiK-0)

Closes https://github.com/codecov/engineering-team/issues/1952

## Screenshot
<img width="1294" alt="Screenshot 2024-07-04 at 08 35 03" src="https://github.com/codecov/gazebo/assets/159931558/a1f5da97-bdf8-4f49-b5ce-c18c1b620472">
