### PR TITLE
feat: Add share with admin button to DefaultOrgSelector

### DIFF
--- a/src/pages/DefaultOrgSelector/GitHubHelpBanner/GitHubHelpBanner.spec.tsx
+++ b/src/pages/DefaultOrgSelector/GitHubHelpBanner/GitHubHelpBanner.spec.tsx
@@ -129,7 +129,7 @@ describe('GitHubHelpBanner', () => {
         wrapper: wrapper(),
       })
 
-      const reSync = screen.getByText(/Resync/)
+      const reSync = screen.getByText(/resync/)
       expect(reSync).toBeInTheDocument()
 
       await user.click(reSync)
@@ -138,6 +138,78 @@ describe('GitHubHelpBanner', () => {
 
       const syncing = await screen.findByText(/Syncing your organizations.../)
       expect(syncing).toBeInTheDocument()
+    })
+  })
+
+  describe('when user clicks on share request', () => {
+    it('renders the AppInstallModal', async () => {
+      const { user } = setup()
+
+      render(<GitHubHelpBanner />, {
+        wrapper: wrapper(),
+      })
+
+      const share = await screen.findByText(/share request/)
+      expect(share).toBeInTheDocument()
+      let modal = screen.queryByText('Share GitHub app installation')
+      expect(modal).not.toBeInTheDocument()
+
+      await user.click(share)
+
+      modal = await screen.findByText('Share GitHub app installation')
+      expect(modal).toBeInTheDocument()
+    })
+
+    describe('and then clicks close in the modal', () => {
+      it('hides the AppInstallModal', async () => {
+        const { user } = setup()
+
+        render(<GitHubHelpBanner />, {
+          wrapper: wrapper(),
+        })
+
+        const share = await screen.findByText(/share request/)
+        expect(share).toBeInTheDocument()
+        let modal = screen.queryByText('Share GitHub app installation')
+        expect(modal).not.toBeInTheDocument()
+
+        await user.click(share)
+
+        modal = await screen.findByText('Share GitHub app installation')
+        expect(modal).toBeInTheDocument()
+
+        const close = await screen.findByTestId('modal-close-icon')
+
+        await user.click(close)
+
+        expect(modal).not.toBeInTheDocument()
+      })
+    })
+
+    describe('and then clicks done in the modal', () => {
+      it('hides the AppInstallModal', async () => {
+        const { user } = setup()
+
+        render(<GitHubHelpBanner />, {
+          wrapper: wrapper(),
+        })
+
+        const share = await screen.findByText(/share request/)
+        expect(share).toBeInTheDocument()
+        let modal = screen.queryByText('Share GitHub app installation')
+        expect(modal).not.toBeInTheDocument()
+
+        await user.click(share)
+
+        modal = await screen.findByText('Share GitHub app installation')
+        expect(modal).toBeInTheDocument()
+
+        const done = await screen.findByTestId('close-modal')
+
+        await user.click(done)
+
+        expect(modal).not.toBeInTheDocument()
+      })
     })
   })
 })

--- a/src/pages/DefaultOrgSelector/GitHubHelpBanner/GitHubHelpBanner.tsx
+++ b/src/pages/DefaultOrgSelector/GitHubHelpBanner/GitHubHelpBanner.tsx
@@ -1,6 +1,8 @@
+import { useState } from 'react'
 import { useParams } from 'react-router-dom'
 
 import { useResyncUser } from 'services/user'
+import AppInstallModal from 'shared/AppInstallModal'
 import { providerToName } from 'shared/utils'
 import A from 'ui/A'
 import Banner from 'ui/Banner'
