### PR TITLE
feat: add back and cancel btns to TOS and Org select pages

### DIFF
--- a/src/pages/DefaultOrgSelector/DefaultOrgSelector.jsx
+++ b/src/pages/DefaultOrgSelector/DefaultOrgSelector.jsx
@@ -174,7 +174,7 @@ function DefaultOrgSelector() {
             Cancel
           </Button>
           <Button hook="user selects org, continues to app" type="submit">
-            Continue to app
+            Continue to Codecov
           </Button>
         </div>
       </form>

--- a/src/pages/DefaultOrgSelector/DefaultOrgSelector.jsx
+++ b/src/pages/DefaultOrgSelector/DefaultOrgSelector.jsx
@@ -125,7 +125,7 @@ function DefaultOrgSelector() {
   return (
     <div className="mx-auto w-full max-w-[38rem]">
       <h1 className="pb-3 pt-20 text-2xl font-semibold">
-        Which organization are you using today?
+        Which organization are you working with today?
       </h1>
       <form onSubmit={handleSubmit(onSubmit)}>
         <div className="my-4 flex flex-col gap-4 border-y border-ds-gray-tertiary py-6">
@@ -164,9 +164,17 @@ function DefaultOrgSelector() {
           />
           <GitHubHelpBanner />
         </div>
-        <div className="flex justify-end">
+        <div className="flex justify-end gap-2">
+          <Button
+            to={{ pageName: 'login' }}
+            variant="plain"
+            disabled={false}
+            hook="org-select-cancel-button"
+          >
+            Cancel
+          </Button>
           <Button hook="user selects org, continues to app" type="submit">
-            Continue
+            Continue to app
           </Button>
         </div>
       </form>

--- a/src/pages/DefaultOrgSelector/DefaultOrgSelector.spec.jsx
+++ b/src/pages/DefaultOrgSelector/DefaultOrgSelector.spec.jsx
@@ -219,12 +219,12 @@ describe('DefaultOrgSelector', () => {
       render(<DefaultOrgSelector />, { wrapper: wrapper() })
 
       let selectLabel = screen.queryByText(
-        /Which organization are you using today?/
+        /Which organization are you working with today?/
       )
       expect(selectLabel).not.toBeInTheDocument()
 
       selectLabel = await screen.findByText(
-        /Which organization are you using today?/
+        /Which organization are you working with today?/
       )
       expect(selectLabel).toBeInTheDocument()
     })
@@ -391,6 +391,43 @@ describe('DefaultOrgSelector', () => {
     })
   })
 
+  describe('on cancel', () => {
+    it('sends user back to the login page', async () => {
+      setup({
+        useUserData: mockUserData,
+        myOrganizationsData: {
+          me: {
+            myOrganizations: {
+              edges: [
+                {
+                  node: {
+                    avatarUrl:
+                      'https://avatars0.githubusercontent.com/u/8226205?v=3&s=55',
+                    username: 'criticalRole',
+                    ownerid: 1,
+                  },
+                },
+              ],
+              pageInfo: { hasNextPage: false, endCursor: 'MTI=' },
+            },
+          },
+        },
+      })
+
+      render(<DefaultOrgSelector />, { wrapper: wrapper() })
+
+      const header = await screen.findByText(
+        /Which organization are you working with today?/
+      )
+      expect(header).toBeInTheDocument()
+
+      const cancel = await screen.findByRole('link', { name: /Cancel/ })
+      await userEvent.click(cancel)
+
+      expect(testLocation.pathname).toBe('/login')
+    })
+  })
+
   describe('on submit', () => {
     beforeEach(() => jest.resetAllMocks())
     it('fires update default org mutation', async () => {
@@ -418,7 +455,7 @@ describe('DefaultOrgSelector', () => {
       render(<DefaultOrgSelector />, { wrapper: wrapper() })
 
       const selectLabel = await screen.findByText(
-        /Which organization are you using today?/
+        /Which organization are you working with today?/
       )
       expect(selectLabel).toBeInTheDocument()
 
@@ -474,7 +511,7 @@ describe('DefaultOrgSelector', () => {
       render(<DefaultOrgSelector />, { wrapper: wrapper() })
 
       const selectLabel = await screen.findByText(
-        /Which organization are you using today?/
+        /Which organization are you working with today?/
       )
       expect(selectLabel).toBeInTheDocument()
 
@@ -612,7 +649,7 @@ describe('DefaultOrgSelector', () => {
       render(<DefaultOrgSelector />, { wrapper: wrapper() })
 
       const selectLabel = await screen.findByText(
-        /Which organization are you using today?/
+        /Which organization are you working with today?/
       )
       expect(selectLabel).toBeInTheDocument()
 
@@ -671,7 +708,7 @@ describe('DefaultOrgSelector', () => {
       render(<DefaultOrgSelector />, { wrapper: wrapper() })
 
       const selectLabel = await screen.findByText(
-        /Which organization are you using today?/
+        /Which organization are you working with today?/
       )
       expect(selectLabel).toBeInTheDocument()
 
@@ -887,7 +924,7 @@ describe('DefaultOrgSelector', () => {
       render(<DefaultOrgSelector />, { wrapper: wrapper() })
 
       const selectLabel = await screen.findByText(
-        /Which organization are you using today?/
+        /Which organization are you working with today?/
       )
       expect(selectLabel).toBeInTheDocument()
 
@@ -951,7 +988,7 @@ describe('DefaultOrgSelector', () => {
       render(<DefaultOrgSelector />, { wrapper: wrapper() })
 
       const selectLabel = await screen.findByText(
-        /Which organization are you using today?/
+        /Which organization are you working with today?/
       )
       expect(selectLabel).toBeInTheDocument()
 
@@ -1054,7 +1091,7 @@ describe('DefaultOrgSelector', () => {
       render(<DefaultOrgSelector />, { wrapper: wrapper() })
 
       const selectLabel = await screen.findByText(
-        /Which organization are you using today?/
+        /Which organization are you working with today?/
       )
       expect(selectLabel).toBeInTheDocument()
 
@@ -1168,7 +1205,7 @@ describe('DefaultOrgSelector', () => {
       render(<DefaultOrgSelector />, { wrapper: wrapper() })
 
       const selectLabel = await screen.findByText(
-        /Which organization are you using today?/
+        /Which organization are you working with today?/
       )
       expect(selectLabel).toBeInTheDocument()
 

--- a/src/pages/DefaultOrgSelector/DefaultOrgSelector.spec.jsx
+++ b/src/pages/DefaultOrgSelector/DefaultOrgSelector.spec.jsx
@@ -468,7 +468,7 @@ describe('DefaultOrgSelector', () => {
       await user.click(orgInList)
 
       const submit = await screen.findByRole('button', {
-        name: /Continue/,
+        name: /Continue to Codecov/,
       })
 
       await user.click(submit)

--- a/src/pages/TermsOfService/TermsOfService.spec.tsx
+++ b/src/pages/TermsOfService/TermsOfService.spec.tsx
@@ -261,6 +261,20 @@ describe('TermsOfService', () => {
     })
   })
 
+  describe('on back', () => {
+    it('sends user back to the login page', async () => {
+      render(<TermsOfService />, { wrapper })
+
+      const welcome = await screen.findByText(/Welcome to Codecov/i)
+      expect(welcome).toBeInTheDocument()
+
+      const back = await screen.findByRole('link', { name: /Back/ })
+      await userEvent.click(back)
+
+      expect(testLocation.pathname).toBe('/login')
+    })
+  })
+
   /*
    * This is to test the various form validation edge cases case with different data.
    * The describe.each function takes an array of arrays, each array is a test case.

--- a/src/pages/TermsOfService/TermsOfService.tsx
+++ b/src/pages/TermsOfService/TermsOfService.tsx
@@ -237,7 +237,15 @@ export default function TermsOfService() {
             .
           </p>
         )}
-        <div className="mt-3 flex justify-end">
+        <div className="mt-3 flex justify-end gap-2">
+          <Button
+            to={{ pageName: 'login' }}
+            variant="plain"
+            disabled={false}
+            hook="tos-back-button"
+          >
+            Back
+          </Button>
           <Button
             disabled={isDisabled({
               isValid: formState.isValid,

--- a/src/ui/Button/Button.stories.jsx
+++ b/src/ui/Button/Button.stories.jsx
@@ -44,6 +44,12 @@ PlainButton.args = {
   variant: 'plain',
 }
 
+export const ListboxButton = Template.bind({})
+ListboxButton.args = {
+  children: 'Listbox button',
+  variant: 'listbox',
+}
+
 export const GitHubButton = Template.bind({})
 GitHubButton.args = {
   children: 'GitHub Button',


### PR DESCRIPTION
# Description

Closes https://github.com/codecov/engineering-team/issues/1940

Added a story for Listbox variant of the Button as it seems like it was missed.

I believe keeping copy text as "Which organization" is more grammatically correct for org selector as we have a list.

Figma: bottom of [https://www.figma.com/design/kbJfmcDgAuptsJR5KB28O9/GH-293-(nav%2C-header%2C-and-related-elements)?node-id=322-1385&t=rNtuPGrNv5Adbn8H-1](url)

# Code Example

# Notable Changes

# Screenshots

https://github.com/user-attachments/assets/c1ba2f75-66ed-4023-985e-63d3ada3cc96



![Screenshot 2024-07-11 at 2 53 42 PM](https://github.com/user-attachments/assets/c9177f8d-cb21-48c8-bdc0-1870f2cc3961)
![Screenshot 2024-07-11 at 2 53 58 PM](https://github.com/user-attachments/assets/b1e1c411-d2d2-4216-bfd3-f81827b2f8f7)


# Link to Sample Entry

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.