### PR TITLE
feat: Implement coverage group for configuration manager page

### DIFF
--- a/src/pages/RepoPage/SettingsTab/tabs/ConfigurationManager/ConfigurationManager.spec.tsx
+++ b/src/pages/RepoPage/SettingsTab/tabs/ConfigurationManager/ConfigurationManager.spec.tsx
@@ -1,12 +1,256 @@
-import { render, screen } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { render, screen, waitFor } from '@testing-library/react'
+import { graphql } from 'msw'
+import { setupServer } from 'msw/node'
+import { MemoryRouter, Route } from 'react-router'
+
+import { TierNames, TTierNames } from 'services/tier'
 
 import ConfigurationManager from './ConfigurationManager'
+import { RepositoryConfiguration } from './hooks/useRepoConfigurationStatus/useRepoConfigurationStatus'
+
+interface mockRepoConfigArgs {
+  tierName?: TTierNames
+  flags?: boolean
+  components?: boolean
+  coverage?: boolean
+  yaml?: string | null
+  bundleAnalysis?: boolean
+  testAnalytics?: boolean
+}
+
+const yamlWithProjectStatus = 'coverage:\n  status:\n    project: true\n'
+
+function mockRepoConfig({
+  tierName = TierNames.PRO,
+  flags = false,
+  components = false,
+  coverage = false,
+  yaml = null,
+  bundleAnalysis = false,
+  testAnalytics = false,
+}: mockRepoConfigArgs): RepositoryConfiguration {
+  return {
+    plan: {
+      tierName: tierName,
+    },
+    repository: {
+      __typename: 'Repository',
+      flagsCount: flags ? 1 : 0,
+      componentsCount: components ? 1 : 0,
+      coverageEnabled: coverage,
+      bundleAnalysisEnabled: bundleAnalysis,
+      testAnalyticsEnabled: testAnalytics,
+      yaml,
+    },
+  }
+}
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      retry: false,
+    },
+  },
+})
+const server = setupServer()
+const wrapper: React.FC<React.PropsWithChildren> = ({ children }) => (
+  <QueryClientProvider client={queryClient}>
+    <MemoryRouter initialEntries={['/gh/codecov/cool-repo/settings/config']}>
+      <Route path="/:provider/:owner/:repo/settings/config">{children}</Route>
+    </MemoryRouter>
+  </QueryClientProvider>
+)
+
+beforeAll(() => {
+  server.listen()
+})
+afterEach(() => {
+  queryClient.clear()
+  server.resetHandlers()
+})
+afterAll(() => {
+  server.close()
+})
+
+interface SetupArgs {
+  repoConfig?: RepositoryConfiguration
+}
 
 describe('Configuration Manager', () => {
-  it('temp: renders Configuration Manager', async () => {
-    render(<ConfigurationManager />)
+  function setup({ repoConfig = mockRepoConfig({}) }: SetupArgs) {
+    server.use(
+      graphql.query('GetRepoConfigurationStatus', (req, res, ctx) => {
+        return res(ctx.status(200), ctx.data({ owner: repoConfig }))
+      })
+    )
+  }
 
-    const text = await screen.findByText('Configuration Manager')
-    expect(text).toBeInTheDocument()
+  describe('CoverageConfiguration', () => {
+    it('renders feature block', async () => {
+      setup({})
+      render(<ConfigurationManager />, { wrapper })
+
+      const heading = await screen.findByRole('heading', { name: 'Coverage' })
+      expect(heading).toBeInTheDocument()
+    })
+
+    it('renders features', async () => {
+      setup({})
+      render(<ConfigurationManager />, { wrapper })
+
+      const coverage = await screen.findByText('Coverage reports')
+      expect(coverage).toBeInTheDocument()
+      const yaml = await screen.findByText('YAML')
+      expect(yaml).toBeInTheDocument()
+      const projectStatus = await screen.findByText('Project coverage')
+      expect(projectStatus).toBeInTheDocument()
+      const flags = await screen.findByText('Flags')
+      expect(flags).toBeInTheDocument()
+      const components = await screen.findByText('Components')
+      expect(components).toBeInTheDocument()
+    })
+
+    describe('when coverage is not configured', () => {
+      it('renders Get Started button', async () => {
+        setup({
+          repoConfig: mockRepoConfig({
+            bundleAnalysis: true,
+            testAnalytics: true,
+          }),
+        })
+        render(<ConfigurationManager />, { wrapper })
+
+        const button = await screen.findByRole('link', { name: 'Get Started' })
+        expect(button).toBeInTheDocument()
+        expect(button).toHaveAttribute('href', '/gh/codecov/cool-repo')
+      })
+
+      it('does not render configuration statuses', async () => {
+        setup({})
+        render(<ConfigurationManager />, { wrapper })
+
+        await waitFor(() => screen.findByRole('link', { name: 'Get Started' }))
+
+        const configuredStatus = screen.queryByText('Configured')
+        expect(configuredStatus).not.toBeInTheDocument()
+
+        const unconfiguredStatus = screen.queryByText('not enabled')
+        expect(unconfiguredStatus).not.toBeInTheDocument()
+      })
+    })
+
+    describe('when only coverage is configured', () => {
+      it('renders Configured status', async () => {
+        setup({ repoConfig: mockRepoConfig({ coverage: true }) })
+        render(<ConfigurationManager />, { wrapper })
+
+        const configuredStatus = await screen.findByText('Configured')
+        expect(configuredStatus).toBeInTheDocument()
+      })
+
+      it('renders not enabled status for all other features', async () => {
+        setup({ repoConfig: mockRepoConfig({ coverage: true }) })
+        render(<ConfigurationManager />, { wrapper })
+
+        const notEnabledStatus = await screen.findAllByText('not enabled')
+        expect(notEnabledStatus).toHaveLength(4)
+      })
+    })
+
+    describe('when yaml is configured', () => {
+      it('renders Configured status', async () => {
+        setup({ repoConfig: mockRepoConfig({ coverage: true, yaml: 'yaml' }) })
+        render(<ConfigurationManager />, { wrapper })
+
+        const configuredStatus = await screen.findAllByText('Configured')
+        expect(configuredStatus).toHaveLength(2)
+      })
+    })
+
+    describe('when project status checks are configured', () => {
+      it('renders Configured status', async () => {
+        setup({
+          repoConfig: mockRepoConfig({
+            coverage: true,
+            yaml: yamlWithProjectStatus,
+          }),
+        })
+        render(<ConfigurationManager />, { wrapper })
+
+        const configuredStatus = await screen.findAllByText('Configured')
+        expect(configuredStatus).toHaveLength(3)
+      })
+    })
+
+    describe('when flags are configured', () => {
+      it('renders Configured status', async () => {
+        setup({ repoConfig: mockRepoConfig({ coverage: true, flags: true }) })
+        render(<ConfigurationManager />, { wrapper })
+
+        const configuredStatus = await screen.findAllByText('Configured')
+        expect(configuredStatus).toHaveLength(2)
+      })
+    })
+
+    describe('when components are configured', () => {
+      it('renders Configured status', async () => {
+        setup({
+          repoConfig: mockRepoConfig({ coverage: true, components: true }),
+        })
+        render(<ConfigurationManager />, { wrapper })
+
+        const configuredStatus = await screen.findAllByText('Configured')
+        expect(configuredStatus).toHaveLength(2)
+      })
+    })
+
+    describe('when not on team plan', () => {
+      it('does not render upgrade to pro messaging', async () => {
+        setup({ repoConfig: mockRepoConfig({ tierName: 'pro' }) })
+        render(<ConfigurationManager />, { wrapper })
+
+        await waitFor(() => screen.findByRole('link', { name: 'Get Started' }))
+
+        const upgrade = screen.queryByText('Available with Pro Plan')
+        expect(upgrade).not.toBeInTheDocument()
+      })
+    })
+
+    describe('when on team plan', () => {
+      it('renders upgrade to pro message', async () => {
+        setup({ repoConfig: mockRepoConfig({ tierName: 'team' }) })
+        render(<ConfigurationManager />, { wrapper })
+
+        const upgrade = await screen.findByText('Available with Pro Plan')
+        expect(upgrade).toBeInTheDocument()
+      })
+
+      it('hides configured status for pro only items', async () => {
+        setup({
+          repoConfig: mockRepoConfig({
+            tierName: 'team',
+            coverage: true,
+            yaml: yamlWithProjectStatus,
+            flags: true,
+            components: true,
+          }),
+        })
+        render(<ConfigurationManager />, { wrapper })
+
+        const configuredStatus = await screen.findAllByText('Configured')
+        expect(configuredStatus).toHaveLength(2)
+      })
+
+      it('hides unconfigured status for pro only items', async () => {
+        setup({
+          repoConfig: mockRepoConfig({ tierName: 'team', coverage: true }),
+        })
+        render(<ConfigurationManager />, { wrapper })
+
+        const unconfiguredStatus = await screen.findAllByText('not enabled')
+        expect(unconfiguredStatus).toHaveLength(1)
+      })
+    })
   })
 })

--- a/src/pages/RepoPage/SettingsTab/tabs/ConfigurationManager/ConfigurationManager.tsx
+++ b/src/pages/RepoPage/SettingsTab/tabs/ConfigurationManager/ConfigurationManager.tsx
@@ -1,5 +1,106 @@
+import { useParams } from 'react-router'
+
+import { TierNames } from 'services/tier'
+
+import FeatureGroup from './components/FeatureGroup'
+import FeatureItem from './components/FeatureItem/FeatureItem'
+import {
+  RepositoryConfiguration,
+  useRepoConfigurationStatus,
+} from './hooks/useRepoConfigurationStatus/useRepoConfigurationStatus'
+
+interface URLParams {
+  provider: string
+  owner: string
+  repo: string
+}
+
 function ConfigurationManager() {
-  return <p>Configuration Manager</p>
+  const { provider, owner, repo } = useParams<URLParams>()
+  const { data: repoConfiguration } = useRepoConfigurationStatus({
+    provider,
+    owner,
+    repo,
+  })
+
+  return (
+    <div className="flex flex-col gap-6 lg:w-3/4">
+      <CoverageConfiguration repoConfiguration={repoConfiguration} />
+    </div>
+  )
 }
 
 export default ConfigurationManager
+
+interface CoverageConfigurationProps {
+  repoConfiguration: RepositoryConfiguration
+}
+
+function CoverageConfiguration({
+  repoConfiguration,
+}: CoverageConfigurationProps) {
+  const coverageEnabled = !!repoConfiguration?.repository?.coverageEnabled
+  const isTeamPlan = repoConfiguration?.plan?.tierName === TierNames.TEAM
+  const yaml = repoConfiguration?.repository?.yaml
+  const hasProjectStatus = !!yaml && yaml.includes('project:')
+  const hasFlags = !!repoConfiguration?.repository?.flagsCount
+  const hasComponents = !!repoConfiguration?.repository?.componentsCount
+
+  return (
+    <FeatureGroup
+      title="Coverage"
+      getStartedLink="repo"
+      showGetStartedLink={!coverageEnabled}
+    >
+      <FeatureGroup.UniversalItems>
+        <FeatureItem
+          name="Coverage reports"
+          configured={coverageEnabled}
+          docsLink="quickStart"
+          getStartedLink="repo"
+          hiddenStatus={!coverageEnabled}
+        >
+          Uploading coverage reports and reporting in PR comment
+        </FeatureItem>
+        <FeatureItem
+          name="YAML"
+          configured={!!yaml}
+          docsLink="codecovYaml"
+          getStartedLink="codecovYaml"
+          hiddenStatus={!coverageEnabled}
+        >
+          Customize your reporting preferences
+        </FeatureItem>
+      </FeatureGroup.UniversalItems>
+      <FeatureGroup.ProItems isTeamPlan={isTeamPlan}>
+        <FeatureItem
+          name="Project coverage"
+          configured={hasProjectStatus}
+          docsLink="statusChecks"
+          hiddenStatus={!coverageEnabled || isTeamPlan}
+          getStartedLink="statusChecks"
+        >
+          Include project coverage reporting in PR comment
+        </FeatureItem>
+        <FeatureItem
+          name="Flags"
+          configured={hasFlags}
+          hiddenStatus={!coverageEnabled || isTeamPlan}
+          docsLink="flags"
+          getStartedLink="flags"
+        >
+          Organize your coverage data into custom groups
+        </FeatureItem>
+        <FeatureItem
+          name="Components"
+          configured={hasComponents}
+          hiddenStatus={!coverageEnabled || isTeamPlan}
+          docsLink="components"
+          getStartedLink="components"
+        >
+          Organize your coverage data into custom groups
+        </FeatureItem>
+      </FeatureGroup.ProItems>
+    </FeatureGroup>
+  )
+}

--- a/src/pages/RepoPage/SettingsTab/tabs/ConfigurationManager/ConfigurationManager.tsx
+++ b/src/pages/RepoPage/SettingsTab/tabs/ConfigurationManager/ConfigurationManager.tsx
@@ -80,7 +80,7 @@ function CoverageConfiguration({
           hiddenStatus={!coverageEnabled || isTeamPlan}
           getStartedLink="statusChecks"
         >
-          Include project coverage reporting in PR comment
+          Include project coverage reporting
         </FeatureItem>
         <FeatureItem
           name="Flags"

--- a/src/pages/RepoPage/SettingsTab/tabs/ConfigurationManager/hooks/useRepoConfigurationStatus/useRepoConfigurationStatus.tsx
+++ b/src/pages/RepoPage/SettingsTab/tabs/ConfigurationManager/hooks/useRepoConfigurationStatus/useRepoConfigurationStatus.tsx
@@ -28,10 +28,9 @@ const PlanSchema = z
 
 export type RepositoryConfiguration =
   | {
-      plan?: z.infer<typeof PlanSchema>
-      repository?: z.infer<typeof RepositorySchema>
+      plan: z.infer<typeof PlanSchema>
+      repository: z.infer<typeof RepositorySchema> | null
     }
-  | null
   | undefined
 
 const RequestSchema = z.object({

--- a/src/services/navigation/useNavLinks/useStaticNavLinks.js
+++ b/src/services/navigation/useNavLinks/useStaticNavLinks.js
@@ -252,6 +252,12 @@ export function useStaticNavLinks() {
       isExternalLink: true,
       openNewTab: true,
     },
+    statusChecks: {
+      text: 'Status Checks',
+      path: () => 'https://docs.codecov.com/docs/commit-status',
+      isExternalLink: true,
+      openNewTab: true,
+    },
     ciProviderWorkflow: {
       text: 'CI provider workflow',
       path: () => 'https://circleci.com/blog/what-is-continuous-integration',


### PR DESCRIPTION
Implements the Coverage group of feature for the configuration manager page in repo settings. We may come back to change some of these links. Will be discussing this project more with design and product next week, but this can be merged now as-is since it's behind a feature flag.

I have okayed the use of Card header and footer with design - but this change is not reflected in figma yet.

[Design](https://www.figma.com/design/JTajBZUaEeqfijoy1mCDsz/GH-1509?node-id=1-238&t=RJi59kHV7GIoPEge-0)

Closes https://github.com/codecov/engineering-team/issues/2106

Screenshots showing all the items working:

![Screenshot 2024-07-26 at 11 44 58](https://github.com/user-attachments/assets/a5cadade-9f0b-4f70-9447-ae8a9cd8869f)

![Screenshot 2024-07-26 at 11 45 13](https://github.com/user-attachments/assets/02300a13-ab6b-4798-b5f1-cb3ea404b301)

![Screenshot 2024-07-26 at 11 45 33](https://github.com/user-attachments/assets/2fbebcef-1533-4371-b66a-1e9ea6adde36)

![Screenshot 2024-07-26 at 11 45 48](https://github.com/user-attachments/assets/e01eab3b-3e0c-43f2-9588-546d5d084617)

![Screenshot 2024-07-26 at 11 47 59](https://github.com/user-attachments/assets/ae3d047b-b75c-4acd-a890-bf248ba2b361)
