### PR TITLE
fix: Add Breadcrumb failed test table

### DIFF
--- a/src/pages/RepoPage/FailedTestsTab/FailedTestsTable/FailedTestsTable.spec.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/FailedTestsTable/FailedTestsTable.spec.tsx
@@ -11,6 +11,8 @@ import { setupServer } from 'msw/node'
 import { mockIsIntersecting } from 'react-intersection-observer/test-utils'
 import { MemoryRouter, Route } from 'react-router-dom'
 
+import { RepoBreadcrumbProvider } from 'pages/RepoPage/context'
+
 import FailedTestsTable from './FailedTestsTable'
 
 import { OrderingDirection, OrderingParameter } from '../hooks'
@@ -48,12 +50,14 @@ const wrapper =
   ({ children }) => (
     <QueryClientProvider client={queryClient}>
       <MemoryRouter initialEntries={initialEntries}>
-        <Route path="/:provider/:owner/:repo/tests" exact>
-          {children}
-        </Route>
-        <Route path="/:provider/:owner/:repo/tests/:branch" exact>
-          {children}
-        </Route>
+        <RepoBreadcrumbProvider>
+          <Route path="/:provider/:owner/:repo/tests" exact>
+            {children}
+          </Route>
+          <Route path="/:provider/:owner/:repo/tests/:branch" exact>
+            {children}
+          </Route>
+        </RepoBreadcrumbProvider>
       </MemoryRouter>
     </QueryClientProvider>
   )

--- a/src/pages/RepoPage/FailedTestsTab/FailedTestsTable/FailedTestsTable.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/FailedTestsTable/FailedTestsTable.tsx
@@ -169,7 +169,7 @@ const FailedTestsTable = () => {
         children: (
           <span className="inline-flex items-center gap-1">
             <Icon name="branch" variant="developer" size="sm" />
-            {decodeURIComponent(branch ?? '')}
+            {branch ? getDecodedBranch(branch) : undefined}
           </span>
         ),
       },

--- a/src/pages/RepoPage/FailedTestsTab/FailedTestsTable/FailedTestsTable.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/FailedTestsTable/FailedTestsTable.tsx
@@ -8,10 +8,11 @@ import {
 } from '@tanstack/react-table'
 import cs from 'classnames'
 import isEmpty from 'lodash/isEmpty'
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useLayoutEffect, useMemo, useState } from 'react'
 import { useInView } from 'react-intersection-observer'
 import { useParams } from 'react-router-dom'
 
+import { useCrumbs } from 'pages/RepoPage/context'
 import { formatTimeToNow } from 'shared/utils/dates'
 import Icon from 'ui/Icon'
 import Spinner from 'ui/Spinner'
@@ -139,6 +140,7 @@ const FailedTestsTable = () => {
     },
   ])
   const { provider, owner, repo, branch } = useParams<URLParams>()
+  const { setBreadcrumbs } = useCrumbs()
 
   const {
     data: testData,
@@ -158,6 +160,21 @@ const FailedTestsTable = () => {
       suspense: false,
     },
   })
+
+  useLayoutEffect(() => {
+    setBreadcrumbs([
+      {
+        pageName: '',
+        readOnly: true,
+        children: (
+          <span className="inline-flex items-center gap-1">
+            <Icon name="branch" variant="developer" size="sm" />
+            {decodeURIComponent(branch ?? '')}
+          </span>
+        ),
+      },
+    ])
+  }, [branch, setBreadcrumbs])
 
   const tableData = useMemo(() => {
     return testData?.testResults


### PR DESCRIPTION
# Description

This PR aims to add the breadcrumb to the failed test table, similar to https://github.com/codecov/gazebo/pull/3080

# Screenshots

https://github.com/user-attachments/assets/32272e7f-440f-4add-980b-09870d3fce97

# Link to Sample Entry

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.