### PR TITLE
fix: File explorer sticky top bar in wrong location

### DIFF
--- a/src/pages/RepoPage/CoverageTab/OverviewTab/subroute/FileExplorer/FileExplorer.jsx
+++ b/src/pages/RepoPage/CoverageTab/OverviewTab/subroute/FileExplorer/FileExplorer.jsx
@@ -23,7 +23,7 @@ function FileExplorer() {
 
   return (
     <>
-      <div className="sticky top-[4.5rem] z-10 flex justify-between gap-2 bg-white pt-2">
+      <div className="sticky top-0 z-10 flex justify-between gap-2 bg-white pt-2">
         <div className="flex flex-1 items-center gap-4">
           <DisplayTypeButton
             dataLength={branchData?.length}

--- a/src/ui/FileViewer/ToggleHeader/Title/Title.spec.tsx
+++ b/src/ui/FileViewer/ToggleHeader/Title/Title.spec.tsx
@@ -173,7 +173,7 @@ describe('Title', () => {
       const rootDiv = screen.getByTestId('title-wrapper-div')
       expect(rootDiv).toHaveClass('z-10')
       expect(rootDiv).toHaveClass('sticky')
-      expect(rootDiv).toHaveClass('top-[4.5rem]')
+      expect(rootDiv).toHaveClass('top-0')
     })
   })
 })

--- a/src/ui/FileViewer/ToggleHeader/Title/Title.tsx
+++ b/src/ui/FileViewer/ToggleHeader/Title/Title.tsx
@@ -22,7 +22,7 @@ function Title({ title, children, sticky = false }: TitleProps) {
       data-testid="title-wrapper-div"
       className={cn(
         'flex w-full flex-1 flex-col flex-wrap items-start justify-between gap-4 bg-white px-0 sm:flex-row sm:items-center md:mb-1 lg:w-auto lg:flex-none',
-        { 'z-10 sticky top-[4.5rem]': sticky }
+        { 'z-10 sticky top-0': sticky }
       )}
     >
       {title ? (


### PR DESCRIPTION
Fixes the file explorer top bar sticking in the wrong place:

![Screenshot 2024-08-08 at 11 25 49](https://github.com/user-attachments/assets/50ded13f-e44b-4756-8f12-e362aa395bed)
