### PR TITLE
fix: Move render error down the download link in upload card. 

### DIFF
--- a/src/pages/CommitDetailPage/CommitCoverage/UploadsCard/RenderError.tsx
+++ b/src/pages/CommitDetailPage/CommitCoverage/UploadsCard/RenderError.tsx
@@ -46,9 +46,9 @@ const ErrorMessage = ({ errorCode, count }: ErrorMessageProps) => {
 
   if (errorCode === ErrorCodeEnum.reportEmpty) {
     return (
-      <span className="mt-3 flex items-start gap-1 text-ds-primary-red">
+      <span className="mt-3 flex items-start gap-1 text-balance text-ds-primary-red">
         {icon}
-        <p className="w-11/12">
+        <p className="w-full">
           Unusable report due to issues such as source code unavailability, path
           mismatch, empty report, or incorrect data format. Please visit our{' '}
           <A

--- a/src/pages/CommitDetailPage/CommitCoverage/UploadsCard/Upload.jsx
+++ b/src/pages/CommitDetailPage/CommitCoverage/UploadsCard/Upload.jsx
@@ -56,7 +56,6 @@ const Upload = ({
           />
 
           <UploadReference ciUrl={ciUrl} name={name} buildCode={buildCode} />
-          <RenderError errors={errors} state={state} />
         </div>
         {createdAt && (
           <span className="text-xs text-ds-gray-quinary">
@@ -82,6 +81,7 @@ const Upload = ({
           </A>
         )}
       </div>
+      <RenderError errors={errors} state={state} />
     </div>
   )
 }


### PR DESCRIPTION
# Description
Fixing text wrap + place of error in upload card.

# Screenshots 
<img width="638" alt="Screenshot 2024-07-16 at 1 44 17 PM" src="https://github.com/user-attachments/assets/1fadc85c-fb34-4a85-8cd6-7be672e1c040">
<img width="638" alt="Screenshot 2024-07-16 at 1 44 06 PM" src="https://github.com/user-attachments/assets/f6799115-7c89-4834-b634-a4c647081677">


issue: https://github.com/codecov/engineering-team/issues/2085 

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.