### PR TITLE
feat: new ui dropdown component

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,3 +1,4 @@
 yarnPath: .yarn/releases/yarn-4.3.1.cjs
 nodeLinker: node-modules
 enableHardenedMode: false
+enableImmutableInstalls: false

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,2 +1,3 @@
 yarnPath: .yarn/releases/yarn-4.3.1.cjs
 nodeLinker: node-modules
+enableHardenedMode: false

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "@hookform/resolvers": "^2.8.5",
     "@radix-ui/react-accordion": "^1.1.2",
     "@radix-ui/react-collapsible": "^1.0.3",
+    "@radix-ui/react-dropdown-menu": "^2.1.1",
     "@radix-ui/react-label": "^2.0.2",
     "@radix-ui/react-popover": "^1.0.6",
     "@radix-ui/react-radio-group": "^1.1.3",

--- a/src/ui/Dropdown/Dropdown.spec.tsx
+++ b/src/ui/Dropdown/Dropdown.spec.tsx
@@ -1,0 +1,107 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+import { Dropdown } from './Dropdown'
+
+describe('Dropdown', () => {
+  function setup() {
+    const user = userEvent.setup()
+
+    return { user }
+  }
+
+  describe('rendering component', () => {
+    it('only renders the trigger', () => {
+      render(
+        <Dropdown>
+          <Dropdown.Trigger>My Dropdown</Dropdown.Trigger>
+          <Dropdown.Content>
+            <Dropdown.Item>First item</Dropdown.Item>
+            <Dropdown.Item>Second item</Dropdown.Item>
+            <Dropdown.Item>Third item</Dropdown.Item>
+          </Dropdown.Content>
+        </Dropdown>
+      )
+
+      const firstTitle = screen.getByText('My Dropdown')
+      expect(firstTitle).toBeInTheDocument()
+
+      const secondTitle = screen.queryByText('First item')
+      expect(secondTitle).not.toBeInTheDocument()
+    })
+
+    describe('opening a dropdown', () => {
+      it('renders the content', async () => {
+        const { user } = setup()
+        render(
+          <Dropdown>
+            <Dropdown.Trigger>My Dropdown</Dropdown.Trigger>
+            <Dropdown.Content>
+              <Dropdown.Item>First item</Dropdown.Item>
+              <Dropdown.Item>Second item</Dropdown.Item>
+              <Dropdown.Item>Third item</Dropdown.Item>
+            </Dropdown.Content>
+          </Dropdown>
+        )
+
+        const dropdownTrigger = screen.getByText('My Dropdown')
+        expect(dropdownTrigger).toBeInTheDocument()
+        await user.click(dropdownTrigger)
+
+        const firstItem = screen.getByText('First item')
+        expect(firstItem).toBeInTheDocument()
+      })
+      it('renders the label', async () => {
+        const { user } = setup()
+        render(
+          <Dropdown>
+            <Dropdown.Trigger>My Dropdown</Dropdown.Trigger>
+            <Dropdown.Content>
+              <Dropdown.Label>The Label</Dropdown.Label>
+              <Dropdown.Item>First item</Dropdown.Item>
+              <Dropdown.Item>Second item</Dropdown.Item>
+              <Dropdown.Item>Third item</Dropdown.Item>
+            </Dropdown.Content>
+          </Dropdown>
+        )
+
+        const dropdownTrigger = screen.getByText('My Dropdown')
+        expect(dropdownTrigger).toBeInTheDocument()
+        await user.click(dropdownTrigger)
+
+        // const firstItem = screen.getByText('First item')
+        // expect(firstItem).toBeInTheDocument()
+
+        const label = screen.getByText('The Label')
+        expect(label).toBeInTheDocument()
+      })
+    })
+
+    describe('closing a dropdown', () => {
+      it('hides the content', async () => {
+        const { user } = setup()
+        render(
+          <Dropdown>
+            <Dropdown.Trigger>My Dropdown</Dropdown.Trigger>
+            <Dropdown.Content>
+              <Dropdown.Item>First item</Dropdown.Item>
+              <Dropdown.Item>Second item</Dropdown.Item>
+              <Dropdown.Item>Third item</Dropdown.Item>
+            </Dropdown.Content>
+          </Dropdown>
+        )
+
+        const dropdownTrigger = screen.getByText('My Dropdown')
+        expect(dropdownTrigger).toBeInTheDocument()
+        await user.click(dropdownTrigger)
+
+        const firstItem = screen.getByText('First item')
+        expect(firstItem).toBeInTheDocument()
+        await user.click(firstItem)
+
+        const newFirstItem = screen.queryByText('First item')
+        expect(newFirstItem).not.toBeInTheDocument()
+      })
+    })
+  })
+})

