### PR TITLE
chore: Remove faker

### DIFF
--- a/package.json
+++ b/package.json
@@ -144,7 +144,6 @@
     "eslint-plugin-import": "^2.25.4",
     "eslint-plugin-storybook": "^0.8.0",
     "eslint-plugin-tailwindcss": "^3.17.4",
-    "faker": "^5.5.3",
     "http-proxy-middleware": "^2.0.6",
     "husky": "^7.0.4",
     "jest-junit": "^13.0.0",

--- a/src/services/charts/mocks.js
+++ b/src/services/charts/mocks.js
@@ -1,5 +1,4 @@
 /* eslint-disable camelcase */
-import faker from 'faker'
 import { rest } from 'msw'
 
 const repoUri = '/internal/charts/:provider/:owner/coverage/repository'
@@ -22,49 +21,6 @@ export const orgCoverageHandler = rest.get(orgUri, (req, res, ctx) => {
   } else if (query.get('grouping_unit') === 'quarterly') {
     return res(ctx.status(200), ctx.json(exampleQuarterRes))
   }
-})
-
-const createCoverage = () => ({
-  date: faker.date.between('2020-01-01', '2020-12-30'),
-  total_hits: faker.datatype.number({ min: 0, max: 100 }),
-  total_misses: faker.datatype.number({ min: 0, max: 100 }),
-  total_partials: faker.datatype.number({ min: 0, max: 100 }),
-  total_lines: faker.datatype.number({ min: 0, max: 100 }),
-  coverage: faker.datatype.float({ min: 0, max: 100 }),
-})
-
-export const randomOrgCoverageHandler = rest.get(orgUri, (req, res, ctx) => {
-  return res(
-    ctx.status(200),
-    ctx.json({
-      coverage: [
-        createCoverage(),
-        createCoverage(),
-        createCoverage(),
-        createCoverage(),
-        createCoverage(),
-        createCoverage(),
-        createCoverage(),
-        createCoverage(),
-        createCoverage(),
-        createCoverage(),
-        createCoverage(),
-        createCoverage(),
-        createCoverage(),
-        createCoverage(),
-        createCoverage(),
-        createCoverage(),
-        createCoverage(),
-        createCoverage(),
-        createCoverage(),
-        createCoverage(),
-        createCoverage(),
-        createCoverage(),
-        createCoverage(),
-        createCoverage(),
-      ],
-    })
-  )
 })
 
 export const exampleQuarterRes = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -10207,13 +10207,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"faker@npm:^5.5.3":
-  version: 5.5.3
-  resolution: "faker@npm:5.5.3"
-  checksum: 10c0/55ee2fb6425df717253f237b4e952c94efe33da23a5826ca41c6ecb31ccfb49d06c5de64b82b6994ca9c76c05eab4dbf779cea047455fff6e62cc9d585c7d460
-  languageName: node
-  linkType: hard
-
 "fast-deep-equal@npm:^2.0.1":
   version: 2.0.1
   resolution: "fast-deep-equal@npm:2.0.1"
@@ -10811,7 +10804,6 @@ __metadata:
     eslint-plugin-import: "npm:^2.25.4"
     eslint-plugin-storybook: "npm:^0.8.0"
     eslint-plugin-tailwindcss: "npm:^3.17.4"
-    faker: "npm:^5.5.3"
     http-proxy-middleware: "npm:^2.0.6"
     husky: "npm:^7.0.4"
     jest-junit: "npm:^13.0.0"


### PR DESCRIPTION
# Description

This PR aims to remove the devDependency "faker" which only looked to be used in 1 set of mocks in our whole repo. Those mocks weren't being used anywhere, so this seemed to be a no-brainer.

New faker package is something completely different too -> https://www.npmjs.com/package/@faker-js/faker

# Link to Sample Entry

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.