### PR TITLE
feat: Add delinquent alert when user has due payment

### DIFF
--- a/src/mocks/handlers.js
+++ b/src/mocks/handlers.js
@@ -1,6 +1,5 @@
 import { graphql } from 'msw'
 
-import { randomAccountDetailsHandler } from 'services/account/mocks'
 import { repoCoverageHandler } from 'services/charts/mocks'
 import { commitErrored } from 'services/commit/mocks'
 import {
@@ -12,7 +11,6 @@ import { randomUsersHandler } from 'services/users/mocks'
 
 export const handlers = [
   repoCoverageHandler,
-  randomAccountDetailsHandler,
   randomUsersHandler,
   commitErrored,
   flagsSelectHandler,

--- a/src/pages/PlanPage/subRoutes/CurrentOrgPlan/CurrentOrgPlan.spec.tsx
+++ b/src/pages/PlanPage/subRoutes/CurrentOrgPlan/CurrentOrgPlan.spec.tsx
@@ -269,4 +269,25 @@ describe('CurrentOrgPlan', () => {
       expect(screen.queryByText(/BillingDetails/i)).not.toBeInTheDocument()
     })
   })
+
+  describe('when user is a delinquent', () => {
+    it('renders the delinquent banner', () => {
+      setup({
+        accountDetails: {
+          ...mockedAccountDetails,
+          delinquent: true,
+        } as z.infer<typeof AccountDetailsSchema>,
+      })
+
+      render(<CurrentOrgPlan />, { wrapper })
+      expect(
+        screen.getByText('Your most recent payment failed')
+      ).toBeInTheDocument()
+      expect(
+        screen.getByText(
+          'Please try a different card or contact support at support@codecov.io'
+        )
+      ).toBeInTheDocument()
+    })
+  })
 })

--- a/src/pages/PlanPage/subRoutes/CurrentOrgPlan/CurrentOrgPlan.spec.tsx
+++ b/src/pages/PlanPage/subRoutes/CurrentOrgPlan/CurrentOrgPlan.spec.tsx
@@ -285,7 +285,7 @@ describe('CurrentOrgPlan', () => {
       ).toBeInTheDocument()
       expect(
         screen.getByText(
-          'Please try a different card or contact support at support@codecov.io'
+          'Please try a different card or contact support at support@codecov.io.'
         )
       ).toBeInTheDocument()
     })

--- a/src/pages/PlanPage/subRoutes/CurrentOrgPlan/CurrentOrgPlan.tsx
+++ b/src/pages/PlanPage/subRoutes/CurrentOrgPlan/CurrentOrgPlan.tsx
@@ -24,6 +24,7 @@ function CurrentOrgPlan() {
   })
 
   const scheduledPhase = accountDetails?.scheduleDetail?.scheduledPhase
+  const isDelinquent = accountDetails?.delinquent
   const scheduleStart = scheduledPhase
     ? getScheduleStart(scheduledPhase)
     : undefined
@@ -43,6 +44,7 @@ function CurrentOrgPlan() {
         />
       ) : null}
       <InfoMessageStripeCallback />
+      {isDelinquent ? <DelinquentAlert /> : null}
       {accountDetails?.plan ? (
         <div className="flex flex-col gap-4 sm:mr-4 sm:flex-initial md:w-2/3 lg:w-3/4">
           {planUpdatedNotification.alertOption ? (
@@ -72,6 +74,20 @@ function CurrentOrgPlan() {
         </div>
       ) : null}
     </div>
+  )
+}
+
+const DelinquentAlert = () => {
+  return (
+    <>
+      <Alert variant={'error'}>
+        <Alert.Title>Your most recent payment failed</Alert.Title>
+        <Alert.Description>
+          Please try a different card or contact support at support@codecov.io
+        </Alert.Description>
+      </Alert>
+      <br />
+    </>
   )
 }
 

--- a/src/pages/PlanPage/subRoutes/CurrentOrgPlan/CurrentOrgPlan.tsx
+++ b/src/pages/PlanPage/subRoutes/CurrentOrgPlan/CurrentOrgPlan.tsx
@@ -83,7 +83,7 @@ const DelinquentAlert = () => {
       <Alert variant={'error'}>
         <Alert.Title>Your most recent payment failed</Alert.Title>
         <Alert.Description>
-          Please try a different card or contact support at support@codecov.io
+          Please try a different card or contact support at support@codecov.io.
         </Alert.Description>
       </Alert>
       <br />

--- a/src/services/account/mocks.ts
+++ b/src/services/account/mocks.ts
@@ -154,6 +154,7 @@ export const accountDetailsObject = {
   student_count: 1,
   uses_invoice: true,
   schedule_detail: null,
+  delinquent: null,
 }
 
 export const accountDetailsParsedObj = {
@@ -267,4 +268,5 @@ export const accountDetailsParsedObj = {
   studentCount: 1,
   usesInvoice: true,
   scheduleDetail: null,
+  delinquent: null,
 }

--- a/src/services/account/mocks.ts
+++ b/src/services/account/mocks.ts
@@ -1,15 +1,4 @@
 /* eslint-disable camelcase */
-import { rest } from 'msw'
-
-const accountDetailsUri = '/internal/:provider/:owner/account-details/'
-
-export const randomAccountDetailsHandler = rest.get(
-  accountDetailsUri,
-  (req, res, ctx) => {
-    return res(ctx.status(200), ctx.json(accountDetailsObject))
-  }
-)
-
 export const invoiceObject = {
   amountDue: 1407.0,
   amountPaid: 1407.0,

--- a/src/services/account/useAccountDetails.ts
+++ b/src/services/account/useAccountDetails.ts
@@ -129,6 +129,7 @@ export const AccountDetailsSchema = z.object({
   activatedStudentCount: z.number(),
   activatedUserCount: z.number(),
   checkoutSessionId: z.string().nullable(),
+  delinquent: z.boolean().nullable(),
   email: z.string().nullable(),
   inactiveUserCount: z.number(),
   integrationId: z.number().nullable(),


### PR DESCRIPTION
# Description

This PR aims to add the delinquent alert banner when the user has a payment due. We pull the user's delinquent status off the account-details endpoint, and if true, render the banner

I decided to just create a simple ad-hoc component within the CurrentOrgPlan component since it was just a tiny banner; we may need to pull these alert banners out into a separate component at some point though. _maybe_

Also adds a small UT

Depends on https://github.com/codecov/codecov-api/pull/706

Closes https://github.com/codecov/engineering-team/issues/1814

# Screenshots

![Screenshot 2024-07-23 at 3 12 30 PM](https://github.com/user-attachments/assets/99006545-e7fe-4b1d-afd0-0bbc16bb406f)


# Link to Sample Entry

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.