### PR TITLE
fix: Use numeric type on Failed Test Table columns

### DIFF
--- a/src/pages/RepoPage/FailedTestsTab/FailedTestsTable/FailedTestsTable.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/FailedTestsTable/FailedTestsTable.tsx
@@ -81,6 +81,11 @@ export function getSortingOption(
   return undefined
 }
 
+const isNumericValue = (value: string) =>
+  value === 'avgDuration' ||
+  value === 'failureRate' ||
+  value === 'commitsFailed'
+
 interface FailedTestsColumns {
   name: string
   avgDuration: number | null
@@ -236,6 +241,11 @@ const FailedTestsTable = () => {
                   {row.getVisibleCells().map((cell) => (
                     <td
                       key={cell.id}
+                      {...(isNumericValue(cell.column.id)
+                        ? {
+                            'data-type': 'numeric',
+                          }
+                        : {})}
                       className={cs({
                         'text-right': !['name', 'updatedAt'].includes(
                           cell.column.id


### PR DESCRIPTION
# Description

Update avgDuration, failureRate and commitFailed columns to numeric data type

# Screenshots

<img width="2011" alt="Screenshot 2024-07-29 at 2 29 26 PM" src="https://github.com/user-attachments/assets/4c600d29-41c2-45b6-9bfa-2c695cdd6405">


# Link to Sample Entry

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.