### PR TITLE
fix: Revert change to new github respository secret link in onboarding

### DIFF
--- a/src/pages/RepoPage/CoverageOnboarding/GitHubActions/GitHubActions.spec.tsx
+++ b/src/pages/RepoPage/CoverageOnboarding/GitHubActions/GitHubActions.spec.tsx
@@ -118,7 +118,7 @@ describe('GitHubActions', () => {
       expect(repositorySecretLink).toBeInTheDocument()
       expect(repositorySecretLink).toHaveAttribute(
         'href',
-        'https://github.com/codecov/cool-repo/config/secrets/actions/new'
+        'https://github.com/codecov/cool-repo/settings/secrets/actions/new'
       )
     })
 

--- a/src/services/navigation/useNavLinks/useNavLinks.js
+++ b/src/services/navigation/useNavLinks/useNavLinks.js
@@ -668,7 +668,7 @@ export function useNavLinks() {
           owner: o,
           repo: r,
         }
-      ) => `https://github.com/${owner}/${repo}/config/secrets/actions/new`,
+      ) => `https://github.com/${owner}/${repo}/settings/secrets/actions/new`,
       isExternalLink: true,
       openNewTab: true,
     },

--- a/src/services/navigation/useNavLinks/useNavLinks.spec.js
+++ b/src/services/navigation/useNavLinks/useNavLinks.spec.js
@@ -1602,7 +1602,7 @@ describe('useNavLinks', () => {
 
       const path = result.current.githubRepoSecrets.path()
       expect(path).toBe(
-        'https://github.com/codecov/cool-repo/config/secrets/actions/new'
+        'https://github.com/codecov/cool-repo/settings/secrets/actions/new'
       )
     })
 
@@ -1616,7 +1616,7 @@ describe('useNavLinks', () => {
         repo: 'test-repo',
       })
       expect(path).toBe(
-        'https://github.com/test-owner/test-repo/config/secrets/actions/new'
+        'https://github.com/test-owner/test-repo/settings/secrets/actions/new'
       )
     })
   })


### PR DESCRIPTION
Fixes an an accidental change I made that broke this link in onboarding. 

Closes https://github.com/codecov/engineering-team/issues/2194