### PR TITLE
style: Tweak configuration manager styles

### DIFF
--- a/src/pages/RepoPage/ConfigTab/tabs/ConfigurationManager/ConfigurationManager.spec.tsx
+++ b/src/pages/RepoPage/ConfigTab/tabs/ConfigurationManager/ConfigurationManager.spec.tsx
@@ -124,7 +124,7 @@ describe('Configuration Manager', () => {
         })
         render(<ConfigurationManager />, { wrapper })
 
-        const button = await screen.findByRole('link', { name: 'Get Started' })
+        const button = await screen.findByTestId('FeatureGroup-get-started')
         expect(button).toBeInTheDocument()
         expect(button).toHaveAttribute('href', '/gh/codecov/cool-repo')
       })
@@ -158,7 +158,9 @@ describe('Configuration Manager', () => {
         setup({ repoConfig: mockRepoConfig({ coverage: true }) })
         render(<ConfigurationManager />, { wrapper })
 
-        const notEnabledStatus = await screen.findAllByText('not enabled')
+        const notEnabledStatus = await screen.findAllByTestId(
+          'FeatureItem-get-started'
+        )
         expect(notEnabledStatus).toHaveLength(4)
       })
     })
@@ -255,7 +257,9 @@ describe('Configuration Manager', () => {
         })
         render(<ConfigurationManager />, { wrapper })
 
-        const unconfiguredStatus = await screen.findAllByText('not enabled')
+        const unconfiguredStatus = await screen.findAllByTestId(
+          'FeatureItem-get-started'
+        )
         expect(unconfiguredStatus).toHaveLength(1)
       })
     })
@@ -317,7 +321,7 @@ describe('Configuration Manager', () => {
         await waitFor(() =>
           screen.findByRole('heading', { name: 'Bundle analysis' })
         )
-        const button = await screen.findByRole('link', { name: 'Get Started' })
+        const button = await screen.findByTestId('FeatureGroup-get-started')
         expect(button).toBeInTheDocument()
         expect(button).toHaveAttribute(
           'href',
@@ -394,7 +398,7 @@ describe('Configuration Manager', () => {
         })
         render(<ConfigurationManager />, { wrapper })
 
-        const button = await screen.findByRole('link', { name: 'Get Started' })
+        const button = await screen.findByTestId('FeatureGroup-get-started')
         expect(button).toBeInTheDocument()
         expect(button).toHaveAttribute(
           'href',

--- a/src/pages/RepoPage/ConfigTab/tabs/ConfigurationManager/components/FeatureGroup/FeatureGroup.tsx
+++ b/src/pages/RepoPage/ConfigTab/tabs/ConfigurationManager/components/FeatureGroup/FeatureGroup.tsx
@@ -26,6 +26,7 @@ function FeatureGroup({
             disabled={false}
             variant="primary"
             hook="configuration-get-started"
+            data-testid="FeatureGroup-get-started"
           >
             Get Started
           </Button>

--- a/src/pages/RepoPage/ConfigTab/tabs/ConfigurationManager/components/FeatureItem/FeatureItem.spec.tsx
+++ b/src/pages/RepoPage/ConfigTab/tabs/ConfigurationManager/components/FeatureItem/FeatureItem.spec.tsx
@@ -117,8 +117,19 @@ describe('FeatureItem', () => {
       { wrapper }
     )
 
-    const unconfigured = await screen.findByText('not enabled')
+    const unconfigured = await screen.findByRole('link', {
+      name: 'Get Started',
+    })
     expect(unconfigured).toBeInTheDocument()
+  })
+
+  describe('when getStartedLink is undefinted', () => {
+    it('does not render any configuration status', async () => {
+      render(<FeatureItem name="Name" hiddenStatus={false} />, { wrapper })
+
+      const unconfigured = screen.queryByRole('link', { name: 'Get Started' })
+      expect(unconfigured).not.toBeInTheDocument()
+    })
   })
 
   it('renders name link', async () => {

--- a/src/pages/RepoPage/ConfigTab/tabs/ConfigurationManager/components/FeatureItem/FeatureItem.tsx
+++ b/src/pages/RepoPage/ConfigTab/tabs/ConfigurationManager/components/FeatureItem/FeatureItem.tsx
@@ -20,7 +20,7 @@ function FeatureItem({
   children,
 }: FeatureItemProps) {
   return (
-    <div className="flex items-center">
+    <div className="flex items-center gap-4">
       <div className="flex-1">
         {nameLink ? (
           <A
@@ -34,27 +34,25 @@ function FeatureItem({
         ) : (
           <h4 className="font-semibold">{name}</h4>
         )}
-        <div className="flex items-end gap-1">
-          {children}
-          {docsLink ? (
-            <A
-              to={{ pageName: docsLink }}
-              hook="configuration-docs"
-              isExternal={false}
-              showExternalIcon={false}
-              variant="medium"
-            >
-              <span className="flex items-center text-xs leading-[18px]">
-                docs
-                <Icon
-                  className="left-0 [&_path]:stroke-[3px]"
-                  name="documentText"
-                  size="sm"
-                />
-              </span>
-            </A>
-          ) : null}
-        </div>
+        <span className="pr-1">{children}</span>
+        {docsLink ? (
+          <A
+            to={{ pageName: docsLink }}
+            hook="configuration-docs"
+            isExternal={false}
+            showExternalIcon={false}
+            variant="medium"
+          >
+            <span className="flex h-full items-center text-xs leading-[18px]">
+              docs
+              <Icon
+                className="left-0 [&_path]:stroke-[3px]"
+                name="documentText"
+                size="sm"
+              />
+            </span>
+          </A>
+        ) : null}
       </div>
       {hiddenStatus ? null : (
         <ConfiguredStatus
@@ -82,21 +80,22 @@ const ConfiguredStatus = ({
       </ul>
     )
   }
-  return (
-    <p className="flex items-baseline gap-1 font-medium">
-      <span className="text-ds-gray-quinary">not enabled</span>
-      {getStartedLink ? (
-        <A
-          to={{ pageName: getStartedLink }}
-          hook="configuration-get-started"
-          isExternal={false}
-          showExternalIcon={false}
-        >
-          <span className="text-xs leading-4">get started</span>
-        </A>
-      ) : null}
-    </p>
-  )
+
+  if (getStartedLink) {
+    return (
+      <A
+        to={{ pageName: getStartedLink }}
+        hook="configuration-get-started"
+        isExternal={false}
+        showExternalIcon={false}
+        data-testid="FeatureItem-get-started"
+      >
+        <span className="font-medium">Get Started</span>
+      </A>
+    )
+  }
+
+  return null
 }
 
 export default FeatureItem


### PR DESCRIPTION
Updates the not-enabled status of feature items to just show a get started link instead of "Not enabled get started".

Before:

After:
