### PR TITLE
style: Hide self-hosted header items on small screen sizes

### DIFF
--- a/src/layouts/Header/Header.tsx
+++ b/src/layouts/Header/Header.tsx
@@ -24,10 +24,12 @@ function Header() {
         {!currentUser ? null : (
           <div className="flex items-center justify-end gap-4">
             {config.IS_SELF_HOSTED ? (
-              <Suspense fallback={null}>
-                <SeatDetails />
-                <AdminLink />
-              </Suspense>
+              <div className="hidden items-center justify-end gap-4 md:flex">
+                <Suspense fallback={null}>
+                  <SeatDetails />
+                  <AdminLink />
+                </Suspense>
+              </div>
             ) : null}
             <HelpDropdown />
             <UserDropdown />


### PR DESCRIPTION
Hides the self-hosted header items on small screen sizes as they clutter things up and make weird layouts occur.
