### PR TITLE
fix enterprise url not properly being set during build

### DIFF
--- a/docker/start-nginx.sh
+++ b/docker/start-nginx.sh
@@ -21,15 +21,15 @@ then
   sed -i "s/${SCHEME_BASE}:\/\/${WEB_BASE}/${SCHEME}:\/\/${CODECOV_BASE_HOST}/g" /var/www/app/gazebo/static/js/main.*
   if [[ -n "${GHE_BASE}" ]]; then
     echo "Replacing GHE ${GHE_SCHEME_BASE}://${GHE_BASE}"
-    sed -i "s/r\.[a-zA-Z]\.GHE_URL/\"${GHE_SCHEME_BASE}:\/\/${GHE_BASE}\"/g" /var/www/app/gazebo/static/js/main.*
+    sed -i -r "s/r\.[a-zA-Z]+\.GHE_URL/\"${GHE_SCHEME_BASE}:\/\/${GHE_BASE}\"/g" /var/www/app/gazebo/static/js/main.*
   fi
   if [[ -n "${GLE_BASE}" ]]; then
     echo "Replacing GLE ${GLE_SCHEME_BASE}://${GLE_BASE}"
-    sed -i "s/r\.[a-zA-Z]\.GLE_URL/\"${GLE_SCHEME_BASE}:\/\/${GLE_BASE}\"/g" /var/www/app/gazebo/static/js/main.*
+    sed -i -r "s/r\.[a-zA-Z]+\.GLE_URL/\"${GLE_SCHEME_BASE}:\/\/${GLE_BASE}\"/g" /var/www/app/gazebo/static/js/main.*
   fi
   if [[ -n "${BBS_BASE}" ]]; then
     echo "Replacing BBS ${BBS_SCHEME_BASE}://${BBS_BASE}"
-    sed -i "s/r\.[a-zA-Z]\.BBS_URL/\"${BBS_SCHEME_BASE}:\/\/${BBS_BASE}\"/g" /var/www/app/gazebo/static/js/main.*
+    sed -i -r "s/r\.[a-zA-Z]+\.BBS_URL/\"${BBS_SCHEME_BASE}:\/\/${BBS_BASE}\"/g" /var/www/app/gazebo/static/js/main.*
   fi
 
   export DOLLAR='$'


### PR DESCRIPTION
The old string replacement isn't correct, this handles a case where a string eg r.Ay.GHE_URL doesn't get replaced because we only expect exactly 1 character between the 2 dots. This fix will match at least one character between the 2 dots.

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.