### PR TITLE
feat(sentry): Allow filtering of unwanted third party errors

### DIFF
--- a/craco.config.js
+++ b/craco.config.js
@@ -5,6 +5,7 @@ const WebpackBar = require('webpackbar')
 const { resolve } = require('path')
 
 const SentryPlugin = sentryWebpackPlugin({
+  applicationKey: 'gazebo',
   org: process.env.SENTRY_ORG || 'codecov',
   project: process.env.REACT_APP_SENTRY_PROJECT || 'gazebo',
   authToken: process.env.SENTRY_AUTH_TOKEN,

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "@chromatic-com/storybook": "^1",
     "@codecov/webpack-plugin": "^0.0.1-beta.6",
     "@craco/craco": "^7.1.0",
-    "@sentry/webpack-plugin": "^2.17.0",
+    "@sentry/webpack-plugin": "^2.22.2",
     "@storybook/addon-a11y": "^8.2.6",
     "@storybook/addon-actions": "^8.2.6",
     "@storybook/addon-essentials": "^8.2.6",

--- a/src/sentry.ts
+++ b/src/sentry.ts
@@ -98,14 +98,6 @@ export const setupSentry = ({
     return
   }
 
-  // configure sentry product integrations
-  const replay = Sentry.replayIntegration()
-  const tracing = Sentry.reactRouterV5BrowserTracingIntegration({
-    history,
-  })
-
-  const integrations = [replay, tracing]
-
   const tracePropagationTargets = ['api.codecov.io', 'stage-api.codecov.dev']
   // wrapped in a silent try/catch incase the URL is invalid
   try {
@@ -120,7 +112,22 @@ export const setupSentry = ({
     dsn: config.SENTRY_DSN,
     debug: config.NODE_ENV !== 'production',
     environment: config.SENTRY_ENVIRONMENT,
-    integrations,
+    integrations: [
+      // Adds Sentry Replay
+      Sentry.replayIntegration(),
+
+      // Adds routing instrumentation
+      Sentry.reactRouterV5BrowserTracingIntegration({
+        history,
+      }),
+
+      // Applies a `third_party_code: true` tag to all events that contain code that was not bundled with gazebo.
+      // Allows for filtering of browser extension and random browser errors.
+      Sentry.thirdPartyErrorFilterIntegration({
+        filterKeys: ['gazebo'],
+        behaviour: 'apply-tag-if-contains-third-party-frames',
+      }),
+    ],
     tracePropagationTargets,
     tracesSampleRate: config?.SENTRY_TRACING_SAMPLE_RATE,
     // Capture n% of all sessions

--- a/yarn.lock
+++ b/yarn.lock
@@ -3797,10 +3797,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sentry/babel-plugin-component-annotate@npm:2.21.1":
-  version: 2.21.1
-  resolution: "@sentry/babel-plugin-component-annotate@npm:2.21.1"
-  checksum: 10c0/5a9b912dea02fa971fc270dbd00425451cefa0d466cfaabcaefef55aa2f607634e49dfc7c90e610d0fd342ca078554a60387e721154269f5dd621b1f2bf4fec2
+"@sentry/babel-plugin-component-annotate@npm:2.22.2":
+  version: 2.22.2
+  resolution: "@sentry/babel-plugin-component-annotate@npm:2.22.2"
+  checksum: 10c0/528b6ab481ad989248dfe2ca080a1ff41e21631dcb20f71fb293a3c110c19aeb6efc8338a0c706927c03d49162e0903669e808d1748d95ec2e2d1aeeeb39334f
   languageName: node
   linkType: hard
 
@@ -3819,82 +3819,82 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sentry/bundler-plugin-core@npm:2.21.1":
-  version: 2.21.1
-  resolution: "@sentry/bundler-plugin-core@npm:2.21.1"
+"@sentry/bundler-plugin-core@npm:2.22.2":
+  version: 2.22.2
+  resolution: "@sentry/bundler-plugin-core@npm:2.22.2"
   dependencies:
     "@babel/core": "npm:^7.18.5"
-    "@sentry/babel-plugin-component-annotate": "npm:2.21.1"
-    "@sentry/cli": "npm:^2.22.3"
+    "@sentry/babel-plugin-component-annotate": "npm:2.22.2"
+    "@sentry/cli": "npm:^2.33.1"
     dotenv: "npm:^16.3.1"
     find-up: "npm:^5.0.0"
     glob: "npm:^9.3.2"
     magic-string: "npm:0.30.8"
     unplugin: "npm:1.0.1"
-  checksum: 10c0/25aabf409e27ee8ccad5e80d6f68d8ec5221da8e3e60663d544ae25902193077cdc07e0c576bc219c8cfe7ba98764f7d811bd498d4f26e5ba35b14d358610f4d
+  checksum: 10c0/e12aa15d2e7d8d06f2e260d63a84fe4e5c68375004d2d9ef6b86675796da056c158538d7f37d91aa81695dbe16663b5c2c9c9c4efa2eacdd4318d5fac16e1e57
   languageName: node
   linkType: hard
 
-"@sentry/cli-darwin@npm:2.32.2":
-  version: 2.32.2
-  resolution: "@sentry/cli-darwin@npm:2.32.2"
+"@sentry/cli-darwin@npm:2.33.1":
+  version: 2.33.1
+  resolution: "@sentry/cli-darwin@npm:2.33.1"
   conditions: os=darwin
   languageName: node
   linkType: hard
 
-"@sentry/cli-linux-arm64@npm:2.32.2":
-  version: 2.32.2
-  resolution: "@sentry/cli-linux-arm64@npm:2.32.2"
+"@sentry/cli-linux-arm64@npm:2.33.1":
+  version: 2.33.1
+  resolution: "@sentry/cli-linux-arm64@npm:2.33.1"
   conditions: (os=linux | os=freebsd) & cpu=arm64
   languageName: node
   linkType: hard
 
-"@sentry/cli-linux-arm@npm:2.32.2":
-  version: 2.32.2
-  resolution: "@sentry/cli-linux-arm@npm:2.32.2"
+"@sentry/cli-linux-arm@npm:2.33.1":
+  version: 2.33.1
+  resolution: "@sentry/cli-linux-arm@npm:2.33.1"
   conditions: (os=linux | os=freebsd) & cpu=arm
   languageName: node
   linkType: hard
 
-"@sentry/cli-linux-i686@npm:2.32.2":
-  version: 2.32.2
-  resolution: "@sentry/cli-linux-i686@npm:2.32.2"
+"@sentry/cli-linux-i686@npm:2.33.1":
+  version: 2.33.1
+  resolution: "@sentry/cli-linux-i686@npm:2.33.1"
   conditions: (os=linux | os=freebsd) & (cpu=x86 | cpu=ia32)
   languageName: node
   linkType: hard
 
-"@sentry/cli-linux-x64@npm:2.32.2":
-  version: 2.32.2
-  resolution: "@sentry/cli-linux-x64@npm:2.32.2"
+"@sentry/cli-linux-x64@npm:2.33.1":
+  version: 2.33.1
+  resolution: "@sentry/cli-linux-x64@npm:2.33.1"
   conditions: (os=linux | os=freebsd) & cpu=x64
   languageName: node
   linkType: hard
 
-"@sentry/cli-win32-i686@npm:2.32.2":
-  version: 2.32.2
-  resolution: "@sentry/cli-win32-i686@npm:2.32.2"
+"@sentry/cli-win32-i686@npm:2.33.1":
+  version: 2.33.1
+  resolution: "@sentry/cli-win32-i686@npm:2.33.1"
   conditions: os=win32 & (cpu=x86 | cpu=ia32)
   languageName: node
   linkType: hard
 
-"@sentry/cli-win32-x64@npm:2.32.2":
-  version: 2.32.2
-  resolution: "@sentry/cli-win32-x64@npm:2.32.2"
+"@sentry/cli-win32-x64@npm:2.33.1":
+  version: 2.33.1
+  resolution: "@sentry/cli-win32-x64@npm:2.33.1"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
 
-"@sentry/cli@npm:^2.22.3":
-  version: 2.32.2
-  resolution: "@sentry/cli@npm:2.32.2"
+"@sentry/cli@npm:^2.33.1":
+  version: 2.33.1
+  resolution: "@sentry/cli@npm:2.33.1"
   dependencies:
-    "@sentry/cli-darwin": "npm:2.32.2"
-    "@sentry/cli-linux-arm": "npm:2.32.2"
-    "@sentry/cli-linux-arm64": "npm:2.32.2"
-    "@sentry/cli-linux-i686": "npm:2.32.2"
-    "@sentry/cli-linux-x64": "npm:2.32.2"
-    "@sentry/cli-win32-i686": "npm:2.32.2"
-    "@sentry/cli-win32-x64": "npm:2.32.2"
+    "@sentry/cli-darwin": "npm:2.33.1"
+    "@sentry/cli-linux-arm": "npm:2.33.1"
+    "@sentry/cli-linux-arm64": "npm:2.33.1"
+    "@sentry/cli-linux-i686": "npm:2.33.1"
+    "@sentry/cli-linux-x64": "npm:2.33.1"
+    "@sentry/cli-win32-i686": "npm:2.33.1"
+    "@sentry/cli-win32-x64": "npm:2.33.1"
     https-proxy-agent: "npm:^5.0.0"
     node-fetch: "npm:^2.6.7"
     progress: "npm:^2.0.3"
@@ -3917,7 +3917,7 @@ __metadata:
       optional: true
   bin:
     sentry-cli: bin/sentry-cli
-  checksum: 10c0/ba43448249ba609fe0eed5b5e8b6a7ee38257a9724bd21d4133a3be8df0b5dc5efcf36a950cd6ff2efbf5b5adccc6630e7e21ed692e7ea938f59b4224bb168fd
+  checksum: 10c0/e2dc75e1709bf7252a006663a16d9c24e255a81e6f88b35bf030ffa9c52a3330a3bad6b32bb4d90046e6555ed62609967cc96af3e8f0e9ff8672552d804bd873
   languageName: node
   linkType: hard
 
@@ -3962,16 +3962,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sentry/webpack-plugin@npm:^2.17.0":
-  version: 2.21.1
-  resolution: "@sentry/webpack-plugin@npm:2.21.1"
+"@sentry/webpack-plugin@npm:^2.22.2":
+  version: 2.22.2
+  resolution: "@sentry/webpack-plugin@npm:2.22.2"
   dependencies:
-    "@sentry/bundler-plugin-core": "npm:2.21.1"
+    "@sentry/bundler-plugin-core": "npm:2.22.2"
     unplugin: "npm:1.0.1"
     uuid: "npm:^9.0.0"
   peerDependencies:
     webpack: ">=4.40.0"
-  checksum: 10c0/8acdef52fa2a6eb026e5d2e9114a7ad09b642ee3534a334402ca847deaf37032732d7471c76213e3f3498fcf73d292549dc4b9ab9c6b3fc57bf68c17ff1b4859
+  checksum: 10c0/8b39e775fff2a33db9e7ae7065806dd32df28c0edf6f007627f2a9e9e7f5aad891f50eefb0f41d1ba33cd89eb83176a5c3323df7dfb69525bfd2908a9437994e
   languageName: node
   linkType: hard
 
@@ -10514,7 +10514,7 @@ __metadata:
     "@radix-ui/react-popover": "npm:^1.0.6"
     "@radix-ui/react-radio-group": "npm:^1.1.3"
     "@sentry/react": "npm:^8.24.0"
-    "@sentry/webpack-plugin": "npm:^2.17.0"
+    "@sentry/webpack-plugin": "npm:^2.22.2"
     "@storybook/addon-a11y": "npm:^8.2.6"
     "@storybook/addon-actions": "npm:^8.2.6"
     "@storybook/addon-essentials": "npm:^8.2.6"


### PR DESCRIPTION
This PR bumps the Sentry webpack plugin to the latest version and adds a `clientKey` alongside the `thirdPartyErrorFilterIntegration` which will set a `third_party_error` tag to error events in Sentry whenever the Sentry SDK detects that an error came from a third-party source (for example a browser extension). 