--- a/src/ui/Dropdown/Dropdown.spec.tsx
+++ b/src/ui/Dropdown/Dropdown.spec.tsx
@@ -23,11 +23,11 @@ describe('Dropdown', () => {
         </Dropdown>
       )
 
-      const firstTitle = screen.getByText('My Dropdown')
-      expect(firstTitle).toBeInTheDocument()
+      const dropdownTrigger = screen.getByText('My Dropdown')
+      expect(dropdownTrigger).toBeInTheDocument()
 
-      const secondTitle = screen.queryByText('First item')
-      expect(secondTitle).not.toBeInTheDocument()
+      const firstItem = screen.queryByText('First item')
+      expect(firstItem).not.toBeInTheDocument()
     })
 
     describe('opening a dropdown', () => {
@@ -68,9 +68,6 @@ describe('Dropdown', () => {
         const dropdownTrigger = screen.getByText('My Dropdown')
         expect(dropdownTrigger).toBeInTheDocument()
         await user.click(dropdownTrigger)
-
-        // const firstItem = screen.getByText('First item')
-        // expect(firstItem).toBeInTheDocument()
 
         const label = screen.getByText('The Label')
         expect(label).toBeInTheDocument()

--- a/src/ui/Dropdown/Dropdown.stories.tsx
+++ b/src/ui/Dropdown/Dropdown.stories.tsx
@@ -2,26 +2,31 @@ import { Meta, StoryObj } from '@storybook/react'
 
 import { Dropdown } from './Dropdown'
 
-type DropdownStory = React.ComponentProps<typeof Dropdown> & {
-  titleSize?: 'lg' | 'base'
-}
+type DropdownStory = React.ComponentProps<typeof Dropdown>
 
 const meta: Meta<DropdownStory> = {
   title: 'Components/Dropdown',
   component: Dropdown,
-  //   argTypes: {
-  //     titleSize: {
-  //       description: 'Controls the font size of Card.Title',
-  //       control: 'radio',
-  //       options: ['lg', 'base'],
-  //     },
-  //   },
 } as Meta
 export default meta
 
 type Story = StoryObj<DropdownStory>
 
 export const Default: Story = {
+  render: () => (
+    <Dropdown>
+      <Dropdown.Trigger>Open</Dropdown.Trigger>
+      <Dropdown.Content>
+        <Dropdown.Item>Apple</Dropdown.Item>
+        <Dropdown.Item>Orange</Dropdown.Item>
+        <Dropdown.Item>Strawberry</Dropdown.Item>
+        <Dropdown.Item>Lemon</Dropdown.Item>
+      </Dropdown.Content>
+    </Dropdown>
+  ),
+}
+
+export const WithLabel: Story = {
   render: () => (
     <Dropdown>
       <Dropdown.Trigger>Open</Dropdown.Trigger>
@@ -35,70 +40,3 @@ export const Default: Story = {
     </Dropdown>
   ),
 }
-
-// export const CardWithHeader: Story = {
-//   args: {
-//     titleSize: 'lg',
-//   },
-//   render: (args) => (
-//     <Dropdown>
-//       <Dropdown.Header>
-//         <Dropdown.Title size={args.titleSize}>
-//           A header can have a title.
-//         </Dropdown.Title>
-//         <Dropdown.Description>And it can have a description.</Dropdown.Description>
-//       </Dropdown.Header>
-//       <Dropdown.Content>
-//         The header will place a border between it and the main Dropdown content.
-//       </Dropdown.Content>
-//     </Dropdown>
-//   ),
-// }
-
-// export const CardWithFooter: Story = {
-//   render: () => (
-//     <Card>
-//       <Card.Header>
-//         <Card.Title>Card With Footer</Card.Title>
-//       </Card.Header>
-//       <Card.Content>
-//         A footer will similarly have a border between it and the main Card
-//         content.
-//       </Card.Content>
-//       <Card.Footer>Footer!</Card.Footer>
-//     </Card>
-//   ),
-// }
-
-// export const CardWithCustomStyles: Story = {
-//   render: () => (
-//     <Card className="border-4 border-ds-pink">
-//       <Card.Header className="border-b-4 border-inherit">
-//         <Card.Title className="text-ds-blue">Custom Styles</Card.Title>
-//       </Card.Header>
-//       <Card.Content className="flex gap-5">
-//         <Card className="flex-1">
-//           <Card.Content className="text-center">
-//             Using the <code className="bg-ds-gray-secondary">className</code>{' '}
-//             prop,
-//           </Card.Content>
-//         </Card>
-//         <Card className="flex-1">
-//           <Card.Content className="text-center">
-//             you can set custom styles!
-//           </Card.Content>
-//         </Card>
-//       </Card.Content>
-//       <Card.Footer className="border-t-4 border-inherit text-center">
-//         But if you&apos;re going to do that, consider adding a{' '}
-//         <a
-//           href="https://cva.style/docs/getting-started/variants"
-//           className="text-ds-blue hover:underline"
-//         >
-//           CVA variant
-//         </a>{' '}
-//         for the component instead.
-//       </Card.Footer>
-//     </Card>
-//   ),
-// }

--- a/src/ui/Dropdown/Dropdown.stories.tsx
+++ b/src/ui/Dropdown/Dropdown.stories.tsx
@@ -1,0 +1,104 @@
+import { Meta, StoryObj } from '@storybook/react'
+
+import { Dropdown } from './Dropdown'
+
+type DropdownStory = React.ComponentProps<typeof Dropdown> & {
+  titleSize?: 'lg' | 'base'
+}
+
+const meta: Meta<DropdownStory> = {
+  title: 'Components/Dropdown',
+  component: Dropdown,
+  //   argTypes: {
+  //     titleSize: {
+  //       description: 'Controls the font size of Card.Title',
+  //       control: 'radio',
+  //       options: ['lg', 'base'],
+  //     },
+  //   },
+} as Meta
+export default meta
+
+type Story = StoryObj<DropdownStory>
+
+export const Default: Story = {
+  render: () => (
+    <Dropdown>
+      <Dropdown.Trigger>Open</Dropdown.Trigger>
+      <Dropdown.Content>
+        <Dropdown.Label>My Label</Dropdown.Label>
+        <Dropdown.Item>Apple</Dropdown.Item>
+        <Dropdown.Item>Orange</Dropdown.Item>
+        <Dropdown.Item>Strawberry</Dropdown.Item>
+        <Dropdown.Item>Lemon</Dropdown.Item>
+      </Dropdown.Content>
+    </Dropdown>
+  ),
+}
+
+// export const CardWithHeader: Story = {
+//   args: {
+//     titleSize: 'lg',
+//   },
+//   render: (args) => (
+//     <Dropdown>
+//       <Dropdown.Header>
+//         <Dropdown.Title size={args.titleSize}>
+//           A header can have a title.
+//         </Dropdown.Title>
+//         <Dropdown.Description>And it can have a description.</Dropdown.Description>
+//       </Dropdown.Header>
+//       <Dropdown.Content>
+//         The header will place a border between it and the main Dropdown content.
+//       </Dropdown.Content>
+//     </Dropdown>
+//   ),
+// }
+
+// export const CardWithFooter: Story = {
+//   render: () => (
+//     <Card>
+//       <Card.Header>
+//         <Card.Title>Card With Footer</Card.Title>
+//       </Card.Header>
+//       <Card.Content>
+//         A footer will similarly have a border between it and the main Card
+//         content.
+//       </Card.Content>
+//       <Card.Footer>Footer!</Card.Footer>
+//     </Card>
+//   ),
+// }
+
+// export const CardWithCustomStyles: Story = {
+//   render: () => (
+//     <Card className="border-4 border-ds-pink">
+//       <Card.Header className="border-b-4 border-inherit">
+//         <Card.Title className="text-ds-blue">Custom Styles</Card.Title>
+//       </Card.Header>
+//       <Card.Content className="flex gap-5">
+//         <Card className="flex-1">
+//           <Card.Content className="text-center">
+//             Using the <code className="bg-ds-gray-secondary">className</code>{' '}
+//             prop,
+//           </Card.Content>
+//         </Card>
+//         <Card className="flex-1">
+//           <Card.Content className="text-center">
+//             you can set custom styles!
+//           </Card.Content>
+//         </Card>
+//       </Card.Content>
+//       <Card.Footer className="border-t-4 border-inherit text-center">
+//         But if you&apos;re going to do that, consider adding a{' '}
+//         <a
+//           href="https://cva.style/docs/getting-started/variants"
+//           className="text-ds-blue hover:underline"
+//         >
+//           CVA variant
+//         </a>{' '}
+//         for the component instead.
+//       </Card.Footer>
+//     </Card>
+//   ),
+// }

--- a/src/ui/Dropdown/Dropdown.tsx
+++ b/src/ui/Dropdown/Dropdown.tsx
@@ -9,27 +9,12 @@ import Icon from 'ui/Icon'
 // Check out https://www.radix-ui.com/primitives/docs/components/dropdown-menu to see what other functionality
 // can be incorporated if needed.
 
-// const root = cva(['flex gap-2'])
-
-// interface DropdownProps
-//   extends React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Root>, VariantProps<typeof root> {}
 interface DropdownProps
   extends React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Root> {}
 
-// Todo: remove React.forwardRef
-const Root = React.forwardRef<
-  React.ElementRef<typeof DropdownMenuPrimitive.Root>,
-  DropdownProps
->(({ ...props }, ref) => {
-  return (
-    <DropdownMenuPrimitive.Root
-      // it doesn't look like this component excepts className or ref as props
-      // className={cn(root({ className }))}
-      {...props}
-      // ref={ref}
-    />
-  )
-})
+const Root = ({ ...props }: DropdownProps) => (
+  <DropdownMenuPrimitive.Root {...props} />
+)
 Root.displayName = 'Dropdown'
 
 const trigger = cva('flex items-center gap-1')

--- a/src/ui/Dropdown/Dropdown.tsx
+++ b/src/ui/Dropdown/Dropdown.tsx
@@ -45,7 +45,7 @@ const Trigger = React.forwardRef<
 Trigger.displayName = 'Dropdown.Trigger'
 
 const content = cva(
-  'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-32 overflow-hidden rounded-md border p-1 shadow-md'
+  'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-32 overflow-hidden rounded-md border bg-white shadow-md'
 )
 
 interface ContentProps
@@ -68,7 +68,7 @@ const Content = React.forwardRef<
 Content.displayName = 'Dropdown.Content'
 
 const item = cva(
-  'focus:bg-accent focus:text-accent-foreground relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm text-ds-gray-octonary outline-none transition-colors data-[disabled]:pointer-events-none data-[disabled]:opacity-50'
+  'focus:bg-accent focus:text-accent-foreground relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm text-ds-gray-octonary outline-none transition-colors hover:cursor-pointer hover:bg-ds-gray-secondary data-[disabled]:pointer-events-none data-[disabled]:opacity-50'
 )
 
 interface ItemProps

--- a/src/ui/Dropdown/Dropdown.tsx
+++ b/src/ui/Dropdown/Dropdown.tsx
@@ -1,0 +1,128 @@
+import * as DropdownMenuPrimitive from '@radix-ui/react-dropdown-menu'
+import { cva, VariantProps } from 'cva'
+import * as React from 'react'
+
+import { cn } from 'shared/utils/cn'
+import Icon from 'ui/Icon'
+
+// NOTE: radix-ui's dropdown menu comes with more features such as submenus, separators, and different types of items.
+// Check out https://www.radix-ui.com/primitives/docs/components/dropdown-menu to see what other functionality
+// can be incorporated if needed.
+
+// const root = cva(['flex gap-2'])
+
+// interface DropdownProps
+//   extends React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Root>, VariantProps<typeof root> {}
+interface DropdownProps
+  extends React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Root> {}
+
+// Todo: remove React.forwardRef
+const Root = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.Root>,
+  DropdownProps
+>(({ ...props }, ref) => {
+  return (
+    <DropdownMenuPrimitive.Root
+      // it doesn't look like this component excepts className or ref as props
+      // className={cn(root({ className }))}
+      {...props}
+      // ref={ref}
+    />
+  )
+})
+Root.displayName = 'Dropdown'
+
+const trigger = cva('flex items-center gap-1')
+
+interface TriggerProps
+  extends React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Trigger>,
+    VariantProps<typeof trigger> {}
+
+const Trigger = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.Trigger>,
+  TriggerProps
+>(({ children, className, ...props }, forwardedRef) => (
+  <DropdownMenuPrimitive.Trigger
+    className={cn(trigger({ className }))}
+    {...props}
+  >
+    {children}
+    <span className="text-ds-gray-quinary">
+      <Icon
+        variant="solid"
+        size="sm"
+        name="chevronDown"
+        className="text-ds-gray-octonary"
+      />
+    </span>
+  </DropdownMenuPrimitive.Trigger>
+))
+Trigger.displayName = 'Dropdown.Trigger'
+
+const content = cva(
+  'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-32 overflow-hidden rounded-md border p-1 shadow-md'
+)
+
+interface ContentProps
+  extends React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Content>,
+    VariantProps<typeof content> {}
+
+const Content = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.Content>,
+  ContentProps
+>(({ className, sideOffset = 4, ...props }, ref) => (
+  <DropdownMenuPrimitive.Portal>
+    <DropdownMenuPrimitive.Content
+      ref={ref}
+      sideOffset={sideOffset}
+      className={cn(content({ className }))}
+      {...props}
+    />
+  </DropdownMenuPrimitive.Portal>
+))
+Content.displayName = 'Dropdown.Content'
+
+const item = cva(
+  'focus:bg-accent focus:text-accent-foreground relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm text-ds-gray-octonary outline-none transition-colors data-[disabled]:pointer-events-none data-[disabled]:opacity-50'
+)
+
+interface ItemProps
+  extends React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Item>,
+    VariantProps<typeof item> {}
+
+const Item = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.Item>,
+  ItemProps & { inset?: boolean }
+>(({ className, inset, ...props }, ref) => (
+  <DropdownMenuPrimitive.Item
+    ref={ref}
+    className={cn(inset && 'pl-8', item({ className }))}
+    {...props}
+  />
+))
+Item.displayName = 'Dropdown.Item'
+
+const label = cva('px-2 py-1.5 text-sm font-semibold')
+
+interface LabelProps
+  extends React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Label>,
+    VariantProps<typeof label> {}
+
+const Label = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.Label>,
+  LabelProps & { inset?: boolean }
+>(({ className, inset, ...props }, ref) => (
+  <DropdownMenuPrimitive.Label
+    ref={ref}
+    className={cn(inset && 'pl-8', label({ className }))}
+    {...props}
+  />
+))
+Label.displayName = 'Dropdown.Label'
+
+export const Dropdown = Object.assign(Root, {
+  Trigger,
+  Content,
+  Item,
+  Label,
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -3191,6 +3191,31 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@radix-ui/react-dropdown-menu@npm:^2.1.1":
+  version: 2.1.1
+  resolution: "@radix-ui/react-dropdown-menu@npm:2.1.1"
+  dependencies:
+    "@radix-ui/primitive": "npm:1.1.0"
+    "@radix-ui/react-compose-refs": "npm:1.1.0"
+    "@radix-ui/react-context": "npm:1.1.0"
+    "@radix-ui/react-id": "npm:1.1.0"
+    "@radix-ui/react-menu": "npm:2.1.1"
+    "@radix-ui/react-primitive": "npm:2.0.0"
+    "@radix-ui/react-use-controllable-state": "npm:1.1.0"
+  peerDependencies:
+    "@types/react": "*"
+    "@types/react-dom": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    "@types/react-dom":
+      optional: true
+  checksum: 10c0/b54f1e41ddc8c3709ba2f8a59621138268d0380aca8399450a234997cc2214e4a6acf1a64ab387558ba39c0bd5839995a668bd71781762daac7618a2d71b4082
+  languageName: node
+  linkType: hard
+
 "@radix-ui/react-focus-guards@npm:1.0.1":
   version: 1.0.1
   resolution: "@radix-ui/react-focus-guards@npm:1.0.1"
@@ -3309,6 +3334,42 @@ __metadata:
     "@types/react-dom":
       optional: true
   checksum: 10c0/282d3b1b72ff14b431b3bb427d66d14253bbd30fad2437d8f4e7d5c0b6a41f6f7ed157460e02fb91b67b1c8cebc65f2c6fe1d3a32f4459d41238fc0fd4719875
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-menu@npm:2.1.1":
+  version: 2.1.1
+  resolution: "@radix-ui/react-menu@npm:2.1.1"
+  dependencies:
+    "@radix-ui/primitive": "npm:1.1.0"
+    "@radix-ui/react-collection": "npm:1.1.0"
+    "@radix-ui/react-compose-refs": "npm:1.1.0"
+    "@radix-ui/react-context": "npm:1.1.0"
+    "@radix-ui/react-direction": "npm:1.1.0"
+    "@radix-ui/react-dismissable-layer": "npm:1.1.0"
+    "@radix-ui/react-focus-guards": "npm:1.1.0"
+    "@radix-ui/react-focus-scope": "npm:1.1.0"
+    "@radix-ui/react-id": "npm:1.1.0"
+    "@radix-ui/react-popper": "npm:1.2.0"
+    "@radix-ui/react-portal": "npm:1.1.1"
+    "@radix-ui/react-presence": "npm:1.1.0"
+    "@radix-ui/react-primitive": "npm:2.0.0"
+    "@radix-ui/react-roving-focus": "npm:1.1.0"
+    "@radix-ui/react-slot": "npm:1.1.0"
+    "@radix-ui/react-use-callback-ref": "npm:1.1.0"
+    aria-hidden: "npm:^1.1.1"
+    react-remove-scroll: "npm:2.5.7"
+  peerDependencies:
+    "@types/react": "*"
+    "@types/react-dom": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    "@types/react-dom":
+      optional: true
+  checksum: 10c0/2cb11867430276d8db595886ae0e01e67a555676d37e108d5a6c386df23329482115a041b6a4057fad6b855aa423681805c20d1f290fd1502e521e8e55aafb54
   languageName: node
   linkType: hard
 
@@ -11651,6 +11712,7 @@ __metadata:
     "@hookform/resolvers": "npm:^2.8.5"
     "@radix-ui/react-accordion": "npm:^1.1.2"
     "@radix-ui/react-collapsible": "npm:^1.0.3"
+    "@radix-ui/react-dropdown-menu": "npm:^2.1.1"
     "@radix-ui/react-label": "npm:^2.0.2"
     "@radix-ui/react-popover": "npm:^1.0.6"
     "@radix-ui/react-radio-group": "npm:^1.1.3"


### PR DESCRIPTION
# Description

Creating Dropdown component with new shadcn/radix/cva archetype.

Closes https://github.com/codecov/engineering-team/issues/1942

Figma: section 2 of https://www.figma.com/design/kbJfmcDgAuptsJR5KB28O9/GH-293-(nav%2C-header%2C-and-related-elements)?node-id=322-1385&t=Nga242WoJqfXLEvv-1
Storybook: https://preview-pr-3020-storybook.codecov.dev/

# Code Example

# Notable Changes

# Screenshots

# Link to Sample Entry

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.