### PR TITLE
Remove the "Subscription Update Failed" banner when there is no error

### DIFF
--- a/src/pages/PlanPage/subRoutes/CurrentOrgPlan/InfoMessageStripeCallback/InfoMessageStripeCallback.spec.tsx
+++ b/src/pages/PlanPage/subRoutes/CurrentOrgPlan/InfoMessageStripeCallback/InfoMessageStripeCallback.spec.tsx
@@ -31,16 +31,4 @@ describe('InfoMessageStripeCallback', () => {
       ).toBeInTheDocument()
     })
   })
-
-  describe('when rendering with cancel in the url', () => {
-    it('renders a cancel message', async () => {
-      render(<InfoMessageStripeCallback />, {
-        wrapper: wrapper('/account/gh/codecov?cancel'),
-      })
-
-      await expect(
-        screen.getByText(/Subscription Update Failed/)
-      ).toBeInTheDocument()
-    })
-  })
 })

--- a/src/pages/PlanPage/subRoutes/CurrentOrgPlan/InfoMessageStripeCallback/InfoMessageStripeCallback.tsx
+++ b/src/pages/PlanPage/subRoutes/CurrentOrgPlan/InfoMessageStripeCallback/InfoMessageStripeCallback.tsx
@@ -23,19 +23,6 @@ function InfoMessageStripeCallback() {
       </div>
     )
 
-  if ('cancel' in urlParams)
-    return (
-      <div className="col-start-1 col-end-13 mb-4">
-        <Message variant="error">
-          <h2 className="text-lg">Subscription Update Failed</h2>
-          <p className="text-sm">
-            Your subscription did not update. If you believe this to be an
-            error, please contact support@codecov.io.
-          </p>
-        </Message>
-      </div>
-    )
-
   return null
 }
 

--- a/src/pages/PlanPage/subRoutes/CurrentOrgPlan/InfoMessageStripeCallback/InfoMessageStripeCallback.tsx
+++ b/src/pages/PlanPage/subRoutes/CurrentOrgPlan/InfoMessageStripeCallback/InfoMessageStripeCallback.tsx
@@ -4,7 +4,7 @@ import { useLocation } from 'react-router-dom'
 import Message from 'old_ui/Message'
 
 // Stripe redirects to this page with ?success or ?cancel in the URL
-// this component takes care of rendering a message if those message are present
+// this component takes care of rendering a message if it is successful
 function InfoMessageStripeCallback() {
   const urlParams = qs.parse(useLocation().search, {
     ignoreQueryPrefix: true,


### PR DESCRIPTION
# Description

This closes https://github.com/codecov/engineering-team/issues/1795.

The error banner will no longer render when the user navigates back from the stripe checkout session. We have a `DelinquentAlert` in the parent component that handles any relevant messaging. 

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.