### PR TITLE
fix: show team plan on upgrade plan page when click team upgrade and has sentryId

### DIFF
--- a/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/PlanTypeOptions/PlanTypeOptions.spec.tsx
+++ b/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/PlanTypeOptions/PlanTypeOptions.spec.tsx
@@ -265,6 +265,40 @@ describe('PlanTypeOptions', () => {
         expect(teamBtn).not.toHaveClass('bg-ds-primary-base')
       })
 
+      describe('plan param is set to team', () => {
+        it('renders Team button as "selected"', async () => {
+          const { mockSetFormValue, mockSetSelectedPlan, planValue } = setup({
+            planValue: Plans.USERS_BASIC,
+            hasSentryPlans: false,
+            hasTeamPlans: true,
+          })
+
+          render(
+            <PlanTypeOptions
+              multipleTiers={true}
+              setFormValue={mockSetFormValue}
+              setSelectedPlan={mockSetSelectedPlan}
+              newPlan={planValue}
+            />,
+            {
+              wrapper: wrapper('/gh/codecov?plan=team'),
+            }
+          )
+
+          const proBtn = await screen.findByRole('button', {
+            name: 'Pro',
+          })
+          expect(proBtn).toBeInTheDocument()
+          expect(proBtn).not.toHaveClass('bg-ds-primary-base')
+
+          const teamBtn = await screen.findByRole('button', {
+            name: 'Team',
+          })
+          expect(teamBtn).toBeInTheDocument()
+          expect(teamBtn).toHaveClass('bg-ds-primary-base')
+        })
+      })
+
       describe('user clicks Team button', () => {
         it('calls setValue and setSelectedPlan', async () => {
           const { user, mockSetFormValue, mockSetSelectedPlan, planValue } =

--- a/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/PlanTypeOptions/PlanTypeOptions.tsx
+++ b/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/PlanTypeOptions/PlanTypeOptions.tsx
@@ -6,6 +6,7 @@ import {
   useAccountDetails,
   useAvailablePlans,
 } from 'services/account'
+import { TierNames } from 'services/tier'
 import {
   canApplySentryUpgrade,
   findProPlans,
@@ -19,6 +20,7 @@ import { TEAM_PLAN_MAX_ACTIVE_USERS } from 'shared/utils/upgradeForm'
 import OptionButton from 'ui/OptionButton'
 
 import { TierName } from '../constants'
+import { usePlanParams } from '../hooks/usePlanParams'
 import { UpgradeFormFields } from '../UpgradeForm'
 
 interface PlanTypeOptionsProps {
@@ -38,6 +40,7 @@ const PlanTypeOptions: React.FC<PlanTypeOptionsProps> = ({
   const { data: plans } = useAvailablePlans({ provider, owner })
   const { data: accountDetails } = useAccountDetails({ provider, owner })
   const { proPlanYear, proPlanMonth } = findProPlans({ plans })
+  const planParam = usePlanParams()
 
   const { sentryPlanYear, sentryPlanMonth } = findSentryPlans({ plans })
   const { teamPlanYear, teamPlanMonth } = findTeamPlans({
@@ -53,7 +56,10 @@ const PlanTypeOptions: React.FC<PlanTypeOptionsProps> = ({
 
   const currentFormValue = newPlan
   let planOption = null
-  if (isTeamPlan(currentFormValue)) {
+  if (
+    (hasTeamPlans && planParam === TierNames.TEAM) ||
+    isTeamPlan(currentFormValue)
+  ) {
     planOption = TierName.TEAM
   } else {
     planOption = TierName.PRO

--- a/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/UpdateBlurb/UpdateBlurb.tsx
+++ b/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/UpdateBlurb/UpdateBlurb.tsx
@@ -21,7 +21,7 @@ const UpdateBlurb = ({
   const currentIsFree = isFreePlan(currentPlan?.value)
   const currentIsTeam = isTeamPlan(currentPlan?.value)
   const selectedIsTeam = isTeamPlan(selectedPlan?.value)
-  const diffPlanType = currentIsTeam !== selectedIsTeam
+  const diffPlanType = currentIsFree || currentIsTeam !== selectedIsTeam
 
   const currentIsAnnual = isAnnualPlan(currentPlan?.value)
   const selectedIsAnnual = isAnnualPlan(newPlanName)


### PR DESCRIPTION
# Description

Slight regression from https://github.com/codecov/gazebo/pull/2739, no longer pulling the query param if exists when user has a sentryId and clicks upgrade plan from developer (free) plan state

This only affected users who had a sentry account linked

Also fixed a small issue where user was on Free plan -> Pro plan and the bullet point showing `You are changing from the Developer plan to the [Pro plan]`

Closes https://github.com/codecov/engineering-team/issues/2051

# Code Example

# Notable Changes

# Screenshots


https://github.com/user-attachments/assets/2f6ebdf3-f181-42a8-9fe6-5a710e9083fb



# Link to Sample Entry

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.