### PR TITLE
fix: refresh user query on continue from org selection

### DIFF
--- a/src/services/defaultOrganization/useUpdateDefaultOrganization.spec.tsx
+++ b/src/services/defaultOrganization/useUpdateDefaultOrganization.spec.tsx
@@ -68,12 +68,8 @@ describe('useUpdateDefaultOrganization', () => {
           result.current.data.data.updateDefaultOrganization.username
         await waitFor(() => expect(username).toBe('Gilmore'))
 
-        // expect(invalidateQueries).toHaveBeenLastCalledWith({
-        //   queryKey: ['currentUser'],
-        // })
         expect(invalidateQueries).toHaveBeenCalledTimes(2)
-        // equal to: expect(getUserByID.mock.calls).toEqual([[{id:0}],[{id:1}]])
-        expect(invalidateQueries).toHaveBeenNthCalledWith(1, ['DetailOwner']) // AssertionError: expected 1st "spy" call to have been called with \[ { id: +1 } \]
+        expect(invalidateQueries).toHaveBeenNthCalledWith(1, ['DetailOwner'])
         expect(invalidateQueries).toHaveBeenNthCalledWith(2, ['currentUser'])
       })
     })

--- a/src/services/defaultOrganization/useUpdateDefaultOrganization.spec.tsx
+++ b/src/services/defaultOrganization/useUpdateDefaultOrganization.spec.tsx
@@ -60,12 +60,21 @@ describe('useUpdateDefaultOrganization', () => {
           wrapper,
         })
         result.current.mutate({ username: 'codecov' })
+        const invalidateQueries = jest.spyOn(queryClient, 'invalidateQueries')
 
         await waitFor(() => expect(result.current.isSuccess).toBeTruthy())
 
         const username =
           result.current.data.data.updateDefaultOrganization.username
         await waitFor(() => expect(username).toBe('Gilmore'))
+
+        // expect(invalidateQueries).toHaveBeenLastCalledWith({
+        //   queryKey: ['currentUser'],
+        // })
+        expect(invalidateQueries).toHaveBeenCalledTimes(2)
+        // equal to: expect(getUserByID.mock.calls).toEqual([[{id:0}],[{id:1}]])
+        expect(invalidateQueries).toHaveBeenNthCalledWith(1, ['DetailOwner']) // AssertionError: expected 1st "spy" call to have been called with \[ { id: +1 } \]
+        expect(invalidateQueries).toHaveBeenNthCalledWith(2, ['currentUser'])
       })
     })
   })

--- a/src/services/defaultOrganization/useUpdateDefaultOrganization.ts
+++ b/src/services/defaultOrganization/useUpdateDefaultOrganization.ts
@@ -41,6 +41,7 @@ export function useUpdateDefaultOrganization() {
         )
       } else {
         queryClient.invalidateQueries(['DetailOwner'])
+        queryClient.invalidateQueries(['currentUser'])
       }
     },
     onError: (e: any) => {


### PR DESCRIPTION
# Description

Redirect on clicking "Continue" button was technically working and rerouting correctly but the new user info after mutating the user's -> owner -> defaultOrgUsername wasn't being refreshed so the code still thought we needed to show the org selector component. As it exists, a refresh after clicking continue would reflect the correct behavior. With this change to invalidate the query, we now will get the new user data and change the UI accordingly.

Closes https://github.com/codecov/engineering-team/issues/1842

# Code Example

# Notable Changes

# Screenshots

https://github.com/codecov/gazebo/assets/170470397/c9c76dbf-531e-499b-ae3d-305da6ebda08



# Link to Sample Entry

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.