### PR TITLE
Fix Whitespace in `BotErrorBanner`

### DIFF
--- a/src/pages/CommitDetailPage/CommitCoverage/BotErrorBanner/BotErrorBanner.jsx
+++ b/src/pages/CommitDetailPage/CommitCoverage/BotErrorBanner/BotErrorBanner.jsx
@@ -41,12 +41,10 @@ const BotErrorContent = () => {
   if (ghWithNoApp) {
     return (
       <p>
-        <span>
-          The bot posts the coverage report comment on pull requests. If
-          you&apos;re using GitHub, the best way to integrate with Codecov.io is
-          to Install
-        </span>
-        <A to={{ pageName: 'codecovGithubApp' }}> Codecov&apos;s GitHub App.</A>
+        The bot posts the coverage report comment on pull requests. If
+        you&apos;re using GitHub, the best way to integrate with Codecov.io is
+        to Install{' '}
+        <A to={{ pageName: 'codecovGithubApp' }}>Codecov&apos;s GitHub App.</A>
       </p>
     )
   }
@@ -89,7 +87,7 @@ const BotErrorHeading = () => {
 
   return (
     <p className="font-semibold">
-      <A to={{ pageName: 'teamBot' }}>Team bot </A> is missing
+      <A to={{ pageName: 'teamBot' }}>Team bot</A> is missing
     </p>
   )
 }


### PR DESCRIPTION
Previously, there was no space between `to InstallCodecov's App`, which is fixed now.
I also removed the `span`, as all other error variants don’t have one either.

![image](https://github.com/user-attachments/assets/8ff95134-115b-4579-b1cf-fcef298f1bea)