### PR TITLE
fix: Update schema for account details with correct tax info

### DIFF
--- a/src/pages/PlanPage/subRoutes/CurrentOrgPlan/BillingDetails/BillingDetails.spec.tsx
+++ b/src/pages/PlanPage/subRoutes/CurrentOrgPlan/BillingDetails/BillingDetails.spec.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { render, screen, waitFor } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 import { rest } from 'msw'
 import { setupServer } from 'msw/node'
 import { MemoryRouter, Route } from 'react-router-dom'
@@ -64,7 +64,13 @@ describe('BillingDetails', () => {
             ctx.status(200),
             ctx.json({
               subscriptionDetail: hasTax
-                ? { ...mockSubscription, taxIds: ['lol', 'nice'] }
+                ? {
+                    ...mockSubscription,
+                    taxIds: [
+                      { type: 'k', value: 'lol' },
+                      { type: 'nah', value: 'nice' },
+                    ],
+                  }
                 : mockSubscription,
             })
           )
@@ -108,13 +114,11 @@ describe('BillingDetails', () => {
       expect(taxSection).toBeInTheDocument()
     })
 
-    it('does not render tax info if does not exist', async () => {
+    it('does not render tax info if does not exist', () => {
       setup({ hasSubscription: true, hasTax: false })
       render(<BillingDetails />, { wrapper })
 
-      await waitFor(() => {
-        expect(screen.queryByText(/Tax ID/)).not.toBeInTheDocument()
-      })
+      expect(screen.queryByText(/Tax ID/)).not.toBeInTheDocument()
     })
   })
 

--- a/src/pages/PlanPage/subRoutes/CurrentOrgPlan/BillingDetails/BillingDetails.tsx
+++ b/src/pages/PlanPage/subRoutes/CurrentOrgPlan/BillingDetails/BillingDetails.tsx
@@ -42,7 +42,7 @@ function BillingDetails() {
         <div className="flex flex-col gap-2 p-4">
           <h4 className="font-semibold">Tax ID</h4>
           {subscriptionDetail.taxIds.map((val, index) => (
-            <p key={index}>{val}</p>
+            <p key={index}>{val?.value}</p>
           ))}
         </div>
       ) : null}

--- a/src/services/account/useAccountDetails.ts
+++ b/src/services/account/useAccountDetails.ts
@@ -98,7 +98,14 @@ export const SubscriptionDetailSchema = z
       .nullable(),
     defaultPaymentMethod: PaymentMethodSchema.nullable(),
     latestInvoice: InvoiceSchema,
-    taxIds: z.array(z.string()),
+    taxIds: z.array(
+      z
+        .object({
+          type: z.string(),
+          value: z.string(),
+        })
+        .nullish()
+    ),
     trialEnd: z.number().nullable(),
   })
   .nullable()


### PR DESCRIPTION
# Description

Zod schema failing to parse account-details endpoint due to incorrect schema type.

This PR updates with the correct schema type, parsing bare minimum we need from tax info. Tested locally by hard coding customer data into local and confirming page now loads correctly.

# Screenshots

# Link to Sample Entry

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.