### PR TITLE
feat: Add Tax information to Plan Page

### DIFF
--- a/src/pages/PlanPage/subRoutes/CurrentOrgPlan/BillingDetails/BillingDetails.spec.tsx
+++ b/src/pages/PlanPage/subRoutes/CurrentOrgPlan/BillingDetails/BillingDetails.spec.tsx
@@ -60,10 +60,6 @@ describe('BillingDetails', () => {
     server.use(
       rest.get('/internal/gh/:owner/account-details/', (req, res, ctx) => {
         if (hasSubscription) {
-          const sub = hasTax
-            ? { ...mockSubscription, taxIds: ['lol', 'nice'] }
-            : mockSubscription
-          console.log(hasTax, sub.taxIds.length > 0)
           return res(
             ctx.status(200),
             ctx.json({

--- a/src/pages/PlanPage/subRoutes/CurrentOrgPlan/BillingDetails/BillingDetails.tsx
+++ b/src/pages/PlanPage/subRoutes/CurrentOrgPlan/BillingDetails/BillingDetails.tsx
@@ -38,6 +38,14 @@ function BillingDetails() {
         provider={provider}
         owner={owner}
       />
+      {subscriptionDetail.taxIds.length > 0 ? (
+        <div className="flex flex-col gap-2 p-4">
+          <h4 className="font-semibold">Tax ID</h4>
+          {subscriptionDetail.taxIds.map((val, index) => (
+            <p key={index}>{val}</p>
+          ))}
+        </div>
+      ) : null}
     </div>
   )
 }

--- a/src/pages/PlanPage/subRoutes/CurrentOrgPlan/LatestInvoiceCard/LatestInvoiceCard.spec.tsx
+++ b/src/pages/PlanPage/subRoutes/CurrentOrgPlan/LatestInvoiceCard/LatestInvoiceCard.spec.tsx
@@ -40,8 +40,8 @@ describe('LatestInvoiceCard', () => {
       expect(tab).toBeInTheDocument()
     })
 
-    it('renders the link to See All invoices', () => {
-      const tab = screen.getByText(/See all invoices/)
+    it('renders the link to View all invoices', () => {
+      const tab = screen.getByText(/View/)
       expect(tab).toBeInTheDocument()
     })
   })

--- a/src/pages/PlanPage/subRoutes/CurrentOrgPlan/LatestInvoiceCard/LatestInvoiceCard.tsx
+++ b/src/pages/PlanPage/subRoutes/CurrentOrgPlan/LatestInvoiceCard/LatestInvoiceCard.tsx
@@ -23,7 +23,18 @@ function LatestInvoiceCard() {
 
   return (
     <div className="flex flex-col border">
-      <h3 className="p-4 font-semibold">Invoices</h3>
+      <h3 className="flex justify-between p-4 font-semibold">
+        Invoices
+        <A
+          to={{ pageName: 'invoicesPage' }}
+          hook="all-invoice-page"
+          variant="semibold"
+          isExternal={false}
+        >
+          View
+          <Icon name="chevronRight" size="sm" variant="solid" />
+        </A>
+      </h3>
       <hr />
       <div className="flex items-center gap-4 p-4">
         <img src={invoiceImg} alt="invoice icon" />
@@ -51,17 +62,6 @@ function LatestInvoiceCard() {
             </A>
           </div>
         </div>
-      </div>
-      <div className="flex self-start p-4">
-        <A
-          to={{ pageName: 'invoicesPage' }}
-          hook="all-invoice-page"
-          variant="semibold"
-          isExternal={false}
-        >
-          See all invoices{' '}
-          <Icon name="chevronRight" size="sm" variant="solid" />
-        </A>
       </div>
     </div>
   )

--- a/src/services/account/mocks.js
+++ b/src/services/account/mocks.js
@@ -126,6 +126,7 @@ export const accountDetailsObject = {
         phone: null,
       },
     },
+    tax_ids: [],
     trial_end: null,
     cancel_at_period_end: false,
     current_period_end: 1636479475,
@@ -239,6 +240,7 @@ export const accountDetailsParsedObj = {
       },
     },
     trialEnd: null,
+    taxIds: [],
     cancelAtPeriodEnd: false,
     currentPeriodEnd: 1636479475,
     customer: {

--- a/src/services/account/useAccountDetails.ts
+++ b/src/services/account/useAccountDetails.ts
@@ -98,7 +98,8 @@ export const SubscriptionDetailSchema = z
       .nullable(),
     defaultPaymentMethod: PaymentMethodSchema.nullable(),
     latestInvoice: InvoiceSchema,
-    trialEnd: z.number().nullish(),
+    taxIds: z.array(z.string()),
+    trialEnd: z.number().nullable(),
   })
   .nullable()
 


### PR DESCRIPTION
# Description

This PR aims to add the Tax ID section to the billing details page if the Tax IDs exist (an array comes back from GQL always, but could have 0 length).

We also have some minor updates to the zod schema for account details to accommodate this change, and a small change for "See all invoices" button -> "View"

Closes https://github.com/codecov/engineering-team/issues/1973

# Screenshots

<img width="523" alt="Screenshot 2024-07-09 at 3 46 53 PM" src="https://github.com/codecov/gazebo/assets/159853603/8e3ae4f3-7af7-4221-8de5-13307ab8722e">


# Link to Sample Entry

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.