### PR TITLE
fix: add breadcrumb to bundle content page

### DIFF
--- a/src/pages/RepoPage/BundlesTab/BundleContent/BundleContent.spec.tsx
+++ b/src/pages/RepoPage/BundlesTab/BundleContent/BundleContent.spec.tsx
@@ -6,6 +6,8 @@ import { setupServer } from 'msw/node'
 import { Suspense } from 'react'
 import { MemoryRouter, Route } from 'react-router-dom'
 
+import { RepoBreadcrumbProvider } from 'pages/RepoPage/context'
+
 import BundleContent from './BundleContent'
 
 jest.mock('./BundleSelection', () => () => <div>BundleSelection</div>)
@@ -240,7 +242,9 @@ const wrapper =
             '/:provider/:owner/:repo/bundles',
           ]}
         >
-          <Suspense fallback={<p>Loading</p>}>{children}</Suspense>
+          <RepoBreadcrumbProvider>
+            <Suspense fallback={<p>Loading</p>}>{children}</Suspense>
+          </RepoBreadcrumbProvider>
         </Route>
       </MemoryRouter>
     </QueryClientProvider>

--- a/src/pages/RepoPage/BundlesTab/BundleContent/BundleContent.tsx
+++ b/src/pages/RepoPage/BundlesTab/BundleContent/BundleContent.tsx
@@ -1,10 +1,12 @@
-import { lazy, Suspense, useEffect } from 'react'
+import { lazy, Suspense, useEffect, useLayoutEffect } from 'react'
 import { Switch, useParams } from 'react-router-dom'
 
 import { SentryRoute } from 'sentry'
 
+import { useCrumbs } from 'pages/RepoPage/context'
 import { useBranchBundleSummary } from 'services/bundleAnalysis'
 import { metrics } from 'shared/utils/metrics'
+import Icon from 'ui/Icon'
 import Spinner from 'ui/Spinner'
 
 import AssetsTable from './AssetsTable'
@@ -34,12 +36,28 @@ const Loader = () => (
 
 const BundleContent: React.FC = () => {
   const { provider, owner, repo, branch, bundle } = useParams<URLParams>()
+  const { setBreadcrumbs } = useCrumbs()
 
   useEffect(() => {
     metrics.increment('bundles_tab.bundle_details.visited_page', 1)
   }, [])
 
   const { data } = useBranchBundleSummary({ provider, owner, repo, branch })
+
+  useLayoutEffect(() => {
+    setBreadcrumbs([
+      {
+        pageName: '',
+        readOnly: true,
+        children: (
+          <span className="inline-flex items-center gap-1">
+            <Icon name="branch" variant="developer" size="sm" />
+            {decodeURIComponent(branch ?? '')}
+          </span>
+        ),
+      },
+    ])
+  }, [branch, setBreadcrumbs])
 
   const bundleType = data?.branch?.head?.bundleAnalysisReport?.__typename
 


### PR DESCRIPTION
# Description

Adds the breadcrumb to the bundle content page, where prior it didn't exist

Closes https://github.com/codecov/engineering-team/issues/2062

# Screenshots

**BEFORE**
<img width="876" alt="Screenshot 2024-07-29 at 2 54 30 PM" src="https://github.com/user-attachments/assets/9ebe4b5d-f1b2-4e40-bf1e-6b7dd473aea9">

**AFTER**
<img width="557" alt="Screenshot 2024-07-29 at 2 50 51 PM" src="https://github.com/user-attachments/assets/33ed7605-61ab-495a-8c5f-4e7558252f75">


# Link to Sample Entry

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.