### PR TITLE
dev: remove double yarn install on dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,8 +1,8 @@
 # syntax = docker/dockerfile:1.3
 FROM node:20-alpine3.17 as npm
 RUN apk -U add git 
-RUN corepack enable && corepack prepare yarn@stable --activate
 RUN mkdir /home/workspace
+RUN corepack enable
 COPY package.json /home/workspace
 WORKDIR /home/workspace
 RUN yarn install
@@ -50,11 +50,11 @@ ENV REACT_APP_ENV=$REACT_APP_ENV_ARG
 ENV REACT_APP_CODECOV_VERSION=$REACT_APP_CODECOV_VERSION
 ENV GENERATE_SOURCEMAP=false
 RUN mkdir /home/workspace
-COPY --from=npm /home/workspace/node_modules /home/workspace/node_modules
+# COPY --from=npm /home/workspace/node_modules /home/workspace/node_modules
 WORKDIR /home/workspace
 RUN apk -U add git
-RUN corepack enable && corepack prepare yarn@stable --activate
 COPY . /home/workspace
+RUN corepack enable
 RUN yarn install
 RUN yarn build && rm -f build/mockServiceWorker.js
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,7 @@
 # syntax = docker/dockerfile:1.3
 FROM node:20-alpine3.17 as npm
 RUN apk -U add git 
-RUN apk add --no-cache yarn
+RUN corepack enable && corepack prepare yarn@stable --activate
 RUN mkdir /home/workspace
 COPY package.json /home/workspace
 WORKDIR /home/workspace
@@ -53,7 +53,7 @@ RUN mkdir /home/workspace
 COPY --from=npm /home/workspace/node_modules /home/workspace/node_modules
 WORKDIR /home/workspace
 RUN apk -U add git
-RUN apk add --no-cache yarn
+RUN corepack enable && corepack prepare yarn@stable --activate
 COPY . /home/workspace
 RUN yarn install
 RUN yarn build && rm -f build/mockServiceWorker.js

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,12 +1,4 @@
 # syntax = docker/dockerfile:1.3
-FROM node:20-alpine3.17 as npm
-RUN apk -U add git 
-RUN mkdir /home/workspace
-RUN corepack enable
-COPY package.json /home/workspace
-WORKDIR /home/workspace
-RUN yarn install
-
 FROM            alpine:3.17 as uploader
 USER            root
 WORKDIR         /tmp
@@ -50,7 +42,6 @@ ENV REACT_APP_ENV=$REACT_APP_ENV_ARG
 ENV REACT_APP_CODECOV_VERSION=$REACT_APP_CODECOV_VERSION
 ENV GENERATE_SOURCEMAP=false
 RUN mkdir /home/workspace
-# COPY --from=npm /home/workspace/node_modules /home/workspace/node_modules
 WORKDIR /home/workspace
 RUN apk -U add git
 COPY . /home/workspace


### PR DESCRIPTION
# Description

saw that yarn was being installed at v1.22.19, and then later at 4.3.1, this PR aims to get rid of the original npm builder that was just getting overwritten with the second yarn install. I think previously we were using the separate npm builder because downloading and using the packages was taking 2+ minutes where now it takes ~30 seconds

This leads to a timing improvement overall of ~1.5 minutes pre/post (25% faster)

Pre: https://github.com/codecov/gazebo/actions/runs/10255316136/job/28372007061 (6:14)
Post: https://github.com/codecov/gazebo/actions/runs/10275127882/job/28433206745 (4:38)

# Link to Sample Entry

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.