### PR TITLE
ref: Convert pull/commit details page error banners to Alert component

### DIFF
--- a/src/pages/CommitDetailPage/CommitBundleAnalysis/CommitBundleAnalysis.spec.tsx
+++ b/src/pages/CommitDetailPage/CommitBundleAnalysis/CommitBundleAnalysis.spec.tsx
@@ -319,7 +319,7 @@ describe('CommitBundleAnalysis', () => {
         render(<CommitBundleAnalysis />, { wrapper })
 
         const message = await screen.findByText(
-          'Unable to compare commits because the head commit of the commit is not found.'
+          'Unable to compare commits because the head commit is not found.'
         )
         expect(message).toBeInTheDocument()
       })
@@ -496,7 +496,7 @@ describe('CommitBundleAnalysis', () => {
           render(<CommitBundleAnalysis />, { wrapper })
 
           const message = await screen.findByText(
-            'Unable to compare commits because the head commit of the commit is not found.'
+            'Unable to compare commits because the head commit is not found.'
           )
           expect(message).toBeInTheDocument()
         })

--- a/src/pages/CommitDetailPage/CommitBundleAnalysis/ErrorBanner/ErrorBanner.spec.tsx
+++ b/src/pages/CommitDetailPage/CommitBundleAnalysis/ErrorBanner/ErrorBanner.spec.tsx
@@ -40,7 +40,7 @@ describe('ErrorBanner', () => {
       render(<ErrorBanner errorType="MissingHeadCommit" />, { wrapper })
 
       const description = screen.getByText(
-        /Unable to compare commits because the head commit of the commit is not found./
+        /Unable to compare commits because the head commit is not found./
       )
       expect(description).toBeInTheDocument()
     })
@@ -58,7 +58,7 @@ describe('ErrorBanner', () => {
       render(<ErrorBanner errorType="MissingHeadReport" />, { wrapper })
 
       const description = screen.getByText(
-        /Unable to compare commits because the head of the commit request did not upload a bundle analysis report./
+        /Unable to compare commits because the head commit did not upload a bundle analysis report./
       )
       expect(description).toBeInTheDocument()
     })

--- a/src/pages/CommitDetailPage/CommitBundleAnalysis/ErrorBanner/ErrorBanner.tsx
+++ b/src/pages/CommitDetailPage/CommitBundleAnalysis/ErrorBanner/ErrorBanner.tsx
@@ -1,7 +1,7 @@
 import { TBundleAnalysisComparisonResult } from 'pages/CommitDetailPage/hooks'
 import { ComparisonReturnType } from 'shared/utils/comparison'
 import A from 'ui/A'
