### PR TITLE
feat: Implement remaining Navigator functionality for new header

### DIFF
--- a/src/layouts/Header/Header.spec.tsx
+++ b/src/layouts/Header/Header.spec.tsx
@@ -104,43 +104,72 @@ describe('Header', () => {
     )
   }
 
-  describe('placeholder new header', () => {
-    it('shows when currentUser is defined', async () => {
-      setup({})
-      render(<Header />, { wrapper })
-
-      const text = await screen.findByText('Navigator')
-      expect(text).toBeInTheDocument()
-    })
-  })
-
-  describe('guest header', () => {
-    it('shows when currentUser is null', async () => {
+  describe('when are not logged in', () => {
+    it('shows guest header', async () => {
       setup({ user: mockNullUser })
       render(<Header />, { wrapper })
 
-      const link = await screen.findByText('Guest header')
-      expect(link).toBeInTheDocument()
+      const guestHeader = await screen.findByText('Guest header')
+      expect(guestHeader).toBeInTheDocument()
+    })
+  })
+
+  describe('when logged in', () => {
+    it('shows navigator', async () => {
+      setup({})
+      render(<Header />, { wrapper })
+
+      const navigator = await screen.findByText('Navigator')
+      expect(navigator).toBeInTheDocument()
+    })
+
+    it('shows help dropdown', async () => {
+      setup({})
+      render(<Header />, { wrapper })
+
+      const helpDropdown = await screen.findByText(/Help Dropdown/)
+      expect(helpDropdown).toBeInTheDocument()
+    })
+
+    it('shows user dropdown', async () => {
+      setup({})
+      render(<Header />, { wrapper })
+
+      const userDropdown = await screen.findByText(/User Dropdown/)
+      expect(userDropdown).toBeInTheDocument()
     })
   })
 
   describe('when on self-hosted', () => {
-    it('shows seat details', async () => {
-      config.IS_SELF_HOSTED = true
-      setup({})
-      render(<Header />, { wrapper })
+    describe('and are not logged in', () => {
+      it('shows guest header', async () => {
+        config.IS_SELF_HOSTED = true
+        setup({})
+        render(<Header />, { wrapper })
 
-      const text = await screen.findByText(/Seat Details/)
-      expect(text).toBeInTheDocument()
+        const guestHeader = await screen.findByText('Guest header')
+        expect(guestHeader).toBeInTheDocument()
+      })
     })
 
-    it('shows Admin link', async () => {
-      config.IS_SELF_HOSTED = true
-      setup({})
-      render(<Header />, { wrapper })
+    describe('and are logged in', () => {
+      it('shows seat details', async () => {
+        config.IS_SELF_HOSTED = true
+        setup({})
+        render(<Header />, { wrapper })
 
-      const text = await screen.findByText(/Admin Link/)
-      expect(text).toBeInTheDocument()
+        const text = await screen.findByText(/Seat Details/)
+        expect(text).toBeInTheDocument()
+      })
+
+      it('shows Admin link', async () => {
+        config.IS_SELF_HOSTED = true
+        setup({})
+        render(<Header />, { wrapper })
+
+        const text = await screen.findByText(/Admin Link/)
+        expect(text).toBeInTheDocument()
+      })
     })
   })
 })

--- a/src/layouts/Header/Header.tsx
+++ b/src/layouts/Header/Header.tsx
@@ -11,16 +11,16 @@ import SeatDetails from './components/SeatDetails'
 import UserDropdown from './components/UserDropdown'
 
 function Header() {
-  const { data: currentUser } = useUser()
+  const currentUser = useUser()
 
-  if (!currentUser) {
+  if (!currentUser.data) {
     return <h1>Guest header</h1>
   }
 
   return (
     <div className="container flex h-14 w-full items-center">
       <div className="flex-1">
-        <Navigator />
+        <Navigator currentUser={currentUser} />
       </div>
       <div className="flex items-center justify-end gap-4">
         {config.IS_SELF_HOSTED ? (

--- a/src/layouts/Header/Header.tsx
+++ b/src/layouts/Header/Header.tsx
@@ -22,7 +22,7 @@ function Header() {
       <div className="flex-1">
         <Navigator />
       </div>
-      <div className="flex items-center gap-4">
+      <div className="flex items-center justify-end gap-4">
         {config.IS_SELF_HOSTED ? (
           <Suspense fallback={null}>
             <SeatDetails />

--- a/src/layouts/Header/Header.tsx
+++ b/src/layouts/Header/Header.tsx
@@ -11,9 +11,9 @@ import SeatDetails from './components/SeatDetails'
 import UserDropdown from './components/UserDropdown'
 
 function Header() {
-  const currentUser = useUser()
+  const { data: currentUser } = useUser()
 
-  if (!currentUser.data) {
+  if (!currentUser) {
     return <h1>Guest header</h1>
   }
 

--- a/src/layouts/Header/components/Navigator/MyContextSwitcher.spec.tsx
+++ b/src/layouts/Header/components/Navigator/MyContextSwitcher.spec.tsx
@@ -1,0 +1,167 @@
+import { render, screen, waitFor } from 'custom-testing-library'
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import userEvent from '@testing-library/user-event'
+import { graphql } from 'msw'
+import { setupServer } from 'msw/node'
+import { MemoryRouter, Route } from 'react-router-dom'
+import useIntersection from 'react-use/lib/useIntersection'
+
+import { useImage } from 'services/image'
+
+import MyContextSwitcher from './MyContextSwitcher'
+
+jest.mock('services/image')
+jest.mock('react-use/lib/useIntersection')
+const mockedUseImage = useImage as jest.Mock
+const mockedUseIntersection = useIntersection as jest.Mock
+
+const queryClient = new QueryClient({
+  defaultOptions: { queries: { retry: false } },
+})
+const server = setupServer()
+
+const org1 = {
+  username: 'codecov',
+  avatarUrl: 'https://github.com/codecov.png?size=40',
+}
+
+const org2 = {
+  username: 'spotify',
+  avatarUrl: 'https://github.com/spotify.png?size=40',
+}
+
+const wrapper: (initialEntries?: string) => React.FC<React.PropsWithChildren> =
+  (initialEntries = '/gh') =>
+  ({ children }) =>
+    (
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter initialEntries={[initialEntries]}>
+          <Route path="/:provider/:owner" exact>
+            {children}
+          </Route>
+        </MemoryRouter>
+      </QueryClientProvider>
+    )
+
+beforeAll(() => server.listen())
+
+afterEach(() => {
+  queryClient.clear()
+  server.restoreHandlers()
+})
+
+afterAll(() => server.close())
+
+describe('MyContextSwitcher', () => {
+  function setup(noData = false) {
+    const user = userEvent.setup()
+
+    mockedUseImage.mockReturnValue({
+      src: 'imageUrl',
+      isLoading: false,
+      error: null,
+    })
+    server.use(
+      graphql.query('MyContexts', (req, res, ctx) => {
+        if (noData) {
+          return res(ctx.status(200), ctx.data({}))
+        }
+
+        const orgList = !!req.variables?.after ? org2 : org1
+        const hasNextPage = req.variables?.after ? false : true
+        const endCursor = req.variables?.after ? 'second' : 'first'
+
+        const queryData = {
+          me: {
+            owner: {
+              username: 'cool-user',
+              avatarUrl: 'http://127.0.0.1/avatar-url',
+              defaultOrgUsername: null,
+            },
+            myOrganizations: {
+              edges: [{ node: orgList }],
+              pageInfo: {
+                hasNextPage,
+                endCursor,
+              },
+            },
+          },
+        }
+
+        return res(ctx.status(200), ctx.data(queryData))
+      }),
+      graphql.query('DetailOwner', (req, res, ctx) => {
+        if (noData) {
+          return res(ctx.status(200), ctx.data({}))
+        }
+
+        const queryData = {
+          owner: {
+            username: 'codecov',
+            avatarUrl: 'http://127.0.0.1/avatar-url',
+          },
+        }
+
+        return res(ctx.status(200), ctx.data(queryData))
+      })
+    )
+
+    return { user }
+  }
+
+  describe('when there are no contexts (user not logged in)', () => {
+    beforeEach(() => {
+      setup(true)
+    })
+
+    it('renders nothing', async () => {
+      const { container } = render(
+        <MyContextSwitcher pageName="accountPage" />,
+        {
+          wrapper: wrapper(),
+        }
+      )
+
+      await waitFor(() => expect(container).toBeEmptyDOMElement())
+    })
+  })
+
+  describe('when the user has some contexts', () => {
+    it('renders the button with the organization', async () => {
+      setup()
+      render(<MyContextSwitcher pageName="owner" />, {
+        wrapper: wrapper('/gh/codecov'),
+      })
+
+      const button = await screen.findByRole('button', {
+        name: /codecov/i,
+      })
+      expect(button).toBeInTheDocument()
+    })
+  })
+
+  describe('user "scrolls" and fetches next page', () => {
+    beforeEach(() => {
+      setup()
+      mockedUseIntersection.mockReturnValue({ isIntersecting: true })
+    })
+
+    it('loads second item', async () => {
+      render(<MyContextSwitcher pageName="owner" />, {
+        wrapper: wrapper('/gh/codecov'),
+      })
+
+      const button = await screen.findByRole('button', {
+        name: /codecov/i,
+      })
+      expect(button).toBeInTheDocument()
+
+      await waitFor(() => queryClient.isFetching)
+      await waitFor(() => !queryClient.isFetching)
+
+      const spotify = await screen.findByText(/spotify/i)
+      expect(spotify).toBeInTheDocument()
+    })
+  })
+})

--- a/src/layouts/Header/components/Navigator/MyContextSwitcher.tsx
+++ b/src/layouts/Header/components/Navigator/MyContextSwitcher.tsx
@@ -1,0 +1,58 @@
+import PropTypes from 'prop-types'
+import { useParams } from 'react-router-dom'
+
+import { useMyContexts, useOwner } from 'services/user'
+import ContextSwitcher from 'ui/ContextSwitcher'
+
+interface URLParams {
+  provider: string
+  owner: string
+}
+
+interface MyContextSwitcherProps {
+  pageName: string
+}
+
+function MyContextSwitcher({ pageName }: MyContextSwitcherProps) {
+  const { provider, owner } = useParams<URLParams>()
+  const {
+    data: myContexts,
+    hasNextPage,
+    fetchNextPage,
+    isLoading,
+  } = useMyContexts({ provider })
+  const { data: activeContext } = useOwner({ username: owner })
+
+  if (!myContexts || !myContexts?.currentUser) return null
+
+  const { currentUser, myOrganizations } = myContexts
+
+  const contexts = [
+    {
+      owner: currentUser,
+      pageName,
+    },
+    ...myOrganizations.map((context) => ({
+      owner: context,
+      pageName,
+    })),
+  ]
+
+  return (
+    <div className="max-w-[350px]">
+      <ContextSwitcher
+        activeContext={activeContext}
+        contexts={contexts}
+        currentUser={currentUser}
+        isLoading={isLoading}
+        onLoadMore={() => hasNextPage && fetchNextPage()}
+      />
+    </div>
+  )
+}
+
+MyContextSwitcher.propTypes = {
+  pageName: PropTypes.string.isRequired,
+}
+
+export default MyContextSwitcher

--- a/src/layouts/Header/components/Navigator/MyContextSwitcher.tsx
+++ b/src/layouts/Header/components/Navigator/MyContextSwitcher.tsx
@@ -1,4 +1,3 @@
-import PropTypes from 'prop-types'
 import { useParams } from 'react-router-dom'
 
 import { useMyContexts, useOwner } from 'services/user'
@@ -39,7 +38,7 @@ function MyContextSwitcher({ pageName }: MyContextSwitcherProps) {
   ]
 
   return (
-    <div className="max-w-[350px]">
+    <div className="max-w-[500px]">
       <ContextSwitcher
         activeContext={activeContext}
         contexts={contexts}
@@ -49,10 +48,6 @@ function MyContextSwitcher({ pageName }: MyContextSwitcherProps) {
       />
     </div>
   )
-}
-
-MyContextSwitcher.propTypes = {
-  pageName: PropTypes.string.isRequired,
 }
 
 export default MyContextSwitcher

--- a/src/layouts/Header/components/Navigator/Navigator.spec.tsx
+++ b/src/layouts/Header/components/Navigator/Navigator.spec.tsx
@@ -6,7 +6,7 @@ import { setupServer } from 'msw/node'
 import { useLayoutEffect } from 'react'
 import { MemoryRouter, Route, useParams } from 'react-router-dom'
 
-import { RepoBreadcrumbProvider , useCrumbs } from 'pages/RepoPage/context'
+import { RepoBreadcrumbProvider, useCrumbs } from 'pages/RepoPage/context'
 
 import Navigator from './Navigator'
 

--- a/src/layouts/Header/components/Navigator/Navigator.spec.tsx
+++ b/src/layouts/Header/components/Navigator/Navigator.spec.tsx
@@ -6,6 +6,7 @@ import { RepoBreadcrumbProvider } from 'pages/RepoPage/context'
 import Navigator from './Navigator'
 
 jest.mock('ui/Breadcrumb', () => () => 'Breadcrumb')
+jest.mock('./MyContextSwitcher', () => () => 'MyContextSwitcher')
 
 const wrapper: (initialEntries?: string) => React.FC<React.PropsWithChildren> =
   (initialEntries = '/gh/codecov') =>
@@ -23,10 +24,54 @@ const wrapper: (initialEntries?: string) => React.FC<React.PropsWithChildren> =
       </MemoryRouter>
     )
 
+const mockUser = {
+  owner: {
+    defaultOrgUsername: 'codecov',
+  },
+  email: 'jane.doe@codecov.io',
+  privateAccess: true,
+  onboardingCompleted: true,
+  businessEmail: 'jane.doe@codecov.io',
+  termsAgreement: true,
+  user: {
+    name: 'Jane Doe',
+    username: 'janedoe',
+    avatarUrl: 'http://127.0.0.1/avatar-url',
+    avatar: 'http://127.0.0.1/avatar-url',
+    student: false,
+    studentCreatedAt: null,
+    studentUpdatedAt: null,
+    customerIntent: 'PERSONAL',
+  },
+  trackingMetadata: {
+    service: 'github',
+    ownerid: 123,
+    serviceId: '123',
+    plan: 'users-basic',
+    staff: false,
+    hasYaml: false,
+    bot: null,
+    delinquent: null,
+    didTrial: null,
+    planProvider: null,
+    planUserCount: 1,
+    createdAt: 'timestamp',
+    updatedAt: 'timestamp',
+    profile: {
+      createdAt: 'timestamp',
+      otherGoal: null,
+      typeProjects: [],
+      goals: [],
+    },
+  },
+}
+
 describe('Header Navigator', () => {
   describe('when on repo page', () => {
     it('should render repo breadcrumb', async () => {
-      render(<Navigator />, { wrapper: wrapper('/gh/codecov/test-repo') })
+      render(<Navigator currentUser={mockUser} />, {
+        wrapper: wrapper('/gh/codecov/test-repo'),
+      })
 
       const breadcrumb = await screen.findByText('Breadcrumb')
       expect(breadcrumb).toBeInTheDocument()
@@ -35,7 +80,7 @@ describe('Header Navigator', () => {
 
   describe('temp: when not on repo page', () => {
     it('should render MyContextSwitcher', async () => {
-      render(<Navigator />, { wrapper: wrapper() })
+      render(<Navigator currentUser={mockUser} />, { wrapper: wrapper() })
 
       const switcher = await screen.findByText('MyContextSwitcher')
       expect(switcher).toBeInTheDocument()

--- a/src/layouts/Header/components/Navigator/Navigator.tsx
+++ b/src/layouts/Header/components/Navigator/Navigator.tsx
@@ -19,7 +19,7 @@ function Navigator({ currentUser }: NavigatorProps) {
     return <Breadcrumb paths={breadcrumbs} largeFont />
   }
 
-  // Selfhosted admin settings
+  // Self-hosted admin settings
   if (path.startsWith('/admin/:provider')) {
     const defaultOrg =
       currentUser?.owner?.defaultOrgUsername ?? currentUser?.user?.username
@@ -33,6 +33,7 @@ function Navigator({ currentUser }: NavigatorProps) {
           },
           { pageName: '', readOnly: true, text: 'Admin' },
         ]}
+        largeFont
       />
     )
   }

--- a/src/layouts/Header/components/Navigator/Navigator.tsx
+++ b/src/layouts/Header/components/Navigator/Navigator.tsx
@@ -1,13 +1,13 @@
 import { useRouteMatch } from 'react-router-dom'
 
 import { useCrumbs } from 'pages/RepoPage/context'
-import { useUser } from 'services/user'
+import { Me } from 'services/user'
 import Breadcrumb from 'ui/Breadcrumb'
 
 import MyContextSwitcher from './MyContextSwitcher'
 
 interface NavigatorProps {
-  currentUser: ReturnType<typeof useUser>
+  currentUser: Me
 }
 
 function Navigator({ currentUser }: NavigatorProps) {
@@ -22,8 +22,7 @@ function Navigator({ currentUser }: NavigatorProps) {
   // Selfhosted admin settings
   if (path.startsWith('/admin/:provider')) {
     const defaultOrg =
-      currentUser.data?.owner?.defaultOrgUsername ??
-      currentUser.data?.user?.username
+      currentUser?.owner?.defaultOrgUsername ?? currentUser?.user?.username
     return (
       <Breadcrumb
         paths={[

--- a/src/layouts/Header/components/Navigator/Navigator.tsx
+++ b/src/layouts/Header/components/Navigator/Navigator.tsx
@@ -3,15 +3,28 @@ import { useRouteMatch } from 'react-router-dom'
 import { useCrumbs } from 'pages/RepoPage/context'
 import Breadcrumb from 'ui/Breadcrumb'
 
+import MyContextSwitcher from './MyContextSwitcher'
+
 function Navigator() {
   const { path } = useRouteMatch()
   const { breadcrumbs } = useCrumbs()
 
   if (path.startsWith('/:provider/:owner/:repo')) {
-    return <Breadcrumb paths={breadcrumbs} />
+    return <Breadcrumb paths={breadcrumbs} largeFont />
   }
 
-  return <p>MyContextSwitcher</p>
+  let pageName = 'owner'
+  if (path.startsWith('/analytics/:provider/:owner')) {
+    pageName = 'analytics'
+  } else if (path.startsWith('/members/:provider/:owner')) {
+    pageName = 'membersTab'
+  } else if (path.startsWith('/plan/:provider/:owner')) {
+    pageName = 'planTab'
+  } else if (path.startsWith('/account/:provider/:owner')) {
+    pageName = 'accountAdmin'
+  }
+
+  return <MyContextSwitcher pageName={pageName} />
 }
 
 export default Navigator

--- a/src/layouts/Header/components/Navigator/Navigator.tsx
+++ b/src/layouts/Header/components/Navigator/Navigator.tsx
@@ -1,18 +1,44 @@
 import { useRouteMatch } from 'react-router-dom'
 
 import { useCrumbs } from 'pages/RepoPage/context'
+import { useUser } from 'services/user'
 import Breadcrumb from 'ui/Breadcrumb'
 
 import MyContextSwitcher from './MyContextSwitcher'
 
-function Navigator() {
+interface NavigatorProps {
+  currentUser: ReturnType<typeof useUser>
+}
+
+function Navigator({ currentUser }: NavigatorProps) {
   const { path } = useRouteMatch()
   const { breadcrumbs } = useCrumbs()
 
+  // Repo page
   if (path.startsWith('/:provider/:owner/:repo')) {
     return <Breadcrumb paths={breadcrumbs} largeFont />
   }
 
+  // Selfhosted admin settings
+  if (path.startsWith('/admin/:provider')) {
+    const defaultOrg =
+      currentUser.data?.owner?.defaultOrgUsername ??
+      currentUser.data?.user?.username
+    return (
+      <Breadcrumb
+        paths={[
+          {
+            pageName: 'owner',
+            text: defaultOrg,
+            options: { owner: defaultOrg },
+          },
+          { pageName: '', readOnly: true, text: 'Admin' },
+        ]}
+      />
+    )
+  }
+
+  // Everything else uses MyContextSwitcher
   let pageName = 'owner'
   if (path.startsWith('/analytics/:provider/:owner')) {
     pageName = 'analytics'

--- a/src/services/user/useOwner.js
+++ b/src/services/user/useOwner.js
@@ -9,16 +9,16 @@ export function useOwner({
 }) {
   const { provider } = useParams()
   const query = `
-      query DetailOwner($username: String!) {
-        owner(username: $username) {
-          ownerid
-          username
-          avatarUrl
-          isCurrentUserPartOfOrg
-          isAdmin
-        }
+    query DetailOwner($username: String!) {
+      owner(username: $username) {
+        ownerid
+        username
+        avatarUrl
+        isCurrentUserPartOfOrg
+        isAdmin
       }
-    `
+    }
+  `
 
   const variables = {
     username,

--- a/src/services/user/useUser.ts
+++ b/src/services/user/useUser.ts
@@ -68,7 +68,7 @@ const MeSchema = z.object({
   }),
 })
 
-type Me = z.infer<typeof MeSchema>
+export type Me = z.infer<typeof MeSchema>
 
 const UserSchema = z.object({
   me: MeSchema.nullable(),

--- a/src/ui/Breadcrumb/Breadcrumb.jsx
+++ b/src/ui/Breadcrumb/Breadcrumb.jsx
@@ -3,12 +3,18 @@ import PropTypes from 'prop-types'
 import { Fragment } from 'react'
 
 import AppLink from 'shared/AppLink'
+import { cn } from 'shared/utils/cn'
 import A from 'ui/A'
 
-function Breadcrumb({ paths = [] }) {
+function Breadcrumb({ paths = [], largeFont = false }) {
   return (
     // space-x-1 doesn't work when text is rendered rtl, using margins
-    <nav className="flex flex-1 items-center truncate text-ds-gray-octonary [&>*]:mr-1">
+    <nav
+      className={cn(
+        'flex flex-1 items-center truncate text-ds-gray-octonary [&>*]:mr-1',
+        { 'text-lg': largeFont }
+      )}
+    >
       {paths.map((to, i) => {
         return (
           <Fragment key={i}>
@@ -32,4 +38,5 @@ export default Breadcrumb
 
 Breadcrumb.propTypes = {
   paths: PropTypes.arrayOf(PropTypes.shape(AppLink.propTypes)),
+  largeFont: PropTypes.bool,
 }

--- a/src/ui/ContextSwitcher/ContextSwitcher.jsx
+++ b/src/ui/ContextSwitcher/ContextSwitcher.jsx
@@ -205,7 +205,7 @@ ContextSwitcher.propTypes = {
     PropTypes.shape({
       owner: PropTypes.shape({
         avatarUrl: PropTypes.string.isRequired,
-        username: PropTypes.string.isRequired,
+        username: PropTypes.string,
       }),
       pageName: PropTypes.string.isRequired,
     })


### PR DESCRIPTION
Adds logic for adjusting the navigator shown on different pages of the app along with actually rendering those navigators.

I'm still doing another styling pass over everything so please ignore minor styling issues for now!

[Design](https://www.figma.com/design/kbJfmcDgAuptsJR5KB28O9/GH-293-(nav%2C-header%2C-and-related-elements)?node-id=327-2668&t=Ds53xQRyUmGhvcmF-0)

## Screenshots
Owner page shows Context switcher for navigation:
<img width="1317" alt="Screenshot 2024-07-12 at 16 56 39" src="https://github.com/user-attachments/assets/6a857d7e-01ec-434b-acee-b73dc6ce23dd">

Self-hosted admin settings uses a breadcrumb:
<img width="1313" alt="Screenshot 2024-07-12 at 16 58 39" src="https://github.com/user-attachments/assets/6fa1e121-492a-4e1f-b34b-84f2ac1bca35">

Repo page uses a breadcrumb:
<img width="1333" alt="Screenshot 2024-07-12 at 16 59 33" src="https://github.com/user-attachments/assets/d4d4f461-2e70-4fb9-b014-0feeaa2d2791">
