### PR TITLE
unfeat: Remove branch breadcrumb on repo page

### DIFF
--- a/src/pages/CommitDetailPage/CommitDetailPage.tsx
+++ b/src/pages/CommitDetailPage/CommitDetailPage.tsx
@@ -82,6 +82,7 @@ const CommitDetailPage: React.FC = () => {
         text: shortSHA,
       },
     ])
+    return () => setBreadcrumbs([])
   }, [
     setBreadcrumbs,
     commitSha,

--- a/src/pages/PullRequestPage/PullRequestPage.tsx
+++ b/src/pages/PullRequestPage/PullRequestPage.tsx
@@ -89,6 +89,7 @@ function PullRequestPage() {
         text: pullId,
       },
     ])
+    return () => setBreadcrumbs([])
   }, [setBreadcrumbs, pullId, setBaseCrumbs, owner, repo, overview])
 
   if (!isLoading && !data?.pull) {

--- a/src/pages/RepoPage/BundlesTab/BundleContent/BundleContent.spec.tsx
+++ b/src/pages/RepoPage/BundlesTab/BundleContent/BundleContent.spec.tsx
@@ -6,8 +6,6 @@ import { setupServer } from 'msw/node'
 import { Suspense } from 'react'
 import { MemoryRouter, Route } from 'react-router-dom'
 
-import { RepoBreadcrumbProvider } from 'pages/RepoPage/context'
-
 import BundleContent from './BundleContent'
 
 jest.mock('./BundleSelection', () => () => <div>BundleSelection</div>)
@@ -242,9 +240,7 @@ const wrapper =
             '/:provider/:owner/:repo/bundles',
           ]}
         >
-          <RepoBreadcrumbProvider>
-            <Suspense fallback={<p>Loading</p>}>{children}</Suspense>
-          </RepoBreadcrumbProvider>
+          <Suspense fallback={<p>Loading</p>}>{children}</Suspense>
         </Route>
       </MemoryRouter>
     </QueryClientProvider>

--- a/src/pages/RepoPage/BundlesTab/BundleContent/BundleContent.tsx
+++ b/src/pages/RepoPage/BundlesTab/BundleContent/BundleContent.tsx
@@ -1,12 +1,10 @@
-import { lazy, Suspense, useEffect, useLayoutEffect } from 'react'
+import { lazy, Suspense, useEffect } from 'react'
 import { Switch, useParams } from 'react-router-dom'
 
 import { SentryRoute } from 'sentry'
 
-import { useCrumbs } from 'pages/RepoPage/context'
 import { useBranchBundleSummary } from 'services/bundleAnalysis'
 import { metrics } from 'shared/utils/metrics'
-import Icon from 'ui/Icon'
 import Spinner from 'ui/Spinner'
 
 import AssetsTable from './AssetsTable'
