### PR TITLE
fix: Avatars not loading for github provider

### DIFF
--- a/src/shared/utils/ownerHelpers.js
+++ b/src/shared/utils/ownerHelpers.js
@@ -1,5 +1,6 @@
 export function getOwnerImg(provider, owner) {
   return {
     gh: `https://github.com/${owner}.png?size=40`,
+    github: `https://github.com/${owner}.png?size=40`,
   }[provider]
 }


### PR DESCRIPTION
Noticed [this issue](https://codecov.sentry.io/issues/3747448258/?project=5514400&query=is%3Aunresolved+issue.priority%3A%5Bhigh%2C+medium%5D&referrer=issue-stream&statsPeriod=7d&stream_index=0) seems to be happening quite a bit, so I tested locally and found that we don't have a url mapper for the 'github' provider, only for 'gh'. This PR adds a mapper for 'github'.
