### PR TITLE
feat: Create OKTA hooks and hook them up with form 

### DIFF
--- a/src/pages/AccountSettings/tabs/OktaAccess/OktaAccess.spec.tsx
+++ b/src/pages/AccountSettings/tabs/OktaAccess/OktaAccess.spec.tsx
@@ -43,6 +43,24 @@ describe('OktaAccess', () => {
           ctx.status(200),
           ctx.data({ owner: { username: 'codecov', isAdmin } })
         )
+      ),
+      graphql.query('GetOktaConfig', (req, res, ctx) =>
+        res(
+          ctx.status(200),
+          ctx.data({
+            owner: {
+              account: {
+                oktaConfig: {
+                  enabled: true,
+                  enforced: true,
+                  url: 'https://okta.com',
+                  clientId: 'clientId',
+                  clientSecret: 'clientSecret',
+                },
+              },
+            },
+          })
+        )
       )
     )
   }

--- a/src/pages/AccountSettings/tabs/OktaAccess/OktaConfigForm/OktaConfigForm.tsx
+++ b/src/pages/AccountSettings/tabs/OktaAccess/OktaConfigForm/OktaConfigForm.tsx
@@ -34,15 +34,14 @@ export function OktaConfigForm() {
 
   const { provider, owner } = useParams<URLParams>()
 
-  const [oktaEnabled, setOktaEnabled] = useState(false)
-  const [oktaLoginEnforce, setOktaLoginEnforce] = useState(false)
-  const [showPassword, setShowPassword] = useState(false)
-
   const { data } = useOktaConfig({
     provider,
     username: owner,
   })
   const oktaConfig = data?.owner?.account?.oktaConfig
+  const [oktaEnabled, setOktaEnabled] = useState(oktaConfig?.enabled)
+  const [oktaLoginEnforce, setOktaLoginEnforce] = useState(oktaConfig?.enforced)
+  const [showPassword, setShowPassword] = useState(false)
 
   const onSubmit: SubmitHandler<FormValues> = (data) => {
     console.log('Form Data: ', data)
@@ -91,6 +90,7 @@ export function OktaConfigForm() {
               </label>
               <div className="relative">
                 <TextInput
+                  defaultValue={oktaConfig?.clientSecret}
                   {...register('clientSecret', { required: true })}
                   type={showPassword ? 'text' : 'password'}
                   id="clientSecret"
@@ -119,6 +119,7 @@ export function OktaConfigForm() {
                 Redirect URI
               </label>
               <TextInput
+                defaultValue={oktaConfig?.url}
                 {...register('redirectUri', { required: true })}
                 type="text"
                 id="redirectUri"
@@ -133,7 +134,7 @@ export function OktaConfigForm() {
             <div>
               <Button
                 type="submit"
-                disabled={!formState.isValid}
+                disabled={!formState.isValid || !formState.isDirty}
                 to={undefined}
                 hook="save okta form changes"
               >

--- a/src/pages/AccountSettings/tabs/OktaAccess/OktaConfigForm/OktaConfigForm.tsx
+++ b/src/pages/AccountSettings/tabs/OktaAccess/OktaConfigForm/OktaConfigForm.tsx
@@ -1,6 +1,7 @@
 import { zodResolver } from '@hookform/resolvers/zod'
 import { useState } from 'react'
 import { SubmitHandler, useForm } from 'react-hook-form'
+import { useParams } from 'react-router-dom'
 import { z } from 'zod'
 
 import Banner from 'ui/Banner'
@@ -11,6 +12,8 @@ import Icon from 'ui/Icon'
 import TextInput from 'ui/TextInput'
 import Toggle from 'ui/Toggle'
 
+import { useOktaConfig } from '../hooks'
+
 const FormSchema = z.object({
   clientId: z.string().min(1, 'Client ID is required'),
   clientSecret: z.string().min(1, 'Client Secret is required'),
@@ -18,6 +21,10 @@ const FormSchema = z.object({
 })
 
 type FormValues = z.infer<typeof FormSchema>
+interface URLParams {
+  provider: string
+  owner: string
+}
 
 export function OktaConfigForm() {
   const { register, handleSubmit, formState } = useForm<FormValues>({
@@ -25,9 +32,17 @@ export function OktaConfigForm() {
     mode: 'onChange',
   })
 
+  const { provider, owner } = useParams<URLParams>()
+
   const [oktaEnabled, setOktaEnabled] = useState(false)
   const [oktaLoginEnforce, setOktaLoginEnforce] = useState(false)
   const [showPassword, setShowPassword] = useState(false)
+
+  const { data } = useOktaConfig({
+    provider,
+    username: owner,
+  })
+  const oktaConfig = data?.owner?.account?.oktaConfig
 
   const onSubmit: SubmitHandler<FormValues> = (data) => {
     console.log('Form Data: ', data)
@@ -56,6 +71,7 @@ export function OktaConfigForm() {
                 Client ID
               </label>
               <TextInput
+                defaultValue={oktaConfig?.clientId}
                 {...register('clientId', {
                   required: true,
                 })}

--- a/src/pages/AccountSettings/tabs/OktaAccess/OktaConfigForm/OktaConfigForm.tsx
+++ b/src/pages/AccountSettings/tabs/OktaAccess/OktaConfigForm/OktaConfigForm.tsx
@@ -181,7 +181,7 @@ export function OktaConfigForm() {
 
                     mutate({
                       enabled: !oktaEnabled,
-                      enforced: oktaLoginEnforce ? false : oktaLoginEnforce,
+                      enforced: false,
                     })
                   }}
                   value={oktaEnabled}

--- a/src/pages/AccountSettings/tabs/OktaAccess/hooks/index.ts
+++ b/src/pages/AccountSettings/tabs/OktaAccess/hooks/index.ts
@@ -1,1 +1,2 @@
 export { useOktaConfig } from './useOktaConfig'
+export { useUpdateOktaConfig } from './useUpdateOktaConfig'

--- a/src/pages/AccountSettings/tabs/OktaAccess/hooks/index.ts
+++ b/src/pages/AccountSettings/tabs/OktaAccess/hooks/index.ts
@@ -1,0 +1,1 @@
+export { useOktaConfig } from './useOktaConfig'

--- a/src/pages/AccountSettings/tabs/OktaAccess/hooks/useOktaConfig.spec.tsx
+++ b/src/pages/AccountSettings/tabs/OktaAccess/hooks/useOktaConfig.spec.tsx
@@ -1,0 +1,103 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { renderHook, waitFor } from '@testing-library/react'
+import { graphql } from 'msw'
+import { setupServer } from 'msw/node'
+
+import { useOktaConfig } from './useOktaConfig'
+
+const oktaConfigMock = {
+  enabled: true,
+  enforced: true,
+  url: 'https://okta.com',
+  clientId: 'clientId',
+  clientSecret: 'clientSecret',
+}
+
+const queryClient = new QueryClient({
+  defaultOptions: { queries: { retry: false } },
+})
+const server = setupServer()
+
+const wrapper: React.FC<React.PropsWithChildren> = ({ children }) => (
+  <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+)
+
+beforeAll(() => {
+  server.listen()
+})
+
+afterEach(() => {
+  queryClient.clear()
+  server.resetHandlers()
+})
+
+afterAll(() => {
+  server.close()
+})
+
+describe('useOktaConfig', () => {
+  function setup(oktaConfigData = {}) {
+    server.use(
+      graphql.query('GetOktaConfig', (req, res, ctx) =>
+        res(
+          ctx.status(200),
+          ctx.data({
+            owner: {
+              account: { oktaConfig: oktaConfigData },
+            },
+          })
+        )
+      )
+    )
+  }
+
+  describe('calling hook', () => {
+    describe('there is valid data', () => {
+      it('returns okta config data', async () => {
+        setup(oktaConfigMock)
+
+        const { result } = renderHook(
+          () =>
+            useOktaConfig({
+              provider: 'gh',
+              username: 'codecov',
+            }),
+          { wrapper }
+        )
+
+        await waitFor(() =>
+          expect(result.current.data).toStrictEqual({
+            owner: {
+              account: {
+                oktaConfig: oktaConfigMock,
+              },
+            },
+          })
+        )
+      })
+    })
+
+    describe('invalid schema', () => {
+      it('rejects with 404 status', async () => {
+        setup({})
+
+        const { result } = renderHook(
+          () =>
+            useOktaConfig({
+              provider: 'gh',
+              username: 'codecov',
+            }),
+          { wrapper }
+        )
+
+        await waitFor(() =>
+          expect(result.current.error).toStrictEqual({
+            status: 404,
+            data: {},
+            dev: 'useOktaConfig - 404 failed to parse',
+          })
+        )
+      })
+    })
+  })
+})

--- a/src/pages/AccountSettings/tabs/OktaAccess/hooks/useOktaConfig.tsx
+++ b/src/pages/AccountSettings/tabs/OktaAccess/hooks/useOktaConfig.tsx
@@ -1,0 +1,76 @@
+import { useQuery, type UseQueryOptions } from '@tanstack/react-query'
+import { z } from 'zod'
+
+import Api from 'shared/api'
+import { NetworkErrorObject } from 'shared/api/helpers'
+
+export const OktaConfigSchema = z.object({
+  enabled: z.boolean(),
+  enforced: z.boolean(),
+  url: z.string(),
+  clientId: z.string(),
+  clientSecret: z.string(),
+})
+
+const AccountSchema = z.object({
+  oktaConfig: OktaConfigSchema.nullable(),
+})
+
+const OwnerSchema = z.object({
+  account: AccountSchema.nullable(),
+})
+
+const OktaConfigRequestSchema = z.object({
+  owner: OwnerSchema.nullable(),
+})
+
+const oktaConfigQuery = `
+  query GetOktaConfig($username: String!) {
+    owner(username: $username) {
+      account {
+        oktaConfig {
+          enabled
+          enforced
+          url
+          clientId
+          clientSecret
+        }
+      }
+    }
+  }
+`
+
+interface UseOktaConfigArgs {
+  provider: string
+  username: string
+  opts?: UseQueryOptions<z.infer<typeof OktaConfigRequestSchema>>
+}
+
+export function useOktaConfig({ provider, username, opts }: UseOktaConfigArgs) {
+  return useQuery({
+    queryKey: ['GetOktaConfig', provider, username, oktaConfigQuery],
+    queryFn: ({ signal }) => {
+      return Api.graphql({
+        provider,
+        query: oktaConfigQuery,
+        signal,
+        variables: {
+          username,
+        },
+      }).then((res) => {
+        const parsedRes = OktaConfigRequestSchema.safeParse(res?.data)
+
+        if (!parsedRes.success) {
+          return Promise.reject({
+            status: 404,
+            data: {},
+            dev: 'useOktaConfig - 404 failed to parse',
+          } satisfies NetworkErrorObject)
+        }
+
+        return parsedRes.data
+      })
+    },
+    ...(!!opts && opts),
+  })
+}

--- a/src/pages/AccountSettings/tabs/OktaAccess/hooks/useUpdateOktaConfig.spec.tsx
+++ b/src/pages/AccountSettings/tabs/OktaAccess/hooks/useUpdateOktaConfig.spec.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { renderHook, waitFor } from '@testing-library/react'
+import { render, renderHook, screen, waitFor } from '@testing-library/react'
 import { graphql } from 'msw'
 import { setupServer } from 'msw/node'
 import { MemoryRouter, Route } from 'react-router-dom'
@@ -196,5 +196,25 @@ describe('useUpdateOktaConfig', () => {
         })
       )
     })
+  })
+})
+
+describe('When okta config message is rendered', () => {
+  it('renders the correct message', () => {
+    render(<SaveOktaConfigMessage />, { wrapper: wrapper() })
+
+    const message = screen.getByText(/Error saving Okta config./)
+    expect(message).toBeInTheDocument()
+  })
+
+  it('renders the correct link', () => {
+    render(<SaveOktaConfigMessage />, { wrapper: wrapper() })
+
+    const link = screen.getByText(/Contact us/)
+    expect(link).toBeInTheDocument()
+    expect(link).toHaveAttribute(
+      'href',
+      'https://codecovpro.zendesk.com/hc/en-us'
+    )
   })
 })

--- a/src/pages/AccountSettings/tabs/OktaAccess/hooks/useUpdateOktaConfig.spec.tsx
+++ b/src/pages/AccountSettings/tabs/OktaAccess/hooks/useUpdateOktaConfig.spec.tsx
@@ -85,7 +85,7 @@ describe('useUpdateOktaConfig', () => {
       )
     })
 
-    it('failes on invalid response schema', async () => {
+    it('fails on invalid response schema', async () => {
       setup({
         saveOktaConfig: {
           error: {

--- a/src/pages/AccountSettings/tabs/OktaAccess/hooks/useUpdateOktaConfig.spec.tsx
+++ b/src/pages/AccountSettings/tabs/OktaAccess/hooks/useUpdateOktaConfig.spec.tsx
@@ -6,7 +6,10 @@ import { MemoryRouter, Route } from 'react-router-dom'
 
 import { useAddNotification } from 'services/toastNotification'
 
-import { useUpdateOktaConfig } from './useUpdateOktaConfig'
+import {
+  SaveOktaConfigMessage,
+  useUpdateOktaConfig,
+} from './useUpdateOktaConfig'
 
 jest.mock('services/toastNotification')
 const mockedToastNotification = useAddNotification as jest.Mock
@@ -110,7 +113,7 @@ describe('useUpdateOktaConfig', () => {
       )
     })
 
-    it('shows an error toast notification on error response', async () => {
+    it('shows an error toast notification on validation error response', async () => {
       setup({
         saveOktaConfig: {
           error: {
@@ -132,7 +135,63 @@ describe('useUpdateOktaConfig', () => {
       await waitFor(() =>
         expect(addToast).toHaveBeenCalledWith({
           type: 'error',
-          text: expect.anything(),
+          text: <SaveOktaConfigMessage />,
+          disappearAfter: 10000,
+        })
+      )
+    })
+
+    it('shows an error toast notification on unauthorized error response', async () => {
+      setup({
+        saveOktaConfig: {
+          error: {
+            __typename: 'UnauthorizedError',
+            message: 'Unauthorized',
+          },
+        },
+      })
+
+      const { result } = renderHook(
+        () => useUpdateOktaConfig({ provider, owner }),
+        {
+          wrapper: wrapper(),
+        }
+      )
+
+      result.current.mutate(oktaConfigDetails)
+
+      await waitFor(() =>
+        expect(addToast).toHaveBeenCalledWith({
+          type: 'error',
+          text: <SaveOktaConfigMessage />,
+          disappearAfter: 10000,
+        })
+      )
+    })
+
+    it('shows an error toast notification on unauthenticated error response', async () => {
+      setup({
+        saveOktaConfig: {
+          error: {
+            __typename: 'UnauthenticatedError',
+            message: 'Unauthenticated',
+          },
+        },
+      })
+
+      const { result } = renderHook(
+        () => useUpdateOktaConfig({ provider, owner }),
+        {
+          wrapper: wrapper(),
+        }
+      )
+
+      result.current.mutate(oktaConfigDetails)
+
+      await waitFor(() =>
+        expect(addToast).toHaveBeenCalledWith({
+          type: 'error',
+          text: <SaveOktaConfigMessage />,
           disappearAfter: 10000,
         })
       )

--- a/src/pages/AccountSettings/tabs/OktaAccess/hooks/useUpdateOktaConfig.spec.tsx
+++ b/src/pages/AccountSettings/tabs/OktaAccess/hooks/useUpdateOktaConfig.spec.tsx
@@ -1,0 +1,141 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { renderHook, waitFor } from '@testing-library/react'
+import { graphql } from 'msw'
+import { setupServer } from 'msw/node'
+import { MemoryRouter, Route } from 'react-router-dom'
+
+import { useAddNotification } from 'services/toastNotification'
+
+import { useUpdateOktaConfig } from './useUpdateOktaConfig'
+
+jest.mock('services/toastNotification')
+const mockedToastNotification = useAddNotification as jest.Mock
+
+const queryClient = new QueryClient({
+  defaultOptions: { queries: { retry: false } },
+})
+
+const wrapper =
+  (initialEntries = '/gh/codecov'): React.FC<React.PropsWithChildren> =>
+  ({ children }) =>
+    (
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter initialEntries={[initialEntries]}>
+          <Route path="/:provider/:owner">{children}</Route>
+        </MemoryRouter>
+      </QueryClientProvider>
+    )
+
+const provider = 'gh'
+const owner = 'codecov'
+
+const oktaConfigDetails = {
+  clientId: 'test-client-id',
+  clientSecret: 'test-client-secret',
+  url: 'https://example.com',
+  enabled: true,
+  enforced: true,
+  orgUsername: owner,
+}
+
+const server = setupServer()
+
+beforeAll(() => server.listen())
+afterEach(() => server.resetHandlers())
+afterAll(() => server.close())
+
+describe('useUpdateOktaConfig', () => {
+  const addToast = jest.fn()
+
+  const setup = (response: any) => {
+    mockedToastNotification.mockReturnValue(addToast)
+
+    server.use(
+      graphql.mutation(`SaveOktaConfig`, (req, res, ctx) => {
+        return res(ctx.status(200), ctx.data(response))
+      })
+    )
+  }
+
+  describe('when calling the mutation', () => {
+    it('shows a success toast notification on successful response', async () => {
+      setup({
+        saveOktaConfig: {
+          error: null,
+        },
+      })
+
+      const { result } = renderHook(
+        () => useUpdateOktaConfig({ provider, owner }),
+        {
+          wrapper: wrapper(),
+        }
+      )
+
+      await waitFor(() => result.current.mutate(oktaConfigDetails))
+      await waitFor(() =>
+        expect(addToast).toHaveBeenCalledWith({
+          type: 'success',
+          text: 'Okta configuration saved successfully!',
+          disappearAfter: 10000,
+        })
+      )
+    })
+
+    it('failes on invalid response schema', async () => {
+      setup({
+        saveOktaConfig: {
+          error: {
+            __typename: 'RandomError',
+            message: 'Invalid input',
+          },
+        },
+      })
+
+      const { result } = renderHook(
+        () => useUpdateOktaConfig({ provider, owner }),
+        {
+          wrapper: wrapper(),
+        }
+      )
+
+      result.current.mutate(oktaConfigDetails)
+
+      await waitFor(() =>
+        expect(addToast).toHaveBeenCalledWith({
+          type: 'error',
+          text: expect.anything(),
+          disappearAfter: 10000,
+        })
+      )
+    })
+
+    it('shows an error toast notification on error response', async () => {
+      setup({
+        saveOktaConfig: {
+          error: {
+            __typename: 'ValidationError',
+            message: 'Invalid input',
+          },
+        },
+      })
+
+      const { result } = renderHook(
+        () => useUpdateOktaConfig({ provider, owner }),
+        {
+          wrapper: wrapper(),
+        }
+      )
+
+      result.current.mutate(oktaConfigDetails)
+
+      await waitFor(() =>
+        expect(addToast).toHaveBeenCalledWith({
+          type: 'error',
+          text: expect.anything(),
+          disappearAfter: 10000,
+        })
+      )
+    })
+  })
+})

--- a/src/pages/AccountSettings/tabs/OktaAccess/hooks/useUpdateOktaConfig.tsx
+++ b/src/pages/AccountSettings/tabs/OktaAccess/hooks/useUpdateOktaConfig.tsx
@@ -1,0 +1,150 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import z from 'zod'
+
+import { useAddNotification } from 'services/toastNotification'
+import Api from 'shared/api'
+import { NetworkErrorObject } from 'shared/api/helpers'
+import A from 'ui/A'
+
+const TOAST_DURATION = 10000
+
+const query = `
+  mutation SaveOktaConfig($input: SaveOktaConfigInput!) {
+    saveOktaConfig(input: $input) {
+      error {
+        __typename
+        ... on UnauthorizedError {
+          message
+          __typename
+        }
+        ... on ValidationError {
+          message
+          __typename
+        }
+        ... on UnauthenticatedError {
+          __typename
+          message
+        }
+      }
+    }
+  }
+`
+
+const ResponseSchema = z.object({
+  saveOktaConfig: z
+    .object({
+      error: z
+        .union([
+          z.object({
+            __typename: z.literal('UnauthorizedError'),
+            message: z.string(),
+          }),
+          z.object({
+            __typename: z.literal('ValidationError'),
+            message: z.string(),
+          }),
+          z.object({
+            __typename: z.literal('UnauthenticatedError'),
+            message: z.string(),
+          }),
+        ])
+        .nullable(),
+    })
+    .nullable(),
+})
+
+const SaveOktaConfigMessage = () => (
+  <p>
+    Error saving Okta config.{' '}
+    <A to={{ pageName: 'support' }} hook="support-link" isExternal={true}>
+      Contact us
+    </A>{' '}
+    and we&apos;ll help you out.
+  </p>
+)
+
+interface URLParams {
+  provider: string
+  owner: string
+}
+
+type MutationFnParams = {
+  clientId?: string
+  clientSecret?: string
+  url?: string
+  enabled?: boolean
+  enforced?: boolean
+}
+
+export const useUpdateOktaConfig = ({ provider, owner }: URLParams) => {
+  const addToast = useAddNotification()
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: ({
+      clientId,
+      clientSecret,
+      url,
+      enabled,
+      enforced,
+    }: MutationFnParams) => {
+      return Api.graphqlMutation({
+        provider,
+        query,
+        variables: {
+          input: {
+            clientId,
+            clientSecret,
+            url,
+            enabled,
+            enforced,
+            orgUsername: owner,
+          },
+        },
+        mutationPath: 'saveOktaConfig',
+      })
+    },
+    onSuccess: ({ data }) => {
+      const parsedData = ResponseSchema.safeParse(data)
+      if (!parsedData.success) {
+        return Promise.reject({
+          status: 404,
+          data: {},
+          dev: 'useUpdateOktaConfig - 404 failed to parse',
+        } satisfies NetworkErrorObject)
+      }
+
+      const error = parsedData.data.saveOktaConfig?.error
+      if (error) {
+        if (
+          error.__typename === 'ValidationError' ||
+          error.__typename === 'UnauthorizedError' ||
+          error.__typename === 'UnauthenticatedError'
+        ) {
+          addToast({
+            type: 'error',
+            text: <SaveOktaConfigMessage />,
+            disappearAfter: TOAST_DURATION,
+          })
+        }
+      } else {
+        addToast({
+          type: 'success',
+          text: 'Okta configuration saved successfully!',
+          disappearAfter: TOAST_DURATION,
+        })
+      }
+    },
+    onError: () => {
+      addToast({
+        type: 'error',
+        text: <SaveOktaConfigMessage />,
+        disappearAfter: TOAST_DURATION,
+      })
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries(['GetOktaConfig'])
+    },
+    retry: false,
+  })
+}

--- a/src/pages/AccountSettings/tabs/OktaAccess/hooks/useUpdateOktaConfig.tsx
+++ b/src/pages/AccountSettings/tabs/OktaAccess/hooks/useUpdateOktaConfig.tsx
@@ -53,7 +53,7 @@ const ResponseSchema = z.object({
     .nullable(),
 })
 
-const SaveOktaConfigMessage = () => (
+export const SaveOktaConfigMessage = () => (
   <p>
     Error saving Okta config.{' '}
     <A to={{ pageName: 'support' }} hook="support-link" isExternal={true}>


### PR DESCRIPTION
# Description
waiting for: 

- [x] https://github.com/codecov/codecov-api/pull/661

Now that API is ready, i'm creating 2 new hooks:
- Fetch okta config values 
- Mutate okta config values 

# Notable Changes
- Create new hooks 
- New changes in form 
- Tests 

# Screenshots

https://github.com/codecov/gazebo/assets/91732700/684ca743-33bd-4561-a00b-1a3a3980a5b6


https://github.com/codecov/gazebo/assets/91732700/e18ca6d2-1b7d-468f-abf5-1cec11d4bfbe


closes: https://github.com/codecov/engineering-team/issues/1983 and https://github.com/codecov/engineering-team/issues/2044

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.