### PR TITLE
feat: Create hook for test results

### DIFF
--- a/src/pages/RepoPage/FailedTestsTab/hooks/index.ts
+++ b/src/pages/RepoPage/FailedTestsTab/hooks/index.ts
@@ -1,0 +1,1 @@
+export { useInfiniteTestResults } from './useInfiniteTestResults'

--- a/src/pages/RepoPage/FailedTestsTab/hooks/useInfiniteTestResults.spec.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/hooks/useInfiniteTestResults.spec.tsx
@@ -1,0 +1,283 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { renderHook, waitFor } from '@testing-library/react'
+import { graphql } from 'msw'
+import { setupServer } from 'msw/node'
+
+import { useInfiniteTestResults } from './useInfiniteTestResults'
+
+const mockTestResults = {
+  owner: {
+    repository: {
+      __typename: 'Repository',
+      testResults: {
+        edges: [
+          {
+            node: {
+              updatedAt: '2023-01-01T00:00:00Z',
+              name: 'test-1',
+              commitsFailed: 1,
+              failureRate: 0.1,
+              avgDuration: 10,
+            },
+          },
+          {
+            node: {
+              updatedAt: '2023-01-02T00:00:00Z',
+              name: 'test-2',
+              commitsFailed: 2,
+              failureRate: 0.2,
+              avgDuration: 20,
+            },
+          },
+        ],
+        pageInfo: {
+          endCursor: 'cursor-2',
+          hasNextPage: true,
+        },
+      },
+    },
+  },
+}
+
+const mockNotFoundError = {
+  owner: {
+    repository: {
+      __typename: 'NotFoundError',
+      message: 'Repository not found',
+    },
+  },
+}
+
+const mockOwnerNotActivatedError = {
+  owner: {
+    repository: {
+      __typename: 'OwnerNotActivatedError',
+      message: 'Owner not activated',
+    },
+  },
+}
+
+const mockNullOwner = {
+  owner: null,
+}
+
+const mockUnsuccessfulParseError = {}
+
+const queryClient = new QueryClient({
+  defaultOptions: { queries: { retry: false } },
+})
+const server = setupServer()
+
+const wrapper: React.FC<React.PropsWithChildren> = ({ children }) => (
+  <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+)
+
+beforeAll(() => {
+  server.listen()
+})
+afterEach(() => {
+  queryClient.clear()
+  server.resetHandlers()
+})
+afterAll(() => {
+  server.close()
+})
+
+interface SetupArgs {
+  isNotFoundError?: boolean
+  isOwnerNotActivatedError?: boolean
+  isUnsuccessfulParseError?: boolean
+  isNullOwner?: boolean
+}
+
+describe('useInfiniteTestResults', () => {
+  function setup({
+    isNotFoundError = false,
+    isOwnerNotActivatedError = false,
+    isUnsuccessfulParseError = false,
+    isNullOwner = false,
+  }: SetupArgs) {
+    server.use(
+      graphql.query('GetTestResults', (req, res, ctx) => {
+        if (isNotFoundError) {
+          return res(ctx.status(200), ctx.data(mockNotFoundError))
+        } else if (isOwnerNotActivatedError) {
+          return res(ctx.status(200), ctx.data(mockOwnerNotActivatedError))
+        } else if (isUnsuccessfulParseError) {
+          return res(ctx.status(200), ctx.data(mockUnsuccessfulParseError))
+        } else if (isNullOwner) {
+          return res(ctx.status(200), ctx.data(mockNullOwner))
+        } else {
+          return res(ctx.status(200), ctx.data(mockTestResults))
+        }
+      })
+    )
+  }
+
+  describe('calling hook', () => {
+    describe('returns repository typename of Repository', () => {
+      describe('there is valid data', () => {
+        it('fetches the test results data', async () => {
+          setup({})
+          const { result } = renderHook(
+            () =>
+              useInfiniteTestResults({
+                provider: 'gh',
+                owner: 'codecov',
+                repo: 'cool-repo',
+                filters: { branch: 'main' },
+              }),
+            { wrapper }
+          )
+
+          await waitFor(() =>
+            expect(result.current.data.testResults).toStrictEqual([
+              {
+                updatedAt: '2023-01-01T00:00:00Z',
+                name: 'test-1',
+                commitsFailed: 1,
+                failureRate: 0.1,
+                avgDuration: 10,
+              },
+              {
+                updatedAt: '2023-01-02T00:00:00Z',
+                name: 'test-2',
+                commitsFailed: 2,
+                failureRate: 0.2,
+                avgDuration: 20,
+              },
+            ])
+          )
+        })
+      })
+
+      describe('there is a null owner', () => {
+        it('returns an empty array', async () => {
+          setup({ isNullOwner: true })
+          const { result } = renderHook(
+            () =>
+              useInfiniteTestResults({
+                provider: 'gh',
+                owner: 'codecov',
+                repo: 'cool-repo',
+                filters: { branch: 'main' },
+              }),
+            { wrapper }
+          )
+
+          await waitFor(() =>
+            expect(result.current.data.testResults).toStrictEqual([])
+          )
+        })
+      })
+    })
+
+    describe('returns NotFoundError __typename', () => {
+      let oldConsoleError = console.error
+
+      beforeEach(() => {
+        console.error = () => null
+      })
+
+      afterEach(() => {
+        console.error = oldConsoleError
+      })
+
+      it('throws a 404', async () => {
+        setup({ isNotFoundError: true })
+        const { result } = renderHook(
+          () =>
+            useInfiniteTestResults({
+              provider: 'gh',
+              owner: 'codecov',
+              repo: 'cool-repo',
+              filters: { branch: 'main' },
+            }),
+          { wrapper }
+        )
+
+        await waitFor(() => expect(result.current.isError).toBeTruthy())
+        await waitFor(() =>
+          expect(result.current.error).toEqual(
+            expect.objectContaining({
+              status: 404,
+              dev: 'useInfiniteTestResults - 404 Not found error',
+            })
+          )
+        )
+      })
+    })
+
+    describe('returns OwnerNotActivatedError __typename', () => {
+      let oldConsoleError = console.error
+
+      beforeEach(() => {
+        console.error = () => null
+      })
+
+      afterEach(() => {
+        console.error = oldConsoleError
+      })
+
+      it('throws a 403', async () => {
+        setup({ isOwnerNotActivatedError: true })
+        const { result } = renderHook(
+          () =>
+            useInfiniteTestResults({
+              provider: 'gh',
+              owner: 'codecov',
+              repo: 'cool-repo',
+              filters: { branch: 'main' },
+            }),
+          { wrapper }
+        )
+
+        await waitFor(() => expect(result.current.isError).toBeTruthy())
+        await waitFor(() =>
+          expect(result.current.error).toEqual(
+            expect.objectContaining({
+              status: 403,
+              dev: 'useInfiniteTestResults - 403 Owner not activated',
+            })
+          )
+        )
+      })
+    })
+
+    describe('unsuccessful parse of zod schema', () => {
+      let oldConsoleError = console.error
+
+      beforeEach(() => {
+        console.error = () => null
+      })
+
+      afterEach(() => {
+        console.error = oldConsoleError
+      })
+
+      it('throws a 404', async () => {
+        setup({ isUnsuccessfulParseError: true })
+        const { result } = renderHook(
+          () =>
+            useInfiniteTestResults({
+              provider: 'gh',
+              owner: 'codecov',
+              repo: 'cool-repo',
+              filters: { branch: 'main' },
+            }),
+          { wrapper }
+        )
+
+        await waitFor(() => expect(result.current.isError).toBeTruthy())
+        await waitFor(() =>
+          expect(result.current.error).toEqual(
+            expect.objectContaining({
+              status: 404,
+              dev: 'useInfiniteTestResults - 404 Failed to parse data',
+            })
+          )
+        )
+      })
+    })
+  })
+})

