### PR TITLE
fix: Make isGithubRateLimited param nullable

### DIFF
--- a/src/services/repo/useRepoRateLimitStatus.tsx
+++ b/src/services/repo/useRepoRateLimitStatus.tsx
@@ -10,7 +10,7 @@ import {
 
 const RepositorySchema = z.object({
   __typename: z.literal('Repository'),
-  isGithubRateLimited: z.boolean(),
+  isGithubRateLimited: z.boolean().nullable(),
 })
 
 const RequestSchema = z.object({

--- a/src/services/user/useOwnerRateLimitStatus.tsx
+++ b/src/services/user/useOwnerRateLimitStatus.tsx
@@ -10,7 +10,7 @@ export const RequestSchema = z
       .object({
         owner: z
           .object({
-            isGithubRateLimited: z.boolean(),
+            isGithubRateLimited: z.boolean().nullable(),
           })
           .nullable(),
       })


### PR DESCRIPTION
In API this param is nullable now if it errors out, we want to make the same update on the zod schema

# Screenshots

# Link to Sample Entry

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.