### PR TITLE
feat: Add testResultsCount to useTestResults

### DIFF
--- a/src/pages/RepoPage/FailedTestsTab/hooks/useInfiniteTestResults.spec.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/hooks/useInfiniteTestResults.spec.tsx
@@ -35,6 +35,7 @@ const mockTestResults = {
           hasNextPage: true,
         },
       },
+      testResultsCount: 2,
     },
   },
 }

--- a/src/pages/RepoPage/FailedTestsTab/hooks/useInfiniteTestResults.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/hooks/useInfiniteTestResults.tsx
@@ -40,6 +40,7 @@ const GetTestResultsSchema = z.object({
               hasNextPage: z.boolean(),
             }),
           }),
+          testResultsCount: z.number(),
         }),
         RepoNotFoundErrorSchema,
         RepoOwnerNotActivatedErrorSchema,
@@ -83,6 +84,7 @@ query GetTestResults(
             hasNextPage
           }
         }
+        testResultsCount
       }
       ... on NotFoundError {
         message


### PR DESCRIPTION
# Description
Needed for test results UI. 

- [ ] Need to https://github.com/codecov/codecov-api/pull/703 merge first 

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.