### PR TITLE
feat: Add show/hide chart toggle on bundles tab

### DIFF
--- a/src/pages/RepoPage/BundlesTab/BundleContent/BundleChart/BundleChart.tsx
+++ b/src/pages/RepoPage/BundlesTab/BundleContent/BundleChart/BundleChart.tsx
@@ -31,7 +31,7 @@ export function BundleChart() {
   })
 
   return (
-    <div className="pb-4 pt-6">
+    <div className="mx-auto w-[98%] pb-4 pt-1">
       <TrendDropdown />
       {isLoading ? (
         <Placeholder />

--- a/src/pages/RepoPage/BundlesTab/BundleContent/BundleContent.tsx
+++ b/src/pages/RepoPage/BundlesTab/BundleContent/BundleContent.tsx
@@ -11,6 +11,7 @@ import AssetsTable from './AssetsTable'
 import { BundleChart } from './BundleChart'
 import BundleSummary from './BundleSummary'
 import InfoBanner from './InfoBanner'
+import { ToggleElement } from './ToggleElement'
 
 const AssetEmptyTable = lazy(() => import('./AssetsTable/EmptyTable'))
 const ErrorBanner = lazy(() => import('./ErrorBanner'))
@@ -47,7 +48,13 @@ const BundleContent: React.FC = () => {
         {bundleType === 'BundleAnalysisReport' ? (
           <Switch>
             <SentryRoute path="/:provider/:owner/:repo/bundles/:branch/:bundle">
-              <BundleChart />
+              <ToggleElement
+                showElement="Show chart"
+                hideElement="Hide chart"
+                localStorageKey="is-bundle-chart-hidden"
+              >
+                <BundleChart />
+              </ToggleElement>
               <Suspense fallback={<Loader />}>
                 <AssetsTable />
               </Suspense>

--- a/src/pages/RepoPage/BundlesTab/BundleContent/ToggleElement/ToggleElement.spec.tsx
+++ b/src/pages/RepoPage/BundlesTab/BundleContent/ToggleElement/ToggleElement.spec.tsx
@@ -1,0 +1,138 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+import { ToggleElement } from './ToggleElement'
+
+jest.spyOn(window.localStorage.__proto__, 'setItem')
+window.localStorage.__proto__.setItem = jest.fn()
+
+describe('ToggleElement', () => {
+  function setup() {
+    const user = userEvent.setup()
+    return { user }
+  }
+
+  describe('renders open toggle', () => {
+    it('toggle controls', () => {
+      render(
+        <ToggleElement
+          localStorageKey="c2"
+          showElement="Show Chart"
+          hideElement="Hide Chart"
+        >
+          Cool contents
+        </ToggleElement>
+      )
+
+      const hideChart = screen.getByText('Hide Chart')
+      expect(hideChart).toBeInTheDocument()
+    })
+
+    it('children', () => {
+      render(
+        <ToggleElement
+          localStorageKey="c2"
+          showElement="Show Chart"
+          hideElement="Hide Chart"
+        >
+          Cool contents
+        </ToggleElement>
+      )
+
+      const contents = screen.getByText('Cool contents')
+      expect(contents).toBeInTheDocument()
+    })
+  })
+
+  describe('renders closed toggle', () => {
+    it('toggle controls', async () => {
+      const { user } = setup()
+      render(
+        <ToggleElement
+          localStorageKey="c2"
+          showElement="Show Chart"
+          hideElement="Hide Chart"
+        >
+          Cool contents
+        </ToggleElement>
+      )
+
+      const hideChart = screen.getByText('Hide Chart')
+      expect(hideChart).toBeInTheDocument()
+
+      const button = screen.getByRole('button')
+      await user.click(button)
+
+      const removedHideChart = screen.queryByText('Hide Chart')
+      expect(removedHideChart).not.toBeInTheDocument()
+
+      const ShowSChart = screen.getByText('Show Chart')
+      expect(ShowSChart).toBeInTheDocument()
+    })
+
+    it('children', async () => {
+      const { user } = setup()
+      render(
+        <ToggleElement
+          localStorageKey="c2"
+          showElement="Show Chart"
+          hideElement="Hide Chart"
+        >
+          Cool contents
+        </ToggleElement>
+      )
+
+      const contents = screen.getByText('Cool contents')
+      expect(contents).not.toHaveClass('hidden')
+
+      const button = screen.getByRole('button')
+      await user.click(button)
+
+      const hiddenContents = screen.getByText('Cool contents')
+      expect(hiddenContents).toHaveClass('hidden')
+    })
+  })
+
+  describe('localStorage', () => {
+    describe('first click', () => {
+      it('sets value to true', async () => {
+        const { user } = setup()
+        render(
+          <ToggleElement
+            localStorageKey="c2"
+            showElement="Show Chart"
+            hideElement="Hide Chart"
+          >
+            Cool contents
+          </ToggleElement>
+        )
+
+        const button = screen.getByRole('button')
+        await user.click(button)
+
+        expect(window.localStorage.setItem).toHaveBeenCalledWith('c2', 'true')
+      })
+    })
+
+    describe('second click', () => {
+      it('swaps vale to false', async () => {
+        const { user } = setup()
+        render(
+          <ToggleElement
+            localStorageKey="c2"
+            showElement="Show Chart"
+            hideElement="Hide Chart"
+          >
+            Cool contents
+          </ToggleElement>
+        )
+
+        const button = screen.getByRole('button')
+        await user.click(button)
+        await user.click(button)
+
+        expect(window.localStorage.setItem).toHaveBeenCalledWith('c2', 'false')
+      })
+    })
+  })
+})

--- a/src/pages/RepoPage/BundlesTab/BundleContent/ToggleElement/ToggleElement.tsx
+++ b/src/pages/RepoPage/BundlesTab/BundleContent/ToggleElement/ToggleElement.tsx
@@ -1,0 +1,48 @@
+import { useState } from 'react'
+
+import { cn } from 'shared/utils/cn'
+import Icon from 'ui/Icon'
+
+interface ToggleElementProps {
+  showElement: string
+  hideElement: string
+  localStorageKey: string
+  children: React.ReactNode
+}
+
+export function ToggleElement({
+  showElement,
+  hideElement,
+  localStorageKey,
+  children,
+}: ToggleElementProps) {
+  const [isHidden, setIsHidden] = useState(
+    () => localStorage.getItem(localStorageKey) === 'true'
+  )
+
+  return (
+    <div className="hidden lg:block">
+      <button
+        data-cy="toggle-chart"
+        data-marketing="toggle-chart"
+        className="flex cursor-pointer items-center pt-2 text-ds-primary-base hover:underline [&[data-state=open]>span:first-child]:rotate-90"
+        data-state={isHidden ? 'closed' : 'open'}
+        onClick={() => {
+          setIsHidden(!isHidden)
+          localStorage.setItem(localStorageKey, String(!isHidden))
+        }}
+      >
+        <span className="transition-transform duration-200">
+          <Icon size="md" variant="solid" name="chevronRight" />
+        </span>
+        {isHidden ? showElement : hideElement}
+      </button>
+      <div
+        data-testid="toggle-element-contents"
+        className={cn('', { hidden: isHidden })}
+      >
+        {children}
+      </div>
+    </div>
+  )
+}

--- a/src/pages/RepoPage/BundlesTab/BundleContent/ToggleElement/index.ts
+++ b/src/pages/RepoPage/BundlesTab/BundleContent/ToggleElement/index.ts
@@ -1,0 +1,1 @@
+export { ToggleElement } from './ToggleElement'


### PR DESCRIPTION
# Description

This PR quickly adds in a `ToggleElement` component that allows the user to toggle the trend chart on the bundles tab, when toggling it will save the value to local storage so it remembers the users preference upon re-visiting the page.

# Notable Changes

- Add in `ToggleElement` component
- Make `BundleChart` slight narrower
- Wrap `BundleChart` with `ToggleElement`
- Create/Update tests

# Screenshots

https://github.com/codecov/gazebo/assets/105234307/218f6b69-26eb-47ff-b9e8-eb506fbb4ea2