### PR TITLE
feat: Implement useRepoConfigurationStatus

### DIFF
--- a/src/pages/RepoPage/SettingsTab/tabs/ConfigurationManager/hooks/useRepoConfigurationStatus/useRepoConfigurationStatus.spec.tsx
+++ b/src/pages/RepoPage/SettingsTab/tabs/ConfigurationManager/hooks/useRepoConfigurationStatus/useRepoConfigurationStatus.spec.tsx
@@ -1,0 +1,190 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { renderHook, waitFor } from '@testing-library/react'
+import { graphql } from 'msw'
+import { setupServer } from 'msw/node'
+
+import { useRepoConfigurationStatus } from './useRepoConfigurationStatus'
+
+const mockRepoNotFound = {
+  owner: {
+    plan: null,
+    repository: {
+      __typename: 'NotFoundError',
+      message: 'not found error',
+    },
+  },
+}
+
+const mockOwnerNotActivated = {
+  owner: {
+    plan: null,
+    repository: {
+      __typename: 'OwnerNotActivatedError',
+      message: 'owner not activated error',
+    },
+  },
+}
+
+const mockGoodResponse = {
+  owner: {
+    plan: null,
+    repository: {
+      __typename: 'Repository',
+      flagsCount: 2,
+      componentsCount: 3,
+      coverageEnabled: true,
+      bundleAnalysisEnabled: true,
+      testAnalyticsEnabled: true,
+      yaml: 'yaml',
+    },
+  },
+}
+
+const queryClient = new QueryClient({
+  defaultOptions: { queries: { retry: false } },
+})
+const server = setupServer()
+
+const wrapper: React.FC<React.PropsWithChildren> = ({ children }) => (
+  <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+)
+
+beforeAll(() => {
+  server.listen()
+})
+afterEach(() => {
+  queryClient.clear()
+  server.resetHandlers()
+})
+afterAll(() => {
+  server.close()
+})
+
+interface SetupArgs {
+  badResponse?: boolean
+  repoNotFound?: boolean
+  ownerNotActivated?: boolean
+}
+
+describe('useRepoConfigurationStatus', () => {
+  function setup({
+    badResponse = false,
+    repoNotFound = false,
+    ownerNotActivated = false,
+  }: SetupArgs) {
+    server.use(
+      graphql.query('GetRepoConfigurationStatus', (req, res, ctx) => {
+        if (badResponse) {
+          return res(ctx.status(200), ctx.data({}))
+        } else if (repoNotFound) {
+          return res(ctx.status(200), ctx.data(mockRepoNotFound))
+        } else if (ownerNotActivated) {
+          return res(ctx.status(200), ctx.data(mockOwnerNotActivated))
+        }
+        return res(ctx.status(200), ctx.data(mockGoodResponse))
+      })
+    )
+  }
+
+  it('returns 404 on bad response', async () => {
+    setup({ badResponse: true })
+    console.error = () => {}
+    const { result } = renderHook(
+      () =>
+        useRepoConfigurationStatus({
+          provider: 'gh',
+          owner: 'codecov',
+          repo: 'cool-repo',
+        }),
+      { wrapper }
+    )
+
+    await waitFor(() => expect(result.current.status).toBe('error'))
+
+    await waitFor(() =>
+      expect(result.current.failureReason).toMatchObject({
+        status: 404,
+        data: {},
+        dev: 'useRepoConfigurationStatus - 404 Failed to parse data',
+      })
+    )
+  })
+
+  it('returns 404 on repo not found', async () => {
+    setup({ repoNotFound: true })
+    console.error = () => {}
+    const { result } = renderHook(
+      () =>
+        useRepoConfigurationStatus({
+          provider: 'gh',
+          owner: 'codecov',
+          repo: 'cool-repo',
+        }),
+      { wrapper }
+    )
+
+    await waitFor(() => expect(result.current.status).toBe('error'))
+
+    await waitFor(() =>
+      expect(result.current.failureReason).toMatchObject({
+        status: 404,
+        data: {},
+        dev: 'useRepoConfigurationStatus - 404 Not found error',
+      })
+    )
+  })
+
+  it('returns 403 on owner not activated', async () => {
+    setup({ ownerNotActivated: true })
+    console.error = () => {}
+    const { result } = renderHook(
+      () =>
+        useRepoConfigurationStatus({
+          provider: 'gh',
+          owner: 'codecov',
+          repo: 'cool-repo',
+        }),
+      { wrapper }
+    )
+
+    await waitFor(() => expect(result.current.status).toBe('error'))
+
+    await waitFor(() =>
+      expect(result.current.failureReason).toMatchObject({
+        status: 403,
+        data: {},
+        dev: 'useRepoConfigurationStatus - 403 Owner not activated error',
+      })
+    )
+  })
+
+  it('returns data on good response', async () => {
+    setup({})
+    const { result } = renderHook(
+      () =>
+        useRepoConfigurationStatus({
+          provider: 'gh',
+          owner: 'codecov',
+          repo: 'cool-repo',
+        }),
+      { wrapper }
+    )
+
+    await waitFor(() => expect(result.current.status).toBe('success'))
+
+    await waitFor(() =>
+      expect(result.current.data).toMatchObject({
+        plan: null,
+        repository: {
+          __typename: 'Repository',
+          flagsCount: 2,
+          componentsCount: 3,
+          coverageEnabled: true,
+          bundleAnalysisEnabled: true,
+          testAnalyticsEnabled: true,
+          yaml: 'yaml',
+        },
+      })
+    )
+  })
+})

