### PR TITLE
fix: Don't fire update default org if user already has a default org

### DIFF
--- a/src/layouts/BaseLayout/hooks/useUserAccessGate.js
+++ b/src/layouts/BaseLayout/hooks/useUserAccessGate.js
@@ -61,12 +61,16 @@ const useUserAccessGate = () => {
   })
 
   useEffect(() => {
-    if (userData?.user?.customerIntent === CustomerIntent.PERSONAL) {
+    if (
+      userData?.user?.customerIntent === CustomerIntent.PERSONAL &&
+      !userData?.owner?.defaultOrgUsername
+    ) {
       updateDefaultOrg({ username: userData?.user?.username })
     }
   }, [
     userData?.user?.customerIntent,
     userData?.user?.username,
+    userData?.owner?.defaultOrgUsername,
     updateDefaultOrg,
   ])
 

--- a/src/layouts/BaseLayout/hooks/useUserAccessGate.spec.tsx
+++ b/src/layouts/BaseLayout/hooks/useUserAccessGate.spec.tsx
@@ -813,6 +813,24 @@ describe('useUserAccessGate', () => {
           })
         )
       })
+
+      it('does not fire if current owner already has a default org', async () => {
+        const { mockMutationVariables } = setup({
+          user: userHasDefaultOrg,
+          internalUser: internalUserHasSyncedProviders,
+        })
+
+        const { result } = renderHook(() => useUserAccessGate(), {
+          wrapper: wrapper(['/gh']),
+        })
+
+        await waitFor(() => result.current.isLoading)
+        await waitFor(() => !result.current.isLoading)
+
+        await waitFor(() =>
+          expect(mockMutationVariables).not.toHaveBeenCalled()
+        )
+      })
     })
 
     describe('when customer intent is set to BUSINESS', () => {


### PR DESCRIPTION
# Description
When user set customer intent to personal on onboarding, their default org is always their personal account, this PR is fixing the bug to allow user to switch between default orgs despite their customer intent after the first login. 

Closes: https://github.com/codecov/internal-issues/issues/586

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.