@@ -25,45 +27,72 @@ function ResyncButton() {
 
   return (
     <span className="flex gap-1">
+      <span>💡</span>
+      if you installed the app recently you may need to{' '}
       <button
         className="text-ds-blue hover:underline"
         onClick={() => triggerResync()}
         type="button"
       >
-        Resync
+        resync
       </button>
-      to refresh your organizations.
     </span>
   )
 }
 
 function GitHubHelpBanner() {
+  const [showModal, setShowModal] = useState(false)
   const { provider } = useParams<{ provider: string }>()
   if (providerToName(provider) !== 'Github') return null
 
   return (
-    <Banner variant="plain">
-      <BannerHeading>
-        <div className="flex gap-1 text-sm">
-          <Icon size="sm" name="lightBulb" variant="solid" />
-          <h2 className="font-semibold">Don&apos;t see your organization? </h2>
-          <A
-            hook="help finding an org"
-            to={{ pageName: 'codecovGithubAppSelectTarget' }}
-            isExternal={true}
-          >
-            GitHub App is required
-            <Icon name="chevronRight" size="sm" variant="solid" />
-          </A>
-        </div>
-      </BannerHeading>
-      <BannerContent>
-        <div className="ml-4 flex flex-col gap-6 text-xs font-light">
-          <p>You&apos;ll need the organization admin to install the app.</p>
-          <ResyncButton />
-        </div>
-      </BannerContent>
-    </Banner>
+    <>
+      <Banner variant="plain">
+        <BannerHeading>
+          <div className="flex gap-1 text-sm">
+            <Icon size="sm" name="lightBulb" variant="solid" />
+            <h2 className="font-semibold">
+              Don&apos;t see your organization?{' '}
+            </h2>
+            <A
+              hook="help finding an org"
+              to={{ pageName: 'codecovGithubAppSelectTarget' }}
+              isExternal={true}
+            >
+              GitHub App is required
+              <Icon name="chevronRight" size="sm" variant="solid" />
+            </A>
+          </div>
+        </BannerHeading>
+        <BannerContent>
+          <div className="ml-4 flex flex-col gap-6 text-xs font-light">
+            <p>
+              You&apos;ll need the organization admin to install the app -{' '}
+              <A
+                to={undefined}
+                hook="gh-org-share-request"
+                disabled={false}
+                isExternal={false}
+                onClick={() => setShowModal(true)}
+              >
+                <span className="flex items-center">
+                  share request
+                  <div className="flex size-3 items-center">
+                    <Icon name="chevronRight" size="flex" variant="solid" />
+                  </div>
+                </span>
+              </A>
+            </p>
+            <ResyncButton />
+          </div>
+        </BannerContent>
+      </Banner>
+      <AppInstallModal
+        isOpen={showModal}
+        onClose={() => setShowModal(false)}
+        onComplete={() => setShowModal(false)}
+      />
+    </>
   )
 }
 

--- a/src/pages/DefaultOrgSelector/GitHubHelpBanner/GitHubHelpBanner.tsx
+++ b/src/pages/DefaultOrgSelector/GitHubHelpBanner/GitHubHelpBanner.tsx
@@ -58,6 +58,7 @@ function GitHubHelpBanner() {
               hook="help finding an org"
               to={{ pageName: 'codecovGithubAppSelectTarget' }}
               isExternal={true}
+              showExternalIcon={false}
             >
               GitHub App is required
               <Icon name="chevronRight" size="sm" variant="solid" />

--- a/src/shared/AppInstallModal/AppInstallModal.spec.tsx
+++ b/src/shared/AppInstallModal/AppInstallModal.spec.tsx
@@ -1,0 +1,92 @@
+import { render, screen } from '@testing-library/react'
+import { userEvent } from '@testing-library/user-event'
+
+import AppInstallModal from './AppInstallModal'
+
+afterEach(() => {
+  jest.resetAllMocks()
+})
+
+describe('AppInstallModal', () => {
+  const onClose = jest.fn()
+  const onComplete = jest.fn()
+
+  describe('when isOpen is false', () => {
+    it('does not render', async () => {
+      render(
+        <AppInstallModal
+          isOpen={false}
+          onClose={onClose}
+          onComplete={onComplete}
+        />
+      )
+
+      const copy = screen.queryByText(/Copy the link below/)
+      expect(copy).not.toBeInTheDocument()
+    })
+  })
+
+  describe('when isOpen is true', () => {
+    it('renders', async () => {
+      render(
+        <AppInstallModal
+          isOpen={true}
+          onClose={onClose}
+          onComplete={onComplete}
+        />
+      )
+
+      const copy = await screen.findByText(/Copy the link below/)
+      expect(copy).toBeInTheDocument()
+
+      const snippet = await screen.findByText(
+        /approve the installation of the Codecov app on GitHub for our organization?/
+      )
+      expect(snippet).toBeInTheDocument()
+    })
+  })
+
+  describe('when modal is closed', () => {
+    it('calls onClose', async () => {
+      const user = userEvent.setup()
+      render(
+        <AppInstallModal
+          isOpen={true}
+          onClose={onClose}
+          onComplete={onComplete}
+        />
+      )
+
+      const closeButton = await screen.findByTestId('modal-close-icon')
+      expect(closeButton).toBeInTheDocument()
+
+      expect(onClose).not.toHaveBeenCalled()
+
+      await user.click(closeButton)
+
+      expect(onClose).toHaveBeenCalled()
+    })
+  })
+
+  describe('when modal is "completed"', () => {
+    it('calls onComplete', async () => {
+      const user = userEvent.setup()
+      render(
+        <AppInstallModal
+          isOpen={true}
+          onClose={onClose}
+          onComplete={onComplete}
+        />
+      )
+
+      const doneButton = await screen.findByTestId('close-modal')
+      expect(doneButton).toBeInTheDocument()
+
+      expect(onComplete).not.toHaveBeenCalled()
+
+      await user.click(doneButton)
+
+      expect(onComplete).toHaveBeenCalled()
+    })
+  })
+})

--- a/src/shared/AppInstallModal/AppInstallModal.tsx
+++ b/src/shared/AppInstallModal/AppInstallModal.tsx
@@ -1,0 +1,53 @@
+import Button from 'ui/Button'
+import { CodeSnippet } from 'ui/CodeSnippet'
+import Modal from 'ui/Modal'
+
+const COPY_APP_INSTALL_STRING =
+  "Hello, could you help approve the installation of the Codecov app on GitHub for our organization? Here's the link: https://github.com/apps/codecov/installations/select_target"
+
+interface AppInstallModalProps {
+  isOpen: boolean
+  onClose: () => void
+  onComplete: () => void
+}
+
+function AppInstallModal({
+  isOpen,
+  onClose,
+  onComplete,
+}: AppInstallModalProps) {
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      title="Share GitHub app installation"
+      customHeaderClassname="text-lg"
+      body={
+        <div className="flex flex-col">
+          <span className="mb-4 text-sm">
+            Copy the link below and share it with your organization&apos;s admin
+            or owner to assist.
+          </span>
+          <CodeSnippet clipboard={COPY_APP_INSTALL_STRING}>
+            <div className="w-[90%] text-wrap">{COPY_APP_INSTALL_STRING}</div>
+          </CodeSnippet>
+        </div>
+      }
+      footer={
+        <div>
+          <Button
+            to={undefined}
+            hook="close-modal"
+            disabled={false}
+            variant="primary"
+            onClick={onComplete}
+          >
+            Done
+          </Button>
+        </div>
+      }
+    />
+  )
+}
+
+export default AppInstallModal