--- a/src/pages/RepoPage/SettingsTab/tabs/ConfigurationManager/hooks/useRepoConfigurationStatus/useRepoConfigurationStatus.tsx
+++ b/src/pages/RepoPage/SettingsTab/tabs/ConfigurationManager/hooks/useRepoConfigurationStatus/useRepoConfigurationStatus.tsx
@@ -1,0 +1,142 @@
+import { useQuery } from '@tanstack/react-query'
+import { z } from 'zod'
+
+import {
+  RepoNotFoundErrorSchema,
+  RepoOwnerNotActivatedErrorSchema,
+} from 'services/repo'
+import { TierNames } from 'services/tier'
+import Api from 'shared/api/api'
+import { NetworkErrorObject } from 'shared/api/helpers'
+import A from 'ui/A'
+
+const RepositorySchema = z.object({
+  __typename: z.literal('Repository'),
+  flagsCount: z.number(),
+  componentsCount: z.number(),
+  coverageEnabled: z.boolean().nullable(),
+  bundleAnalysisEnabled: z.boolean().nullable(),
+  testAnalyticsEnabled: z.boolean().nullable(),
+  yaml: z.string().nullable(),
+})
+
+const PlanSchema = z
+  .object({
+    tierName: z.nativeEnum(TierNames),
+  })
+  .nullable()
+
+export type RepositoryConfiguration =
+  | {
+      plan?: z.infer<typeof PlanSchema> | null
+      repository?: z.infer<typeof RepositorySchema>
+    }
+  | null
+  | undefined
+
+const RequestSchema = z.object({
+  owner: z
+    .object({
+      plan: PlanSchema,
+      repository: z.discriminatedUnion('__typename', [
+        RepositorySchema,
+        RepoNotFoundErrorSchema,
+        RepoOwnerNotActivatedErrorSchema,
+      ]),
+    })
+    .nullable(),
+})
+
+const query = `query GetRepoConfigurationStatus($owner: String!, $repo: String!){
+  owner(username: $owner) {
+    plan {
+      tierName
+    }
+    repository(name:$repo) {
+      __typename
+      ... on Repository {
+        flagsCount
+        componentsCount
+        coverageEnabled
+        bundleAnalysisEnabled
+        testAnalyticsEnabled
+        yaml
+      }
+      ... on NotFoundError {
+        message
+      }
+      ... on OwnerNotActivatedError {
+        message
+      }
+    }
+  }
+}`
+
+interface UseRepoConfigurationStatusArgs {
+  provider: string
+  owner: string
+  repo: string
+}
+
+export function useRepoConfigurationStatus({
+  provider,
+  owner,
+  repo,
+}: UseRepoConfigurationStatusArgs) {
+  return useQuery({
+    queryKey: ['GetRepoConfigurationStatus', provider, owner, repo],
+    queryFn: ({ signal }) => {
+      return Api.graphql({
+        provider,
+        signal,
+        query,
+        variables: {
+          owner,
+          repo,
+        },
+      }).then((res) => {
+        const parsedRes = RequestSchema.safeParse(res?.data)
+
+        if (!parsedRes.success) {
+          return Promise.reject({
+            status: 404,
+            data: {},
+            dev: 'useRepoConfigurationStatus - 404 Failed to parse data',
+          } satisfies NetworkErrorObject)
+        }
+
+        const data = parsedRes.data
+
+        if (data?.owner?.repository?.__typename === 'NotFoundError') {
+          return Promise.reject({
+            status: 404,
+            data: {},
+            dev: 'useRepoConfigurationStatus - 404 Not found error',
+          } satisfies NetworkErrorObject)
+        }
+
+        if (data?.owner?.repository?.__typename === 'OwnerNotActivatedError') {
+          return Promise.reject({
+            status: 403,
+            data: {
+              detail: (
+                <p>
+                  Activation is required to view this repo, please{' '}
+                  {/* @ts-expect-error */}
+                  <A to={{ pageName: 'membersTab' }}>click here </A> to activate
+                  your account.
+                </p>
+              ),
+            },
+            dev: 'useRepoConfigurationStatus - 403 Owner not activated error',
+          } satisfies NetworkErrorObject)
+        }
+
+        return {
+          plan: data?.owner?.plan,
+          repository: data?.owner?.repository,
+        }
+      })
+    },
+  })
+}

--- a/src/pages/RepoPage/SettingsTab/tabs/ConfigurationManager/hooks/useRepoConfigurationStatus/useRepoConfigurationStatus.tsx
+++ b/src/pages/RepoPage/SettingsTab/tabs/ConfigurationManager/hooks/useRepoConfigurationStatus/useRepoConfigurationStatus.tsx
@@ -28,7 +28,7 @@ const PlanSchema = z
 
 export type RepositoryConfiguration =
   | {
-      plan?: z.infer<typeof PlanSchema> | null
+      plan?: z.infer<typeof PlanSchema>
       repository?: z.infer<typeof RepositorySchema>
     }
   | null
@@ -133,8 +133,8 @@ export function useRepoConfigurationStatus({
         }
 
         return {
-          plan: data?.owner?.plan,
-          repository: data?.owner?.repository,
+          plan: data?.owner?.plan ?? null,
+          repository: data?.owner?.repository ?? null,
         }
       })
     },


### PR DESCRIPTION
Implements useRepoConfigurationStatus, which is the data fetching hook for the new Configuration Manager settings page. No invocation exists yet as it will come in a future PR. Just hook implementation and unit tests here.