@@ -36,28 +34,12 @@ const Loader = () => (
 
 const BundleContent: React.FC = () => {
   const { provider, owner, repo, branch, bundle } = useParams<URLParams>()
-  const { setBreadcrumbs } = useCrumbs()
 
   useEffect(() => {
     metrics.increment('bundles_tab.bundle_details.visited_page', 1)
   }, [])
 
   const { data } = useBranchBundleSummary({ provider, owner, repo, branch })
-
-  useLayoutEffect(() => {
-    setBreadcrumbs([
-      {
-        pageName: '',
-        readOnly: true,
-        children: (
-          <span className="inline-flex items-center gap-1">
-            <Icon name="branch" variant="developer" size="sm" />
-            {decodeURIComponent(branch ?? '')}
-          </span>
-        ),
-      },
-    ])
-  }, [branch, setBreadcrumbs])
 
   const bundleType = data?.branch?.head?.bundleAnalysisReport?.__typename
 

--- a/src/pages/RepoPage/CommitsTab/CommitsTab.jsx
+++ b/src/pages/RepoPage/CommitsTab/CommitsTab.jsx
@@ -1,11 +1,4 @@
-import {
-  lazy,
-  Suspense,
-  useEffect,
-  useLayoutEffect,
-  useRef,
-  useState,
-} from 'react'
+import { lazy, Suspense, useEffect, useRef, useState } from 'react'
 import { useParams } from 'react-router-dom'
 
 import { useBranchHasCommits } from 'services/branches'
@@ -19,8 +12,6 @@ import Spinner from 'ui/Spinner'
 
 import { filterItems, statusEnum } from './enums'
 import { useCommitsTabBranchSelector } from './hooks'
-
-import { useCrumbs } from '../context'
 
 const ALL_BRANCHES = 'All branches'
 const CommitsTable = lazy(() => import('./CommitsTable'))
@@ -86,7 +77,6 @@ const useControlParams = ({ defaultBranch }) => {
 }
 
 function CommitsTab() {
-  const { setBreadcrumbs } = useCrumbs()
   const { provider, owner, repo } = useParams()
 
   const { data: overview } = useRepoOverview({
@@ -107,7 +97,6 @@ function CommitsTab() {
   const {
     branchList,
     branchSelectorProps,
-    currentBranchSelected,
     branchesFetchNextPage,
     branchListIsFetching,
     branchListHasNextPage,
@@ -119,21 +108,6 @@ function CommitsTab() {
     defaultBranch: overview?.defaultBranch,
     isAllCommits: selectedBranch === ALL_BRANCHES,
   })
-
-  useLayoutEffect(() => {
-    setBreadcrumbs([
-      {
-        pageName: '',
-        readOnly: true,
-        children: (
-          <span className="inline-flex items-center gap-1">
-            <Icon name="branch" variant="developer" size="sm" />
-            {currentBranchSelected}
-          </span>
-        ),
-      },
-    ])
-  }, [currentBranchSelected, setBreadcrumbs])
 
   const newBranches = [...(isSearching ? [] : [ALL_BRANCHES]), ...branchList]
 

--- a/src/pages/RepoPage/CoverageTab/OverviewTab/Summary/Summary.jsx
+++ b/src/pages/RepoPage/CoverageTab/OverviewTab/Summary/Summary.jsx
@@ -1,7 +1,5 @@
-import { useLayoutEffect } from 'react'
 import { Redirect, useParams } from 'react-router-dom'
 
-import { useCrumbs } from 'pages/RepoPage/context'
 import { useRepoConfig } from 'services/repo/useRepoConfig'
 import { determineProgressColor } from 'shared/utils/determineProgressColor'
 import A from 'ui/A'
@@ -20,7 +18,6 @@ const YAML_STATE = Object.freeze({
 
 const Summary = () => {
   const { provider, owner, repo } = useParams()
-  const { setBreadcrumbs } = useCrumbs()
   const { setNewPath, redirectState } = useCoverageRedirect()
   const { data: repoConfigData } = useRepoConfig({ provider, owner, repo })
 
@@ -35,21 +32,6 @@ const Summary = () => {
     branchListFetchNextPage,
     setBranchSearchTerm,
   } = useSummary()
-
-  useLayoutEffect(() => {
-    setBreadcrumbs([
-      {
-        pageName: '',
-        readOnly: true,
-        children: (
-          <span className="inline-flex items-center gap-1">
-            <Icon name="branch" variant="developer" size="sm" />
-            {currentBranchSelected?.name}
-          </span>
-        ),
-      },
-    ])
-  }, [currentBranchSelected?.name, setBreadcrumbs])
 
   const onChangeHandler = ({ name }) => {
     setNewPath(name)

--- a/src/pages/RepoPage/CoverageTab/OverviewTab/Summary/Summary.spec.jsx
+++ b/src/pages/RepoPage/CoverageTab/OverviewTab/Summary/Summary.spec.jsx
@@ -7,8 +7,6 @@ import { Suspense } from 'react'
 import { MemoryRouter, Route } from 'react-router-dom'
 import useIntersection from 'react-use/lib/useIntersection'
 
-import { RepoBreadcrumbProvider } from 'pages/RepoPage/context'
-
 import Summary from './Summary'
 
 import { useCoverageRedirect } from '../summaryHooks'
@@ -127,9 +125,7 @@ const wrapper =
     <QueryClientProvider client={queryClient}>
       <MemoryRouter initialEntries={[initialEntries]}>
         <Route path="/:provider/:owner/:repo">
-          <RepoBreadcrumbProvider>
-            <Suspense fallback={<div>loading</div>}>{children}</Suspense>
-          </RepoBreadcrumbProvider>
+          <Suspense fallback={<div>loading</div>}>{children}</Suspense>
         </Route>
         <Route path="*" render={({ location }) => location.pathname} />
       </MemoryRouter>

--- a/src/pages/RepoPage/CoverageTab/OverviewTab/SummaryTeamPlan/SummaryTeamPlan.spec.tsx
+++ b/src/pages/RepoPage/CoverageTab/OverviewTab/SummaryTeamPlan/SummaryTeamPlan.spec.tsx
@@ -7,8 +7,6 @@ import { Suspense } from 'react'
 import { MemoryRouter, Route } from 'react-router-dom'
 import useIntersection from 'react-use/lib/useIntersection'
 
-import { RepoBreadcrumbProvider } from 'pages/RepoPage/context'
-
 import SummaryTeamPlan from './SummaryTeamPlan'
 
 import { useCoverageRedirect } from '../summaryHooks'
@@ -117,9 +115,7 @@ const wrapper =
     <QueryClientProvider client={queryClient}>
       <MemoryRouter initialEntries={[initialEntries]}>
         <Route path="/:provider/:owner/:repo">
-          <RepoBreadcrumbProvider>
-            <Suspense fallback={<div>loading</div>}>{children}</Suspense>
-          </RepoBreadcrumbProvider>
+          <Suspense fallback={<div>loading</div>}>{children}</Suspense>
         </Route>
         <Route path="*" render={({ location }) => location.pathname} />
       </MemoryRouter>

--- a/src/pages/RepoPage/CoverageTab/OverviewTab/SummaryTeamPlan/SummaryTeamPlan.tsx
+++ b/src/pages/RepoPage/CoverageTab/OverviewTab/SummaryTeamPlan/SummaryTeamPlan.tsx
@@ -1,7 +1,5 @@
-import { useLayoutEffect } from 'react'
 import { Redirect } from 'react-router-dom'
 
-import { useCrumbs } from 'pages/RepoPage/context'
 import A from 'ui/A'
 import Icon from 'ui/Icon'
 import Select from 'ui/Select'
@@ -14,7 +12,6 @@ const YAML_STATE = Object.freeze({
 })
 
 const SummaryTeamPlan = () => {
-  const { setBreadcrumbs } = useCrumbs()
   const { setNewPath, redirectState } = useCoverageRedirect()
 
   const {
@@ -28,21 +25,6 @@ const SummaryTeamPlan = () => {
     branchListFetchNextPage,
     setBranchSearchTerm,
   } = useSummary()
-
-  useLayoutEffect(() => {
-    setBreadcrumbs([
-      {
-        pageName: '',
-        readOnly: true,
-        children: (
-          <span className="inline-flex items-center gap-1">
-            <Icon name="branch" variant="developer" size="sm" />
-            {currentBranchSelected?.name}
-          </span>
-        ),
-      },
-    ])
-  }, [currentBranchSelected?.name, setBreadcrumbs])
 
   const onChangeHandler = ({ name }: { name: string }) => {
     setNewPath(name)


### PR DESCRIPTION
Removes the branch breadcrumb on RepoPage. Part of the header overhaul work, but waited to do this until the old header was removed to make things easier.

Closes https://github.com/codecov/engineering-team/issues/2066
