### PR TITLE
feat: Add self-hosted items to new header

### DIFF
--- a/src/layouts/EnterpriseLoginLayout/Header/Header.tsx
+++ b/src/layouts/EnterpriseLoginLayout/Header/Header.tsx
@@ -22,7 +22,7 @@ function Header() {
           to={{
             pageName: 'root',
           }}
-          variant="header"
+          variant="headerDeprecated"
           data-testid="homepage-link"
           hook="homepage-link"
           isExternal
@@ -33,7 +33,7 @@ function Header() {
         <A
           hook="header-enterprise"
           to={{ pageName: 'docs' }}
-          variant="header"
+          variant="headerDeprecated"
           showExternalIcon={false}
           isExternal
         >
@@ -41,7 +41,7 @@ function Header() {
         </A>
         <A
           to={{ pageName: 'support' }}
-          variant="header"
+          variant="headerDeprecated"
           showExternalIcon={false}
           hook="support-link"
           isExternal
@@ -50,7 +50,7 @@ function Header() {
         </A>
         <A
           to={{ pageName: 'blog' }}
-          variant="header"
+          variant="headerDeprecated"
           showExternalIcon={false}
           hook="blog-link"
           isExternal

--- a/src/layouts/Header/Header.spec.tsx
+++ b/src/layouts/Header/Header.spec.tsx
@@ -4,6 +4,8 @@ import { graphql } from 'msw'
 import { setupServer } from 'msw/node'
 import { MemoryRouter, Route } from 'react-router-dom'
 
+import config from 'config'
+
 import { User } from 'services/user'
 
 import Header from './Header'
@@ -11,6 +13,15 @@ import Header from './Header'
 jest.mock(
   'src/layouts/Header/components/UserDropdown',
   () => () => 'User Dropdown'
+)
+jest.mock(
+  'src/layouts/Header/components/HelpDropdown',
+  () => () => 'Help Dropdown'
+)
+jest.mock('src/layouts/Header/components/AdminLink', () => () => 'Admin Link')
+jest.mock(
+  'src/layouts/Header/components/SeatDetails',
+  () => () => 'Seat Details'
 )
 
 const mockUser = {
@@ -109,6 +120,26 @@ describe('Header', () => {
 
       const link = await screen.findByText('Guest header')
       expect(link).toBeInTheDocument()
+    })
+  })
+
+  describe('when on self-hosted', () => {
+    it('shows seat details', async () => {
+      config.IS_SELF_HOSTED = true
+      setup({})
+      render(<Header />, { wrapper })
+
+      const text = await screen.findByText(/Seat Details/)
+      expect(text).toBeInTheDocument()
+    })
+
+    it('shows Admin link', async () => {
+      config.IS_SELF_HOSTED = true
+      setup({})
+      render(<Header />, { wrapper })
+
+      const text = await screen.findByText(/Admin Link/)
+      expect(text).toBeInTheDocument()
     })
   })
 })

--- a/src/layouts/Header/Header.tsx
+++ b/src/layouts/Header/Header.tsx
@@ -1,5 +1,8 @@
+import config from 'config'
+
 import { useUser } from 'services/user'
 
+import AdminLink from './components/AdminLink'
 import HelpDropdown from './components/HelpDropdown'
 import UserDropdown from './components/UserDropdown'
 
@@ -14,7 +17,12 @@ function Header() {
     <div className="container flex h-14 w-full items-center">
       <div className="flex-1">Navigation</div>
       <div className="flex items-center gap-4">
-        <div>Self hosted stuff</div>
+        {config.IS_SELF_HOSTED ? (
+          <>
+            <div>Self hosted seats</div>
+            <AdminLink />
+          </>
+        ) : null}
         <HelpDropdown />
         <UserDropdown />
       </div>

--- a/src/layouts/Header/Header.tsx
+++ b/src/layouts/Header/Header.tsx
@@ -1,3 +1,5 @@
+import { Suspense } from 'react'
+
 import config from 'config'
 
 import { useUser } from 'services/user'
@@ -19,10 +21,10 @@ function Header() {
       <div className="flex-1">Navigation</div>
       <div className="flex items-center gap-4">
         {config.IS_SELF_HOSTED ? (
-          <>
+          <Suspense fallback={null}>
             <SeatDetails />
             <AdminLink />
-          </>
+          </Suspense>
         ) : null}
         <HelpDropdown />
         <UserDropdown />

--- a/src/layouts/Header/Header.tsx
+++ b/src/layouts/Header/Header.tsx
@@ -4,6 +4,7 @@ import { useUser } from 'services/user'
 
 import AdminLink from './components/AdminLink'
 import HelpDropdown from './components/HelpDropdown'
+import SeatDetails from './components/SeatDetails'
 import UserDropdown from './components/UserDropdown'
 
 function Header() {
@@ -19,7 +20,7 @@ function Header() {
       <div className="flex items-center gap-4">
         {config.IS_SELF_HOSTED ? (
           <>
-            <div>Self hosted seats</div>
+            <SeatDetails />
             <AdminLink />
           </>
         ) : null}

--- a/src/layouts/Header/components/AdminLink/AdminLink.spec.tsx
+++ b/src/layouts/Header/components/AdminLink/AdminLink.spec.tsx
@@ -1,0 +1,86 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { render, screen } from '@testing-library/react'
+import { rest } from 'msw'
+import { setupServer } from 'msw/node'
+import { MemoryRouter, Route } from 'react-router-dom'
+
+import AdminLink from './AdminLink'
+
+const wrapper: ({
+  initialEntries,
+}: {
+  initialEntries?: string
+}) => React.FC<React.PropsWithChildren> =
+  ({ initialEntries = '/gh' }) =>
+  ({ children }) =>
+    (
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter initialEntries={[initialEntries]}>
+          <Route path="/:provider" exact>
+            {children}
+          </Route>
+        </MemoryRouter>
+      </QueryClientProvider>
+    )
+
+const queryClient = new QueryClient({
+  defaultOptions: { queries: { retry: false } },
+})
+
+const server = setupServer()
+beforeAll(() => server.listen())
+beforeEach(() => {
+  server.resetHandlers()
+  queryClient.clear()
+})
+afterAll(() => server.close())
+
+describe('AdminLink', () => {
+  function setup(data = {}) {
+    server.use(
+      rest.get('/internal/users/current', (req, res, ctx) =>
+        res(ctx.status(200), ctx.json(data))
+      )
+    )
+  }
+
+  describe('user is an admin', () => {
+    beforeEach(() => {
+      setup({
+        activated: false,
+        email: 'codecov@codecov.io',
+        isAdmin: true,
+        name: 'Codecov',
+        ownerid: 2,
+        username: 'codecov',
+      })
+    })
+
+    it('renders link to access page', async () => {
+      render(<AdminLink />, { wrapper: wrapper({}) })
+      const link = await screen.findByText(/Admin/)
+
+      expect(link).toBeInTheDocument()
+      expect(link).toHaveAttribute('href', '/admin/gh/access')
+    })
+  })
+
+  describe('user is not an admin', () => {
+    beforeEach(() => {
+      setup({
+        activated: false,
+        email: 'codecov@codecov.io',
+        isAdmin: false,
+        name: 'Codecov',
+        ownerid: 2,
+        username: 'codecov',
+      })
+    })
+
+    const { container } = render(<AdminLink />, { wrapper: wrapper({}) })
+
+    it('renders nothing', () => {
+      expect(container).toBeEmptyDOMElement()
+    })
+  })
+})

--- a/src/layouts/Header/components/AdminLink/AdminLink.tsx
+++ b/src/layouts/Header/components/AdminLink/AdminLink.tsx
@@ -3,7 +3,7 @@ import A from 'ui/A'
 import Icon from 'ui/Icon'
 
 function AdminLink() {
-  const { data: user } = useSelfHostedCurrentUser({ suspense: false })
+  const { data: user } = useSelfHostedCurrentUser()
 
   if (!user?.isAdmin) {
     return null

--- a/src/layouts/Header/components/AdminLink/AdminLink.tsx
+++ b/src/layouts/Header/components/AdminLink/AdminLink.tsx
@@ -1,0 +1,24 @@
+import { useSelfHostedCurrentUser } from 'services/selfHosted'
+import A from 'ui/A'
+import Icon from 'ui/Icon'
+
+function AdminLink() {
+  const { data: user } = useSelfHostedCurrentUser({ suspense: false })
+
+  if (!user?.isAdmin) {
+    return null
+  }
+
+  return (
+    <A
+      variant="newHeader"
+      to={{ pageName: 'access' }}
+      isExternal={false}
+      hook="header-admin-link"
+    >
+      <Icon size="md" name="cog" variant="solid" /> Admin
+    </A>
+  )
+}
+
+export default AdminLink

--- a/src/layouts/Header/components/AdminLink/index.ts
+++ b/src/layouts/Header/components/AdminLink/index.ts
@@ -1,0 +1,1 @@
+export { default } from './AdminLink'

--- a/src/layouts/Header/components/SeatDetails/SeatDetails.spec.tsx
+++ b/src/layouts/Header/components/SeatDetails/SeatDetails.spec.tsx
@@ -1,0 +1,96 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { render, screen } from '@testing-library/react'
+import { graphql } from 'msw'
+import { setupServer } from 'msw/node'
+import { MemoryRouter, Route } from 'react-router-dom'
+
+import SeatDetails from './SeatDetails'
+
+const mockData = {
+  config: {
+    seatsUsed: 5,
+    seatsLimit: 10,
+  },
+}
+
+const mockUndefinedSeats = {
+  config: {},
+}
+
+const wrapper: ({
+  initialEntries,
+}: {
+  initialEntries?: string
+}) => React.FC<React.PropsWithChildren> =
+  ({ initialEntries = '/gh' }) =>
+  ({ children }) =>
+    (
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter initialEntries={[initialEntries]}>
+          <Route path="/:provider" exact>
+            {children}
+          </Route>
+        </MemoryRouter>
+      </QueryClientProvider>
+    )
+
+const queryClient = new QueryClient({
+  defaultOptions: { queries: { retry: false } },
+})
+
+const server = setupServer()
+beforeAll(() => server.listen())
+beforeEach(() => {
+  server.resetHandlers()
+  queryClient.clear()
+})
+afterAll(() => server.close())
+
+describe('SeatDetails', () => {
+  function setup({ data = mockData }: { data?: any }) {
+    server.use(
+      graphql.query('Seats', (req, res, ctx) =>
+        res(ctx.status(200), ctx.data(data))
+      )
+    )
+  }
+
+  describe('renders component', () => {
+    describe('values are defined', () => {
+      beforeEach(() => {
+        setup({})
+      })
+
+      it('displays the number of active seats', async () => {
+        render(<SeatDetails />, { wrapper: wrapper({}) })
+        const number = await screen.findByText('5')
+        expect(number).toBeInTheDocument()
+
+        const text = await screen.findByText(/active users/)
+        expect(text).toBeInTheDocument()
+      })
+
+      it('displays the number of total seats', async () => {
+        render(<SeatDetails />, { wrapper: wrapper({}) })
+
+        const number = await screen.findByText('10')
+        expect(number).toBeInTheDocument()
+
+        const text = await screen.findByText(/available seats/)
+        expect(text).toBeInTheDocument()
+      })
+    })
+
+    describe('values are undefined', () => {
+      beforeEach(() => {
+        setup({ data: mockUndefinedSeats })
+      })
+
+      const { container } = render(<SeatDetails />, { wrapper: wrapper({}) })
+
+      it('renders nothing', () => {
+        expect(container).toBeEmptyDOMElement()
+      })
+    })
+  })
+})

--- a/src/layouts/Header/components/SeatDetails/SeatDetails.spec.tsx
+++ b/src/layouts/Header/components/SeatDetails/SeatDetails.spec.tsx
@@ -81,15 +81,15 @@ describe('SeatDetails', () => {
       })
     })
 
-    describe('values are undefined', () => {
-      beforeEach(() => {
+    describe('when values are undefined', () => {
+      it('renders error message', async () => {
         setup({ data: mockUndefinedSeats })
-      })
+        render(<SeatDetails />, { wrapper: wrapper({}) })
 
-      const { container } = render(<SeatDetails />, { wrapper: wrapper({}) })
-
-      it('renders nothing', () => {
-        expect(container).toBeEmptyDOMElement()
+        const message = await screen.findByText(
+          'Unable to get seat usage information'
+        )
+        expect(message).toBeInTheDocument()
       })
     })
   })

--- a/src/layouts/Header/components/SeatDetails/SeatDetails.tsx
+++ b/src/layouts/Header/components/SeatDetails/SeatDetails.tsx
@@ -1,9 +1,7 @@
 import { useSelfHostedSeatsConfig } from 'services/selfHosted'
 
 function SeatDetails() {
-  const { data: selfHostedSeats } = useSelfHostedSeatsConfig({
-    suspense: false,
-  })
+  const { data: selfHostedSeats } = useSelfHostedSeatsConfig()
 
   if (!selfHostedSeats?.seatsUsed || !selfHostedSeats?.seatsLimit) {
     return <p>Unable to get seat usage information</p>

--- a/src/layouts/Header/components/SeatDetails/SeatDetails.tsx
+++ b/src/layouts/Header/components/SeatDetails/SeatDetails.tsx
@@ -1,0 +1,22 @@
+import { useSelfHostedSeatsConfig } from 'services/selfHosted'
+
+function SeatDetails() {
+  const { data: selfHostedSeats } = useSelfHostedSeatsConfig({
+    suspense: false,
+  })
+
+  if (!selfHostedSeats?.seatsUsed && !selfHostedSeats?.seatsLimit) {
+    return null
+  }
+
+  return (
+    <p>
+      <span className="font-semibold">{selfHostedSeats?.seatsUsed}</span> active
+      users of{' '}
+      <span className="font-semibold">{selfHostedSeats?.seatsLimit}</span>{' '}
+      available seats
+    </p>
+  )
+}
+
+export default SeatDetails

--- a/src/layouts/Header/components/SeatDetails/SeatDetails.tsx
+++ b/src/layouts/Header/components/SeatDetails/SeatDetails.tsx
@@ -5,8 +5,8 @@ function SeatDetails() {
     suspense: false,
   })
 
-  if (!selfHostedSeats?.seatsUsed && !selfHostedSeats?.seatsLimit) {
-    return null
+  if (!selfHostedSeats?.seatsUsed || !selfHostedSeats?.seatsLimit) {
+    return <p>Unable to get seat usage information</p>
   }
 
   return (

--- a/src/layouts/Header/components/SeatDetails/index.ts
+++ b/src/layouts/Header/components/SeatDetails/index.ts
@@ -1,0 +1,1 @@
+export { default } from './SeatDetails'

--- a/src/layouts/OldHeader/DesktopMenu.tsx
+++ b/src/layouts/OldHeader/DesktopMenu.tsx
@@ -18,7 +18,7 @@ export function LoginPrompt() {
     >
       <A
         to={{ pageName: 'signIn', options: { to } }}
-        variant="header"
+        variant="headerDeprecated"
         isExternal={false}
         hook="desktop-menu-login-link"
       >
@@ -54,7 +54,7 @@ export const LogoButton = ({
         pageName: pageName,
         options: { owner: defaultOrg },
       }}
-      variant="header"
+      variant="headerDeprecated"
       data-testid="homepage-link"
       isExternal={pageName === 'root' ? true : false}
       hook="desktop-menu-homepage-link"
@@ -80,7 +80,7 @@ function DesktopMenu() {
         <LogoButton defaultOrg={defaultOrg} />
         <A
           to={{ pageName: 'docs' }}
-          variant="header"
+          variant="headerDeprecated"
           isExternal={false}
           showExternalIcon={false}
           hook="desktop-menu-docs-link"
@@ -89,7 +89,7 @@ function DesktopMenu() {
         </A>
         <A
           to={{ pageName: 'support' }}
-          variant="header"
+          variant="headerDeprecated"
           isExternal={false}
           showExternalIcon={false}
           hook="desktop-menu-support-link"
@@ -98,7 +98,7 @@ function DesktopMenu() {
         </A>
         <A
           to={{ pageName: 'blog' }}
-          variant="header"
+          variant="headerDeprecated"
           isExternal={false}
           showExternalIcon={false}
           hook="desktop-menu-blog-link"

--- a/src/ui/A/A.jsx
+++ b/src/ui/A/A.jsx
@@ -13,8 +13,8 @@ const baseClass = `
 `
 const variantClasses = {
   default: `text-ds-blue`,
-  newHeader: `font-semibold`, // clean up when old header gets removed
-  header: `font-semibold text-ds-gray-secondary`,
+  header: `font-semibold`,
+  headerDeprecated: `font-semibold text-ds-gray-secondary`,
   guestHeader: `font-semibold text-ds-gray-senary`,
   link: `text-ds-blue-darker`,
   semibold: 'text-ds-blue-darker font-semibold',
@@ -105,6 +105,7 @@ A.propTypes = {
   variant: PropTypes.oneOf([
     'default',
     'header',
+    'headerDeprecated',
     'guestHeader',
     'link',
     'code',

--- a/src/ui/A/A.jsx
+++ b/src/ui/A/A.jsx
@@ -13,6 +13,7 @@ const baseClass = `
 `
 const variantClasses = {
   default: `text-ds-blue`,
+  newHeader: `font-semibold`, // clean up when old header gets removed
   header: `font-semibold text-ds-gray-secondary`,
   guestHeader: `font-semibold text-ds-gray-senary`,
   link: `text-ds-blue-darker`,


### PR DESCRIPTION
Adds self-hosted/enterprise header items.

[Design](https://www.figma.com/design/kbJfmcDgAuptsJR5KB28O9/GH-293-(nav%2C-header%2C-and-related-elements)?node-id=322-1385&t=obSouBUmcJD9rdK1-0)

Closes https://github.com/codecov/engineering-team/issues/1954

![Screenshot 2024-07-09 at 12 25 41](https://github.com/codecov/gazebo/assets/159931558/5fd2e40c-1b81-47ed-ad8a-58deab16b56c)