### PR TITLE
feat: Add framework selector to GitHub Actions coverage onboarding

### DIFF
--- a/src/pages/RepoPage/CoverageOnboarding/GitHubActions/GitHubActions.spec.tsx
+++ b/src/pages/RepoPage/CoverageOnboarding/GitHubActions/GitHubActions.spec.tsx
@@ -125,14 +125,6 @@ describe('GitHubActions', () => {
       expect(blurb).toBeInTheDocument()
     })
 
-    it('renders framework selector', async () => {
-      setup({})
-      render(<GitHubActions />, { wrapper })
-
-      const selector = await screen.findByTestId('framework-selector')
-      expect(selector).toBeInTheDocument()
-    })
-
     it('renders install step', async () => {
       setup({})
       render(<GitHubActions />, { wrapper })
@@ -159,37 +151,127 @@ describe('GitHubActions', () => {
       expect(command).toBeInTheDocument()
     })
 
-    it('renders example collapsible', async () => {
-      setup({})
-      render(<GitHubActions />, { wrapper })
+    describe('framework selector', () => {
+      it('renders', async () => {
+        setup({})
+        render(<GitHubActions />, { wrapper })
 
-      const trigger = await screen.findByText((content) =>
-        content.startsWith('Your final GitHub Actions workflow')
-      )
-      expect(trigger).toBeInTheDocument()
+        const selector = await screen.findByRole('combobox')
+        expect(selector).toBeInTheDocument()
+      })
+
+      describe('when clicked', () => {
+        it('renders dropdown', async () => {
+          const { user } = setup({})
+          render(<GitHubActions />, { wrapper })
+
+          const selector = await screen.findByRole('combobox')
+          expect(selector).toBeInTheDocument()
+
+          let vitest = screen.queryByText('Vitest')
+          let pytest = screen.queryByText('Pytest')
+          let go = screen.queryByText('Go')
+          expect(vitest).not.toBeInTheDocument()
+          expect(pytest).not.toBeInTheDocument()
+          expect(go).not.toBeInTheDocument()
+
+          await user.click(selector)
+
+          vitest = await screen.findByText('Vitest')
+          pytest = await screen.findByText('Pytest')
+          go = await screen.findByText('Go')
+          expect(vitest).toBeInTheDocument()
+          expect(pytest).toBeInTheDocument()
+          expect(go).toBeInTheDocument()
+        })
+      })
+
+      describe('when Go is selected', () => {
+        it('does not render install step', async () => {
+          const { user } = setup({})
+          render(<GitHubActions />, { wrapper })
+
+          const selector = await screen.findByRole('combobox')
+          expect(selector).toBeInTheDocument()
+
+          await user.click(selector)
+
+          const go = await screen.findByText('Go')
+          expect(go).toBeInTheDocument()
+
+          await user.click(go)
+
+          const install = screen.queryByText(
+            'Install requirements in your terminal:'
+          )
+          expect(install).not.toBeInTheDocument()
+        })
+
+        it('updates run step', async () => {
+          const { user } = setup({})
+          render(<GitHubActions />, { wrapper })
+
+          const selector = await screen.findByRole('combobox')
+          expect(selector).toBeInTheDocument()
+
+          await user.click(selector)
+
+          const go = await screen.findByText('Go')
+          expect(go).toBeInTheDocument()
+
+          await user.click(go)
+
+          const run = await screen.findByText(
+            'In a GitHub Action, run tests and generate a coverage report:'
+          )
+          expect(run).toBeInTheDocument()
+
+          const command = await screen.findByText(
+            'go test -coverprofile=coverage.txt'
+          )
+          expect(command).toBeInTheDocument()
+        })
+
+        it('updates example yaml', async () => {
+          const { user } = setup({})
+          render(<GitHubActions />, { wrapper })
+
+          const selector = await screen.findByRole('combobox')
+          expect(selector).toBeInTheDocument()
+
+          await user.click(selector)
+
+          const go = await screen.findByText('Go')
+          expect(go).toBeInTheDocument()
+
+          await user.click(go)
+
+          const trigger = await screen.findByText((content) =>
+            content.startsWith('Your final GitHub Actions workflow')
+          )
+          expect(trigger).toBeInTheDocument()
+
+          await user.click(trigger)
+
+          const yaml = await screen.findByText(/go mod download/)
+          expect(yaml).toBeInTheDocument()
+        })
+      })
     })
 
-    describe('when collapsible is open', () => {
-      it('renders example GHA yaml', async () => {
-        const { user } = setup({})
+    describe('example collapsible', () => {
+      it('renders', async () => {
+        setup({})
         render(<GitHubActions />, { wrapper })
 
         const trigger = await screen.findByText((content) =>
           content.startsWith('Your final GitHub Actions workflow')
         )
         expect(trigger).toBeInTheDocument()
-
-        let example = screen.queryByText(/name: Run tests and upload coverage/)
-        expect(example).not.toBeInTheDocument()
-
-        await user.click(trigger)
-
-        example = await screen.findByText(/name: Run tests and upload coverage/)
-        expect(example).toBeInTheDocument()
       })
 
-      describe('if using repo token', () => {
-        it('does not show repo slug in yaml', async () => {
+      describe('when the collapsible is open', () => {
+        it('renders example GHA yaml', async () => {
           const { user } = setup({})
           render(<GitHubActions />, { wrapper })
 
@@ -198,16 +280,55 @@ describe('GitHubActions', () => {
           )
           expect(trigger).toBeInTheDocument()
 
+          let example = screen.queryByText(
+            /name: Run tests and upload coverage/
+          )
+          expect(example).not.toBeInTheDocument()
+
           await user.click(trigger)
 
-          const slug = screen.queryByText(/slug: codecov\/cool-repo/)
-          expect(slug).not.toBeInTheDocument()
+          example = await screen.findByText(
+            /name: Run tests and upload coverage/
+          )
+          expect(example).toBeInTheDocument()
         })
-      })
 
-      describe('if using org token', () => {
-        it('shows repo slug in yaml', async () => {
-          const { user } = setup({ hasOrgUploadToken: true })
+        describe('if using repo token', () => {
+          it('does not show repo slug in yaml', async () => {
+            const { user } = setup({})
+            render(<GitHubActions />, { wrapper })
+
+            const trigger = await screen.findByText((content) =>
+              content.startsWith('Your final GitHub Actions workflow')
+            )
+            expect(trigger).toBeInTheDocument()
+
+            await user.click(trigger)
+
+            const slug = screen.queryByText(/slug: codecov\/cool-repo/)
+            expect(slug).not.toBeInTheDocument()
+          })
+        })
+
+        describe('if using org token', () => {
+          it('shows repo slug in yaml', async () => {
+            const { user } = setup({ hasOrgUploadToken: true })
+            render(<GitHubActions />, { wrapper })
+
+            const trigger = await screen.findByText((content) =>
+              content.startsWith('Your final GitHub Actions workflow')
+            )
+            expect(trigger).toBeInTheDocument()
+
+            await user.click(trigger)
+
+            const slug = await screen.findByText(/slug: codecov\/cool-repo/)
+            expect(slug).toBeInTheDocument()
+          })
+        })
+
+        it('renders learn more blurb', async () => {
+          const { user } = setup({})
           render(<GitHubActions />, { wrapper })
 
           const trigger = await screen.findByText((content) =>
@@ -215,29 +336,14 @@ describe('GitHubActions', () => {
           )
           expect(trigger).toBeInTheDocument()
 
+          let blurb = screen.queryByText(/about generating coverage reports/)
+          expect(blurb).not.toBeInTheDocument()
+
           await user.click(trigger)
 
-          const slug = await screen.findByText(/slug: codecov\/cool-repo/)
-          expect(slug).toBeInTheDocument()
+          blurb = await screen.findByText(/about generating coverage reports/)
+          expect(blurb).toBeInTheDocument()
         })
-      })
-
-      it('renders learn more blurb', async () => {
-        const { user } = setup({})
-        render(<GitHubActions />, { wrapper })
-
-        const trigger = await screen.findByText((content) =>
-          content.startsWith('Your final GitHub Actions workflow')
-        )
-        expect(trigger).toBeInTheDocument()
-
-        let blurb = screen.queryByText(/about generating coverage reports/)
-        expect(blurb).not.toBeInTheDocument()
-
-        await user.click(trigger)
-
-        blurb = await screen.findByText(/about generating coverage reports/)
-        expect(blurb).toBeInTheDocument()
       })
     })
   })
@@ -366,16 +472,25 @@ describe('GitHubActions', () => {
       const user = userEvent.setup()
       render(<GitHubActions />, { wrapper })
 
+      // Expand the yaml example dropdown to make that snippet visible
+      const trigger = await screen.findByText((content) =>
+        content.startsWith('Your final GitHub Actions workflow')
+      )
+      expect(trigger).toBeInTheDocument()
+
+      await user.click(trigger)
+
       const copyCommands = await screen.findAllByTestId(
         'clipboard-code-snippet'
       )
-      expect(copyCommands.length).toEqual(4)
+      expect(copyCommands.length).toEqual(5)
 
       const promises: Promise<void>[] = []
       copyCommands.forEach((copy) => promises.push(user.click(copy)))
       await Promise.all(promises)
 
-      expect(mockMetricMutationVariables).toHaveBeenCalledTimes(3)
+      // One of the code-snippets does not have a metric associated with it
+      expect(mockMetricMutationVariables).toHaveBeenCalledTimes(4)
     })
   })
 })

--- a/src/pages/RepoPage/CoverageOnboarding/GitHubActions/GitHubActions.tsx
+++ b/src/pages/RepoPage/CoverageOnboarding/GitHubActions/GitHubActions.tsx
@@ -234,7 +234,7 @@ jobs:
             <code>.json</code>, and <code>.txt</code> report formats.
           </p>
 
-          <div className="max-w-64" data-testid="framework-selector">
+          <div className="max-w-64">
             <Select
               // @ts-expect-error - Select has some TS issues because it's still written in JS
               items={Object.keys(frameworkInstructions)}

--- a/src/pages/RepoPage/CoverageOnboarding/GitHubActions/GitHubActions.tsx
+++ b/src/pages/RepoPage/CoverageOnboarding/GitHubActions/GitHubActions.tsx
@@ -57,7 +57,7 @@ function Step1({ orgUploadToken, owner, repo }: Step1Props) {
     Jest: {
       install: 'npm install --save-dev jest',
       run: 'npx jest --coverage',
-      workflow: `name: Run test and upload coverage
+      workflow: `name: Run tests and upload coverage
 
 on: 
   push
@@ -95,7 +95,7 @@ jobs:
     Vitest: {
       install: 'npm install --save-dev vitest @vitest/coverage-v8',
       run: 'npx vitest run --coverage',
-      workflow: `name: Run test and upload coverage
+      workflow: `name: Run tests and upload coverage
 
 on: 
   push
@@ -133,7 +133,7 @@ jobs:
     Pytest: {
       install: 'pip install pytest pytest-cov',
       run: 'pytest --cov',
-      workflow: `name: Run test and upload coverage
+      workflow: `name: Run tests and upload coverage
 
 on: 
   push
@@ -171,7 +171,7 @@ jobs:
     Go: {
       install: undefined,
       run: 'go test -coverprofile=coverage.txt',
-      workflow: `name: Run test and upload coverage
+      workflow: `name: Run tests and upload coverage
 
 on: 
   push
@@ -234,7 +234,7 @@ jobs:
             <code>.json</code>, and <code>.txt</code> report formats.
           </p>
 
-          <div className="max-w-64">
+          <div className="max-w-64" data-testid="framework-selector">
             <Select
               // @ts-expect-error - Select has some TS issues because it's still written in JS
               items={Object.keys(frameworkInstructions)}

--- a/src/pages/RepoPage/CoverageOnboarding/GitHubActions/GitHubActions.tsx
+++ b/src/pages/RepoPage/CoverageOnboarding/GitHubActions/GitHubActions.tsx
@@ -45,6 +45,8 @@ function GitHubActions() {
   )
 }
 
+type Framework = 'Jest' | 'Vitest' | 'Pytest' | 'Go'
+
 interface Step1Props {
   orgUploadToken: string | null | undefined
   owner: string
@@ -52,7 +54,6 @@ interface Step1Props {
 }
 
 function Step1({ orgUploadToken, owner, repo }: Step1Props) {
-  type Framework = 'Jest' | 'Vitest' | 'Pytest' | 'Go'
   const frameworkInstructions = {
     Jest: {
       install: 'npm install --save-dev jest',
@@ -278,9 +279,9 @@ jobs:
       </Card>
       <ExpandableSection className="-mt-px">
         <ExpandableSection.Trigger>
-          <p>
+          <p className="font-normal">
             Your final GitHub Actions workflow for a project using 
-            <span className="text-[#A67F59]">{framework}</span>
+            <span className="text-codecov-code">{framework}</span>
              could look something like this:
           </p>
         </ExpandableSection.Trigger>

--- a/src/pages/RepoPage/CoverageOnboarding/GitHubActions/GitHubActions.tsx
+++ b/src/pages/RepoPage/CoverageOnboarding/GitHubActions/GitHubActions.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react'
 import { useParams } from 'react-router-dom'
 
 import { useStoreCodecovEventMetric } from 'services/codecovEventMetrics'
@@ -7,8 +8,9 @@ import { useFlags } from 'shared/featureFlags'
 import A from 'ui/A'
 import { Card } from 'ui/Card'
 import { CodeSnippet } from 'ui/CodeSnippet'
+import { ExpandableSection } from 'ui/ExpandableSection'
+import Select from 'ui/Select'
 
-import ExampleBlurb from '../ExampleBlurb'
 import LearnMoreBlurb from '../LearnMoreBlurb'
 
 interface URLParams {
@@ -31,25 +33,11 @@ function GitHubActions() {
 
   const uploadToken = orgUploadToken ?? data?.repository?.uploadToken ?? ''
   const tokenCopy = orgUploadToken ? 'global' : 'repository'
-  // prettier-ignore
-  const actionString =
-  `- name: Upload coverage reports to Codecov
-  uses: codecov/codecov-action@v4.0.1
-  with:
-    token: \${{ secrets.CODECOV_TOKEN }}${
-      orgUploadToken
-        ? `
-    slug: ${owner}/${repo}`
-        : ''
-  }`
 
   return (
     <div className="flex flex-col gap-6">
-      <Step1 tokenCopy={tokenCopy} uploadToken={uploadToken} />
-      <Step2
-        defaultBranch={data?.repository?.defaultBranch ?? ''}
-        actionString={actionString}
-      />
+      <Step1 orgUploadToken={orgUploadToken} owner={owner} repo={repo} />
+      <Step2 tokenCopy={tokenCopy} uploadToken={uploadToken} />
       <Step3 />
       <FeedbackCTA />
       <LearnMoreBlurb />
@@ -58,22 +46,290 @@ function GitHubActions() {
 }
 
 interface Step1Props {
+  orgUploadToken: string | null | undefined
+  owner: string
+  repo: string
+}
+
+function Step1({ orgUploadToken, owner, repo }: Step1Props) {
+  type Framework = 'Jest' | 'Vitest' | 'Pytest' | 'Go'
+  const frameworkInstructions = {
+    Jest: {
+      install: 'npm install --save-dev jest',
+      run: 'npx jest --coverage',
+      workflow: `name: Run test and upload coverage
+
+on: 
+  push
+
+jobs:
+  test:
+    name: Run tests and collect coverage
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Run tests
+        run: npx jest --coverage
+
+      - name: Upload results to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          token: \${{ secrets.CODECOV_TOKEN }}${
+            orgUploadToken
+              ? `
+          slug: ${owner}/${repo}`
+              : ''
+          }
+`,
+    },
+    Vitest: {
+      install: 'npm install --save-dev vitest @vitest/coverage-v8',
+      run: 'npx vitest run --coverage',
+      workflow: `name: Run test and upload coverage
+
+on: 
+  push
+
+jobs:
+  test:
+    name: Run tests and collect coverage
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Run tests
+        run: npx vitest run --coverage
+
+      - name: Upload results to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          token: \${{ secrets.CODECOV_TOKEN }}${
+            orgUploadToken
+              ? `
+          slug: ${owner}/${repo}`
+              : ''
+          }
+`,
+    },
+    Pytest: {
+      install: 'pip install pytest pytest-cov',
+      run: 'pytest --cov',
+      workflow: `name: Run test and upload coverage
+
+on: 
+  push
+
+jobs:
+  test:
+    name: Run tests and collect coverage
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+
+      - name: Install dependencies
+        run: pip install pytest pytest-cov
+
+      - name: Run tests
+        run: pytest --cov
+
+      - name: Upload results to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          token: \${{ secrets.CODECOV_TOKEN }}${
+            orgUploadToken
+              ? `
+          slug: ${owner}/${repo}`
+              : ''
+          }
+`,
+    },
+    Go: {
+      install: undefined,
+      run: 'go test -coverprofile=coverage.txt',
+      workflow: `name: Run test and upload coverage
+
+on: 
+  push
+
+jobs:
+  test:
+    name: Run tests and collect coverage
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+
+      - name: Install dependencies
+        run: go mod download
+
+      - name: Run tests
+        run: go test -coverprofile=coverage.txt
+
+      - name: Upload results to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          token: \${{ secrets.CODECOV_TOKEN }}${
+            orgUploadToken
+              ? `
+          slug: ${owner}/${repo}`
+              : ''
+          }
+`,
+    },
+  }
+
+  const [framework, setFramework] = useState<Framework>('Jest')
+  const { mutate: storeEventMetric } = useStoreCodecovEventMetric()
+
+  return (
+    <div>
+      <Card>
+        <Card.Header>
+          <Card.Title size="base">
+            Step 1: Generate and upload coverage reports in your CI
+          </Card.Title>
+        </Card.Header>
+        <Card.Content className="flex flex-col gap-4">
+          <p>
+            Select your testing framework below to generate your coverage
+            reports. If your language isn&apos;t listed, visit our{' '}
+            <A
+              to={{ pageName: 'exampleRepos' }}
+              isExternal
+              hook="supported-languages-docs"
+            >
+              supported languages doc
+            </A>{' '}
+            for example repositories. Codecov supports most <code>.xml</code>,{' '}
+            <code>.json</code>, and <code>.txt</code> report formats.
+          </p>
+
+          <div className="max-w-64">
+            <Select
+              // @ts-expect-error - Select has some TS issues because it's still written in JS
+              items={Object.keys(frameworkInstructions)}
+              value={framework}
+              onChange={(value: Framework) => setFramework(value)}
+            />
+          </div>
+
+          {frameworkInstructions[framework].install ? (
+            <>
+              <p>Install requirements in your terminal:</p>
+              <CodeSnippet
+                clipboard={frameworkInstructions[framework].install}
+                clipboardOnClick={() =>
+                  storeEventMetric({
+                    owner,
+                    event: 'COPIED_TEXT',
+                    jsonPayload: { text: `coverage GHA ${framework} install` },
+                  })
+                }
+              >
+                {frameworkInstructions[framework].install}
+              </CodeSnippet>
+            </>
+          ) : null}
+
+          <p>In a GitHub Action, run tests and generate a coverage report:</p>
+          <CodeSnippet
+            clipboard={frameworkInstructions[framework].run}
+            clipboardOnClick={() =>
+              storeEventMetric({
+                owner,
+                event: 'COPIED_TEXT',
+                jsonPayload: { text: `coverage GHA ${framework} run` },
+              })
+            }
+          >
+            {frameworkInstructions[framework].run}
+          </CodeSnippet>
+        </Card.Content>
+      </Card>
+      <ExpandableSection className="-mt-px">
+        <ExpandableSection.Trigger>
+          <p>
+            Your final GitHub Actions workflow for a project using 
+            <span className="text-[#A67F59]">{framework}</span>
+             could look something like this:
+          </p>
+        </ExpandableSection.Trigger>
+        <ExpandableSection.Content>
+          <CodeSnippet
+            clipboard={frameworkInstructions[framework].workflow}
+            clipboardOnClick={() =>
+              storeEventMetric({
+                owner,
+                event: 'COPIED_TEXT',
+                jsonPayload: { text: `coverage GHA ${framework} action` },
+              })
+            }
+          >
+            {frameworkInstructions[framework].workflow}
+          </CodeSnippet>
+          <p className="pt-4">
+            <A
+              to={{ pageName: 'exampleRepos' }}
+              isExternal
+              hook="supported-languages-docs"
+            >
+              Learn more
+            </A>{' '}
+            about generating coverage reports with {framework}
+          </p>
+        </ExpandableSection.Content>
+      </ExpandableSection>
+    </div>
+  )
+}
+
+interface Step2Props {
   tokenCopy: string
   uploadToken: string
 }
 
-function Step1({ tokenCopy, uploadToken }: Step1Props) {
+function Step2({ tokenCopy, uploadToken }: Step2Props) {
   const { mutate: storeEventMetric } = useStoreCodecovEventMetric()
   const { owner } = useParams<URLParams>()
   return (
     <Card>
       <Card.Header>
         <Card.Title size="base">
-          Step 1: add {tokenCopy} token as{' '}
+          Step 2: add {tokenCopy} token as{' '}
           <A
             to={{ pageName: 'githubRepoSecrets' }}
             isExternal
-            hook="GitHub-repo-secrects-link"
+            hook="GitHub-repo-secrets-link"
           >
             repository secret
           </A>
@@ -99,61 +355,13 @@ function Step1({ tokenCopy, uploadToken }: Step1Props) {
               storeEventMetric({
                 owner,
                 event: 'COPIED_TEXT',
-                jsonPayload: { text: 'Step 1 GHA' },
+                jsonPayload: { text: 'Step 2 GHA' },
               })
             }
           >
             {uploadToken}
           </CodeSnippet>
         </div>
-      </Card.Content>
-    </Card>
-  )
-}
-
-interface Step2Props {
-  defaultBranch: string
-  actionString: string
-}
-
-function Step2({ defaultBranch, actionString }: Step2Props) {
-  const { mutate: storeEventMetric } = useStoreCodecovEventMetric()
-  const { owner } = useParams<URLParams>()
-  return (
-    <Card>
-      <Card.Header>
-        <Card.Title size="base">
-          Step 2: add Codecov to your{' '}
-          <A
-            to={{
-              pageName: 'githubRepoActions',
-            }}
-            options={{ branch: defaultBranch }}
-            isExternal
-            hook="GitHub-repo-actions-link"
-          >
-            GitHub Actions workflow yaml file
-          </A>
-        </Card.Title>
-      </Card.Header>
-      <Card.Content className="flex flex-col gap-4">
-        <p>
-          After tests run, this will upload your coverage report to Codecov:
-        </p>
-
-        <CodeSnippet
-          clipboard={actionString}
-          clipboardOnClick={() =>
-            storeEventMetric({
-              owner,
-              event: 'COPIED_TEXT',
-              jsonPayload: { text: 'Step 2 GHA' },
-            })
-          }
-        >
-          {actionString}
-        </CodeSnippet>
-        <ExampleBlurb />
       </Card.Content>
     </Card>
   )

--- a/src/pages/RepoPage/FailedTestsTab/CodecovCLI/CodecovCLI.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/CodecovCLI/CodecovCLI.tsx
@@ -1,5 +1,3 @@
-import { useState } from 'react'
-
 import testsPRComment from 'assets/svg/onboardingTests/testsPRComment.svg'
 import testsRunning from 'assets/svg/onboardingTests/testsRunning.svg'
 import A from 'ui/A'
@@ -139,8 +137,6 @@ function Step4() {
 }
 
 function Step5() {
-  const [isExpanded, setIsExpanded] = useState(false)
-
   return (
     <div>
       <Card>
@@ -160,11 +156,8 @@ function Step5() {
         </Card.Content>
       </Card>
       <ExpandableSection className="-mt-px">
-        <ExpandableSection.Trigger
-          isExpanded={isExpanded}
-          onClick={() => setIsExpanded(!isExpanded)}
-        >
-          <p className="font-normal">
+        <ExpandableSection.Trigger>
+          <p>
             Here are examples of failed test reports in PR comments. Comment
             generation may take time.
           </p>

--- a/src/pages/RepoPage/FailedTestsTab/GitHubActions/GitHubActions.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/GitHubActions/GitHubActions.tsx
@@ -1,5 +1,3 @@
-import { useState } from 'react'
-
 import testsPRComment from 'assets/svg/onboardingTests/testsPRComment.svg'
 import testsRunning from 'assets/svg/onboardingTests/testsRunning.svg'
 import A from 'ui/A'
@@ -78,8 +76,6 @@ const JobsScript = `jobs:
           token: \${{ secrets.CODECOV_TOKEN }}`
 
 function Step2() {
-  const [isExpanded, setIsExpanded] = useState(false)
-
   return (
     <div>
       <Card>
@@ -105,11 +101,8 @@ function Step2() {
         </Card.Content>
       </Card>
       <ExpandableSection className="-mt-px">
-        <ExpandableSection.Trigger
-          isExpanded={isExpanded}
-          onClick={() => setIsExpanded(!isExpanded)}
-        >
-          <p className="font-normal">
+        <ExpandableSection.Trigger>
+          <p>
             Your final <span className="text-codecov-code">ci.yaml</span> file
             for a project using{' '}
             <span className="text-codecov-code">pytest</span> could look
@@ -125,8 +118,6 @@ function Step2() {
 }
 
 function Step3() {
-  const [isExpanded, setIsExpanded] = useState(false)
-
   return (
     <div>
       <Card>
@@ -146,11 +137,8 @@ function Step3() {
         </Card.Content>
       </Card>
       <ExpandableSection className="-mt-px">
-        <ExpandableSection.Trigger
-          isExpanded={isExpanded}
-          onClick={() => setIsExpanded(!isExpanded)}
-        >
-          <p className="font-normal">
+        <ExpandableSection.Trigger>
+          <p>
             Here are examples of failed test reports in PR comments. Comment
             generation may take time.
           </p>

--- a/src/ui/ExpandableSection/ExpandableSection.tsx
+++ b/src/ui/ExpandableSection/ExpandableSection.tsx
@@ -21,28 +21,31 @@ ExpandableSectionRoot.displayName = 'ExpandableSectionRoot'
 
 interface ExpandableSectionTriggerProps
   extends React.ComponentPropsWithoutRef<typeof Collapsible.Trigger> {
-  isExpanded: boolean
+  isExpanded?: boolean
   children: ReactNode
 }
 
 const ExpandableSectionTrigger = forwardRef<
   React.ElementRef<typeof Collapsible.Trigger>,
   ExpandableSectionTriggerProps
->(({ isExpanded, className, children, ...props }, ref) => (
-  <Collapsible.Trigger asChild>
-    <button
+>(({ className, children, ...props }, ref) => {
+  return (
+    <Collapsible.Trigger
       className={cn(
-        'flex w-full items-center justify-between p-4 text-left font-semibold hover:bg-gray-100',
+        'flex w-full items-center justify-between p-4 text-left hover:bg-gray-100',
+        '[&_#expandable-icon]:data-[state=open]:rotate-180',
         className
       )}
       {...props}
       ref={ref}
     >
       <span>{children}</span>
-      <Icon name={isExpanded ? 'chevronUp' : 'chevronDown'} size="sm" />
-    </button>
-  </Collapsible.Trigger>
-))
+      <span id="expandable-icon" className="rotate-0 transition-transform">
+        <Icon name="chevronUp" size="sm" />
+      </span>
+    </Collapsible.Trigger>
+  )
+})
 
 ExpandableSectionTrigger.displayName = 'ExpandableSectionTrigger'
 


### PR DESCRIPTION
Adds a framework selector to the GitHub Actions coverage onboarding page.

Have approved the differences in copy with design.

[Design](https://www.figma.com/design/3zN1Mh6rjYKLxqoUD1XJOI/GH-1920?node-id=1-2&t=A6Hb7zQfZQDlClRE-0)

Closes https://github.com/codecov/engineering-team/issues/1920

![Screenshot 2024-08-08 at 11 29 07](https://github.com/user-attachments/assets/5c06284f-d0df-40ee-8578-2dd997b8eb1e)

<img width="890" alt="Screenshot 2024-08-08 at 11 32 03" src="https://github.com/user-attachments/assets/0d40fdfd-8054-4822-96b3-329f0a8cfeb6">

