### PR TITLE
fix: Nulls when address info doesn't exist on Plan page

### DIFF
--- a/src/pages/PlanPage/subRoutes/CurrentOrgPlan/BillingDetails/Address/AddressCard.spec.tsx
+++ b/src/pages/PlanPage/subRoutes/CurrentOrgPlan/BillingDetails/Address/AddressCard.spec.tsx
@@ -172,6 +172,46 @@ describe('AddressCard', () => {
       expect(screen.getByText(/San Francisco, CA 12345/)).toBeInTheDocument()
     })
 
+    it('can render partial information too', () => {
+      render(
+        <AddressCard
+          // @ts-expect-error weird param funkiness
+          subscriptionDetail={{
+            ...subscriptionDetail,
+            defaultPaymentMethod: {
+              card: {
+                brand: 'visa',
+                expMonth: 12,
+                expYear: 2021,
+                last4: '1234',
+              },
+              billingDetails: {
+                name: null,
+                email: null,
+                phone: null,
+                address: {
+                  line1: null,
+                  line2: null,
+                  city: null,
+                  country: null,
+                  state: null,
+                  postalCode: '12345',
+                },
+              },
+            },
+          }}
+          provider="gh"
+          owner="codecov"
+        />
+      )
+
+      expect(screen.getByText('Cardholder name')).toBeInTheDocument()
+      expect(screen.getByText('N/A')).toBeInTheDocument()
+      expect(screen.getByText('Billing address')).toBeInTheDocument()
+      expect(screen.queryByText(/null/)).not.toBeInTheDocument()
+      expect(screen.getByText('12345')).toBeInTheDocument()
+    })
+
     it('renders the card holder information', () => {
       render(
         <AddressCard

--- a/src/pages/PlanPage/subRoutes/CurrentOrgPlan/BillingDetails/Address/AddressCard.tsx
+++ b/src/pages/PlanPage/subRoutes/CurrentOrgPlan/BillingDetails/Address/AddressCard.tsx
@@ -70,13 +70,20 @@ function BillingInner({ billingDetails, setIsFormOpen }: BillingInnerProps) {
   if (billingDetails) {
     return (
       <div>
-        <p>{`${billingDetails.name}`}</p>
+        <p>{`${billingDetails.name ?? 'N/A'}`}</p>
         <br />
         <h4 className="mb-2 font-semibold">Billing address</h4>
-        <p>{`${billingDetails.address?.line1} ${
+        <p>{`${billingDetails.address?.line1 ?? ''} ${
           billingDetails.address?.line2 ?? ''
         }`}</p>
-        <p>{`${billingDetails.address?.city}, ${billingDetails.address?.state} ${billingDetails.address?.postalCode}`}</p>
+        <p>
+          {billingDetails.address?.city
+            ? `${billingDetails.address?.city}, `
+            : ''}
+          {`${billingDetails.address?.state ?? ''} ${
+            billingDetails.address?.postalCode ?? ''
+          }`}
+        </p>
       </div>
     )
   }


### PR DESCRIPTION
# Description

Just doing a little polish for the nulls that appear when some user address info doesn't exist

# Link to Sample Entry

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.