### PR TITLE
dev: Remove yup and convert to zod

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,6 @@
     "semver": "7.5.2",
     "tailwind-merge": "^2.3.0",
     "victory": "^37.0.2",
-    "yup": "^0.32.11",
     "zod": "^3.21.4"
   },
   "devDependencies": {

--- a/src/pages/AccountSettings/tabs/Profile/NameEmailCard/NameEmailCard.jsx
+++ b/src/pages/AccountSettings/tabs/Profile/NameEmailCard/NameEmailCard.jsx
@@ -1,7 +1,7 @@
-import { yupResolver } from '@hookform/resolvers/yup'
+import { zodResolver } from '@hookform/resolvers/zod'
 import PropTypes from 'prop-types'
 import { useForm } from 'react-hook-form'
-import * as yup from 'yup'
+import { z } from 'zod'
 
 import Card from 'old_ui/Card'
 import { useAddNotification } from 'services/toastNotification'
@@ -10,19 +10,19 @@ import Button from 'ui/Button'
 import TextInput from 'ui/TextInput'
 
 function getSchema() {
-  return yup.object().shape({
-    name: yup.string().required('Name is required'),
-    email: yup
+  return z.object({
+    name: z.string().min(1, { message: 'Name is required' }),
+    email: z
       .string()
       .email('Not a valid email')
-      .required('Email is required'),
+      .min(1, { message: 'Email is required' }),
   })
 }
 
 function NameEmailCard({ currentUser, provider }) {
   const addToast = useAddNotification()
   const { register, handleSubmit, formState, reset } = useForm({
-    resolver: yupResolver(getSchema()),
+    resolver: zodResolver(getSchema()),
     defaultValues: {
       email: currentUser?.email,
       name: currentUser?.name,

--- a/src/pages/AccountSettings/tabs/Profile/NameEmailCard/NameEmailCard.spec.jsx
+++ b/src/pages/AccountSettings/tabs/Profile/NameEmailCard/NameEmailCard.spec.jsx
@@ -166,8 +166,8 @@ describe('NameEmailCard', () => {
       })
       await user.click(button)
 
-      const emailRequired = await screen.findByText('Email is required')
-      expect(emailRequired).toBeInTheDocument()
+      const notValidEmail = await screen.findByText('Not a valid email')
+      expect(notValidEmail).toBeInTheDocument()
     })
   })
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1739,7 +1739,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime@npm:^7.1.2, @babel/runtime@npm:^7.11.2, @babel/runtime@npm:^7.12.13, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.13.10, @babel/runtime@npm:^7.14.8, @babel/runtime@npm:^7.15.4, @babel/runtime@npm:^7.16.3, @babel/runtime@npm:^7.17.8, @babel/runtime@npm:^7.21.0, @babel/runtime@npm:^7.7.6, @babel/runtime@npm:^7.8.4, @babel/runtime@npm:^7.9.2":
+"@babel/runtime@npm:^7.1.2, @babel/runtime@npm:^7.11.2, @babel/runtime@npm:^7.12.13, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.13.10, @babel/runtime@npm:^7.14.8, @babel/runtime@npm:^7.16.3, @babel/runtime@npm:^7.17.8, @babel/runtime@npm:^7.21.0, @babel/runtime@npm:^7.7.6, @babel/runtime@npm:^7.8.4, @babel/runtime@npm:^7.9.2":
   version: 7.24.8
   resolution: "@babel/runtime@npm:7.24.8"
   dependencies:
@@ -6406,7 +6406,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/lodash@npm:4.17.6, @types/lodash@npm:^4.14.167, @types/lodash@npm:^4.14.175":
+"@types/lodash@npm:4.17.6, @types/lodash@npm:^4.14.167":
   version: 4.17.6
   resolution: "@types/lodash@npm:4.17.6"
   checksum: 10c0/3b197ac47af9443fee8c4719c5ffde527d7febc018b827d44a6bc2523c728c7adfdd25196fdcfe3eed827993e0c41a917d0da6e78938b18b2be94164789f1117
@@ -11819,7 +11819,6 @@ __metadata:
     victory: "npm:^37.0.2"
     webpack: "npm:^5.84.1"
     webpackbar: "npm:^6.0.1"
-    yup: "npm:^0.32.11"
     zod: "npm:^3.21.4"
   languageName: unknown
   linkType: soft
@@ -14579,13 +14578,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash-es@npm:^4.17.21":
-  version: 4.17.21
-  resolution: "lodash-es@npm:4.17.21"
-  checksum: 10c0/fb407355f7e6cd523a9383e76e6b455321f0f153a6c9625e21a8827d10c54c2a2341bd2ae8d034358b60e07325e1330c14c224ff582d04612a46a4f0479ff2f2
-  languageName: node
-  linkType: hard
-
 "lodash.camelcase@npm:^4.3.0":
   version: 4.3.0
   resolution: "lodash.camelcase@npm:4.3.0"
@@ -15846,13 +15838,6 @@ __metadata:
     react: "*"
     react-dom: "*"
   checksum: 10c0/7328c973852d2471bd154c61d21392a3d6357f276a7a090b8a179fb06d71ba58c987b04c0bd80efebd87aa4f433428a25e37820e65484b3c4c44b84339b99d87
-  languageName: node
-  linkType: hard
-
-"nanoclone@npm:^0.2.1":
-  version: 0.2.1
-  resolution: "nanoclone@npm:0.2.1"
-  checksum: 10c0/760b569ea841c9678fdf8d763c6d7bb093f0889150087f82d86c536a318b302939c82ce35cdaec999d0f687789d0d79d0f3f75a272d7a98dfac7a067c0b47053
   languageName: node
   linkType: hard
 
@@ -17766,13 +17751,6 @@ __metadata:
     object-assign: "npm:^4.1.1"
     react-is: "npm:^16.13.1"
   checksum: 10c0/59ece7ca2fb9838031d73a48d4becb9a7cc1ed10e610517c7d8f19a1e02fa47f7c27d557d8a5702bec3cfeccddc853579832b43f449e54635803f277b1c78077
-  languageName: node
-  linkType: hard
-
-"property-expr@npm:^2.0.4":
-  version: 2.0.6
-  resolution: "property-expr@npm:2.0.6"
-  checksum: 10c0/69b7da15038a1146d6447c69c445306f66a33c425271235bb20507f1846dbf9577a8f9dfafe8acbfcb66f924b270157f155248308f026a68758f35fc72265b3c
   languageName: node
   linkType: hard
 
@@ -20600,13 +20578,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"toposort@npm:^2.0.2":
-  version: 2.0.2
-  resolution: "toposort@npm:2.0.2"
-  checksum: 10c0/ab9ca91fce4b972ccae9e2f539d755bf799a0c7eb60da07fd985fce0f14c159ed1e92305ff55697693b5bc13e300f5417db90e2593b127d421c9f6c440950222
-  languageName: node
-  linkType: hard
-
 "tough-cookie@npm:^4.0.0":
   version: 4.1.4
   resolution: "tough-cookie@npm:4.1.4"
@@ -22858,21 +22829,6 @@ __metadata:
   version: 1.1.1
   resolution: "yocto-queue@npm:1.1.1"
   checksum: 10c0/cb287fe5e6acfa82690acb43c283de34e945c571a78a939774f6eaba7c285bacdf6c90fbc16ce530060863984c906d2b4c6ceb069c94d1e0a06d5f2b458e2a92
-  languageName: node
-  linkType: hard
-
-"yup@npm:^0.32.11":
-  version: 0.32.11
-  resolution: "yup@npm:0.32.11"
-  dependencies:
-    "@babel/runtime": "npm:^7.15.4"
-    "@types/lodash": "npm:^4.14.175"
-    lodash: "npm:^4.17.21"
-    lodash-es: "npm:^4.17.21"
-    nanoclone: "npm:^0.2.1"
-    property-expr: "npm:^2.0.4"
-    toposort: "npm:^2.0.2"
-  checksum: 10c0/f0802798dc64b49f313886b983a9bea5f283e2094ee2aa1197587b84f50ac5b5d03af99857c313139e63dc02558fac3aaa343503bdbffa96f70006b39d1f59c9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Description

Saw we were using a package called "yup," and was wondering what it was used for. Realized it's basically just zod, and that there was only one usage in the codebase

Looked simple enough to remove and we save 18KB from doing so!
- https://bundlephobia.com/package/yup@0.32.11 for ref
- **Edit:** Apparently bundle analysis is telling us 33KB, even better!

Closes https://github.com/codecov/engineering-team/issues/2153

# Screenshots

<img width="674" alt="Screenshot 2024-07-25 at 5 23 25 PM" src="https://github.com/user-attachments/assets/91a13731-4dce-46b4-9bcf-53b79dc01448">


# Link to Sample Entry

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.