### PR TITLE
[gazebo] Add subtotals row on coverage page + test fix

### DIFF
--- a/src/pages/RepoPage/CoverageTab/ComponentsTab/subroute/ComponentsTable/ComponentsTable.spec.tsx
+++ b/src/pages/RepoPage/CoverageTab/ComponentsTab/subroute/ComponentsTable/ComponentsTable.spec.tsx
@@ -180,6 +180,11 @@ describe('ComponentsTable', () => {
   describe('when rendered', () => {
     beforeEach(() => {
       setup({})
+      jest.useFakeTimers().setSystemTime(new Date('2024-02-02'))
+    })
+
+    afterAll(() => {
+      jest.useRealTimers()
     })
 
     it('renders table headers', async () => {

--- a/src/pages/RepoPage/CoverageTab/OverviewTab/subroute/FileExplorer/CodeTreeTable/CodeTreeTable.tsx
+++ b/src/pages/RepoPage/CoverageTab/OverviewTab/subroute/FileExplorer/CodeTreeTable/CodeTreeTable.tsx
@@ -87,6 +87,8 @@ const baseColumns = [
   }),
 ]
 
+type ColumnType = (typeof baseColumns)[number]
+
 function CodeTreeTable() {
   const [sorting, setSorting] = useTableDefaultSort()
   const ordering = getOrderingDirection(sorting)
@@ -110,6 +112,33 @@ function CodeTreeTable() {
     onSortingChange: setSorting,
     manualSorting: true,
   })
+
+  const subtotalRow = (column: ColumnType) => {
+    const columnId = column.id as keyof Row
+
+    if (columnId === 'name') {
+      return <p className="pl-1">Subtotal</p>
+    }
+
+    const columnsToSum = ['lines', 'hits', 'partials', 'misses']
+
+    if (columnsToSum.includes(columnId)) {
+      return calculateColumnTotal(columnId)
+    }
+
+    return null
+  }
+
+  const calculateColumnTotal = (columnId: keyof Row) => {
+    const total = data.reduce((sum, row) => {
+      const value = row[columnId]
+      const numericValue =
+        typeof value === 'string' ? parseInt(value, 10) || 0 : 0
+      return sum + numericValue
+    }, 0)
+
+    return total
+  }
 
   return (
     <div className="flex flex-col gap-4">
@@ -165,25 +194,42 @@ function CodeTreeTable() {
                 </td>
               </tr>
             ) : (
-              table.getRowModel().rows.map((row) => (
-                <tr key={row.id} className="hover:bg-gray-100">
-                  {row.getVisibleCells().map((cell) => (
-                    <td
-                      key={cell.id}
-                      className={cs({
-                        'w-2/12': cell.column.id === 'percentCovered',
-                        'text-right w-1/12': cell.column.id !== 'name',
-                        'w-4/12': cell.column.id === 'name',
-                      })}
-                    >
-                      {flexRender(
-                        cell.column.columnDef.cell,
-                        cell.getContext()
-                      )}
-                    </td>
-                  ))}
-                </tr>
-              ))
+              <>
+                {table.getRowModel().rows.map((row) => (
+                  <tr key={row.id} className="hover:bg-gray-100">
+                    {row.getVisibleCells().map((cell) => (
+                      <td
+                        key={cell.id}
+                        className={cs({
+                          'w-2/12': cell.column.id === 'percentCovered',
+                          'text-right w-1/12': cell.column.id !== 'name',
+                          'w-4/12': cell.column.id === 'name',
+                        })}
+                      >
+                        {flexRender(
+                          cell.column.columnDef.cell,
+                          cell.getContext()
+                        )}
+                      </td>
+                    ))}
+                  </tr>
+                ))}
+                {data.length >= 2 && (
+                  <tr className="bg-gray-200">
+                    {baseColumns.map((column) => (
+                      <td
+                        key={column.id}
+                        className={cs({
+                          'text-right w-1/12': column.id !== 'name',
+                          'w-4/12 ml-6': column.id === 'name',
+                        })}
+                      >
+                        {subtotalRow(column)}
+                      </td>
+                    ))}
+                  </tr>
+                )}
+              </>
             )}
           </tbody>
         </table>


### PR DESCRIPTION
# Description
See [design](https://www.figma.com/design/y0XTfMFA4gXnMEe5JsZ753/GH-1269?node-id=19-1045&t=l24ROFhzK2uJYtIu-0).

https://github.com/codecov/engineering-team/issues/1453 is the original issue. 

Since we auto update the coverage totals already, this issue has been updated to sum up the column totals in each row(excluding name and coverage %) IFF we have 2 or more rows. 
 
# Screenshots

<img width="1365" alt="Screenshot 2024-07-02 at 11 51 18 AM" src="https://github.com/codecov/gazebo/assets/148245014/791c67db-52a2-4701-b975-d16c87c5451f">


# Link to Sample Entry

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.