### PR TITLE
feat: Adjust Sentry user feedback instances

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@radix-ui/react-label": "^2.0.2",
     "@radix-ui/react-popover": "^1.0.6",
     "@radix-ui/react-radio-group": "^1.1.3",
-    "@sentry/react": "^8.18.0",
+    "@sentry/react": "^8.24.0",
     "@stripe/react-stripe-js": "^2.7.1",
     "@stripe/stripe-js": "^3.4.0",
     "@tanstack/react-query": "^4.29.5",

--- a/src/layouts/Header/components/HelpDropdown/HelpDropdown.tsx
+++ b/src/layouts/Header/components/HelpDropdown/HelpDropdown.tsx
@@ -15,16 +15,17 @@ type DropdownItem = {
 }
 
 function HelpDropdown() {
-  const { data: form } = useQuery({
+  const { data: form, isSuccess: isFormSuccess } = useQuery({
     queryKey: ['HelpDropdownForm'],
     queryFn: () => SentryUserFeedback.createForm(),
+    suspense: false,
   })
 
   useLayoutEffect(() => {
-    if (!form) return
+    if (!isFormSuccess) return
     form.appendToDom()
     return form.removeFromDom
-  }, [form])
+  }, [form, isFormSuccess])
 
   const items: DropdownItem[] = [
     {
@@ -36,7 +37,7 @@ function HelpDropdown() {
       children: 'Support center',
     },
     {
-      onClick: form?.open,
+      onClick: isFormSuccess ? form.open : () => {},
       hook: 'open-modal',
       children: 'Share feedback',
     },

--- a/src/layouts/Header/components/HelpDropdown/HelpDropdown.tsx
+++ b/src/layouts/Header/components/HelpDropdown/HelpDropdown.tsx
@@ -1,5 +1,7 @@
-import { feedbackIntegration } from '@sentry/react'
-import React, { useEffect } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { useLayoutEffect } from 'react'
+
+import { SentryUserFeedback } from 'sentry'
 
 import Button from 'ui/Button'
 import { Dropdown } from 'ui/Dropdown/Dropdown'
@@ -12,13 +14,17 @@ type DropdownItem = {
   children: React.ReactNode
 }
 
-const removeSentryForm = () => {
-  document.body.style.overflow = ''
-  document.querySelector('#help-dropdown-widget')?.remove()
-}
-
 function HelpDropdown() {
-  useEffect(() => removeSentryForm, [])
+  const { data: form } = useQuery({
+    queryKey: ['HelpDropdownForm'],
+    queryFn: () => SentryUserFeedback.createForm(),
+  })
+
+  useLayoutEffect(() => {
+    if (!form) return
+    form.appendToDom()
+    return form.removeFromDom
+  }, [form])
 
   const items: DropdownItem[] = [
     {
@@ -30,23 +36,7 @@ function HelpDropdown() {
       children: 'Support center',
     },
     {
-      onClick: async () => {
-        const sentryFeedback = feedbackIntegration({
-          showBranding: false,
-          colorScheme: 'light',
-          formTitle: 'Give Feedback',
-          buttonLabel: 'Give Feedback',
-          submitButtonLabel: 'Send Feedback',
-          nameLabel: 'Username',
-          isEmailRequired: true,
-          autoInject: false,
-          id: 'help-dropdown-widget',
-          onFormClose: removeSentryForm,
-        })
-        const form = await sentryFeedback.createForm()
-        form.appendToDom()
-        form.open()
-      },
+      onClick: form?.open,
       hook: 'open-modal',
       children: 'Share feedback',
     },

--- a/src/pages/DefaultOrgSelector/DefaultOrgSelector.jsx
+++ b/src/pages/DefaultOrgSelector/DefaultOrgSelector.jsx
@@ -1,8 +1,12 @@
 import { zodResolver } from '@hookform/resolvers/zod'
-import { useState } from 'react'
+import { useLayoutEffect, useState } from 'react'
 import { Controller, useForm } from 'react-hook-form'
 import { Redirect, useHistory, useParams } from 'react-router-dom'
 import { z } from 'zod'
+
+import config from 'config'
+
+import { SentryBugReporter } from 'sentry'
 
 import { TrialStatuses, usePlanData } from 'services/account'
 import { useStoreCodecovEventMetric } from 'services/codecovEventMetrics'
@@ -99,6 +103,17 @@ function DefaultOrgSelector() {
       ]
     },
   })
+
+  useLayoutEffect(() => {
+    if (!config.SENTRY_DSN) {
+      console.log('bye')
+      return
+    }
+    console.log('hi')
+    const widget = SentryBugReporter.createWidget()
+    console.log(widget)
+    return widget.removeFromDom
+  }, [])
 
   const onSubmit = () => {
     updateDefaultOrg({ username: selectedOrg })

--- a/src/pages/DefaultOrgSelector/DefaultOrgSelector.jsx
+++ b/src/pages/DefaultOrgSelector/DefaultOrgSelector.jsx
@@ -106,12 +106,9 @@ function DefaultOrgSelector() {
 
   useLayoutEffect(() => {
     if (!config.SENTRY_DSN) {
-      console.log('bye')
       return
     }
-    console.log('hi')
     const widget = SentryBugReporter.createWidget()
-    console.log(widget)
     return widget.removeFromDom
   }, [])
 

--- a/src/pages/TermsOfService/TermsOfService.spec.tsx
+++ b/src/pages/TermsOfService/TermsOfService.spec.tsx
@@ -597,6 +597,7 @@ describe('TermsOfService', () => {
       })
     }
   )
+
   describe('sentry user feedback widget', () => {
     describe('when SENTRY_DSN is not defined', () => {
       it('does not render', async () => {

--- a/src/pages/TermsOfService/TermsOfService.tsx
+++ b/src/pages/TermsOfService/TermsOfService.tsx
@@ -1,7 +1,11 @@
 import { zodResolver } from '@hookform/resolvers/zod'
-import { useEffect } from 'react'
+import { useEffect, useLayoutEffect } from 'react'
 import { SubmitHandler, useForm } from 'react-hook-form'
 import { z } from 'zod'
+
+import config from 'config'
+
+import { SentryBugReporter } from 'sentry'
 
 import umbrellaSvg from 'assets/svg/umbrella.svg'
 import { CustomerIntent, useInternalUser } from 'services/user'
@@ -82,6 +86,14 @@ export default function TermsOfService() {
     onError: (error) => setError('apiError', error),
   })
   const { data: currentUser, isLoading: userIsLoading } = useInternalUser({})
+
+  useLayoutEffect(() => {
+    if (!config.SENTRY_DSN) {
+      return
+    }
+    const widget = SentryBugReporter.createWidget()
+    return widget.removeFromDom
+  }, [])
 
   interface FormValues {
     marketingEmail?: string

--- a/src/sentry.ts
+++ b/src/sentry.ts
@@ -78,6 +78,8 @@ export const SentryUserFeedback = Sentry.feedbackIntegration({
   formTitle: 'Give Feedback',
   buttonLabel: 'Give Feedback',
   submitButtonLabel: 'Send Feedback',
+  messagePlaceholder:
+    'Share your experience and suggest opportunities for improvement.',
   nameLabel: 'Username',
   isEmailRequired: true,
   autoInject: false,

--- a/src/sentry.ts
+++ b/src/sentry.ts
@@ -59,6 +59,17 @@ const checkForBlockedUserAgents = () => {
   )
 }
 
+export const SentryBugReporter = Sentry.feedbackIntegration({
+  colorScheme: 'light',
+  showBranding: false,
+  formTitle: 'Give Feedback',
+  buttonLabel: 'Give Feedback',
+  submitButtonLabel: 'Send Feedback',
+  nameLabel: 'Username',
+  isEmailRequired: true,
+  autoInject: false,
+})
+
 export const setupSentry = ({
   history,
 }: {
@@ -76,20 +87,6 @@ export const setupSentry = ({
   })
 
   const integrations = [replay, tracing]
-
-  // Only show feedback button in production
-  if (config.NODE_ENV === 'production') {
-    const feedback = Sentry.feedbackIntegration({
-      colorScheme: 'light',
-      showBranding: false,
-      formTitle: 'Give Feedback',
-      buttonLabel: 'Give Feedback',
-      submitButtonLabel: 'Send Feedback',
-      nameLabel: 'Username',
-      isEmailRequired: true,
-    })
-    integrations.push(feedback)
-  }
 
   const tracePropagationTargets = ['api.codecov.io', 'stage-api.codecov.dev']
   // wrapped in a silent try/catch incase the URL is invalid

--- a/src/sentry.ts
+++ b/src/sentry.ts
@@ -59,6 +59,7 @@ const checkForBlockedUserAgents = () => {
   )
 }
 
+// Bug report user feedback form in user onboarding
 export const SentryBugReporter = Sentry.feedbackIntegration({
   colorScheme: 'light',
   showBranding: false,
@@ -68,6 +69,19 @@ export const SentryBugReporter = Sentry.feedbackIntegration({
   nameLabel: 'Username',
   isEmailRequired: true,
   autoInject: false,
+})
+
+// Help dropdown user feedback form
+export const SentryUserFeedback = Sentry.feedbackIntegration({
+  showBranding: false,
+  colorScheme: 'light',
+  formTitle: 'Give Feedback',
+  buttonLabel: 'Give Feedback',
+  submitButtonLabel: 'Send Feedback',
+  nameLabel: 'Username',
+  isEmailRequired: true,
+  autoInject: false,
+  id: 'help-dropdown-widget',
 })
 
 export const setupSentry = ({

--- a/src/sentry.ts
+++ b/src/sentry.ts
@@ -66,6 +66,8 @@ export const SentryBugReporter = Sentry.feedbackIntegration({
   formTitle: 'Give Feedback',
   buttonLabel: 'Give Feedback',
   submitButtonLabel: 'Send Feedback',
+  messagePlaceholder:
+    'Share your experience and suggest opportunities for improvement.',
   nameLabel: 'Username',
   isEmailRequired: true,
   autoInject: false,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3844,49 +3844,49 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sentry-internal/browser-utils@npm:8.18.0":
-  version: 8.18.0
-  resolution: "@sentry-internal/browser-utils@npm:8.18.0"
+"@sentry-internal/browser-utils@npm:8.24.0":
+  version: 8.24.0
+  resolution: "@sentry-internal/browser-utils@npm:8.24.0"
   dependencies:
-    "@sentry/core": "npm:8.18.0"
-    "@sentry/types": "npm:8.18.0"
-    "@sentry/utils": "npm:8.18.0"
-  checksum: 10c0/de15b00e8ea58c758efe57170c1207990b73a9ce96971c777f3f80825109c542bb37649d6ad9f37bf0de43dc22053aceacf567a22a6437a1bc4d6530fb4a4618
+    "@sentry/core": "npm:8.24.0"
+    "@sentry/types": "npm:8.24.0"
+    "@sentry/utils": "npm:8.24.0"
+  checksum: 10c0/e0b974a82e9b73361ab0e0f049004ccd2609ec0d9b5325cc1fa475c2ea236ec6c59eae6950660a973b8f6efd716ce9534d69c67193e19f94f7d67825b822a8aa
   languageName: node
   linkType: hard
 
-"@sentry-internal/feedback@npm:8.18.0":
-  version: 8.18.0
-  resolution: "@sentry-internal/feedback@npm:8.18.0"
+"@sentry-internal/feedback@npm:8.24.0":
+  version: 8.24.0
+  resolution: "@sentry-internal/feedback@npm:8.24.0"
   dependencies:
-    "@sentry/core": "npm:8.18.0"
-    "@sentry/types": "npm:8.18.0"
-    "@sentry/utils": "npm:8.18.0"
-  checksum: 10c0/0c80c1f0e46c15c3823133ca68b67b0047500d75a1c3e136e35260c4d3f85208844c08ed232a50eb501293e339d8e197a5aeedcc25a186e633c318f959e2c65a
+    "@sentry/core": "npm:8.24.0"
+    "@sentry/types": "npm:8.24.0"
+    "@sentry/utils": "npm:8.24.0"
+  checksum: 10c0/8ad68ba0002d16871c9d3dc6d6dbd8eb9270a43cf187584b1810bfbb849b4380a1edb4e3a8d5b7521848b99911bf8399dae8964dbc1848a5407b2b147bc1fa4c
   languageName: node
   linkType: hard
 
-"@sentry-internal/replay-canvas@npm:8.18.0":
-  version: 8.18.0
-  resolution: "@sentry-internal/replay-canvas@npm:8.18.0"
+"@sentry-internal/replay-canvas@npm:8.24.0":
+  version: 8.24.0
+  resolution: "@sentry-internal/replay-canvas@npm:8.24.0"
   dependencies:
-    "@sentry-internal/replay": "npm:8.18.0"
-    "@sentry/core": "npm:8.18.0"
-    "@sentry/types": "npm:8.18.0"
-    "@sentry/utils": "npm:8.18.0"
-  checksum: 10c0/b915d5a25c07f00ab0919f9a508ced0002bb5ed5de15437a38d871940c9f03fec5a807e062ffb289560385b613319ceae60424e13881866d1d130649caff5259
+    "@sentry-internal/replay": "npm:8.24.0"
+    "@sentry/core": "npm:8.24.0"
+    "@sentry/types": "npm:8.24.0"
+    "@sentry/utils": "npm:8.24.0"
+  checksum: 10c0/579bf4cfe03ccdf562977196b547e2ba5f91fa9942dd3f7278daca978fb85bb036fa61671ae774643e173da65ac18ee1ffe617ed9417ea80635afba2b5c472b0
   languageName: node
   linkType: hard
 
-"@sentry-internal/replay@npm:8.18.0":
-  version: 8.18.0
-  resolution: "@sentry-internal/replay@npm:8.18.0"
+"@sentry-internal/replay@npm:8.24.0":
+  version: 8.24.0
+  resolution: "@sentry-internal/replay@npm:8.24.0"
   dependencies:
-    "@sentry-internal/browser-utils": "npm:8.18.0"
-    "@sentry/core": "npm:8.18.0"
-    "@sentry/types": "npm:8.18.0"
-    "@sentry/utils": "npm:8.18.0"
-  checksum: 10c0/7506a974445c293a1ed3bc4c625e1134f1c646e18868d366c7cc9f55cdedd5c78681ee1c47f3418c5298552d84ef195471512c3417cc1dc402a4326de5dcfb7e
+    "@sentry-internal/browser-utils": "npm:8.24.0"
+    "@sentry/core": "npm:8.24.0"
+    "@sentry/types": "npm:8.24.0"
+    "@sentry/utils": "npm:8.24.0"
+  checksum: 10c0/109854d434b3867bbe0d4b51886009ed213e8af3790ebd702ceb04a0be5b7542cdb8d0e1fca1c231f7fb50fd16799b4ee6150e18b9a64e3ed7d1c4dd2964a716
   languageName: node
   linkType: hard
 
@@ -3897,18 +3897,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sentry/browser@npm:8.18.0":
-  version: 8.18.0
-  resolution: "@sentry/browser@npm:8.18.0"
+"@sentry/browser@npm:8.24.0":
+  version: 8.24.0
+  resolution: "@sentry/browser@npm:8.24.0"
   dependencies:
-    "@sentry-internal/browser-utils": "npm:8.18.0"
-    "@sentry-internal/feedback": "npm:8.18.0"
-    "@sentry-internal/replay": "npm:8.18.0"
-    "@sentry-internal/replay-canvas": "npm:8.18.0"
-    "@sentry/core": "npm:8.18.0"
-    "@sentry/types": "npm:8.18.0"
-    "@sentry/utils": "npm:8.18.0"
-  checksum: 10c0/795d33c1b19e70e4c3f8dcbff606aa29af09eebbf22bca9fed2e141252a183648cac2b1de9c19bd0c75ee50b829bc171c796a8fcba5f8303427f7c697f85a044
+    "@sentry-internal/browser-utils": "npm:8.24.0"
+    "@sentry-internal/feedback": "npm:8.24.0"
+    "@sentry-internal/replay": "npm:8.24.0"
+    "@sentry-internal/replay-canvas": "npm:8.24.0"
+    "@sentry/core": "npm:8.24.0"
+    "@sentry/types": "npm:8.24.0"
+    "@sentry/utils": "npm:8.24.0"
+  checksum: 10c0/99ab8b4840b49aa9909484b848d6c5027484b9738a8722375118d3b3f2a6eda6eafe113a7fc37189fed0a49c8dde8ce12db5ba15db6fc25b2a1c566165434091
   languageName: node
   linkType: hard
 
@@ -4014,44 +4014,44 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sentry/core@npm:8.18.0":
-  version: 8.18.0
-  resolution: "@sentry/core@npm:8.18.0"
+"@sentry/core@npm:8.24.0":
+  version: 8.24.0
+  resolution: "@sentry/core@npm:8.24.0"
   dependencies:
-    "@sentry/types": "npm:8.18.0"
-    "@sentry/utils": "npm:8.18.0"
-  checksum: 10c0/827b859f9d70943325e1d1ebcd1c452c1b154b91dd91e4b9044bcb4b977e35b45c3bfd245f55e8c5bfbd67c0d345218d3896825f325f02b397595f4bb0aa2196
+    "@sentry/types": "npm:8.24.0"
+    "@sentry/utils": "npm:8.24.0"
+  checksum: 10c0/a0b4146c2b37976e4a29ef708efad856fb497497a973fe954d4c09903507315e372d67c31bb1279a1882af8f3c9025f11dceef8886770b211e58c81de7fdb86f
   languageName: node
   linkType: hard
 
-"@sentry/react@npm:^8.18.0":
-  version: 8.18.0
-  resolution: "@sentry/react@npm:8.18.0"
+"@sentry/react@npm:^8.24.0":
+  version: 8.24.0
+  resolution: "@sentry/react@npm:8.24.0"
   dependencies:
-    "@sentry/browser": "npm:8.18.0"
-    "@sentry/core": "npm:8.18.0"
-    "@sentry/types": "npm:8.18.0"
-    "@sentry/utils": "npm:8.18.0"
+    "@sentry/browser": "npm:8.24.0"
+    "@sentry/core": "npm:8.24.0"
+    "@sentry/types": "npm:8.24.0"
+    "@sentry/utils": "npm:8.24.0"
     hoist-non-react-statics: "npm:^3.3.2"
   peerDependencies:
     react: ^16.14.0 || 17.x || 18.x || 19.x
-  checksum: 10c0/a82f46ca4ef9547e28d95de17cd3cac7c0af59c1abfa7a92bf1074ea1b8c069f5afa8a8c5ab42f62b9128b53026e5c28cf95f62585a0ffab9279abb6cadcc596
+  checksum: 10c0/6d304a4cf08cdeccf85c7c420a11516da8e37fe57906ffd3327c88080d4ea8db0dc21d1b48b973fdb44f9d61aeedc230d37cefdaf8b95f93cd51f82e5f24f3ee
   languageName: node
   linkType: hard
 
-"@sentry/types@npm:8.18.0":
-  version: 8.18.0
-  resolution: "@sentry/types@npm:8.18.0"
-  checksum: 10c0/e15e602c62a6a82bd0624fb89b800b5fcf2d1256254bb1d1a4ccea74a653c3e53715b91a67f224bcd46aaea3e8d90ce72d339569b9088bf482b49554cebfc886
+"@sentry/types@npm:8.24.0":
+  version: 8.24.0
+  resolution: "@sentry/types@npm:8.24.0"
+  checksum: 10c0/3a9713ad71f240ef707245a460a01d821d9f0308bc215ca967d0427b6b86d24d22ffc48235f81c059aa835e40b0969eef5568f6e03ffaeff4b6c608156b70acb
   languageName: node
   linkType: hard
 
-"@sentry/utils@npm:8.18.0":
-  version: 8.18.0
-  resolution: "@sentry/utils@npm:8.18.0"
+"@sentry/utils@npm:8.24.0":
+  version: 8.24.0
+  resolution: "@sentry/utils@npm:8.24.0"
   dependencies:
-    "@sentry/types": "npm:8.18.0"
-  checksum: 10c0/177059c3c802f7c83019dda6c97ecf7a50b200a201323d98f4d949b48d7e67b411f65f2c7597015aab964a54ff04809f2e8e1eb575f2e3383a05209d54fa5cec
+    "@sentry/types": "npm:8.24.0"
+  checksum: 10c0/5a9da3c5fbfac886a365fc48d467954a63c0d15bd049cc2a61d24d0146c8f6e8c88f1e57e2666384d834b440d6cc4abdc986d3dda57f7418a310e2032bdbecdc
   languageName: node
   linkType: hard
 
@@ -10728,7 +10728,7 @@ __metadata:
     "@radix-ui/react-label": "npm:^2.0.2"
     "@radix-ui/react-popover": "npm:^1.0.6"
     "@radix-ui/react-radio-group": "npm:^1.1.3"
-    "@sentry/react": "npm:^8.18.0"
+    "@sentry/react": "npm:^8.24.0"
     "@sentry/webpack-plugin": "npm:^2.17.0"
     "@storybook/addon-a11y": "npm:^8.2.6"
     "@storybook/addon-actions": "npm:^8.2.6"


### PR DESCRIPTION
Adjusts the Sentry user feedback integration such that the widget only loads on the user onboarding pages (TermsOfService and DefaultOrgSelector). Also Refactors the existing HelpDropdown instantiation of the feedback integration to be contained in sentry.ts, and makes a minor copy change in the HelpDropdown form.

Closes https://github.com/codecov/engineering-team/issues/2173
Closes https://github.com/codecov/engineering-team/issues/1941