-import Banner from 'ui/Banner'
+import { Alert } from 'ui/Alert'
 
 interface Props {
   errorType?: TBundleAnalysisComparisonResult
@@ -11,20 +11,21 @@ const BannerContent: React.FC<Props> = ({ errorType }) => {
   if (errorType === ComparisonReturnType.MISSING_BASE_COMMIT) {
     return (
       <>
-        {' '}
-        <h1 className="font-semibold">Missing Base Commit</h1>
-        <div className="flex gap-1">
-          <span>
-            Unable to compare commit because no base commit was found.
-          </span>
-          <A
-            hook="compare errors"
-            to={{ pageName: 'missingComparisonCommit' }}
-            isExternal={true}
-          >
-            Learn more here
-          </A>
-        </div>
+        <Alert.Title>Missing Base Commit</Alert.Title>
+        <Alert.Description>
+          <div className="flex flex-wrap gap-1">
+            <span>
+              Unable to compare commit because no base commit was found.
+            </span>
+            <A
+              hook="compare errors"
+              to={{ pageName: 'missingComparisonCommit' }}
+              isExternal={true}
+            >
+              Learn more here
+            </A>
+          </div>
+        </Alert.Description>
       </>
     )
   }
@@ -32,21 +33,22 @@ const BannerContent: React.FC<Props> = ({ errorType }) => {
   if (errorType === ComparisonReturnType.MISSING_HEAD_COMMIT) {
     return (
       <>
-        {' '}
-        <h1 className="font-semibold">Missing Head Commit</h1>
-        <div className="flex gap-1">
-          <span>
-            Unable to compare commits because the head commit of the commit is
-            not found.
-          </span>
-          <A
-            hook="compare errors"
-            to={{ pageName: 'missingComparisonCommit' }}
-            isExternal={true}
-          >
-            Learn more here
-          </A>
-        </div>
+        <Alert.Title>Missing Head Commit</Alert.Title>
+        <Alert.Description>
+          <div className="flex flex-wrap gap-1">
+            <span>
+              Unable to compare commits because the head commit of the commit is
+              not found.
+            </span>
+            <A
+              hook="compare errors"
+              to={{ pageName: 'missingComparisonCommit' }}
+              isExternal={true}
+            >
+              Learn more here
+            </A>
+          </div>
+        </Alert.Description>
       </>
     )
   }
@@ -54,21 +56,22 @@ const BannerContent: React.FC<Props> = ({ errorType }) => {
   if (errorType === ComparisonReturnType.MISSING_HEAD_REPORT) {
     return (
       <>
-        {' '}
-        <h1 className="font-semibold">Missing Head Report</h1>
-        <div className="flex gap-1">
-          <span>
-            Unable to compare commits because the head of the commit request did
-            not upload a bundle analysis report.
-          </span>
-          <A
-            hook="compare errors"
-            to={{ pageName: 'missingComparisonReport' }}
-            isExternal={true}
-          >
-            Learn more here
-          </A>
-        </div>
+        <Alert.Title>Missing Head Report</Alert.Title>
+        <Alert.Description>
+          <div className="flex flex-wrap gap-1">
+            <span>
+              Unable to compare commits because the head of the commit request
+              did not upload a bundle analysis report.
+            </span>
+            <A
+              hook="compare errors"
+              to={{ pageName: 'missingComparisonReport' }}
+              isExternal={true}
+            >
+              Learn more here
+            </A>
+          </div>
+        </Alert.Description>
       </>
     )
   }
@@ -76,21 +79,22 @@ const BannerContent: React.FC<Props> = ({ errorType }) => {
   if (errorType === 'MissingComparison') {
     return (
       <>
-        {' '}
-        <h1 className="font-semibold">Missing Comparison</h1>
-        <div className="flex gap-1">
-          <span>
-            There was an error computing the comparison for the head and base
-            commits.
-          </span>
-          <A
-            hook="compare errors"
-            to={{ pageName: 'missingComparisonReport' }}
-            isExternal={true}
-          >
-            Learn more here
-          </A>
-        </div>
+        <Alert.Title>Missing Comparison</Alert.Title>
+        <Alert.Description>
+          <div className="flex flex-wrap gap-1">
+            <span>
+              There was an error computing the comparison for the head and base
+              commits.
+            </span>
+            <A
+              hook="compare errors"
+              to={{ pageName: 'missingComparisonReport' }}
+              isExternal={true}
+            >
+              Learn more here
+            </A>
+          </div>
+        </Alert.Description>
       </>
     )
   }
@@ -98,21 +102,22 @@ const BannerContent: React.FC<Props> = ({ errorType }) => {
   if (errorType === ComparisonReturnType.MISSING_BASE_REPORT) {
     return (
       <>
-        {' '}
-        <h1 className="font-semibold">Missing Base Report</h1>
-        <div className="flex gap-1">
-          <span>
-            Unable to compare commit because the commit did not upload a bundle
-            analysis report.
-          </span>
-          <A
-            hook="compare errors"
-            to={{ pageName: 'missingComparisonReport' }}
-            isExternal={true}
-          >
-            Learn more here
-          </A>
-        </div>
+        <Alert.Title>Missing Base Report</Alert.Title>
+        <Alert.Description>
+          <div className="flex flex-wrap gap-1">
+            <span>
+              Unable to compare commit because the commit did not upload a
+              bundle analysis report.
+            </span>
+            <A
+              hook="compare errors"
+              to={{ pageName: 'missingComparisonReport' }}
+              isExternal={true}
+            >
+              Learn more here
+            </A>
+          </div>
+        </Alert.Description>
       </>
     )
   }
@@ -122,11 +127,11 @@ const BannerContent: React.FC<Props> = ({ errorType }) => {
 
 const ErrorBanner: React.FC<Props> = ({ errorType }) => {
   return (
-    <Banner variant="warning">
-      <div className="flex flex-col gap-6 text-sm">
+    <>
+      <Alert variant="warning">
         <BannerContent errorType={errorType} />
-      </div>
-    </Banner>
+      </Alert>
+    </>
   )
 }
 

--- a/src/pages/CommitDetailPage/CommitBundleAnalysis/ErrorBanner/ErrorBanner.tsx
+++ b/src/pages/CommitDetailPage/CommitBundleAnalysis/ErrorBanner/ErrorBanner.tsx
@@ -13,7 +13,7 @@ const BannerContent: React.FC<Props> = ({ errorType }) => {
       <>
         <Alert.Title>Missing Base Commit</Alert.Title>
         <Alert.Description>
-          <div className="flex flex-wrap gap-1">
+          <span className="flex flex-wrap gap-1">
             <span>
               Unable to compare commit because no base commit was found.
             </span>
@@ -24,7 +24,7 @@ const BannerContent: React.FC<Props> = ({ errorType }) => {
             >
               Learn more here
             </A>
-          </div>
+          </span>
         </Alert.Description>
       </>
     )
@@ -35,10 +35,9 @@ const BannerContent: React.FC<Props> = ({ errorType }) => {
       <>
         <Alert.Title>Missing Head Commit</Alert.Title>
         <Alert.Description>
-          <div className="flex flex-wrap gap-1">
+          <span className="flex flex-wrap gap-1">
             <span>
-              Unable to compare commits because the head commit of the commit is
-              not found.
+              Unable to compare commits because the head commit is not found.
             </span>
             <A
               hook="compare errors"
@@ -47,7 +46,7 @@ const BannerContent: React.FC<Props> = ({ errorType }) => {
             >
               Learn more here
             </A>
-          </div>
+          </span>
         </Alert.Description>
       </>
     )
@@ -58,10 +57,10 @@ const BannerContent: React.FC<Props> = ({ errorType }) => {
       <>
         <Alert.Title>Missing Head Report</Alert.Title>
         <Alert.Description>
-          <div className="flex flex-wrap gap-1">
+          <span className="flex flex-wrap gap-1">
             <span>
-              Unable to compare commits because the head of the commit request
-              did not upload a bundle analysis report.
+              Unable to compare commits because the head commit did not upload a
+              bundle analysis report.
             </span>
             <A
               hook="compare errors"
@@ -70,7 +69,7 @@ const BannerContent: React.FC<Props> = ({ errorType }) => {
             >
               Learn more here
             </A>
-          </div>
+          </span>
         </Alert.Description>
       </>
     )
@@ -81,7 +80,7 @@ const BannerContent: React.FC<Props> = ({ errorType }) => {
       <>
         <Alert.Title>Missing Comparison</Alert.Title>
         <Alert.Description>
-          <div className="flex flex-wrap gap-1">
+          <span className="flex flex-wrap gap-1">
             <span>
               There was an error computing the comparison for the head and base
               commits.
@@ -93,7 +92,7 @@ const BannerContent: React.FC<Props> = ({ errorType }) => {
             >
               Learn more here
             </A>
-          </div>
+          </span>
         </Alert.Description>
       </>
     )
@@ -104,7 +103,7 @@ const BannerContent: React.FC<Props> = ({ errorType }) => {
       <>
         <Alert.Title>Missing Base Report</Alert.Title>
         <Alert.Description>
-          <div className="flex flex-wrap gap-1">
+          <span className="flex flex-wrap gap-1">
             <span>
               Unable to compare commit because the commit did not upload a
               bundle analysis report.
@@ -116,7 +115,7 @@ const BannerContent: React.FC<Props> = ({ errorType }) => {
             >
               Learn more here
             </A>
-          </div>
+          </span>
         </Alert.Description>
       </>
     )

--- a/src/pages/CommitDetailPage/CommitCoverage/ErrorBanner/ErrorBanner.spec.tsx
+++ b/src/pages/CommitDetailPage/CommitCoverage/ErrorBanner/ErrorBanner.spec.tsx
@@ -69,7 +69,7 @@ describe('ErrorBanner Card', () => {
       )
 
       const errorMsg = screen.getByText(
-        'Unable to compare commits because the head commit of the commit is not found.'
+        'Unable to compare commits because the head commit is not found.'
       )
       expect(errorMsg).toBeInTheDocument()
     })

--- a/src/pages/CommitDetailPage/CommitCoverage/ErrorBanner/ErrorBanner.tsx
+++ b/src/pages/CommitDetailPage/CommitCoverage/ErrorBanner/ErrorBanner.tsx
@@ -3,7 +3,7 @@ import {
   type TComparisonReturnType,
 } from 'shared/utils/comparison'
 import A from 'ui/A'
-import Banner from 'ui/Banner'
+import { Alert } from 'ui/Alert'
 
 interface Props {
   errorType: TComparisonReturnType
@@ -13,20 +13,21 @@ const BannerContent: React.FC<Props> = ({ errorType }) => {
   if (errorType === ComparisonReturnType.MISSING_BASE_COMMIT) {
     return (
       <>
-        {' '}
-        <h1 className="font-semibold">Missing Base Commit</h1>
-        <div className="flex gap-1">
-          <span>
-            Unable to compare commit because no base commit was found.
-          </span>
-          <A
-            hook="compare errors"
-            to={{ pageName: 'missingComparisonCommit' }}
-            isExternal={true}
-          >
-            Learn more here
-          </A>
-        </div>
+        <Alert.Title>Missing Base Commit</Alert.Title>
+        <Alert.Description>
+          <div className="flex flex-wrap gap-1">
+            <span>
+              Unable to compare commit because no base commit was found.
+            </span>
+            <A
+              hook="compare errors"
+              to={{ pageName: 'missingComparisonCommit' }}
+              isExternal={true}
+            >
+              Learn more here
+            </A>
+          </div>
+        </Alert.Description>
       </>
     )
   }
@@ -34,21 +35,22 @@ const BannerContent: React.FC<Props> = ({ errorType }) => {
   if (errorType === ComparisonReturnType.MISSING_HEAD_COMMIT) {
     return (
       <>
-        {' '}
-        <h1 className="font-semibold">Missing Head Commit</h1>
-        <div className="flex gap-1">
-          <span>
-            Unable to compare commits because the head commit of the commit is
-            not found.
-          </span>
-          <A
-            hook="compare errors"
-            to={{ pageName: 'missingComparisonCommit' }}
-            isExternal={true}
-          >
-            Learn more here
-          </A>
-        </div>
+        <Alert.Title>Missing Head Commit</Alert.Title>
+        <Alert.Description>
+          <div className="flex flex-wrap gap-1">
+            <span>
+              Unable to compare commits because the head commit of the commit is
+              not found.
+            </span>
+            <A
+              hook="compare errors"
+              to={{ pageName: 'missingComparisonCommit' }}
+              isExternal={true}
+            >
+              Learn more here
+            </A>
+          </div>
+        </Alert.Description>
       </>
     )
   }
@@ -56,21 +58,22 @@ const BannerContent: React.FC<Props> = ({ errorType }) => {
   if (errorType === ComparisonReturnType.MISSING_BASE_REPORT) {
     return (
       <>
-        {' '}
-        <h1 className="font-semibold">Missing Base Report</h1>
-        <div className="flex gap-1">
-          <span>
-            Unable to compare commit because the commit did not upload a
-            coverage report.
-          </span>
-          <A
-            hook="compare errors"
-            to={{ pageName: 'missingComparisonReport' }}
-            isExternal={true}
-          >
-            Learn more here
-          </A>
-        </div>
+        <Alert.Title>Missing Base Report</Alert.Title>
+        <Alert.Description>
+          <div className="flex flex-wrap gap-1">
+            <span>
+              Unable to compare commit because the commit did not upload a
+              coverage report.
+            </span>
+            <A
+              hook="compare errors"
+              to={{ pageName: 'missingComparisonReport' }}
+              isExternal={true}
+            >
+              Learn more here
+            </A>
+          </div>
+        </Alert.Description>
       </>
     )
   }
@@ -78,21 +81,22 @@ const BannerContent: React.FC<Props> = ({ errorType }) => {
   if (errorType === ComparisonReturnType.MISSING_HEAD_REPORT) {
     return (
       <>
-        {' '}
-        <h1 className="font-semibold">Missing Head Report</h1>
-        <div className="flex gap-1">
-          <span>
-            Unable to compare commits because the head of the commit request did
-            not upload a coverage report.
-          </span>
-          <A
-            hook="compare errors"
-            to={{ pageName: 'missingComparisonReport' }}
-            isExternal={true}
-          >
-            Learn more here
-          </A>
-        </div>
+        <Alert.Title>Missing Head Report</Alert.Title>
+        <Alert.Description>
+          <div className="flex flex-wrap gap-1">
+            <span>
+              Unable to compare commits because the head of the commit request
+              did not upload a coverage report.
+            </span>
+            <A
+              hook="compare errors"
+              to={{ pageName: 'missingComparisonReport' }}
+              isExternal={true}
+            >
+              Learn more here
+            </A>
+          </div>
+        </Alert.Description>
       </>
     )
   }
@@ -100,21 +104,22 @@ const BannerContent: React.FC<Props> = ({ errorType }) => {
   if (errorType === ComparisonReturnType.MISSING_COMPARISON) {
     return (
       <>
-        {' '}
-        <h1 className="font-semibold">Missing Comparison</h1>
-        <div className="flex gap-1">
-          <span>
-            There was an error computing the comparison for the head and base
-            commits.
-          </span>
-          <A
-            hook="compare errors"
-            to={{ pageName: 'missingComparisonReport' }}
-            isExternal={true}
-          >
-            Learn more here
-          </A>
-        </div>
+        <Alert.Title>Missing Comparison</Alert.Title>
+        <Alert.Description>
+          <div className="flex flex-wrap gap-1">
+            <span>
+              There was an error computing the comparison for the head and base
+              commits.
+            </span>
+            <A
+              hook="compare errors"
+              to={{ pageName: 'missingComparisonReport' }}
+              isExternal={true}
+            >
+              Learn more here
+            </A>
+          </div>
+        </Alert.Description>
       </>
     )
   }
@@ -124,11 +129,9 @@ const BannerContent: React.FC<Props> = ({ errorType }) => {
 
 const ErrorBanner: React.FC<Props> = ({ errorType }) => {
   return (
-    <Banner variant="warning">
-      <div className="flex flex-col gap-6 text-sm">
-        <BannerContent errorType={errorType} />
-      </div>
-    </Banner>
+    <Alert variant="warning">
+      <BannerContent errorType={errorType} />
+    </Alert>
   )
 }
 

--- a/src/pages/CommitDetailPage/CommitCoverage/ErrorBanner/ErrorBanner.tsx
+++ b/src/pages/CommitDetailPage/CommitCoverage/ErrorBanner/ErrorBanner.tsx
@@ -15,7 +15,7 @@ const BannerContent: React.FC<Props> = ({ errorType }) => {
       <>
         <Alert.Title>Missing Base Commit</Alert.Title>
         <Alert.Description>
-          <div className="flex flex-wrap gap-1">
+          <span className="flex flex-wrap gap-1">
             <span>
               Unable to compare commit because no base commit was found.
             </span>
@@ -26,7 +26,7 @@ const BannerContent: React.FC<Props> = ({ errorType }) => {
             >
               Learn more here
             </A>
-          </div>
+          </span>
         </Alert.Description>
       </>
     )
@@ -37,10 +37,9 @@ const BannerContent: React.FC<Props> = ({ errorType }) => {
       <>
         <Alert.Title>Missing Head Commit</Alert.Title>
         <Alert.Description>
-          <div className="flex flex-wrap gap-1">
+          <span className="flex flex-wrap gap-1">
             <span>
-              Unable to compare commits because the head commit of the commit is
-              not found.
+              Unable to compare commits because the head commit is not found.
             </span>
             <A
               hook="compare errors"
@@ -49,7 +48,7 @@ const BannerContent: React.FC<Props> = ({ errorType }) => {
             >
               Learn more here
             </A>
-          </div>
+          </span>
         </Alert.Description>
       </>
     )
@@ -60,7 +59,7 @@ const BannerContent: React.FC<Props> = ({ errorType }) => {
       <>
         <Alert.Title>Missing Base Report</Alert.Title>
         <Alert.Description>
-          <div className="flex flex-wrap gap-1">
+          <span className="flex flex-wrap gap-1">
             <span>
               Unable to compare commit because the commit did not upload a
               coverage report.
@@ -72,7 +71,7 @@ const BannerContent: React.FC<Props> = ({ errorType }) => {
             >
               Learn more here
             </A>
-          </div>
+          </span>
         </Alert.Description>
       </>
     )
@@ -83,7 +82,7 @@ const BannerContent: React.FC<Props> = ({ errorType }) => {
       <>
         <Alert.Title>Missing Head Report</Alert.Title>
         <Alert.Description>
-          <div className="flex flex-wrap gap-1">
+          <span className="flex flex-wrap gap-1">
             <span>
               Unable to compare commits because the head of the commit request
               did not upload a coverage report.
@@ -95,7 +94,7 @@ const BannerContent: React.FC<Props> = ({ errorType }) => {
             >
               Learn more here
             </A>
-          </div>
+          </span>
         </Alert.Description>
       </>
     )
@@ -106,7 +105,7 @@ const BannerContent: React.FC<Props> = ({ errorType }) => {
       <>
         <Alert.Title>Missing Comparison</Alert.Title>
         <Alert.Description>
-          <div className="flex flex-wrap gap-1">
+          <span className="flex flex-wrap gap-1">
             <span>
               There was an error computing the comparison for the head and base
               commits.
@@ -118,7 +117,7 @@ const BannerContent: React.FC<Props> = ({ errorType }) => {
             >
               Learn more here
             </A>
-          </div>
+          </span>
         </Alert.Description>
       </>
     )

--- a/src/pages/PullRequestPage/PullBundleAnalysis/ErrorBanner/ErrorBanner.spec.tsx
+++ b/src/pages/PullRequestPage/PullBundleAnalysis/ErrorBanner/ErrorBanner.spec.tsx
@@ -40,7 +40,7 @@ describe('ErrorBanner', () => {
       render(<ErrorBanner errorType="MissingHeadCommit" />, { wrapper })
 
       const description = screen.getByText(
-        /Unable to compare commits because the head commit of the commit is not found./
+        /Unable to compare commits because the head commit is not found./
       )
       expect(description).toBeInTheDocument()
     })
@@ -58,7 +58,7 @@ describe('ErrorBanner', () => {
       render(<ErrorBanner errorType="MissingHeadReport" />, { wrapper })
 
       const description = screen.getByText(
-        /Unable to compare commits because the head of the commit request did not upload a bundle analysis report./
+        /Unable to compare commits because the head commit did not upload a bundle analysis report./
       )
       expect(description).toBeInTheDocument()
     })

--- a/src/pages/PullRequestPage/PullBundleAnalysis/ErrorBanner/ErrorBanner.tsx
+++ b/src/pages/PullRequestPage/PullBundleAnalysis/ErrorBanner/ErrorBanner.tsx
@@ -1,6 +1,6 @@
 import { ComparisonReturnType } from 'shared/utils/comparison'
 import A from 'ui/A'
-import Banner from 'ui/Banner'
+import { Alert } from 'ui/Alert'
 
 import { TBundleAnalysisComparisonResult } from '../../hooks'
 
@@ -12,20 +12,21 @@ const BannerContent: React.FC<Props> = ({ errorType }) => {
   if (errorType === ComparisonReturnType.MISSING_BASE_COMMIT) {
     return (
       <>
-        {' '}
-        <h1 className="font-semibold">Missing Base Commit</h1>
-        <div className="flex gap-1">
-          <span>
-            Unable to compare commit because no base commit was found.
-          </span>
-          <A
-            hook="compare errors"
-            to={{ pageName: 'missingComparisonCommit' }}
-            isExternal={true}
-          >
-            Learn more here
-          </A>
-        </div>
+        <Alert.Title>Missing Base Commit</Alert.Title>
+        <Alert.Description>
+          <div className="flex flex-wrap gap-1">
+            <span>
+              Unable to compare commit because no base commit was found.
+            </span>
+            <A
+              hook="compare errors"
+              to={{ pageName: 'missingComparisonCommit' }}
+              isExternal={true}
+            >
+              Learn more here
+            </A>
+          </div>
+        </Alert.Description>
       </>
     )
   }
@@ -33,21 +34,22 @@ const BannerContent: React.FC<Props> = ({ errorType }) => {
   if (errorType === ComparisonReturnType.MISSING_HEAD_COMMIT) {
     return (
       <>
-        {' '}
-        <h1 className="font-semibold">Missing Head Commit</h1>
-        <div className="flex gap-1">
-          <span>
-            Unable to compare commits because the head commit of the commit is
-            not found.
-          </span>
-          <A
-            hook="compare errors"
-            to={{ pageName: 'missingComparisonCommit' }}
-            isExternal={true}
-          >
-            Learn more here
-          </A>
-        </div>
+        <Alert.Title>Missing Head Commit</Alert.Title>
+        <Alert.Description>
+          <div className="flex flex-wrap gap-1">
+            <span>
+              Unable to compare commits because the head commit of the commit is
+              not found.
+            </span>
+            <A
+              hook="compare errors"
+              to={{ pageName: 'missingComparisonCommit' }}
+              isExternal={true}
+            >
+              Learn more here
+            </A>
+          </div>
+        </Alert.Description>
       </>
     )
   }
@@ -55,21 +57,22 @@ const BannerContent: React.FC<Props> = ({ errorType }) => {
   if (errorType === ComparisonReturnType.MISSING_HEAD_REPORT) {
     return (
       <>
-        {' '}
-        <h1 className="font-semibold">Missing Head Report</h1>
-        <div className="flex gap-1">
-          <span>
-            Unable to compare commits because the head of the commit request did
-            not upload a bundle analysis report.
-          </span>
-          <A
-            hook="compare errors"
-            to={{ pageName: 'missingComparisonReport' }}
-            isExternal={true}
-          >
-            Learn more here
-          </A>
-        </div>
+        <Alert.Title>Missing Head Report</Alert.Title>
+        <Alert.Description>
+          <div className="flex flex-wrap gap-1">
+            <span>
+              Unable to compare commits because the head of the commit request
+              did not upload a bundle analysis report.
+            </span>
+            <A
+              hook="compare errors"
+              to={{ pageName: 'missingComparisonReport' }}
+              isExternal={true}
+            >
+              Learn more here
+            </A>
+          </div>
+        </Alert.Description>
       </>
     )
   }
@@ -77,21 +80,22 @@ const BannerContent: React.FC<Props> = ({ errorType }) => {
   if (errorType === 'MissingComparison') {
     return (
       <>
-        {' '}
-        <h1 className="font-semibold">Missing Comparison</h1>
-        <div className="flex gap-1">
-          <span>
-            There was an error computing the comparison for the head and base
-            commits.
-          </span>
-          <A
-            hook="compare errors"
-            to={{ pageName: 'missingComparisonReport' }}
-            isExternal={true}
-          >
-            Learn more here
-          </A>
-        </div>
+        <Alert.Title>Missing Comparison</Alert.Title>
+        <Alert.Description>
+          <div className="flex flex-wrap gap-1">
+            <span>
+              There was an error computing the comparison for the head and base
+              commits.
+            </span>
+            <A
+              hook="compare errors"
+              to={{ pageName: 'missingComparisonReport' }}
+              isExternal={true}
+            >
+              Learn more here
+            </A>
+          </div>
+        </Alert.Description>
       </>
     )
   }
@@ -99,21 +103,22 @@ const BannerContent: React.FC<Props> = ({ errorType }) => {
   if (errorType === ComparisonReturnType.MISSING_BASE_REPORT) {
     return (
       <>
-        {' '}
-        <h1 className="font-semibold">Missing Base Report</h1>
-        <div className="flex gap-1">
-          <span>
-            Unable to compare commit because the commit did not upload a bundle
-            analysis report.
-          </span>
-          <A
-            hook="compare errors"
-            to={{ pageName: 'missingComparisonReport' }}
-            isExternal={true}
-          >
-            Learn more here
-          </A>
-        </div>
+        <Alert.Title>Missing Base Report</Alert.Title>
+        <Alert.Description>
+          <div className="flex flex-wrap gap-1">
+            <span>
+              Unable to compare commit because the commit did not upload a
+              bundle analysis report.
+            </span>
+            <A
+              hook="compare errors"
+              to={{ pageName: 'missingComparisonReport' }}
+              isExternal={true}
+            >
+              Learn more here
+            </A>
+          </div>
+        </Alert.Description>
       </>
     )
   }
@@ -123,11 +128,9 @@ const BannerContent: React.FC<Props> = ({ errorType }) => {
 
 const ErrorBanner: React.FC<Props> = ({ errorType }) => {
   return (
-    <Banner variant="warning">
-      <div className="flex flex-col gap-6 text-sm">
-        <BannerContent errorType={errorType} />
-      </div>
-    </Banner>
+    <Alert variant="warning">
+      <BannerContent errorType={errorType} />
+    </Alert>
   )
 }
 

--- a/src/pages/PullRequestPage/PullBundleAnalysis/ErrorBanner/ErrorBanner.tsx
+++ b/src/pages/PullRequestPage/PullBundleAnalysis/ErrorBanner/ErrorBanner.tsx
@@ -14,7 +14,7 @@ const BannerContent: React.FC<Props> = ({ errorType }) => {
       <>
         <Alert.Title>Missing Base Commit</Alert.Title>
         <Alert.Description>
-          <div className="flex flex-wrap gap-1">
+          <span className="flex flex-wrap gap-1">
             <span>
               Unable to compare commit because no base commit was found.
             </span>
@@ -25,7 +25,7 @@ const BannerContent: React.FC<Props> = ({ errorType }) => {
             >
               Learn more here
             </A>
-          </div>
+          </span>
         </Alert.Description>
       </>
     )
@@ -36,10 +36,9 @@ const BannerContent: React.FC<Props> = ({ errorType }) => {
       <>
         <Alert.Title>Missing Head Commit</Alert.Title>
         <Alert.Description>
-          <div className="flex flex-wrap gap-1">
+          <span className="flex flex-wrap gap-1">
             <span>
-              Unable to compare commits because the head commit of the commit is
-              not found.
+              Unable to compare commits because the head commit is not found.
             </span>
             <A
               hook="compare errors"
@@ -48,7 +47,7 @@ const BannerContent: React.FC<Props> = ({ errorType }) => {
             >
               Learn more here
             </A>
-          </div>
+          </span>
         </Alert.Description>
       </>
     )
@@ -59,10 +58,10 @@ const BannerContent: React.FC<Props> = ({ errorType }) => {
       <>
         <Alert.Title>Missing Head Report</Alert.Title>
         <Alert.Description>
-          <div className="flex flex-wrap gap-1">
+          <span className="flex flex-wrap gap-1">
             <span>
-              Unable to compare commits because the head of the commit request
-              did not upload a bundle analysis report.
+              Unable to compare commits because the head commit did not upload a
+              bundle analysis report.
             </span>
             <A
               hook="compare errors"
@@ -71,7 +70,7 @@ const BannerContent: React.FC<Props> = ({ errorType }) => {
             >
               Learn more here
             </A>
-          </div>
+          </span>
         </Alert.Description>
       </>
     )
@@ -82,7 +81,7 @@ const BannerContent: React.FC<Props> = ({ errorType }) => {
       <>
         <Alert.Title>Missing Comparison</Alert.Title>
         <Alert.Description>
-          <div className="flex flex-wrap gap-1">
+          <span className="flex flex-wrap gap-1">
             <span>
               There was an error computing the comparison for the head and base
               commits.
@@ -94,7 +93,7 @@ const BannerContent: React.FC<Props> = ({ errorType }) => {
             >
               Learn more here
             </A>
-          </div>
+          </span>
         </Alert.Description>
       </>
     )
@@ -105,7 +104,7 @@ const BannerContent: React.FC<Props> = ({ errorType }) => {
       <>
         <Alert.Title>Missing Base Report</Alert.Title>
         <Alert.Description>
-          <div className="flex flex-wrap gap-1">
+          <span className="flex flex-wrap gap-1">
             <span>
               Unable to compare commit because the commit did not upload a
               bundle analysis report.
@@ -117,7 +116,7 @@ const BannerContent: React.FC<Props> = ({ errorType }) => {
             >
               Learn more here
             </A>
-          </div>
+          </span>
         </Alert.Description>
       </>
     )

--- a/src/pages/PullRequestPage/PullCoverage/ErrorBanner/ErrorBanner.jsx
+++ b/src/pages/PullRequestPage/PullCoverage/ErrorBanner/ErrorBanner.jsx
@@ -10,7 +10,7 @@ function BannerContent({ errorType }) {
       <>
         <Alert.Title>Missing Base Commit</Alert.Title>
         <Alert.Description>
-          <div className="flex flex-wrap gap-1">
+          <span className="flex flex-wrap gap-1">
             <span>
               Unable to compare commits because the base commit of the pull
               request is not found.
@@ -22,7 +22,7 @@ function BannerContent({ errorType }) {
             >
               Learn more here
             </A>
-          </div>
+          </span>
         </Alert.Description>
       </>
     )
@@ -33,7 +33,7 @@ function BannerContent({ errorType }) {
       <>
         <Alert.Title>Missing Head Commit</Alert.Title>
         <Alert.Description>
-          <div className="flex flex-wrap gap-1">
+          <span className="flex flex-wrap gap-1">
             <span>
               Unable to compare commits because the head commit of the pull
               request is not found.
@@ -45,7 +45,7 @@ function BannerContent({ errorType }) {
             >
               Learn more here
             </A>
-          </div>
+          </span>
         </Alert.Description>
       </>
     )
@@ -56,7 +56,7 @@ function BannerContent({ errorType }) {
       <>
         <Alert.Title>Missing Base Report</Alert.Title>
         <Alert.Description>
-          <div className="flex flex-wrap gap-1">
+          <span className="flex flex-wrap gap-1">
             <span>
               Unable to compare commits because the base of the pull request did
               not upload a coverage report.
@@ -68,7 +68,7 @@ function BannerContent({ errorType }) {
             >
               Learn more here
             </A>
-          </div>
+          </span>
         </Alert.Description>
       </>
     )
@@ -79,7 +79,7 @@ function BannerContent({ errorType }) {
       <>
         <Alert.Title>Missing Head Report</Alert.Title>
         <Alert.Description>
-          <div className="flex flex-wrap gap-1">
+          <span className="flex flex-wrap gap-1">
             <span>
               Unable to compare commits because the head of the pull request did
               not upload a coverage report.
@@ -91,7 +91,7 @@ function BannerContent({ errorType }) {
             >
               Learn more here
             </A>
-          </div>
+          </span>
         </Alert.Description>
       </>
     )
@@ -102,7 +102,7 @@ function BannerContent({ errorType }) {
       <>
         <Alert.Title>Missing Comparison</Alert.Title>
         <Alert.Description>
-          <div className="flex flex-wrap gap-1">
+          <span className="flex flex-wrap gap-1">
             <span>
               There was an error computing the comparison for the head and base
               commit.
@@ -114,7 +114,7 @@ function BannerContent({ errorType }) {
             >
               Learn more here
             </A>
-          </div>
+          </span>
         </Alert.Description>
       </>
     )

--- a/src/pages/PullRequestPage/PullCoverage/ErrorBanner/ErrorBanner.jsx
+++ b/src/pages/PullRequestPage/PullCoverage/ErrorBanner/ErrorBanner.jsx
@@ -2,27 +2,28 @@ import PropTypes from 'prop-types'
 
 import { ComparisonReturnType } from 'shared/utils/comparison'
 import A from 'ui/A'
-import Banner from 'ui/Banner'
+import { Alert } from 'ui/Alert'
 
 function BannerContent({ errorType }) {
   if (errorType === ComparisonReturnType.MISSING_BASE_COMMIT) {
     return (
       <>
-        {' '}
-        <h1 className="font-semibold">Missing Base Commit</h1>
-        <div className="flex gap-1">
-          <span>
-            Unable to compare commits because the base commit of the pull
-            request is not found.
-          </span>
-          <A
-            hook="compare errors"
-            to={{ pageName: 'missingComparisonCommit' }}
-            isExternal={true}
-          >
-            Learn more here
-          </A>
-        </div>
+        <Alert.Title>Missing Base Commit</Alert.Title>
+        <Alert.Description>
+          <div className="flex flex-wrap gap-1">
+            <span>
+              Unable to compare commits because the base commit of the pull
+              request is not found.
+            </span>
+            <A
+              hook="compare errors"
+              to={{ pageName: 'missingComparisonCommit' }}
+              isExternal={true}
+            >
+              Learn more here
+            </A>
+          </div>
+        </Alert.Description>
       </>
     )
   }
@@ -30,21 +31,22 @@ function BannerContent({ errorType }) {
   if (errorType === ComparisonReturnType.MISSING_HEAD_COMMIT) {
     return (
       <>
-        {' '}
-        <h1 className="font-semibold">Missing Head Commit</h1>
-        <div className="flex gap-1">
-          <span>
-            Unable to compare commits because the head commit of the pull
-            request is not found.
-          </span>
-          <A
-            hook="compare errors"
-            to={{ pageName: 'missingComparisonCommit' }}
-            isExternal={true}
-          >
-            Learn more here
-          </A>
-        </div>
+        <Alert.Title>Missing Head Commit</Alert.Title>
+        <Alert.Description>
+          <div className="flex flex-wrap gap-1">
+            <span>
+              Unable to compare commits because the head commit of the pull
+              request is not found.
+            </span>
+            <A
+              hook="compare errors"
+              to={{ pageName: 'missingComparisonCommit' }}
+              isExternal={true}
+            >
+              Learn more here
+            </A>
+          </div>
+        </Alert.Description>
       </>
     )
   }
@@ -52,21 +54,22 @@ function BannerContent({ errorType }) {
   if (errorType === ComparisonReturnType.MISSING_BASE_REPORT) {
     return (
       <>
-        {' '}
-        <h1 className="font-semibold">Missing Base Report</h1>
-        <div className="flex gap-1">
-          <span>
-            Unable to compare commits because the base of the pull request did
-            not upload a coverage report.
-          </span>
-          <A
-            hook="compare errors"
-            to={{ pageName: 'missingComparisonReport' }}
-            isExternal={true}
-          >
-            Learn more here
-          </A>
-        </div>
+        <Alert.Title>Missing Base Report</Alert.Title>
+        <Alert.Description>
+          <div className="flex flex-wrap gap-1">
+            <span>
+              Unable to compare commits because the base of the pull request did
+              not upload a coverage report.
+            </span>
+            <A
+              hook="compare errors"
+              to={{ pageName: 'missingComparisonReport' }}
+              isExternal={true}
+            >
+              Learn more here
+            </A>
+          </div>
+        </Alert.Description>
       </>
     )
   }
@@ -74,21 +77,22 @@ function BannerContent({ errorType }) {
   if (errorType === ComparisonReturnType.MISSING_HEAD_REPORT) {
     return (
       <>
-        {' '}
-        <h1 className="font-semibold">Missing Head Report</h1>
-        <div className="flex gap-1">
-          <span>
-            Unable to compare commits because the head of the pull request did
-            not upload a coverage report.
-          </span>
-          <A
-            hook="compare errors"
-            to={{ pageName: 'missingComparisonReport' }}
-            isExternal={true}
-          >
-            Learn more here
-          </A>
-        </div>
+        <Alert.Title>Missing Head Report</Alert.Title>
+        <Alert.Description>
+          <div className="flex flex-wrap gap-1">
+            <span>
+              Unable to compare commits because the head of the pull request did
+              not upload a coverage report.
+            </span>
+            <A
+              hook="compare errors"
+              to={{ pageName: 'missingComparisonReport' }}
+              isExternal={true}
+            >
+              Learn more here
+            </A>
+          </div>
+        </Alert.Description>
       </>
     )
   }
@@ -96,21 +100,22 @@ function BannerContent({ errorType }) {
   if (errorType === ComparisonReturnType.MISSING_COMPARISON) {
     return (
       <>
-        {' '}
-        <h1 className="font-semibold">Missing Comparison</h1>
-        <div className="flex gap-1">
-          <span>
-            There was an error computing the comparison for the head and base
-            commit.
-          </span>
-          <A
-            hook="compare errors"
-            to={{ pageName: 'missingComparisonReport' }}
-            isExternal={true}
-          >
-            Learn more here
-          </A>
-        </div>
+        <Alert.Title>Missing Comparison</Alert.Title>
+        <Alert.Description>
+          <div className="flex flex-wrap gap-1">
+            <span>
+              There was an error computing the comparison for the head and base
+              commit.
+            </span>
+            <A
+              hook="compare errors"
+              to={{ pageName: 'missingComparisonReport' }}
+              isExternal={true}
+            >
+              Learn more here
+            </A>
+          </div>
+        </Alert.Description>
       </>
     )
   }
@@ -124,11 +129,9 @@ BannerContent.propTypes = {
 
 function ErrorBanner({ errorType }) {
   return (
-    <Banner variant="warning">
-      <div className="flex flex-col gap-6 text-sm">
-        <BannerContent errorType={errorType} />
-      </div>
-    </Banner>
+    <Alert variant="warning">
+      <BannerContent errorType={errorType} />
+    </Alert>
   )
 }
 


### PR DESCRIPTION
Converts the error banners on the pull and commit details pages to the new Alert component for consistency across the app.

Closes https://github.com/codecov/engineering-team/issues/1715

Before: 
![Screenshot 2024-07-30 at 14 28 22](https://github.com/user-attachments/assets/9cbcca0c-9f85-42d8-9aee-07cf7217bd1b)

After:
![Screenshot 2024-07-30 at 14 27 05](https://github.com/user-attachments/assets/b626fa8c-030a-4334-8284-055bf1762d9c)