--- a/src/pages/RepoPage/FailedTestsTab/hooks/useInfiniteTestResults.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/hooks/useInfiniteTestResults.tsx
@@ -10,6 +10,7 @@ import {
 } from 'services/repo'
 import Api from 'shared/api'
 import { type NetworkErrorObject } from 'shared/api/helpers'
+import { mapEdges } from 'shared/utils/graphql'
 import A from 'ui/A'
 
 const TestResultSchema = z.object({
@@ -61,7 +62,13 @@ query GetTestResults(
     repository: repository(name: $repo) {
       __typename
       ... on Repository {
-        testResults(filters: $filters, first: $first, after: $after, last: $last, before: $before) {
+        testResults(
+          filters: $filters
+          first: $first
+          after: $after
+          last: $last
+          before: $before
+        ) {
           edges {
             node {
               updatedAt
@@ -85,7 +92,8 @@ query GetTestResults(
       }
     }
   }
-}`
+}
+`
 
 interface UseTestResultsArgs {
   provider: string
@@ -181,10 +189,9 @@ export const useInfiniteTestResults = ({
         }
 
         return {
-          testResults:
-            data?.owner?.repository?.testResults?.edges?.map(
-              (edge) => edge.node
-            ) ?? [],
+          testResults: mapEdges(data?.owner?.repository?.testResults).filter(
+            (item): item is TestResult => item !== null
+          ),
           pageInfo: data?.owner?.repository?.testResults?.pageInfo ?? {
             hasNextPage: false,
             endCursor: null,

--- a/src/pages/RepoPage/FailedTestsTab/hooks/useInfiniteTestResults.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/hooks/useInfiniteTestResults.tsx
@@ -109,7 +109,7 @@ export const useInfiniteTestResults = ({
   owner,
   repo,
   filters,
-  first = 4,
+  first = 20,
   after,
   last,
   before,

--- a/src/pages/RepoPage/FailedTestsTab/hooks/useInfiniteTestResults.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/hooks/useInfiniteTestResults.tsx
@@ -1,0 +1,208 @@
+import {
+  useInfiniteQuery,
+  type UseInfiniteQueryOptions,
+} from '@tanstack/react-query'
+import { z } from 'zod'
+
+import {
+  RepoNotFoundErrorSchema,
+  RepoOwnerNotActivatedErrorSchema,
+} from 'services/repo'
+import Api from 'shared/api'
+import { type NetworkErrorObject } from 'shared/api/helpers'
+import A from 'ui/A'
+
+const TestResultSchema = z.object({
+  updatedAt: z.string(),
+  name: z.string(),
+  commitsFailed: z.number().nullable(),
+  failureRate: z.number().nullable(),
+  avgDuration: z.number().nullable(),
+})
+
+type TestResult = z.infer<typeof TestResultSchema>
+
+const GetTestResultsSchema = z.object({
+  owner: z
+    .object({
+      repository: z.discriminatedUnion('__typename', [
+        z.object({
+          __typename: z.literal('Repository'),
+          testResults: z.object({
+            edges: z.array(
+              z.object({
+                node: TestResultSchema,
+              })
+            ),
+            pageInfo: z.object({
+              endCursor: z.string().nullable(),
+              hasNextPage: z.boolean(),
+            }),
+          }),
+        }),
+        RepoNotFoundErrorSchema,
+        RepoOwnerNotActivatedErrorSchema,
+      ]),
+    })
+    .nullable(),
+})
+
+const query = `
+query GetTestResults(
+  $owner: String!
+  $repo: String!
+  $filters: TestResultsFilters
+  $first: Int
+  $after: String
+  $last: Int
+  $before: String
+) {
+  owner(username: $owner) {
+    repository: repository(name: $repo) {
+      __typename
+      ... on Repository {
+        testResults(filters: $filters, first: $first, after: $after, last: $last, before: $before) {
+          edges {
+            node {
+              updatedAt
+              avgDuration
+              name
+              failureRate
+              commitsFailed
+            }
+          }
+          pageInfo {
+            endCursor
+            hasNextPage
+          }
+        }
+      }
+      ... on NotFoundError {
+        message
+      }
+      ... on OwnerNotActivatedError {
+        message
+      }
+    }
+  }
+}`
+
+interface UseTestResultsArgs {
+  provider: string
+  owner: string
+  repo: string
+  filters?: {
+    branch?: string
+  }
+  first?: number
+  after?: string
+  last?: number
+  before?: string
+  opts?: UseInfiniteQueryOptions<{
+    testResults: TestResult[]
+    pageInfo: { endCursor: string | null; hasNextPage: boolean }
+  }>
+}
+
+export const useInfiniteTestResults = ({
+  provider,
+  owner,
+  repo,
+  filters,
+  first = 4,
+  after,
+  last,
+  before,
+  opts = {},
+}: UseTestResultsArgs) => {
+  const { data, ...rest } = useInfiniteQuery({
+    queryKey: [
+      'GetTestResults',
+      provider,
+      owner,
+      repo,
+      filters,
+      first,
+      after,
+      last,
+      before,
+    ],
+    queryFn: ({ pageParam = after, signal }) =>
+      Api.graphql({
+        provider,
+        query,
+        signal,
+        variables: {
+          provider,
+          owner,
+          repo,
+          filters,
+          first,
+          after: pageParam,
+          last,
+          before,
+        },
+      }).then((res) => {
+        const parsedData = GetTestResultsSchema.safeParse(res?.data)
+
+        if (!parsedData.success) {
+          return Promise.reject({
+            status: 404,
+            data: {},
+            dev: 'useInfiniteTestResults - 404 Failed to parse data',
+          } satisfies NetworkErrorObject)
+        }
+
+        const data = parsedData.data
+
+        if (data?.owner?.repository?.__typename === 'NotFoundError') {
+          return Promise.reject({
+            status: 404,
+            data: {},
+            dev: 'useInfiniteTestResults - 404 Not found error',
+          } satisfies NetworkErrorObject)
+        }
+
+        if (data?.owner?.repository?.__typename === 'OwnerNotActivatedError') {
+          return Promise.reject({
+            status: 403,
+            data: {
+              detail: (
+                <p>
+                  Activation is required to view this repo, please{' '}
+                  {/* @ts-expect-error */}
+                  <A to={{ pageName: 'membersTab' }}>click here </A> to activate
+                  your account.
+                </p>
+              ),
+            },
+            dev: 'useInfiniteTestResults - 403 Owner not activated',
+          } satisfies NetworkErrorObject)
+        }
+
+        return {
+          testResults:
+            data?.owner?.repository?.testResults?.edges?.map(
+              (edge) => edge.node
+            ) ?? [],
+          pageInfo: data?.owner?.repository?.testResults?.pageInfo ?? {
+            hasNextPage: false,
+            endCursor: null,
+          },
+        }
+      }),
+    getNextPageParam: (lastPage) => {
+      return lastPage.pageInfo?.hasNextPage
+        ? lastPage.pageInfo.endCursor
+        : undefined
+    },
+    ...opts,
+  })
+
+  return {
+    data: {
+      testResults: data?.pages?.flatMap((page) => page.testResults) ?? [],
+    },
+    ...rest,
+  }
+}


### PR DESCRIPTION
# Description
Create hook for test results new table

closes: https://github.com/codecov/engineering-team/issues/2071

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.