--- a/src/shared/AppInstallModal/index.ts
+++ b/src/shared/AppInstallModal/index.ts
@@ -1,0 +1,1 @@
+export { default } from './AppInstallModal'

--- a/src/shared/GlobalTopBanners/RequestInstallBanner/RequestInstallBanner.tsx
+++ b/src/shared/GlobalTopBanners/RequestInstallBanner/RequestInstallBanner.tsx
@@ -4,17 +4,14 @@ import { useParams, useRouteMatch } from 'react-router-dom'
 import config from 'config'
 
 import { useLocationParams } from 'services/navigation'
+import AppInstallModal from 'shared/AppInstallModal'
 import { providerToName } from 'shared/utils'
 import { metrics } from 'shared/utils/metrics'
 import Button from 'ui/Button'
-import { CopyClipboard } from 'ui/CopyClipboard'
 import Icon from 'ui/Icon'
-import Modal from 'ui/Modal'
 import TopBanner, { saveToLocalStorage } from 'ui/TopBanner'
 
 const APP_INSTALL_BANNER_KEY = 'request-install-banner'
-const COPY_APP_INSTALL_STRING =
-  "Hello, could you help approve the installation of the Codecov app on GitHub for our organization? Here's the link: https://github.com/apps/codecov/installations/select_target"
 
 interface URLParams {
   provider: string
@@ -89,37 +86,10 @@ const RequestInstallBanner = () => {
           </TopBanner.DismissButton>
         </TopBanner.End>
       </TopBanner>
-      <Modal
+      <AppInstallModal
         isOpen={showAppInstallModal}
         onClose={() => setShowAppInstallModal(false)}
-        title="Share GitHub app installation"
-        body={
-          <div className="flex flex-col">
-            <span className="mb-4 text-sm">
-              Copy the link below and share it with your organization&apos;s
-              admin or owner to assist.
-            </span>
-            <div className="flex items-start gap-4 rounded-md border-2 border-gray-200 bg-gray-100 p-4">
-              <div className="grow overflow-auto whitespace-pre-wrap break-words">
-                {COPY_APP_INSTALL_STRING}
-              </div>
-              <CopyClipboard value={COPY_APP_INSTALL_STRING} />
-            </div>
-          </div>
-        }
-        footer={
-          <div>
-            <Button
-              to={undefined}
-              hook="close-modal"
-              disabled={false}
-              variant="primary"
-              onClick={closeModalAndSaveToLocalStorage}
-            >
-              Done
-            </Button>
-          </div>
-        }
+        onComplete={closeModalAndSaveToLocalStorage}
       />
     </>
   )


### PR DESCRIPTION
Adds a CTA and modal for sharing an app install link with your GitHub admin to the DefaultOrgSelector. Reusing the modal from the request install banner required refactoring it out to its own component.

[Design](https://www.figma.com/design/LTCG0grVc5O6FpVcqmNTUj/GH-764?node-id=165-300&t=1mD3JJQ1fps8gBE0-0)

Closes https://github.com/codecov/engineering-team/issues/1916

<img width="954" alt="Screenshot 2024-08-14 at 14 11 03" src="https://github.com/user-attachments/assets/133d2949-a43d-4df7-970f-e51732a38a98">

<img width="955" alt="Screenshot 2024-08-14 at 14 11 14" src="https://github.com/user-attachments/assets/80d6a529-88e7-486f-97ae-98aebbde94bb">

