### PR TITLE
fix: make readonly yaml editor appear less editable

### DIFF
--- a/src/pages/AccountSettings/tabs/YAML/YamlEditor/YamlEditor.tsx
+++ b/src/pages/AccountSettings/tabs/YAML/YamlEditor/YamlEditor.tsx
@@ -1,4 +1,3 @@
-import PropTypes from 'prop-types'
 import { forwardRef } from 'react'
 import AceEditor from 'react-ace'
 
@@ -6,7 +5,7 @@ import 'ace-builds/src-noconflict/theme-github'
 import 'ace-builds/src-noconflict/mode-yaml'
 import './codecov-theme.css'
 
-const YamlEditor = forwardRef(({ ...props }, ref) => {
+const YamlEditor = forwardRef<AceEditor>(({ ...props }, ref) => {
   return (
     <AceEditor
       ref={ref}
@@ -24,9 +23,5 @@ const YamlEditor = forwardRef(({ ...props }, ref) => {
 })
 
 YamlEditor.displayName = 'YamlEditor'
-
-YamlEditor.propTypes = {
-  value: PropTypes.string,
-}
 
 export default YamlEditor

--- a/src/pages/AccountSettings/tabs/YAML/YamlEditor/codecov-theme.css
+++ b/src/pages/AccountSettings/tabs/YAML/YamlEditor/codecov-theme.css
@@ -33,3 +33,8 @@
 .ace_scroller[style] {
   left: 4rem !important;
 }
+
+/* this is to better indicate that the user cannot edit and is read-only */
+.useReadOnlyCursor .ace_cursor {
+  opacity: 0.2;
+}

--- a/src/pages/RepoPage/SettingsTab/tabs/YamlTab/YAML/YAML.jsx
+++ b/src/pages/RepoPage/SettingsTab/tabs/YamlTab/YAML/YAML.jsx
@@ -14,7 +14,13 @@ function YAML({ yaml }) {
         </p>
       </div>
       <hr />
-      <YamlEditor value={yaml} readOnly placeholder="Repo YAML Configuration" />
+      {/* eslint-disable-next-line tailwindcss/no-custom-classname */}
+      <YamlEditor
+        className="useReadOnlyCursor"
+        value={yaml}
+        readOnly
+        placeholder="Repo YAML Configuration"
+      />
     </div>
   )
 }


### PR DESCRIPTION
# Description

Closes https://github.com/codecov/engineering-team/issues/1851

Changing the focus color of the cursor to be the same as its unfocused version when the editor is read-only

# Code Example

# Notable Changes

# Screenshots

Read-only version:
<img width="614" alt="Screenshot 2024-07-24 at 3 54 53 PM" src="https://github.com/user-attachments/assets/f7464d5a-e9dc-43cb-ada2-06ac0318327d">

Editable version:
<img width="1266" alt="Screenshot 2024-07-24 at 3 54 17 PM" src="https://github.com/user-attachments/assets/fc8bd1c6-6811-4510-ae7e-d3bdb60ae667">


# Link to Sample Entry

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.