### PR TITLE
fix: Update with some okta tweaks

### DIFF
--- a/src/services/navigation/useNavLinks/useNavLinks.js
+++ b/src/services/navigation/useNavLinks/useNavLinks.js
@@ -54,6 +54,13 @@ export function useNavLinks() {
       },
       isExternalLink: true,
     },
+    oktaLogin: {
+      text: 'Authenticate with Okta',
+      path: ({ provider = p, owner = o } = { provider: p, owner: o }) => {
+        return `${config.API_URL}/login/okta/${provider}/${owner}`
+      },
+      isExternalLink: true,
+    },
     owner: {
       path: ({ provider = p, owner = o } = { provider: p, owner: o }) => {
         if (provider && owner) {

--- a/src/services/navigation/useNavLinks/useNavLinks.spec.js
+++ b/src/services/navigation/useNavLinks/useNavLinks.spec.js
@@ -2028,4 +2028,27 @@ describe('useNavLinks', () => {
       expect(path).toBe('/bb/test-owner/test-repo/tests/new/codecov-cli')
     })
   })
+
+  describe('okta login', () => {
+    it('returns the correct link with nothing passed', () => {
+      const { result } = renderHook(() => useNavLinks(), {
+        wrapper: wrapper('/gh/test-owner'),
+      })
+
+      const path = result.current.oktaLogin.path()
+      expect(path).toBe('/login/okta/gh/test-owner')
+    })
+
+    it('can override the params', () => {
+      const { result } = renderHook(() => useNavLinks(), {
+        wrapper: wrapper('/bb/test-owner'),
+      })
+
+      const path = result.current.oktaLogin.path({
+        provider: 'bb',
+        owner: 'test-owner',
+      })
+      expect(path).toBe('/login/okta/bb/test-owner')
+    })
+  })
 })

--- a/src/shared/GlobalTopBanners/OktaBanners/OktaBanners.tsx
+++ b/src/shared/GlobalTopBanners/OktaBanners/OktaBanners.tsx
@@ -2,6 +2,7 @@ import { lazy } from 'react'
 import { useParams } from 'react-router'
 
 import { useOktaConfig } from 'pages/AccountSettings/tabs/OktaAccess/hooks'
+import { useFlags } from 'shared/featureFlags'
 
 interface URLParams {
   provider: string
@@ -13,6 +14,9 @@ const OktaEnforcedBanner = lazy(() => import('../OktaEnforcedBanner'))
 
 function OktaBanners() {
   const { provider, owner } = useParams<URLParams>()
+  const { oktaSettings } = useFlags({
+    oktaSettings: false,
+  })
 
   const { data } = useOktaConfig({
     provider,
@@ -22,7 +26,12 @@ function OktaBanners() {
 
   const oktaConfig = data?.owner?.account?.oktaConfig
 
-  if (!owner || !oktaConfig?.enabled || !data?.owner?.isUserOktaAuthenticated)
+  if (
+    !oktaSettings ||
+    !owner ||
+    !oktaConfig?.enabled ||
+    data?.owner?.isUserOktaAuthenticated
+  )
     return null
 
   return oktaConfig?.enforced ? <OktaEnforcedBanner /> : <OktaEnabledBanner />

--- a/src/shared/GlobalTopBanners/OktaEnabledBanner/OktaEnabledBanner.spec.tsx
+++ b/src/shared/GlobalTopBanners/OktaEnabledBanner/OktaEnabledBanner.spec.tsx
@@ -46,6 +46,6 @@ describe('OktaEnabledBanner', () => {
 
     const link = screen.getByRole('link', { name: /Authenticate/ })
     expect(link).toBeInTheDocument()
-    expect(link).toHaveAttribute('href', '/login/okta')
+    expect(link).toHaveAttribute('href', '/login/okta/gh/codecov')
   })
 })

--- a/src/shared/GlobalTopBanners/OktaEnabledBanner/OktaEnabledBanner.tsx
+++ b/src/shared/GlobalTopBanners/OktaEnabledBanner/OktaEnabledBanner.tsx
@@ -27,10 +27,9 @@ const OktaEnabledBanner = () => {
       <TopBanner.End>
         <Button
           to={{
-            pageName: 'signIn',
-            options: { provider: 'okta' },
+            pageName: 'oktaLogin',
           }}
-          hook=""
+          hook="authenticate-via-okta"
           disabled={false}
           variant="primary"
         >

--- a/src/shared/GlobalTopBanners/OktaEnforcedBanner/OktaEnforcedBanner.spec.tsx
+++ b/src/shared/GlobalTopBanners/OktaEnforcedBanner/OktaEnforcedBanner.spec.tsx
@@ -46,6 +46,6 @@ describe('OktaEnforcedBanner', () => {
 
     const link = screen.getByRole('link', { name: /Authenticate/ })
     expect(link).toBeInTheDocument()
-    expect(link).toHaveAttribute('href', '/login/okta')
+    expect(link).toHaveAttribute('href', '/login/okta/gh/codecov')
   })
 })

--- a/src/shared/GlobalTopBanners/OktaEnforcedBanner/OktaEnforcedBanner.tsx
+++ b/src/shared/GlobalTopBanners/OktaEnforcedBanner/OktaEnforcedBanner.tsx
@@ -27,10 +27,9 @@ const OktaEnforcedBanner = () => {
       <TopBanner.End>
         <Button
           to={{
-            pageName: 'signIn',
-            options: { provider: 'okta' },
+            pageName: 'oktaLogin',
           }}
-          hook=""
+          hook="authenticate-via-okta"
           disabled={false}
           variant="primary"
         >


### PR DESCRIPTION
# Description
-  render the banners when the user is not authenticated 
-  hide the banners behind the feature flag 
- redirect the user to` /login/okta/provider/owner` as okta requests this info 

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.