### PR TITLE
fix: nullish defaultPaymentMethod for Link users

### DIFF
--- a/src/services/account/useAccountDetails.ts
+++ b/src/services/account/useAccountDetails.ts
@@ -67,12 +67,14 @@ export const BillingDetailsSchema = z
 
 export const PaymentMethodSchema = z
   .object({
-    card: z.object({
-      brand: z.string(),
-      expMonth: z.number(),
-      expYear: z.number(),
-      last4: z.string(),
-    }),
+    card: z
+      .object({
+        brand: z.string(),
+        expMonth: z.number(),
+        expYear: z.number(),
+        last4: z.string(),
+      })
+      .nullish(),
     billingDetails: BillingDetailsSchema.nullable(),
   })
   .nullable()


### PR DESCRIPTION
# Description

useAccountDetails zod schema parser was failing due to lack of .nullish() check on defaultPaymentMethod  card property. We didn't realize that users using Link would run into this issue, but this looks to fix it.

# Code Example

# Notable Changes

# Screenshots

# Link to Sample Entry

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.