### PR TITLE
fix: Use new orgs fetched from GH resync

### DIFF
--- a/src/services/user/useResyncUser.js
+++ b/src/services/user/useResyncUser.js
@@ -96,6 +96,9 @@ export function useResyncUser() {
       queryClient.invalidateQueries({
         queryKey: ['repos', provider, owner],
       })
+      queryClient.invalidateQueries({
+        queryKey: ['UseMyOrganizations', provider],
+      })
     }
   }, [isFetching, isSuccess, queryClient, provider, owner])
 


### PR DESCRIPTION
# Description

# Code Example

# Notable Changes

# Screenshots

# Link to Sample Entry

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.