### PR TITLE
feat: Add new meta-framework onboarding doc tabs

### DIFF
--- a/src/pages/RepoPage/BundlesTab/BundleOnboarding/BundleOnboarding.spec.tsx
+++ b/src/pages/RepoPage/BundlesTab/BundleOnboarding/BundleOnboarding.spec.tsx
@@ -66,6 +66,10 @@ const wrapper =
             '/:provider/:owner/:repo/bundles/new',
             '/:provider/:owner/:repo/bundles/new/rollup',
             '/:provider/:owner/:repo/bundles/new/webpack',
+            '/:provider/:owner/:repo/bundles/new/remix',
+            '/:provider/:owner/:repo/bundles/new/sveltekit',
+            '/:provider/:owner/:repo/bundles/new/solidstart',
+            '/:provider/:owner/:repo/bundles/new/nuxt',
             '/:provider',
           ]}
         >
@@ -207,6 +211,86 @@ describe('BundleOnboarding', () => {
         )
       })
     })
+
+    describe('when Remix (Vite) is selected', () => {
+      it('should navigate to /new/remix-vite', async () => {
+        const { user } = setup({})
+        render(<BundleOnboarding />, { wrapper: wrapper() })
+
+        const remix = await screen.findByTestId('remix-radio')
+        expect(remix).toBeInTheDocument()
+        expect(remix).toHaveAttribute('data-state', 'unchecked')
+
+        await user.click(remix)
+
+        expect(remix).toBeInTheDocument()
+        expect(remix).toHaveAttribute('data-state', 'checked')
+
+        expect(testLocation.pathname).toBe(
+          '/gh/codecov/test-repo/bundles/new/remix-vite'
+        )
+      })
+    })
+
+    describe('when SvelteKit is selected', () => {
+      it('should navigate to /new/sveltekit', async () => {
+        const { user } = setup({})
+        render(<BundleOnboarding />, { wrapper: wrapper() })
+
+        const sveltekit = await screen.findByTestId('sveltekit-radio')
+        expect(sveltekit).toBeInTheDocument()
+        expect(sveltekit).toHaveAttribute('data-state', 'unchecked')
+
+        await user.click(sveltekit)
+
+        expect(sveltekit).toBeInTheDocument()
+        expect(sveltekit).toHaveAttribute('data-state', 'checked')
+
+        expect(testLocation.pathname).toBe(
+          '/gh/codecov/test-repo/bundles/new/sveltekit'
+        )
+      })
+    })
+
+    describe('when SolidStart is selected', () => {
+      it('should navigate to /new/solidstart', async () => {
+        const { user } = setup({})
+        render(<BundleOnboarding />, { wrapper: wrapper() })
+
+        const solidstart = await screen.findByTestId('solidstart-radio')
+        expect(solidstart).toBeInTheDocument()
+        expect(solidstart).toHaveAttribute('data-state', 'unchecked')
+
+        await user.click(solidstart)
+
+        expect(solidstart).toBeInTheDocument()
+        expect(solidstart).toHaveAttribute('data-state', 'checked')
+
+        expect(testLocation.pathname).toBe(
+          '/gh/codecov/test-repo/bundles/new/solidstart'
+        )
+      })
+    })
+
+    describe('when Nuxt is selected', () => {
+      it('should navigate to /new/nuxt', async () => {
+        const { user } = setup({})
+        render(<BundleOnboarding />, { wrapper: wrapper() })
+
+        const nuxt = await screen.findByTestId('nuxt-radio')
+        expect(nuxt).toBeInTheDocument()
+        expect(nuxt).toHaveAttribute('data-state', 'unchecked')
+
+        await user.click(nuxt)
+
+        expect(nuxt).toBeInTheDocument()
+        expect(nuxt).toHaveAttribute('data-state', 'checked')
+
+        expect(testLocation.pathname).toBe(
+          '/gh/codecov/test-repo/bundles/new/nuxt'
+        )
+      })
+    })
   })
 
   describe('on /new route', () => {
@@ -236,6 +320,42 @@ describe('BundleOnboarding', () => {
         const webpackTab = await screen.findByTestId('webpack-radio')
         expect(webpackTab).toBeInTheDocument()
         expect(webpackTab).toHaveAttribute('data-state', 'unchecked')
+      })
+
+      it('renders remix tab', async () => {
+        setup({})
+        render(<BundleOnboarding />, { wrapper: wrapper() })
+
+        const remixTab = await screen.findByTestId('remix-radio')
+        expect(remixTab).toBeInTheDocument()
+        expect(remixTab).toHaveAttribute('data-state', 'unchecked')
+      })
+
+      it('renders nuxt tab', async () => {
+        setup({})
+        render(<BundleOnboarding />, { wrapper: wrapper() })
+
+        const nuxtTab = await screen.findByTestId('nuxt-radio')
+        expect(nuxtTab).toBeInTheDocument()
+        expect(nuxtTab).toHaveAttribute('data-state', 'unchecked')
+      })
+
+      it('renders solidstart tab', async () => {
+        setup({})
+        render(<BundleOnboarding />, { wrapper: wrapper() })
+
+        const solidstartTab = await screen.findByTestId('solidstart-radio')
+        expect(solidstartTab).toBeInTheDocument()
+        expect(solidstartTab).toHaveAttribute('data-state', 'unchecked')
+      })
+
+      it('renders sveltekit tab', async () => {
+        setup({})
+        render(<BundleOnboarding />, { wrapper: wrapper() })
+
+        const sveltekitTab = await screen.findByTestId('sveltekit-radio')
+        expect(sveltekitTab).toBeInTheDocument()
+        expect(sveltekitTab).toHaveAttribute('data-state', 'unchecked')
       })
     })
 
@@ -285,6 +405,50 @@ describe('BundleOnboarding', () => {
         const webpackTab = await screen.findByTestId('webpack-radio')
         expect(webpackTab).toBeInTheDocument()
         expect(webpackTab).toHaveAttribute('data-state', 'unchecked')
+      })
+
+      it('renders remix tab', async () => {
+        setup({})
+        render(<BundleOnboarding />, {
+          wrapper: wrapper('/gh/codecov/test-repo/bundles/new/rollup'),
+        })
+
+        const remixTab = await screen.findByTestId('remix-radio')
+        expect(remixTab).toBeInTheDocument()
+        expect(remixTab).toHaveAttribute('data-state', 'unchecked')
+      })
+
+      it('renders nuxt tab', async () => {
+        setup({})
+        render(<BundleOnboarding />, {
+          wrapper: wrapper('/gh/codecov/test-repo/bundles/new/rollup'),
+        })
+
+        const nuxtTab = await screen.findByTestId('nuxt-radio')
+        expect(nuxtTab).toBeInTheDocument()
+        expect(nuxtTab).toHaveAttribute('data-state', 'unchecked')
+      })
+
+      it('renders solidstart tab', async () => {
+        setup({})
+        render(<BundleOnboarding />, {
+          wrapper: wrapper('/gh/codecov/test-repo/bundles/new/rollup'),
+        })
+
+        const solidstartTab = await screen.findByTestId('solidstart-radio')
+        expect(solidstartTab).toBeInTheDocument()
+        expect(solidstartTab).toHaveAttribute('data-state', 'unchecked')
+      })
+
+      it('renders sveltekit tab', async () => {
+        setup({})
+        render(<BundleOnboarding />, {
+          wrapper: wrapper('/gh/codecov/test-repo/bundles/new/rollup'),
+        })
+
+        const sveltekitTab = await screen.findByTestId('sveltekit-radio')
+        expect(sveltekitTab).toBeInTheDocument()
+        expect(sveltekitTab).toHaveAttribute('data-state', 'unchecked')
       })
     })
 
@@ -337,6 +501,50 @@ describe('BundleOnboarding', () => {
         expect(webpackTab).toBeInTheDocument()
         expect(webpackTab).toHaveAttribute('data-state', 'checked')
       })
+
+      it('renders remix tab', async () => {
+        setup({})
+        render(<BundleOnboarding />, {
+          wrapper: wrapper('/gh/codecov/test-repo/bundles/new/webpack'),
+        })
+
+        const remixTab = await screen.findByTestId('remix-radio')
+        expect(remixTab).toBeInTheDocument()
+        expect(remixTab).toHaveAttribute('data-state', 'unchecked')
+      })
+
+      it('renders nuxt tab', async () => {
+        setup({})
+        render(<BundleOnboarding />, {
+          wrapper: wrapper('/gh/codecov/test-repo/bundles/new/webpack'),
+        })
+
+        const nuxtTab = await screen.findByTestId('nuxt-radio')
+        expect(nuxtTab).toBeInTheDocument()
+        expect(nuxtTab).toHaveAttribute('data-state', 'unchecked')
+      })
+
+      it('renders solidstart tab', async () => {
+        setup({})
+        render(<BundleOnboarding />, {
+          wrapper: wrapper('/gh/codecov/test-repo/bundles/new/webpack'),
+        })
+
+        const solidstartTab = await screen.findByTestId('solidstart-radio')
+        expect(solidstartTab).toBeInTheDocument()
+        expect(solidstartTab).toHaveAttribute('data-state', 'unchecked')
+      })
+
+      it('renders sveltekit tab', async () => {
+        setup({})
+        render(<BundleOnboarding />, {
+          wrapper: wrapper('/gh/codecov/test-repo/bundles/new/webpack'),
+        })
+
+        const sveltekitTab = await screen.findByTestId('sveltekit-radio')
+        expect(sveltekitTab).toBeInTheDocument()
+        expect(sveltekitTab).toHaveAttribute('data-state', 'unchecked')
+      })
     })
 
     describe('rendering body', () => {
@@ -348,6 +556,386 @@ describe('BundleOnboarding', () => {
 
         const webpackOnboarding = await screen.findByText(
           /Install the Codecov Webpack Plugin/
+        )
+        expect(webpackOnboarding).toBeInTheDocument()
+      })
+    })
+  })
+
+  describe('on /new/remix-vite route', () => {
+    describe('rendering tabs', () => {
+      it('renders vite tab', async () => {
+        setup({})
+        render(<BundleOnboarding />, {
+          wrapper: wrapper('/gh/codecov/test-repo/bundles/new/remix-vite'),
+        })
+
+        const viteTab = await screen.findByTestId('vite-radio')
+        expect(viteTab).toBeInTheDocument()
+        expect(viteTab).toHaveAttribute('data-state', 'unchecked')
+      })
+
+      it('renders rollup tab', async () => {
+        setup({})
+        render(<BundleOnboarding />, {
+          wrapper: wrapper('/gh/codecov/test-repo/bundles/new/remix-vite'),
+        })
+
+        const rollupTab = await screen.findByTestId('rollup-radio')
+        expect(rollupTab).toBeInTheDocument()
+        expect(rollupTab).toHaveAttribute('data-state', 'unchecked')
+      })
+
+      it('renders webpack tab', async () => {
+        setup({})
+        render(<BundleOnboarding />, {
+          wrapper: wrapper('/gh/codecov/test-repo/bundles/new/remix-vite'),
+        })
+
+        const webpackTab = await screen.findByTestId('webpack-radio')
+        expect(webpackTab).toBeInTheDocument()
+        expect(webpackTab).toHaveAttribute('data-state', 'unchecked')
+      })
+
+      it('renders selected remix tab', async () => {
+        setup({})
+        render(<BundleOnboarding />, {
+          wrapper: wrapper('/gh/codecov/test-repo/bundles/new/remix-vite'),
+        })
+
+        const remixTab = await screen.findByTestId('remix-radio')
+        expect(remixTab).toBeInTheDocument()
+        expect(remixTab).toHaveAttribute('data-state', 'checked')
+      })
+
+      it('renders nuxt tab', async () => {
+        setup({})
+        render(<BundleOnboarding />, {
+          wrapper: wrapper('/gh/codecov/test-repo/bundles/new/remix-vite'),
+        })
+
+        const nuxtTab = await screen.findByTestId('nuxt-radio')
+        expect(nuxtTab).toBeInTheDocument()
+        expect(nuxtTab).toHaveAttribute('data-state', 'unchecked')
+      })
+
+      it('renders solidstart tab', async () => {
+        setup({})
+        render(<BundleOnboarding />, {
+          wrapper: wrapper('/gh/codecov/test-repo/bundles/new/remix-vite'),
+        })
+
+        const solidstartTab = await screen.findByTestId('solidstart-radio')
+        expect(solidstartTab).toBeInTheDocument()
+        expect(solidstartTab).toHaveAttribute('data-state', 'unchecked')
+      })
+
+      it('renders sveltekit tab', async () => {
+        setup({})
+        render(<BundleOnboarding />, {
+          wrapper: wrapper('/gh/codecov/test-repo/bundles/new/remix-vite'),
+        })
+
+        const sveltekitTab = await screen.findByTestId('sveltekit-radio')
+        expect(sveltekitTab).toBeInTheDocument()
+        expect(sveltekitTab).toHaveAttribute('data-state', 'unchecked')
+      })
+    })
+
+    describe('rendering body', () => {
+      it('renders webpack onboarding', async () => {
+        setup({})
+        render(<BundleOnboarding />, {
+          wrapper: wrapper('/gh/codecov/test-repo/bundles/new/remix-vite'),
+        })
+
+        const webpackOnboarding = await screen.findByText(
+          /Install the Codecov Remix (Vite) Plugin/
+        )
+        expect(webpackOnboarding).toBeInTheDocument()
+      })
+    })
+  })
+
+  describe('on /new/nuxt route', () => {
+    describe('rendering tabs', () => {
+      it('renders vite tab', async () => {
+        setup({})
+        render(<BundleOnboarding />, {
+          wrapper: wrapper('/gh/codecov/test-repo/bundles/new/nuxt'),
+        })
+
+        const viteTab = await screen.findByTestId('vite-radio')
+        expect(viteTab).toBeInTheDocument()
+        expect(viteTab).toHaveAttribute('data-state', 'unchecked')
+      })
+
+      it('renders rollup tab', async () => {
+        setup({})
+        render(<BundleOnboarding />, {
+          wrapper: wrapper('/gh/codecov/test-repo/bundles/new/nuxt'),
+        })
+
+        const rollupTab = await screen.findByTestId('rollup-radio')
+        expect(rollupTab).toBeInTheDocument()
+        expect(rollupTab).toHaveAttribute('data-state', 'unchecked')
+      })
+
+      it('renders webpack tab', async () => {
+        setup({})
+        render(<BundleOnboarding />, {
+          wrapper: wrapper('/gh/codecov/test-repo/bundles/new/nuxt'),
+        })
+
+        const webpackTab = await screen.findByTestId('webpack-radio')
+        expect(webpackTab).toBeInTheDocument()
+        expect(webpackTab).toHaveAttribute('data-state', 'unchecked')
+      })
+
+      it('renders remix tab', async () => {
+        setup({})
+        render(<BundleOnboarding />, {
+          wrapper: wrapper('/gh/codecov/test-repo/bundles/new/nuxt'),
+        })
+
+        const remixTab = await screen.findByTestId('remix-radio')
+        expect(remixTab).toBeInTheDocument()
+        expect(remixTab).toHaveAttribute('data-state', 'unchecked')
+      })
+
+      it('renders selected nuxt tab', async () => {
+        setup({})
+        render(<BundleOnboarding />, {
+          wrapper: wrapper('/gh/codecov/test-repo/bundles/new/nuxt'),
+        })
+
+        const nuxtTab = await screen.findByTestId('nuxt-radio')
+        expect(nuxtTab).toBeInTheDocument()
+        expect(nuxtTab).toHaveAttribute('data-state', 'checked')
+      })
+
+      it('renders solidstart tab', async () => {
+        setup({})
+        render(<BundleOnboarding />, {
+          wrapper: wrapper('/gh/codecov/test-repo/bundles/new/nuxt'),
+        })
+
+        const solidstartTab = await screen.findByTestId('solidstart-radio')
+        expect(solidstartTab).toBeInTheDocument()
+        expect(solidstartTab).toHaveAttribute('data-state', 'unchecked')
+      })
+
+      it('renders sveltekit tab', async () => {
+        setup({})
+        render(<BundleOnboarding />, {
+          wrapper: wrapper('/gh/codecov/test-repo/bundles/new/nuxt'),
+        })
+
+        const sveltekitTab = await screen.findByTestId('sveltekit-radio')
+        expect(sveltekitTab).toBeInTheDocument()
+        expect(sveltekitTab).toHaveAttribute('data-state', 'unchecked')
+      })
+    })
+
+    describe('rendering body', () => {
+      it('renders webpack onboarding', async () => {
+        setup({})
+        render(<BundleOnboarding />, {
+          wrapper: wrapper('/gh/codecov/test-repo/bundles/new/nuxt'),
+        })
+
+        const webpackOnboarding = await screen.findByText(
+          /Install the Codecov Nuxt Plugin/
+        )
+        expect(webpackOnboarding).toBeInTheDocument()
+      })
+    })
+  })
+
+  describe('on /new/sveltekit route', () => {
+    describe('rendering tabs', () => {
+      it('renders vite tab', async () => {
+        setup({})
+        render(<BundleOnboarding />, {
+          wrapper: wrapper('/gh/codecov/test-repo/bundles/new/sveltekit'),
+        })
+
+        const viteTab = await screen.findByTestId('vite-radio')
+        expect(viteTab).toBeInTheDocument()
+        expect(viteTab).toHaveAttribute('data-state', 'unchecked')
+      })
+
+      it('renders rollup tab', async () => {
+        setup({})
+        render(<BundleOnboarding />, {
+          wrapper: wrapper('/gh/codecov/test-repo/bundles/new/sveltekit'),
+        })
+
+        const rollupTab = await screen.findByTestId('rollup-radio')
+        expect(rollupTab).toBeInTheDocument()
+        expect(rollupTab).toHaveAttribute('data-state', 'unchecked')
+      })
+
+      it('renders webpack tab', async () => {
+        setup({})
+        render(<BundleOnboarding />, {
+          wrapper: wrapper('/gh/codecov/test-repo/bundles/new/sveltekit'),
+        })
+
+        const webpackTab = await screen.findByTestId('webpack-radio')
+        expect(webpackTab).toBeInTheDocument()
+        expect(webpackTab).toHaveAttribute('data-state', 'unchecked')
+      })
+
+      it('renders remix tab', async () => {
+        setup({})
+        render(<BundleOnboarding />, {
+          wrapper: wrapper('/gh/codecov/test-repo/bundles/new/sveltekit'),
+        })
+
+        const remixTab = await screen.findByTestId('remix-radio')
+        expect(remixTab).toBeInTheDocument()
+        expect(remixTab).toHaveAttribute('data-state', 'unchecked')
+      })
+
+      it('renders nuxt tab', async () => {
+        setup({})
+        render(<BundleOnboarding />, {
+          wrapper: wrapper('/gh/codecov/test-repo/bundles/new/sveltekit'),
+        })
+
+        const nuxtTab = await screen.findByTestId('nuxt-radio')
+        expect(nuxtTab).toBeInTheDocument()
+        expect(nuxtTab).toHaveAttribute('data-state', 'unchecked')
+      })
+
+      it('renders solidstart tab', async () => {
+        setup({})
+        render(<BundleOnboarding />, {
+          wrapper: wrapper('/gh/codecov/test-repo/bundles/new/sveltekit'),
+        })
+
+        const solidstartTab = await screen.findByTestId('solidstart-radio')
+        expect(solidstartTab).toBeInTheDocument()
+        expect(solidstartTab).toHaveAttribute('data-state', 'unchecked')
+      })
+
+      it('renders selected sveltekit tab', async () => {
+        setup({})
+        render(<BundleOnboarding />, {
+          wrapper: wrapper('/gh/codecov/test-repo/bundles/new/sveltekit'),
+        })
+
+        const sveltekitTab = await screen.findByTestId('sveltekit-radio')
+        expect(sveltekitTab).toBeInTheDocument()
+        expect(sveltekitTab).toHaveAttribute('data-state', 'checked')
+      })
+    })
+
+    describe('rendering body', () => {
+      it('renders webpack onboarding', async () => {
+        setup({})
+        render(<BundleOnboarding />, {
+          wrapper: wrapper('/gh/codecov/test-repo/bundles/new/sveltekit'),
+        })
+
+        const webpackOnboarding = await screen.findByText(
+          /Install the Codecov SvelteKit Plugin/
+        )
+        expect(webpackOnboarding).toBeInTheDocument()
+      })
+    })
+  })
+
+  describe('on /new/solidstart route', () => {
+    describe('rendering tabs', () => {
+      it('renders vite tab', async () => {
+        setup({})
+        render(<BundleOnboarding />, {
+          wrapper: wrapper('/gh/codecov/test-repo/bundles/new/solidstart'),
+        })
+
+        const viteTab = await screen.findByTestId('vite-radio')
+        expect(viteTab).toBeInTheDocument()
+        expect(viteTab).toHaveAttribute('data-state', 'unchecked')
+      })
+
+      it('renders rollup tab', async () => {
+        setup({})
+        render(<BundleOnboarding />, {
+          wrapper: wrapper('/gh/codecov/test-repo/bundles/new/solidstart'),
+        })
+
+        const rollupTab = await screen.findByTestId('rollup-radio')
+        expect(rollupTab).toBeInTheDocument()
+        expect(rollupTab).toHaveAttribute('data-state', 'unchecked')
+      })
+
+      it('renders webpack tab', async () => {
+        setup({})
+        render(<BundleOnboarding />, {
+          wrapper: wrapper('/gh/codecov/test-repo/bundles/new/solidstart'),
+        })
+
+        const webpackTab = await screen.findByTestId('webpack-radio')
+        expect(webpackTab).toBeInTheDocument()
+        expect(webpackTab).toHaveAttribute('data-state', 'unchecked')
+      })
+
+      it('renders remix tab', async () => {
+        setup({})
+        render(<BundleOnboarding />, {
+          wrapper: wrapper('/gh/codecov/test-repo/bundles/new/solidstart'),
+        })
+
+        const remixTab = await screen.findByTestId('remix-radio')
+        expect(remixTab).toBeInTheDocument()
+        expect(remixTab).toHaveAttribute('data-state', 'unchecked')
+      })
+
+      it('renders nuxt tab', async () => {
+        setup({})
+        render(<BundleOnboarding />, {
+          wrapper: wrapper('/gh/codecov/test-repo/bundles/new/solidstart'),
+        })
+
+        const nuxtTab = await screen.findByTestId('nuxt-radio')
+        expect(nuxtTab).toBeInTheDocument()
+        expect(nuxtTab).toHaveAttribute('data-state', 'unchecked')
+      })
+
+      it('renders selected solidstart tab', async () => {
+        setup({})
+        render(<BundleOnboarding />, {
+          wrapper: wrapper('/gh/codecov/test-repo/bundles/new/solidstart'),
+        })
+
+        const solidstartTab = await screen.findByTestId('solidstart-radio')
+        expect(solidstartTab).toBeInTheDocument()
+        expect(solidstartTab).toHaveAttribute('data-state', 'checked')
+      })
+
+      it('renders sveltekit tab', async () => {
+        setup({})
+        render(<BundleOnboarding />, {
+          wrapper: wrapper('/gh/codecov/test-repo/bundles/new/solidstart'),
+        })
+
+        const sveltekitTab = await screen.findByTestId('sveltekit-radio')
+        expect(sveltekitTab).toBeInTheDocument()
+        expect(sveltekitTab).toHaveAttribute('data-state', 'unchecked')
+      })
+    })
+
+    describe('rendering body', () => {
+      it('renders webpack onboarding', async () => {
+        setup({})
+        render(<BundleOnboarding />, {
+          wrapper: wrapper('/gh/codecov/test-repo/bundles/new/solidstart'),
+        })
+
+        const webpackOnboarding = await screen.findByText(
+          /Install the Codecov SolidStart Plugin/
         )
         expect(webpackOnboarding).toBeInTheDocument()
       })

--- a/src/pages/RepoPage/BundlesTab/BundleOnboarding/BundleOnboarding.tsx
+++ b/src/pages/RepoPage/BundlesTab/BundleOnboarding/BundleOnboarding.tsx
@@ -12,7 +12,11 @@ import { Card } from 'ui/Card'
 import { RadioTileGroup } from 'ui/RadioTileGroup'
 import Spinner from 'ui/Spinner'
 
+import NuxtOnboarding from './NuxtOnboarding'
+import RemixOnboarding from './RemixOnboarding'
 import RollupOnboarding from './RollupOnboarding'
+import SolidStartOnboarding from './SolidStartOnboarding'
+import SvelteKitOnboarding from './SvelteKitOnboarding'
 import ViteOnboarding from './ViteOnboarding'
 import WebpackOnboarding from './WebpackOnboarding'
 
@@ -32,6 +36,10 @@ const BUNDLER_OPTIONS = {
   Vite: 'Vite',
   Rollup: 'Rollup',
   Webpack: 'Webpack',
+  Remix: 'Remix',
+  Nuxt: 'Nuxt',
+  SvelteKit: 'SvelteKit',
+  SolidStart: 'SolidStart',
 } as const
 type BundlerOption = keyof typeof BUNDLER_OPTIONS
 type BundlerOptionUrls = Record<BundlerOption, string>
@@ -43,6 +51,14 @@ const getInitialBundler = (path: string, urls: BundlerOptionUrls) => {
     return BUNDLER_OPTIONS.Rollup
   } else if (path === urls.Webpack) {
     return BUNDLER_OPTIONS.Webpack
+  } else if (path === urls.Remix) {
+    return BUNDLER_OPTIONS.Remix
+  } else if (path === urls.Nuxt) {
+    return BUNDLER_OPTIONS.Nuxt
+  } else if (path === urls.SvelteKit) {
+    return BUNDLER_OPTIONS.SvelteKit
+  } else if (path === urls.SolidStart) {
+    return BUNDLER_OPTIONS.SolidStart
   }
 }
 
@@ -55,13 +71,26 @@ interface BundlerSelectorProps {
 function BundlerSelector({ provider, owner, repo }: BundlerSelectorProps) {
   const location = useLocation()
   const history = useHistory()
-  const { bundleOnboarding, bundleWebpackOnboarding, bundleRollupOnboarding } =
-    useNavLinks()
+  const {
+    bundleNuxtOnboarding,
+    bundleOnboarding,
+    bundleRemixOnboarding,
+    bundleRollupOnboarding,
+    bundleSolidStartOnboarding,
+    bundleSvelteKitOnboarding,
+    bundleWebpackOnboarding,
+  } = useNavLinks()
   const urls = {
     Vite: bundleOnboarding.path({ provider, owner, repo }),
     Rollup: bundleRollupOnboarding.path({ provider, owner, repo }),
     Webpack: bundleWebpackOnboarding.path({ provider, owner, repo }),
+    Remix: bundleRemixOnboarding.path({ provider, owner, repo }),
+    Nuxt: bundleNuxtOnboarding.path({ provider, owner, repo }),
+    SvelteKit: bundleSvelteKitOnboarding.path({ provider, owner, repo }),
+    SolidStart: bundleSolidStartOnboarding.path({ provider, owner, repo }),
   }
+
+  const itemClass = 'flex-none w-[calc((100%-32px)/3)]'
 
   return (
     <Card>
@@ -74,24 +103,56 @@ function BundlerSelector({ provider, owner, repo }: BundlerSelectorProps) {
           onValueChange={(value: BundlerOption) => {
             history.replace(urls[value])
           }}
+          className="flex-wrap"
         >
           <RadioTileGroup.Item
             value={BUNDLER_OPTIONS.Vite}
             data-testid="vite-radio"
+            className={itemClass}
           >
             <RadioTileGroup.Label>Using Vite</RadioTileGroup.Label>
           </RadioTileGroup.Item>
           <RadioTileGroup.Item
             value={BUNDLER_OPTIONS.Rollup}
             data-testid="rollup-radio"
+            className={itemClass}
           >
             <RadioTileGroup.Label>Using Rollup</RadioTileGroup.Label>
           </RadioTileGroup.Item>
           <RadioTileGroup.Item
             value={BUNDLER_OPTIONS.Webpack}
             data-testid="webpack-radio"
+            className={itemClass}
           >
             <RadioTileGroup.Label>Using Webpack</RadioTileGroup.Label>
+          </RadioTileGroup.Item>
+          <RadioTileGroup.Item
+            value={BUNDLER_OPTIONS.Remix}
+            data-testid="remix-radio"
+            className={itemClass}
+          >
+            <RadioTileGroup.Label>Using Remix (Vite)</RadioTileGroup.Label>
+          </RadioTileGroup.Item>
+          <RadioTileGroup.Item
+            value={BUNDLER_OPTIONS.Nuxt}
+            data-testid="nuxt-radio"
+            className={itemClass}
+          >
+            <RadioTileGroup.Label>Using Nuxt</RadioTileGroup.Label>
+          </RadioTileGroup.Item>
+          <RadioTileGroup.Item
+            value={BUNDLER_OPTIONS.SvelteKit}
+            data-testid="sveltekit-radio"
+            className={itemClass}
+          >
+            <RadioTileGroup.Label>Using SvelteKit</RadioTileGroup.Label>
+          </RadioTileGroup.Item>
+          <RadioTileGroup.Item
+            value={BUNDLER_OPTIONS.SolidStart}
+            data-testid="solidstart-radio"
+            className={itemClass}
+          >
+            <RadioTileGroup.Label>Using SolidStart</RadioTileGroup.Label>
           </RadioTileGroup.Item>
         </RadioTileGroup>
       </Card.Content>
@@ -111,6 +172,18 @@ const Content: React.FC = () => {
         </SentryRoute>
         <SentryRoute path="/:provider/:owner/:repo/bundles/new/webpack">
           <WebpackOnboarding />
+        </SentryRoute>
+        <SentryRoute path="/:provider/:owner/:repo/bundles/new/remix-vite">
+          <RemixOnboarding />
+        </SentryRoute>
+        <SentryRoute path="/:provider/:owner/:repo/bundles/new/nuxt">
+          <NuxtOnboarding />
+        </SentryRoute>
+        <SentryRoute path="/:provider/:owner/:repo/bundles/new/solidstart">
+          <SolidStartOnboarding />
+        </SentryRoute>
+        <SentryRoute path="/:provider/:owner/:repo/bundles/new/sveltekit">
+          <SvelteKitOnboarding />
         </SentryRoute>
       </Switch>
     </Suspense>

--- a/src/pages/RepoPage/BundlesTab/BundleOnboarding/BundleOnboarding.tsx
+++ b/src/pages/RepoPage/BundlesTab/BundleOnboarding/BundleOnboarding.tsx
@@ -59,6 +59,8 @@ const getInitialBundler = (path: string, urls: BundlerOptionUrls) => {
     return BUNDLER_OPTIONS.SvelteKit
   } else if (path === urls.SolidStart) {
     return BUNDLER_OPTIONS.SolidStart
+  } else {
+    return BUNDLER_OPTIONS.Vite
   }
 }
 

--- a/src/pages/RepoPage/BundlesTab/BundleOnboarding/NuxtOnboarding/NuxtOnboarding.spec.tsx
+++ b/src/pages/RepoPage/BundlesTab/BundleOnboarding/NuxtOnboarding/NuxtOnboarding.spec.tsx
@@ -377,7 +377,7 @@ describe('NuxtOnboarding', () => {
       render(<NuxtOnboarding />, { wrapper })
 
       const bodyText = await screen.findByText(
-        'The plugin requires at least one commit to be made to properly upload bundle analysis information up to Codecov.'
+        'The plugin requires at least one commit to be made to properly upload bundle analysis information to Codecov.'
       )
       expect(bodyText).toBeInTheDocument()
     })

--- a/src/pages/RepoPage/BundlesTab/BundleOnboarding/NuxtOnboarding/NuxtOnboarding.spec.tsx
+++ b/src/pages/RepoPage/BundlesTab/BundleOnboarding/NuxtOnboarding/NuxtOnboarding.spec.tsx
@@ -1,0 +1,580 @@
+import * as Sentry from '@sentry/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { render, screen, waitFor, within } from '@testing-library/react'
+import { userEvent } from '@testing-library/user-event'
+import { graphql } from 'msw'
+import { setupServer } from 'msw/node'
+import { MemoryRouter, Route } from 'react-router-dom'
+
+import NuxtOnboarding from './NuxtOnboarding'
+
+const mockGetRepo = {
+  owner: {
+    isCurrentUserPartOfOrg: true,
+    orgUploadToken: '9e6a6189-20f1-482d-ab62-ecfaa2629290',
+    isAdmin: null,
+    isCurrentUserActivated: null,
+    repository: {
+      __typename: 'Repository',
+      private: false,
+      uploadToken: '9e6a6189-20f1-482d-ab62-ecfaa2629295',
+      defaultBranch: 'main',
+      yaml: '',
+      activated: false,
+      oldestCommitAt: '',
+      active: true,
+      isFirstPullRequest: false,
+    },
+  },
+}
+
+const mockGetOrgUploadToken = (hasOrgUploadToken: boolean | null) => ({
+  owner: {
+    orgUploadToken: hasOrgUploadToken
+      ? '9e6a6189-20f1-482d-ab62-ecfaa2629290'
+      : null,
+  },
+})
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      suspense: true,
+      retry: false,
+    },
+  },
+})
+const server = setupServer()
+
+const wrapper: React.FC<React.PropsWithChildren> = ({ children }) => (
+  <QueryClientProvider client={queryClient}>
+    <MemoryRouter initialEntries={['/gh/codecov/test-repo/bundles/new']}>
+      <Route path="/:provider/:owner/:repo/bundles/new">{children}</Route>
+    </MemoryRouter>
+  </QueryClientProvider>
+)
+
+beforeAll(() => {
+  server.listen()
+})
+
+afterEach(() => {
+  queryClient.clear()
+  server.resetHandlers()
+})
+
+afterAll(() => {
+  server.close()
+})
+
+describe('NuxtOnboarding', () => {
+  function setup(hasOrgUploadToken: boolean | null) {
+    // mock out to clear error
+    window.prompt = jest.fn()
+    const user = userEvent.setup()
+
+    server.use(
+      graphql.query('GetRepo', (req, res, ctx) =>
+        res(ctx.status(200), ctx.data(mockGetRepo))
+      ),
+      graphql.query('GetOrgUploadToken', (req, res, ctx) => {
+        return res(
+          ctx.status(200),
+          ctx.data(mockGetOrgUploadToken(hasOrgUploadToken))
+        )
+      })
+    )
+
+    return { user }
+  }
+
+  describe('rendering onboarding', () => {
+    it('sends nuxt onboarding metric', async () => {
+      setup(null)
+      render(<NuxtOnboarding />, { wrapper })
+
+      await waitFor(() =>
+        expect(Sentry.metrics.increment).toHaveBeenCalledWith(
+          'bundles_tab.onboarding.visited_page',
+          1,
+          { tags: { bundler: 'nuxt' } }
+        )
+      )
+    })
+  })
+
+  describe('step 1', () => {
+    it('renders header', async () => {
+      setup(null)
+      render(<NuxtOnboarding />, { wrapper })
+
+      const stepText = await screen.findByText(/Step 1:/)
+      expect(stepText).toBeInTheDocument()
+
+      const headerText = await screen.findByText(
+        /Install the Codecov Nuxt Plugin/
+      )
+      expect(headerText).toBeInTheDocument()
+    })
+
+    it('renders body', async () => {
+      setup(null)
+      render(<NuxtOnboarding />, { wrapper })
+
+      const bodyText = await screen.findByText(/To install the/)
+      expect(bodyText).toBeInTheDocument()
+
+      const pluginName = await screen.findByText('@codecov/nuxt-plugin')
+      expect(pluginName).toBeInTheDocument()
+    })
+
+    describe('code blocks', () => {
+      describe('npm', () => {
+        it('renders npm install', async () => {
+          setup(null)
+          render(<NuxtOnboarding />, { wrapper })
+
+          const npmInstallCommand = await screen.findByText(
+            'npm install @codecov/nuxt-plugin --save-dev'
+          )
+          expect(npmInstallCommand).toBeInTheDocument()
+        })
+
+        describe('user clicks copy button', () => {
+          it('sends metric to sentry', async () => {
+            const { user } = setup(null)
+            render(<NuxtOnboarding />, { wrapper })
+
+            const npmInstall = await screen.findByTestId('nuxt-npm-install')
+            const npmInstallCopy = await within(npmInstall).findByTestId(
+              'clipboard-code-snippet'
+            )
+
+            await user.click(npmInstallCopy)
+
+            await waitFor(() =>
+              expect(Sentry.metrics.increment).toHaveBeenCalledWith(
+                'bundles_tab.onboarding.copied.install_command',
+                1,
+                { tags: { package_manager: 'npm', bundler: 'nuxt' } }
+              )
+            )
+          })
+        })
+      })
+
+      describe('yarn', () => {
+        it('renders yarn install', async () => {
+          setup(null)
+          render(<NuxtOnboarding />, { wrapper })
+
+          const yarnInstallCommand = await screen.findByText(
+            'yarn add @codecov/nuxt-plugin --dev'
+          )
+          expect(yarnInstallCommand).toBeInTheDocument()
+        })
+
+        describe('user clicks copy button', () => {
+          it('sends metric to sentry', async () => {
+            const { user } = setup(null)
+            render(<NuxtOnboarding />, { wrapper })
+
+            const yarnInstall = await screen.findByTestId('nuxt-yarn-install')
+            const yarnInstallCopy = await within(yarnInstall).findByTestId(
+              'clipboard-code-snippet'
+            )
+
+            await user.click(yarnInstallCopy)
+
+            await waitFor(() =>
+              expect(Sentry.metrics.increment).toHaveBeenCalledWith(
+                'bundles_tab.onboarding.copied.install_command',
+                1,
+                { tags: { package_manager: 'yarn', bundler: 'nuxt' } }
+              )
+            )
+          })
+        })
+      })
+
+      describe('pnpm', () => {
+        it('renders pnpm install', async () => {
+          setup(null)
+          render(<NuxtOnboarding />, { wrapper })
+
+          const pnpmInstallCommand = await screen.findByText(
+            'pnpm add @codecov/nuxt-plugin --save-dev'
+          )
+          expect(pnpmInstallCommand).toBeInTheDocument()
+        })
+
+        describe('user clicks copy button', () => {
+          it('sends metric to sentry', async () => {
+            const { user } = setup(null)
+            render(<NuxtOnboarding />, { wrapper })
+
+            const pnpmInstall = await screen.findByTestId('nuxt-pnpm-install')
+            const pnpmInstallCopy = await within(pnpmInstall).findByTestId(
+              'clipboard-code-snippet'
+            )
+
+            await user.click(pnpmInstallCopy)
+
+            await waitFor(() =>
+              expect(Sentry.metrics.increment).toHaveBeenCalledWith(
+                'bundles_tab.onboarding.copied.install_command',
+                1,
+                { tags: { package_manager: 'pnpm', bundler: 'nuxt' } }
+              )
+            )
+          })
+        })
+      })
+    })
+  })
+
+  describe('step 2', () => {
+    it('renders header', async () => {
+      setup(null)
+      render(<NuxtOnboarding />, { wrapper })
+
+      const stepText = await screen.findByText(/Step 2:/)
+      expect(stepText).toBeInTheDocument()
+
+      const headerText = await screen.findByText(/Copy Codecov token/)
+      expect(headerText).toBeInTheDocument()
+    })
+
+    it('renders body', async () => {
+      setup(null)
+      render(<NuxtOnboarding />, { wrapper })
+
+      const bodyText = await screen.findByText(
+        /Set an environment variable in your build environment with the following upload token./
+      )
+      expect(bodyText).toBeInTheDocument()
+    })
+
+    describe('there is an org token', () => {
+      it('renders code block with org token', async () => {
+        setup(true)
+        render(<NuxtOnboarding />, { wrapper })
+
+        const token = await screen.findByText(
+          /9e6a6189-20f1-482d-ab62-ecfaa2629290/
+        )
+        expect(token).toBeInTheDocument()
+      })
+    })
+
+    describe('there is no org token', () => {
+      it('renders code block with repo token', async () => {
+        setup(false)
+        render(<NuxtOnboarding />, { wrapper })
+
+        const token = await screen.findByText(
+          /9e6a6189-20f1-482d-ab62-ecfaa2629295/
+        )
+        expect(token).toBeInTheDocument()
+      })
+    })
+
+    describe('user clicks copy button', () => {
+      it('sends metric to sentry', async () => {
+        const { user } = setup(true)
+        render(<NuxtOnboarding />, { wrapper })
+
+        const uploadToken = await screen.findByTestId('nuxt-upload-token')
+        const uploadTokenCopy = await within(uploadToken).findByTestId(
+          'clipboard-code-snippet'
+        )
+
+        await user.click(uploadTokenCopy)
+
+        await waitFor(() =>
+          expect(Sentry.metrics.increment).toHaveBeenCalledWith(
+            'bundles_tab.onboarding.copied.token',
+            1,
+            { tags: { bundler: 'nuxt' } }
+          )
+        )
+      })
+    })
+  })
+
+  describe('step 3', () => {
+    it('renders header', async () => {
+      setup(null)
+      render(<NuxtOnboarding />, { wrapper })
+
+      const stepText = await screen.findByText(/Step 3:/)
+      expect(stepText).toBeInTheDocument()
+
+      const headerText = await screen.findByText(/Configure the bundler plugin/)
+      expect(headerText).toBeInTheDocument()
+    })
+
+    it('renders body', async () => {
+      setup(null)
+      render(<NuxtOnboarding />, { wrapper })
+
+      const bodyText = await screen.findByText(
+        /Add the plugin to the end of your modules array found inside your/
+      )
+      expect(bodyText).toBeInTheDocument()
+
+      const nuxtConfig = await screen.findByText('nuxt.config.js')
+      expect(nuxtConfig).toBeInTheDocument()
+    })
+
+    it('renders plugin config', async () => {
+      setup(null)
+      render(<NuxtOnboarding />, { wrapper })
+
+      const pluginText = await screen.findByText(/\/\/ nuxt.config.js/)
+      expect(pluginText).toBeInTheDocument()
+    })
+
+    describe('user clicks copy button', () => {
+      it('sends metric to sentry', async () => {
+        const { user } = setup(true)
+        render(<NuxtOnboarding />, { wrapper })
+
+        const pluginConfig = await screen.findByTestId('nuxt-plugin-config')
+        const pluginConfigCopy = await within(pluginConfig).findByTestId(
+          'clipboard-code-snippet'
+        )
+
+        await user.click(pluginConfigCopy)
+
+        await waitFor(() =>
+          expect(Sentry.metrics.increment).toHaveBeenCalledWith(
+            'bundles_tab.onboarding.copied.config',
+            1,
+            { tags: { bundler: 'nuxt' } }
+          )
+        )
+      })
+    })
+  })
+
+  describe('step 4', () => {
+    it('renders header', async () => {
+      setup(null)
+      render(<NuxtOnboarding />, { wrapper })
+
+      const stepText = await screen.findByText(/Step 4:/)
+      expect(stepText).toBeInTheDocument()
+
+      const headerText = await screen.findByText(
+        /Commit and push your latest changes/
+      )
+      expect(headerText).toBeInTheDocument()
+    })
+
+    it('renders body', async () => {
+      setup(null)
+      render(<NuxtOnboarding />, { wrapper })
+
+      const bodyText = await screen.findByText(
+        'The plugin requires at least one commit to be made to properly upload bundle analysis information up to Codecov.'
+      )
+      expect(bodyText).toBeInTheDocument()
+    })
+
+    it('renders git commit', async () => {
+      setup(null)
+      render(<NuxtOnboarding />, { wrapper })
+
+      const gitCommit = await screen.findByText(
+        'git add -A && git commit -m "Add Codecov bundler plugin" && git push'
+      )
+      expect(gitCommit).toBeInTheDocument()
+    })
+
+    describe('user clicks copy button', () => {
+      it('sends metric to sentry', async () => {
+        const { user } = setup(true)
+        render(<NuxtOnboarding />, { wrapper })
+
+        const commitCommand = await screen.findByTestId('nuxt-commit-command')
+        const commitCommandCopy = await within(commitCommand).findByTestId(
+          'clipboard-code-snippet'
+        )
+
+        await user.click(commitCommandCopy)
+
+        await waitFor(() =>
+          expect(Sentry.metrics.increment).toHaveBeenCalledWith(
+            'bundles_tab.onboarding.copied.commit',
+            1,
+            { tags: { bundler: 'nuxt' } }
+          )
+        )
+      })
+    })
+  })
+
+  describe('step 5', () => {
+    it('renders header', async () => {
+      setup(null)
+      render(<NuxtOnboarding />, { wrapper })
+
+      const stepText = await screen.findByText(/Step 5:/)
+      expect(stepText).toBeInTheDocument()
+
+      const headerText = await screen.findByText(/Build the application/)
+      expect(headerText).toBeInTheDocument()
+    })
+
+    it('renders body', async () => {
+      setup(null)
+      render(<NuxtOnboarding />, { wrapper })
+
+      const bodyText = await screen.findByText(
+        'When building your application the plugin will automatically upload the stats information to Codecov.'
+      )
+      expect(bodyText).toBeInTheDocument()
+    })
+
+    describe('renders code block', () => {
+      describe('npm', () => {
+        it('renders npm build', async () => {
+          setup(null)
+          render(<NuxtOnboarding />, { wrapper })
+
+          const npmBuild = await screen.findByText('npm run build')
+          expect(npmBuild).toBeInTheDocument()
+        })
+
+        describe('user clicks copy button', () => {
+          it('sends metric to sentry', async () => {
+            const { user } = setup(true)
+            render(<NuxtOnboarding />, { wrapper })
+
+            const buildCommand = await screen.findByTestId('nuxt-npm-build')
+            const buildCommandCopy = await within(buildCommand).findByTestId(
+              'clipboard-code-snippet'
+            )
+
+            await user.click(buildCommandCopy)
+
+            await waitFor(() =>
+              expect(Sentry.metrics.increment).toHaveBeenCalledWith(
+                'bundles_tab.onboarding.copied.build_command',
+                1,
+                { tags: { package_manager: 'npm', bundler: 'nuxt' } }
+              )
+            )
+          })
+        })
+      })
+
+      describe('yarn', () => {
+        it('renders yarn build', async () => {
+          setup(null)
+          render(<NuxtOnboarding />, { wrapper })
+
+          const yarnBuild = await screen.findByText('yarn run build')
+          expect(yarnBuild).toBeInTheDocument()
+        })
+
+        describe('user clicks copy button', () => {
+          it('sends metric to sentry', async () => {
+            const { user } = setup(true)
+            render(<NuxtOnboarding />, { wrapper })
+
+            const buildCommand = await screen.findByTestId('nuxt-yarn-build')
+            const buildCommandCopy = await within(buildCommand).findByTestId(
+              'clipboard-code-snippet'
+            )
+
+            await user.click(buildCommandCopy)
+
+            await waitFor(() =>
+              expect(Sentry.metrics.increment).toHaveBeenCalledWith(
+                'bundles_tab.onboarding.copied.build_command',
+                1,
+                { tags: { package_manager: 'yarn', bundler: 'nuxt' } }
+              )
+            )
+          })
+        })
+      })
+
+      describe('pnpm', () => {
+        it('renders pnpm build', async () => {
+          setup(null)
+          render(<NuxtOnboarding />, { wrapper })
+
+          const pnpmBuild = await screen.findByText('pnpm run build')
+          expect(pnpmBuild).toBeInTheDocument()
+        })
+
+        describe('user clicks copy button', () => {
+          it('sends metric to sentry', async () => {
+            const { user } = setup(true)
+            render(<NuxtOnboarding />, { wrapper })
+
+            const buildCommand = await screen.findByTestId('nuxt-pnpm-build')
+            const buildCommandCopy = await within(buildCommand).findByTestId(
+              'clipboard-code-snippet'
+            )
+
+            await user.click(buildCommandCopy)
+
+            await waitFor(() =>
+              expect(Sentry.metrics.increment).toHaveBeenCalledWith(
+                'bundles_tab.onboarding.copied.build_command',
+                1,
+                { tags: { package_manager: 'pnpm', bundler: 'nuxt' } }
+              )
+            )
+          })
+        })
+      })
+    })
+  })
+
+  describe('linking out to setup feedback', () => {
+    it('renders correct preview text', async () => {
+      setup(null)
+      render(<NuxtOnboarding />, { wrapper })
+
+      const text = await screen.findByText(/How was your setup experience\?/)
+      expect(text).toBeInTheDocument()
+
+      const letUsKnow = await screen.findByText(/Let us know in/)
+      expect(letUsKnow).toBeInTheDocument()
+    })
+
+    it('renders link', async () => {
+      setup(null)
+      render(<NuxtOnboarding />, { wrapper })
+
+      const link = await screen.findByText('this issue')
+      expect(link).toBeInTheDocument()
+      expect(link).toHaveAttribute(
+        'href',
+        'https://github.com/codecov/feedback/issues/270'
+      )
+    })
+  })
+
+  describe('learn more blurb', () => {
+    it('renders body', async () => {
+      setup(null)
+      render(<NuxtOnboarding />, { wrapper })
+
+      const body = await screen.findByText(/Visit our guide to/)
+      expect(body).toBeInTheDocument()
+
+      const link = await screen.findByRole('link', { name: /learn more/ })
+      expect(link).toBeInTheDocument()
+      expect(link).toHaveAttribute(
+        'href',
+        'https://docs.codecov.com/docs/javascript-bundle-analysis'
+      )
+    })
+  })
+})

--- a/src/pages/RepoPage/BundlesTab/BundleOnboarding/NuxtOnboarding/NuxtOnboarding.tsx
+++ b/src/pages/RepoPage/BundlesTab/BundleOnboarding/NuxtOnboarding/NuxtOnboarding.tsx
@@ -1,0 +1,277 @@
+import React, { useEffect } from 'react'
+import { useParams } from 'react-router-dom'
+
+import { useOrgUploadToken } from 'services/orgUploadToken'
+import { useRepo } from 'services/repo'
+import A from 'ui/A'
+import { Card } from 'ui/Card'
+import { CodeSnippet } from 'ui/CodeSnippet'
+
+import LearnMoreBlurb from '../LearnMoreBlurb'
+import {
+  copiedBuildCommandMetric,
+  copiedCommitMetric,
+  copiedConfigMetric,
+  copiedInstallCommandMetric,
+  copiedTokenMetric,
+  visitedOnboardingMetric,
+} from '../metricHelpers'
+
+const npmInstall = `npm install @codecov/nuxt-plugin --save-dev`
+const yarnInstall = `yarn add @codecov/nuxt-plugin --dev`
+const pnpmInstall = `pnpm add @codecov/nuxt-plugin --save-dev`
+
+const pluginConfig = `// nuxt.config.js
+// https://nuxt.com/docs/api/configuration/nuxt-config
+
+export default defineNuxtConfig({
+  builder: "vite",
+  modules: [
+    // Put the Codecov Nuxt module after all other modules.
+    [
+      "@codecov/nuxt-plugin",
+      {
+        enableBundleAnalysis: process.env.CODECOV_TOKEN !== undefined,
+      	bundleName: "<bundle project name>",
+      	uploadToken: process.env.CODECOV_TOKEN,
+      }
+    ]
+  ],
+});`
+
+const commitString = `git add -A && git commit -m "Add Codecov bundler plugin" && git push`
+
+const npmBuild = `npm run build`
+const yarnBuild = `yarn run build`
+const pnpmBuild = `pnpm run build`
+
+const StepOne: React.FC = () => {
+  return (
+    <Card>
+      <Card.Header>
+        <Card.Title size="base">
+          Step 1: Install the Codecov Nuxt Plugin
+        </Card.Title>
+      </Card.Header>
+      <Card.Content className="flex flex-col gap-4">
+        <p>
+          To install the{' '}
+          <span className="bg-ds-gray-primary px-1 font-mono">
+            @codecov/nuxt-plugin
+          </span>{' '}
+          to your project, use one of the following commands.
+        </p>
+        <CodeSnippet
+          clipboard={npmInstall}
+          clipboardOnClick={() => {
+            copiedInstallCommandMetric('npm', 'nuxt')
+          }}
+          data-testid="nuxt-npm-install"
+        >
+          {npmInstall}
+        </CodeSnippet>
+        <CodeSnippet
+          clipboard={yarnInstall}
+          clipboardOnClick={() => {
+            copiedInstallCommandMetric('yarn', 'nuxt')
+          }}
+          data-testid="nuxt-yarn-install"
+        >
+          {yarnInstall}
+        </CodeSnippet>
+        <CodeSnippet
+          clipboard={pnpmInstall}
+          clipboardOnClick={() => {
+            copiedInstallCommandMetric('pnpm', 'nuxt')
+          }}
+          data-testid="nuxt-pnpm-install"
+        >
+          {pnpmInstall}
+        </CodeSnippet>
+      </Card.Content>
+    </Card>
+  )
+}
+
+const StepTwo: React.FC<{ uploadToken: string }> = ({ uploadToken }) => {
+  return (
+    <Card>
+      <Card.Header>
+        <Card.Title size="base">Step 2: Copy Codecov token</Card.Title>
+      </Card.Header>
+      <Card.Content className="flex flex-col gap-4">
+        <p>
+          Set an environment variable in your build environment with the
+          following upload token.
+        </p>
+        <div className="flex gap-4">
+          <CodeSnippet className="basis-1/3" clipboard="CODECOV_TOKEN">
+            CODECOV_TOKEN
+          </CodeSnippet>
+          <CodeSnippet
+            className="basis-2/3"
+            clipboard={uploadToken}
+            clipboardOnClick={() => {
+              copiedTokenMetric('nuxt')
+            }}
+            data-testid="nuxt-upload-token"
+          >
+            {uploadToken}
+          </CodeSnippet>
+        </div>
+      </Card.Content>
+    </Card>
+  )
+}
+
+const StepThree: React.FC = () => {
+  return (
+    <Card>
+      <Card.Header>
+        <Card.Title size="base">
+          Step 3: Configure the bundler plugin
+        </Card.Title>
+      </Card.Header>
+      <Card.Content className="flex flex-col gap-4">
+        <p>
+          Add the plugin to the end of your modules array found inside your{' '}
+          <span className="bg-ds-gray-primary px-1 font-mono">
+            nuxt.config.js
+          </span>{' '}
+          file, and pass your configuration.
+        </p>
+        <CodeSnippet
+          clipboard={pluginConfig}
+          clipboardOnClick={() => {
+            copiedConfigMetric('nuxt')
+          }}
+          data-testid="nuxt-plugin-config"
+        >
+          {pluginConfig}
+        </CodeSnippet>
+      </Card.Content>
+    </Card>
+  )
+}
+
+const StepFour: React.FC = () => {
+  return (
+    <Card>
+      <Card.Header>
+        <Card.Title size="base">
+          Step 4: Commit and push your latest changes
+        </Card.Title>
+      </Card.Header>
+      <Card.Content className="flex flex-col gap-4">
+        <p>
+          The plugin requires at least one commit to be made to properly upload
+          bundle analysis information up to Codecov.
+        </p>
+        <CodeSnippet
+          clipboard={commitString}
+          clipboardOnClick={() => {
+            copiedCommitMetric('nuxt')
+          }}
+          data-testid="nuxt-commit-command"
+        >
+          {commitString}
+        </CodeSnippet>
+      </Card.Content>
+    </Card>
+  )
+}
+
+const StepFive: React.FC = () => {
+  return (
+    <Card>
+      <Card.Header>
+        <Card.Title size="base">Step 5: Build the application</Card.Title>
+      </Card.Header>
+      <Card.Content className="flex flex-col gap-4">
+        <p>
+          When building your application the plugin will automatically upload
+          the stats information to Codecov.
+        </p>
+        <CodeSnippet
+          clipboard={npmBuild}
+          clipboardOnClick={() => {
+            copiedBuildCommandMetric('npm', 'nuxt')
+          }}
+          data-testid="nuxt-npm-build"
+        >
+          {npmBuild}
+        </CodeSnippet>
+        <CodeSnippet
+          clipboard={yarnBuild}
+          clipboardOnClick={() => {
+            copiedBuildCommandMetric('yarn', 'nuxt')
+          }}
+          data-testid="nuxt-yarn-build"
+        >
+          {yarnBuild}
+        </CodeSnippet>
+        <CodeSnippet
+          clipboard={pnpmBuild}
+          clipboardOnClick={() => {
+            copiedBuildCommandMetric('pnpm', 'nuxt')
+          }}
+          data-testid="nuxt-pnpm-build"
+        >
+          {pnpmBuild}
+        </CodeSnippet>
+      </Card.Content>
+    </Card>
+  )
+}
+
+function FeedbackCTA() {
+  return (
+    <Card>
+      <Card.Content>
+        <p>
+          <span className="font-semibold">How was your setup experience?</span>{' '}
+          Let us know in{' '}
+          <A
+            to={{ pageName: 'bundleConfigFeedback' }}
+            isExternal
+            hook="repo-config-feedback"
+          >
+            this issue
+          </A>
+        </p>
+      </Card.Content>
+    </Card>
+  )
+}
+
+interface URLParams {
+  provider: string
+  owner: string
+  repo: string
+}
+
+const NuxtOnboarding: React.FC = () => {
+  const { provider, owner, repo } = useParams<URLParams>()
+  const { data: repoData } = useRepo({ provider, owner, repo })
+  const { data: orgUploadToken } = useOrgUploadToken({ provider, owner })
+
+  const uploadToken = orgUploadToken ?? repoData?.repository?.uploadToken ?? ''
+
+  useEffect(() => {
+    visitedOnboardingMetric('nuxt')
+  }, [])
+
+  return (
+    <div className="flex flex-col gap-6">
+      <StepOne />
+      <StepTwo uploadToken={uploadToken} />
+      <StepThree />
+      <StepFour />
+      <StepFive />
+      <FeedbackCTA />
+      <LearnMoreBlurb />
+    </div>
+  )
+}
+
+export default NuxtOnboarding

--- a/src/pages/RepoPage/BundlesTab/BundleOnboarding/NuxtOnboarding/NuxtOnboarding.tsx
+++ b/src/pages/RepoPage/BundlesTab/BundleOnboarding/NuxtOnboarding/NuxtOnboarding.tsx
@@ -165,7 +165,7 @@ const StepFour: React.FC = () => {
       <Card.Content className="flex flex-col gap-4">
         <p>
           The plugin requires at least one commit to be made to properly upload
-          bundle analysis information up to Codecov.
+          bundle analysis information to Codecov.
         </p>
         <CodeSnippet
           clipboard={commitString}

--- a/src/pages/RepoPage/BundlesTab/BundleOnboarding/NuxtOnboarding/index.ts
+++ b/src/pages/RepoPage/BundlesTab/BundleOnboarding/NuxtOnboarding/index.ts
@@ -1,0 +1,1 @@
+export { default } from './NuxtOnboarding'

--- a/src/pages/RepoPage/BundlesTab/BundleOnboarding/RemixOnboarding/RemixOnboarding.spec.tsx
+++ b/src/pages/RepoPage/BundlesTab/BundleOnboarding/RemixOnboarding/RemixOnboarding.spec.tsx
@@ -377,7 +377,7 @@ describe('RemixOnboarding', () => {
       render(<RemixOnboarding />, { wrapper })
 
       const bodyText = await screen.findByText(
-        'The plugin requires at least one commit to be made to properly upload bundle analysis information up to Codecov.'
+        'The plugin requires at least one commit to be made to properly upload bundle analysis information to Codecov.'
       )
       expect(bodyText).toBeInTheDocument()
     })

--- a/src/pages/RepoPage/BundlesTab/BundleOnboarding/RemixOnboarding/RemixOnboarding.spec.tsx
+++ b/src/pages/RepoPage/BundlesTab/BundleOnboarding/RemixOnboarding/RemixOnboarding.spec.tsx
@@ -1,0 +1,580 @@
+import * as Sentry from '@sentry/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { render, screen, waitFor, within } from '@testing-library/react'
+import { userEvent } from '@testing-library/user-event'
+import { graphql } from 'msw'
+import { setupServer } from 'msw/node'
+import { MemoryRouter, Route } from 'react-router-dom'
+
+import RemixOnboarding from './RemixOnboarding'
+
+const mockGetRepo = {
+  owner: {
+    isCurrentUserPartOfOrg: true,
+    orgUploadToken: '9e6a6189-20f1-482d-ab62-ecfaa2629290',
+    isAdmin: null,
+    isCurrentUserActivated: null,
+    repository: {
+      __typename: 'Repository',
+      private: false,
+      uploadToken: '9e6a6189-20f1-482d-ab62-ecfaa2629295',
+      defaultBranch: 'main',
+      yaml: '',
+      activated: false,
+      oldestCommitAt: '',
+      active: true,
+      isFirstPullRequest: false,
+    },
+  },
+}
+
+const mockGetOrgUploadToken = (hasOrgUploadToken: boolean | null) => ({
+  owner: {
+    orgUploadToken: hasOrgUploadToken
+      ? '9e6a6189-20f1-482d-ab62-ecfaa2629290'
+      : null,
+  },
+})
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      suspense: true,
+      retry: false,
+    },
+  },
+})
+const server = setupServer()
+
+const wrapper: React.FC<React.PropsWithChildren> = ({ children }) => (
+  <QueryClientProvider client={queryClient}>
+    <MemoryRouter initialEntries={['/gh/codecov/test-repo/bundles/new']}>
+      <Route path="/:provider/:owner/:repo/bundles/new">{children}</Route>
+    </MemoryRouter>
+  </QueryClientProvider>
+)
+
+beforeAll(() => {
+  server.listen()
+})
+
+afterEach(() => {
+  queryClient.clear()
+  server.resetHandlers()
+})
+
+afterAll(() => {
+  server.close()
+})
+
+describe('RemixOnboarding', () => {
+  function setup(hasOrgUploadToken: boolean | null) {
+    // mock out to clear error
+    window.prompt = jest.fn()
+    const user = userEvent.setup()
+
+    server.use(
+      graphql.query('GetRepo', (req, res, ctx) =>
+        res(ctx.status(200), ctx.data(mockGetRepo))
+      ),
+      graphql.query('GetOrgUploadToken', (req, res, ctx) => {
+        return res(
+          ctx.status(200),
+          ctx.data(mockGetOrgUploadToken(hasOrgUploadToken))
+        )
+      })
+    )
+
+    return { user }
+  }
+
+  describe('rendering onboarding', () => {
+    it('sends remix onboarding metric', async () => {
+      setup(null)
+      render(<RemixOnboarding />, { wrapper })
+
+      await waitFor(() =>
+        expect(Sentry.metrics.increment).toHaveBeenCalledWith(
+          'bundles_tab.onboarding.visited_page',
+          1,
+          { tags: { bundler: 'remix' } }
+        )
+      )
+    })
+  })
+
+  describe('step 1', () => {
+    it('renders header', async () => {
+      setup(null)
+      render(<RemixOnboarding />, { wrapper })
+
+      const stepText = await screen.findByText(/Step 1:/)
+      expect(stepText).toBeInTheDocument()
+
+      const headerText = await screen.findByText(
+        /Install the Codecov Remix Vite Plugin/
+      )
+      expect(headerText).toBeInTheDocument()
+    })
+
+    it('renders body', async () => {
+      setup(null)
+      render(<RemixOnboarding />, { wrapper })
+
+      const bodyText = await screen.findByText(/To install the/)
+      expect(bodyText).toBeInTheDocument()
+
+      const pluginName = await screen.findByText('@codecov/remix-vite-plugin')
+      expect(pluginName).toBeInTheDocument()
+    })
+
+    describe('code blocks', () => {
+      describe('npm', () => {
+        it('renders npm install', async () => {
+          setup(null)
+          render(<RemixOnboarding />, { wrapper })
+
+          const npmInstallCommand = await screen.findByText(
+            'npm install @codecov/remix-vite-plugin --save-dev'
+          )
+          expect(npmInstallCommand).toBeInTheDocument()
+        })
+
+        describe('user clicks copy button', () => {
+          it('sends metric to sentry', async () => {
+            const { user } = setup(null)
+            render(<RemixOnboarding />, { wrapper })
+
+            const npmInstall = await screen.findByTestId('remix-npm-install')
+            const npmInstallCopy = await within(npmInstall).findByTestId(
+              'clipboard-code-snippet'
+            )
+
+            await user.click(npmInstallCopy)
+
+            await waitFor(() =>
+              expect(Sentry.metrics.increment).toHaveBeenCalledWith(
+                'bundles_tab.onboarding.copied.install_command',
+                1,
+                { tags: { package_manager: 'npm', bundler: 'remix' } }
+              )
+            )
+          })
+        })
+      })
+
+      describe('yarn', () => {
+        it('renders yarn install', async () => {
+          setup(null)
+          render(<RemixOnboarding />, { wrapper })
+
+          const yarnInstallCommand = await screen.findByText(
+            'yarn add @codecov/remix-vite-plugin --dev'
+          )
+          expect(yarnInstallCommand).toBeInTheDocument()
+        })
+
+        describe('user clicks copy button', () => {
+          it('sends metric to sentry', async () => {
+            const { user } = setup(null)
+            render(<RemixOnboarding />, { wrapper })
+
+            const yarnInstall = await screen.findByTestId('remix-yarn-install')
+            const yarnInstallCopy = await within(yarnInstall).findByTestId(
+              'clipboard-code-snippet'
+            )
+
+            await user.click(yarnInstallCopy)
+
+            await waitFor(() =>
+              expect(Sentry.metrics.increment).toHaveBeenCalledWith(
+                'bundles_tab.onboarding.copied.install_command',
+                1,
+                { tags: { package_manager: 'yarn', bundler: 'remix' } }
+              )
+            )
+          })
+        })
+      })
+
+      describe('pnpm', () => {
+        it('renders pnpm install', async () => {
+          setup(null)
+          render(<RemixOnboarding />, { wrapper })
+
+          const pnpmInstallCommand = await screen.findByText(
+            'pnpm add @codecov/remix-vite-plugin --save-dev'
+          )
+          expect(pnpmInstallCommand).toBeInTheDocument()
+        })
+
+        describe('user clicks copy button', () => {
+          it('sends metric to sentry', async () => {
+            const { user } = setup(null)
+            render(<RemixOnboarding />, { wrapper })
+
+            const pnpmInstall = await screen.findByTestId('remix-pnpm-install')
+            const pnpmInstallCopy = await within(pnpmInstall).findByTestId(
+              'clipboard-code-snippet'
+            )
+
+            await user.click(pnpmInstallCopy)
+
+            await waitFor(() =>
+              expect(Sentry.metrics.increment).toHaveBeenCalledWith(
+                'bundles_tab.onboarding.copied.install_command',
+                1,
+                { tags: { package_manager: 'pnpm', bundler: 'remix' } }
+              )
+            )
+          })
+        })
+      })
+    })
+  })
+
+  describe('step 2', () => {
+    it('renders header', async () => {
+      setup(null)
+      render(<RemixOnboarding />, { wrapper })
+
+      const stepText = await screen.findByText(/Step 2:/)
+      expect(stepText).toBeInTheDocument()
+
+      const headerText = await screen.findByText(/Copy Codecov token/)
+      expect(headerText).toBeInTheDocument()
+    })
+
+    it('renders body', async () => {
+      setup(null)
+      render(<RemixOnboarding />, { wrapper })
+
+      const bodyText = await screen.findByText(
+        /Set an environment variable in your build environment with the following upload token./
+      )
+      expect(bodyText).toBeInTheDocument()
+    })
+
+    describe('there is an org token', () => {
+      it('renders code block with org token', async () => {
+        setup(true)
+        render(<RemixOnboarding />, { wrapper })
+
+        const token = await screen.findByText(
+          /9e6a6189-20f1-482d-ab62-ecfaa2629290/
+        )
+        expect(token).toBeInTheDocument()
+      })
+    })
+
+    describe('there is no org token', () => {
+      it('renders code block with repo token', async () => {
+        setup(false)
+        render(<RemixOnboarding />, { wrapper })
+
+        const token = await screen.findByText(
+          /9e6a6189-20f1-482d-ab62-ecfaa2629295/
+        )
+        expect(token).toBeInTheDocument()
+      })
+    })
+
+    describe('user clicks copy button', () => {
+      it('sends metric to sentry', async () => {
+        const { user } = setup(true)
+        render(<RemixOnboarding />, { wrapper })
+
+        const uploadToken = await screen.findByTestId('remix-upload-token')
+        const uploadTokenCopy = await within(uploadToken).findByTestId(
+          'clipboard-code-snippet'
+        )
+
+        await user.click(uploadTokenCopy)
+
+        await waitFor(() =>
+          expect(Sentry.metrics.increment).toHaveBeenCalledWith(
+            'bundles_tab.onboarding.copied.token',
+            1,
+            { tags: { bundler: 'remix' } }
+          )
+        )
+      })
+    })
+  })
+
+  describe('step 3', () => {
+    it('renders header', async () => {
+      setup(null)
+      render(<RemixOnboarding />, { wrapper })
+
+      const stepText = await screen.findByText(/Step 3:/)
+      expect(stepText).toBeInTheDocument()
+
+      const headerText = await screen.findByText(/Configure the bundler plugin/)
+      expect(headerText).toBeInTheDocument()
+    })
+
+    it('renders body', async () => {
+      setup(null)
+      render(<RemixOnboarding />, { wrapper })
+
+      const bodyText = await screen.findByText(
+        /Add the plugin to the end of your modules array found inside your/
+      )
+      expect(bodyText).toBeInTheDocument()
+
+      const remixConfig = await screen.findByText('vite.config.ts')
+      expect(remixConfig).toBeInTheDocument()
+    })
+
+    it('renders plugin config', async () => {
+      setup(null)
+      render(<RemixOnboarding />, { wrapper })
+
+      const pluginText = await screen.findByText(/\/\/ vite.config.ts/)
+      expect(pluginText).toBeInTheDocument()
+    })
+
+    describe('user clicks copy button', () => {
+      it('sends metric to sentry', async () => {
+        const { user } = setup(true)
+        render(<RemixOnboarding />, { wrapper })
+
+        const pluginConfig = await screen.findByTestId('remix-plugin-config')
+        const pluginConfigCopy = await within(pluginConfig).findByTestId(
+          'clipboard-code-snippet'
+        )
+
+        await user.click(pluginConfigCopy)
+
+        await waitFor(() =>
+          expect(Sentry.metrics.increment).toHaveBeenCalledWith(
+            'bundles_tab.onboarding.copied.config',
+            1,
+            { tags: { bundler: 'remix' } }
+          )
+        )
+      })
+    })
+  })
+
+  describe('step 4', () => {
+    it('renders header', async () => {
+      setup(null)
+      render(<RemixOnboarding />, { wrapper })
+
+      const stepText = await screen.findByText(/Step 4:/)
+      expect(stepText).toBeInTheDocument()
+
+      const headerText = await screen.findByText(
+        /Commit and push your latest changes/
+      )
+      expect(headerText).toBeInTheDocument()
+    })
+
+    it('renders body', async () => {
+      setup(null)
+      render(<RemixOnboarding />, { wrapper })
+
+      const bodyText = await screen.findByText(
+        'The plugin requires at least one commit to be made to properly upload bundle analysis information up to Codecov.'
+      )
+      expect(bodyText).toBeInTheDocument()
+    })
+
+    it('renders git commit', async () => {
+      setup(null)
+      render(<RemixOnboarding />, { wrapper })
+
+      const gitCommit = await screen.findByText(
+        'git add -A && git commit -m "Add Codecov bundler plugin" && git push'
+      )
+      expect(gitCommit).toBeInTheDocument()
+    })
+
+    describe('user clicks copy button', () => {
+      it('sends metric to sentry', async () => {
+        const { user } = setup(true)
+        render(<RemixOnboarding />, { wrapper })
+
+        const commitCommand = await screen.findByTestId('remix-commit-command')
+        const commitCommandCopy = await within(commitCommand).findByTestId(
+          'clipboard-code-snippet'
+        )
+
+        await user.click(commitCommandCopy)
+
+        await waitFor(() =>
+          expect(Sentry.metrics.increment).toHaveBeenCalledWith(
+            'bundles_tab.onboarding.copied.commit',
+            1,
+            { tags: { bundler: 'remix' } }
+          )
+        )
+      })
+    })
+  })
+
+  describe('step 5', () => {
+    it('renders header', async () => {
+      setup(null)
+      render(<RemixOnboarding />, { wrapper })
+
+      const stepText = await screen.findByText(/Step 5:/)
+      expect(stepText).toBeInTheDocument()
+
+      const headerText = await screen.findByText(/Build the application/)
+      expect(headerText).toBeInTheDocument()
+    })
+
+    it('renders body', async () => {
+      setup(null)
+      render(<RemixOnboarding />, { wrapper })
+
+      const bodyText = await screen.findByText(
+        'When building your application the plugin will automatically upload the stats information to Codecov.'
+      )
+      expect(bodyText).toBeInTheDocument()
+    })
+
+    describe('renders code block', () => {
+      describe('npm', () => {
+        it('renders npm build', async () => {
+          setup(null)
+          render(<RemixOnboarding />, { wrapper })
+
+          const npmBuild = await screen.findByText('npm run build')
+          expect(npmBuild).toBeInTheDocument()
+        })
+
+        describe('user clicks copy button', () => {
+          it('sends metric to sentry', async () => {
+            const { user } = setup(true)
+            render(<RemixOnboarding />, { wrapper })
+
+            const buildCommand = await screen.findByTestId('remix-npm-build')
+            const buildCommandCopy = await within(buildCommand).findByTestId(
+              'clipboard-code-snippet'
+            )
+
+            await user.click(buildCommandCopy)
+
+            await waitFor(() =>
+              expect(Sentry.metrics.increment).toHaveBeenCalledWith(
+                'bundles_tab.onboarding.copied.build_command',
+                1,
+                { tags: { package_manager: 'npm', bundler: 'remix' } }
+              )
+            )
+          })
+        })
+      })
+
+      describe('yarn', () => {
+        it('renders yarn build', async () => {
+          setup(null)
+          render(<RemixOnboarding />, { wrapper })
+
+          const yarnBuild = await screen.findByText('yarn run build')
+          expect(yarnBuild).toBeInTheDocument()
+        })
+
+        describe('user clicks copy button', () => {
+          it('sends metric to sentry', async () => {
+            const { user } = setup(true)
+            render(<RemixOnboarding />, { wrapper })
+
+            const buildCommand = await screen.findByTestId('remix-yarn-build')
+            const buildCommandCopy = await within(buildCommand).findByTestId(
+              'clipboard-code-snippet'
+            )
+
+            await user.click(buildCommandCopy)
+
+            await waitFor(() =>
+              expect(Sentry.metrics.increment).toHaveBeenCalledWith(
+                'bundles_tab.onboarding.copied.build_command',
+                1,
+                { tags: { package_manager: 'yarn', bundler: 'remix' } }
+              )
+            )
+          })
+        })
+      })
+
+      describe('pnpm', () => {
+        it('renders pnpm build', async () => {
+          setup(null)
+          render(<RemixOnboarding />, { wrapper })
+
+          const pnpmBuild = await screen.findByText('pnpm run build')
+          expect(pnpmBuild).toBeInTheDocument()
+        })
+
+        describe('user clicks copy button', () => {
+          it('sends metric to sentry', async () => {
+            const { user } = setup(true)
+            render(<RemixOnboarding />, { wrapper })
+
+            const buildCommand = await screen.findByTestId('remix-pnpm-build')
+            const buildCommandCopy = await within(buildCommand).findByTestId(
+              'clipboard-code-snippet'
+            )
+
+            await user.click(buildCommandCopy)
+
+            await waitFor(() =>
+              expect(Sentry.metrics.increment).toHaveBeenCalledWith(
+                'bundles_tab.onboarding.copied.build_command',
+                1,
+                { tags: { package_manager: 'pnpm', bundler: 'remix' } }
+              )
+            )
+          })
+        })
+      })
+    })
+  })
+
+  describe('linking out to setup feedback', () => {
+    it('renders correct preview text', async () => {
+      setup(null)
+      render(<RemixOnboarding />, { wrapper })
+
+      const text = await screen.findByText(/How was your setup experience\?/)
+      expect(text).toBeInTheDocument()
+
+      const letUsKnow = await screen.findByText(/Let us know in/)
+      expect(letUsKnow).toBeInTheDocument()
+    })
+
+    it('renders link', async () => {
+      setup(null)
+      render(<RemixOnboarding />, { wrapper })
+
+      const link = await screen.findByText('this issue')
+      expect(link).toBeInTheDocument()
+      expect(link).toHaveAttribute(
+        'href',
+        'https://github.com/codecov/feedback/issues/270'
+      )
+    })
+  })
+
+  describe('learn more blurb', () => {
+    it('renders body', async () => {
+      setup(null)
+      render(<RemixOnboarding />, { wrapper })
+
+      const body = await screen.findByText(/Visit our guide to/)
+      expect(body).toBeInTheDocument()
+
+      const link = await screen.findByRole('link', { name: /learn more/ })
+      expect(link).toBeInTheDocument()
+      expect(link).toHaveAttribute(
+        'href',
+        'https://docs.codecov.com/docs/javascript-bundle-analysis'
+      )
+    })
+  })
+})

--- a/src/pages/RepoPage/BundlesTab/BundleOnboarding/RemixOnboarding/RemixOnboarding.tsx
+++ b/src/pages/RepoPage/BundlesTab/BundleOnboarding/RemixOnboarding/RemixOnboarding.tsx
@@ -1,0 +1,278 @@
+import React, { useEffect } from 'react'
+import { useParams } from 'react-router-dom'
+
+import { useOrgUploadToken } from 'services/orgUploadToken'
+import { useRepo } from 'services/repo'
+import A from 'ui/A'
+import { Card } from 'ui/Card'
+import { CodeSnippet } from 'ui/CodeSnippet'
+
+import LearnMoreBlurb from '../LearnMoreBlurb'
+import {
+  copiedBuildCommandMetric,
+  copiedCommitMetric,
+  copiedConfigMetric,
+  copiedInstallCommandMetric,
+  copiedTokenMetric,
+  visitedOnboardingMetric,
+} from '../metricHelpers'
+
+const npmInstall = `npm install @codecov/remix-vite-plugin --save-dev`
+const yarnInstall = `yarn add @codecov/remix-vite-plugin --dev`
+const pnpmInstall = `pnpm add @codecov/remix-vite-plugin --save-dev`
+
+const pluginConfig = `// vite.config.ts
+import { vitePlugin as remix } from "@remix-run/dev";
+import { defineConfig } from "vite";
+import tsconfigPaths from "vite-tsconfig-paths";
+import { codecovRemixVitePlugin } from "@codecov/remix-vite-plugin";
+
+export default defineConfig({
+  plugins: [
+    remix(),
+    tsconfigPaths()
+    // Put the Codecov Remix Vite plugin after all other plugins
+    codecovRemixVitePlugin({
+      enableBundleAnalysis: true,
+      bundleName: "example-remix-bundle",
+      uploadToken: process.env.CODECOV_TOKEN,
+    }),
+  ],
+});`
+
+const commitString = `git add -A && git commit -m "Add Codecov bundler plugin" && git push`
+
+const npmBuild = `npm run build`
+const yarnBuild = `yarn run build`
+const pnpmBuild = `pnpm run build`
+
+const StepOne: React.FC = () => {
+  return (
+    <Card>
+      <Card.Header>
+        <Card.Title size="base">
+          Step 1: Install the Codecov Remix Vite Plugin
+        </Card.Title>
+      </Card.Header>
+      <Card.Content className="flex flex-col gap-4">
+        <p>
+          To install the{' '}
+          <span className="bg-ds-gray-primary px-1 font-mono">
+            @codecov/remix-vite-plugin
+          </span>{' '}
+          to your project, use one of the following commands.
+        </p>
+        <CodeSnippet
+          clipboard={npmInstall}
+          clipboardOnClick={() => {
+            copiedInstallCommandMetric('npm', 'remix')
+          }}
+          data-testid="remix-npm-install"
+        >
+          {npmInstall}
+        </CodeSnippet>
+        <CodeSnippet
+          clipboard={yarnInstall}
+          clipboardOnClick={() => {
+            copiedInstallCommandMetric('yarn', 'remix')
+          }}
+          data-testid="remix-yarn-install"
+        >
+          {yarnInstall}
+        </CodeSnippet>
+        <CodeSnippet
+          clipboard={pnpmInstall}
+          clipboardOnClick={() => {
+            copiedInstallCommandMetric('pnpm', 'remix')
+          }}
+          data-testid="remix-pnpm-install"
+        >
+          {pnpmInstall}
+        </CodeSnippet>
+      </Card.Content>
+    </Card>
+  )
+}
+
+const StepTwo: React.FC<{ uploadToken: string }> = ({ uploadToken }) => {
+  return (
+    <Card>
+      <Card.Header>
+        <Card.Title size="base">Step 2: Copy Codecov token</Card.Title>
+      </Card.Header>
+      <Card.Content className="flex flex-col gap-4">
+        <p>
+          Set an environment variable in your build environment with the
+          following upload token.
+        </p>
+        <div className="flex gap-4">
+          <CodeSnippet className="basis-1/3" clipboard="CODECOV_TOKEN">
+            CODECOV_TOKEN
+          </CodeSnippet>
+          <CodeSnippet
+            className="basis-2/3"
+            clipboard={uploadToken}
+            clipboardOnClick={() => {
+              copiedTokenMetric('remix')
+            }}
+            data-testid="remix-upload-token"
+          >
+            {uploadToken}
+          </CodeSnippet>
+        </div>
+      </Card.Content>
+    </Card>
+  )
+}
+
+const StepThree: React.FC = () => {
+  return (
+    <Card>
+      <Card.Header>
+        <Card.Title size="base">
+          Step 3: Configure the bundler plugin
+        </Card.Title>
+      </Card.Header>
+      <Card.Content className="flex flex-col gap-4">
+        <p>
+          Add the plugin to the end of your modules array found inside your{' '}
+          <span className="bg-ds-gray-primary px-1 font-mono">
+            vite.config.ts
+          </span>{' '}
+          file, and pass your configuration.
+        </p>
+        <CodeSnippet
+          clipboard={pluginConfig}
+          clipboardOnClick={() => {
+            copiedConfigMetric('remix')
+          }}
+          data-testid="remix-plugin-config"
+        >
+          {pluginConfig}
+        </CodeSnippet>
+      </Card.Content>
+    </Card>
+  )
+}
+
+const StepFour: React.FC = () => {
+  return (
+    <Card>
+      <Card.Header>
+        <Card.Title size="base">
+          Step 4: Commit and push your latest changes
+        </Card.Title>
+      </Card.Header>
+      <Card.Content className="flex flex-col gap-4">
+        <p>
+          The plugin requires at least one commit to be made to properly upload
+          bundle analysis information up to Codecov.
+        </p>
+        <CodeSnippet
+          clipboard={commitString}
+          clipboardOnClick={() => {
+            copiedCommitMetric('remix')
+          }}
+          data-testid="remix-commit-command"
+        >
+          {commitString}
+        </CodeSnippet>
+      </Card.Content>
+    </Card>
+  )
+}
+
+const StepFive: React.FC = () => {
+  return (
+    <Card>
+      <Card.Header>
+        <Card.Title size="base">Step 5: Build the application</Card.Title>
+      </Card.Header>
+      <Card.Content className="flex flex-col gap-4">
+        <p>
+          When building your application the plugin will automatically upload
+          the stats information to Codecov.
+        </p>
+        <CodeSnippet
+          clipboard={npmBuild}
+          clipboardOnClick={() => {
+            copiedBuildCommandMetric('npm', 'remix')
+          }}
+          data-testid="remix-npm-build"
+        >
+          {npmBuild}
+        </CodeSnippet>
+        <CodeSnippet
+          clipboard={yarnBuild}
+          clipboardOnClick={() => {
+            copiedBuildCommandMetric('yarn', 'remix')
+          }}
+          data-testid="remix-yarn-build"
+        >
+          {yarnBuild}
+        </CodeSnippet>
+        <CodeSnippet
+          clipboard={pnpmBuild}
+          clipboardOnClick={() => {
+            copiedBuildCommandMetric('pnpm', 'remix')
+          }}
+          data-testid="remix-pnpm-build"
+        >
+          {pnpmBuild}
+        </CodeSnippet>
+      </Card.Content>
+    </Card>
+  )
+}
+
+function FeedbackCTA() {
+  return (
+    <Card>
+      <Card.Content>
+        <p>
+          <span className="font-semibold">How was your setup experience?</span>{' '}
+          Let us know in{' '}
+          <A
+            to={{ pageName: 'bundleConfigFeedback' }}
+            isExternal
+            hook="repo-config-feedback"
+          >
+            this issue
+          </A>
+        </p>
+      </Card.Content>
+    </Card>
+  )
+}
+
+interface URLParams {
+  provider: string
+  owner: string
+  repo: string
+}
+
+const RemixOnboarding: React.FC = () => {
+  const { provider, owner, repo } = useParams<URLParams>()
+  const { data: repoData } = useRepo({ provider, owner, repo })
+  const { data: orgUploadToken } = useOrgUploadToken({ provider, owner })
+
+  const uploadToken = orgUploadToken ?? repoData?.repository?.uploadToken ?? ''
+
+  useEffect(() => {
+    visitedOnboardingMetric('remix')
+  }, [])
+
+  return (
+    <div className="flex flex-col gap-6">
+      <StepOne />
+      <StepTwo uploadToken={uploadToken} />
+      <StepThree />
+      <StepFour />
+      <StepFive />
+      <FeedbackCTA />
+      <LearnMoreBlurb />
+    </div>
+  )
+}
+
+export default RemixOnboarding

--- a/src/pages/RepoPage/BundlesTab/BundleOnboarding/RemixOnboarding/RemixOnboarding.tsx
+++ b/src/pages/RepoPage/BundlesTab/BundleOnboarding/RemixOnboarding/RemixOnboarding.tsx
@@ -166,7 +166,7 @@ const StepFour: React.FC = () => {
       <Card.Content className="flex flex-col gap-4">
         <p>
           The plugin requires at least one commit to be made to properly upload
-          bundle analysis information up to Codecov.
+          bundle analysis information to Codecov.
         </p>
         <CodeSnippet
           clipboard={commitString}

--- a/src/pages/RepoPage/BundlesTab/BundleOnboarding/RemixOnboarding/index.ts
+++ b/src/pages/RepoPage/BundlesTab/BundleOnboarding/RemixOnboarding/index.ts
@@ -1,0 +1,1 @@
+export { default } from './RemixOnboarding'

--- a/src/pages/RepoPage/BundlesTab/BundleOnboarding/RollupOnboarding/RollupOnboarding.spec.tsx
+++ b/src/pages/RepoPage/BundlesTab/BundleOnboarding/RollupOnboarding/RollupOnboarding.spec.tsx
@@ -377,7 +377,7 @@ describe('RollupOnboarding', () => {
       render(<RollupOnboarding />, { wrapper })
 
       const bodyText = await screen.findByText(
-        'The plugin requires at least one commit to be made to properly upload bundle analysis information up to Codecov.'
+        'The plugin requires at least one commit to be made to properly upload bundle analysis information to Codecov.'
       )
       expect(bodyText).toBeInTheDocument()
     })

--- a/src/pages/RepoPage/BundlesTab/BundleOnboarding/RollupOnboarding/RollupOnboarding.tsx
+++ b/src/pages/RepoPage/BundlesTab/BundleOnboarding/RollupOnboarding/RollupOnboarding.tsx
@@ -163,7 +163,7 @@ const StepFour: React.FC = () => {
       <Card.Content className="flex flex-col gap-4">
         <p>
           The plugin requires at least one commit to be made to properly upload
-          bundle analysis information up to Codecov.
+          bundle analysis information to Codecov.
         </p>
         <CodeSnippet
           clipboard={commitString}

--- a/src/pages/RepoPage/BundlesTab/BundleOnboarding/SolidStartOnboarding/SolidStartOnboarding.spec.tsx
+++ b/src/pages/RepoPage/BundlesTab/BundleOnboarding/SolidStartOnboarding/SolidStartOnboarding.spec.tsx
@@ -385,7 +385,7 @@ describe('SolidStartOnboarding', () => {
       render(<SolidStartOnboarding />, { wrapper })
 
       const bodyText = await screen.findByText(
-        'The plugin requires at least one commit to be made to properly upload bundle analysis information up to Codecov.'
+        'The plugin requires at least one commit to be made to properly upload bundle analysis information to Codecov.'
       )
       expect(bodyText).toBeInTheDocument()
     })

--- a/src/pages/RepoPage/BundlesTab/BundleOnboarding/SolidStartOnboarding/SolidStartOnboarding.spec.tsx
+++ b/src/pages/RepoPage/BundlesTab/BundleOnboarding/SolidStartOnboarding/SolidStartOnboarding.spec.tsx
@@ -1,0 +1,596 @@
+import * as Sentry from '@sentry/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { render, screen, waitFor, within } from '@testing-library/react'
+import { userEvent } from '@testing-library/user-event'
+import { graphql } from 'msw'
+import { setupServer } from 'msw/node'
+import { MemoryRouter, Route } from 'react-router-dom'
+
+import SolidStartOnboarding from './SolidStartOnboarding'
+
+const mockGetRepo = {
+  owner: {
+    isCurrentUserPartOfOrg: true,
+    orgUploadToken: '9e6a6189-20f1-482d-ab62-ecfaa2629290',
+    isAdmin: null,
+    isCurrentUserActivated: null,
+    repository: {
+      __typename: 'Repository',
+      private: false,
+      uploadToken: '9e6a6189-20f1-482d-ab62-ecfaa2629295',
+      defaultBranch: 'main',
+      yaml: '',
+      activated: false,
+      oldestCommitAt: '',
+      active: true,
+      isFirstPullRequest: false,
+    },
+  },
+}
+
+const mockGetOrgUploadToken = (hasOrgUploadToken: boolean | null) => ({
+  owner: {
+    orgUploadToken: hasOrgUploadToken
+      ? '9e6a6189-20f1-482d-ab62-ecfaa2629290'
+      : null,
+  },
+})
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      suspense: true,
+      retry: false,
+    },
+  },
+})
+const server = setupServer()
+
+const wrapper: React.FC<React.PropsWithChildren> = ({ children }) => (
+  <QueryClientProvider client={queryClient}>
+    <MemoryRouter initialEntries={['/gh/codecov/test-repo/bundles/new']}>
+      <Route path="/:provider/:owner/:repo/bundles/new">{children}</Route>
+    </MemoryRouter>
+  </QueryClientProvider>
+)
+
+beforeAll(() => {
+  server.listen()
+})
+
+afterEach(() => {
+  queryClient.clear()
+  server.resetHandlers()
+})
+
+afterAll(() => {
+  server.close()
+})
+
+describe('SolidStartOnboarding', () => {
+  function setup(hasOrgUploadToken: boolean | null) {
+    // mock out to clear error
+    window.prompt = jest.fn()
+    const user = userEvent.setup()
+
+    server.use(
+      graphql.query('GetRepo', (req, res, ctx) =>
+        res(ctx.status(200), ctx.data(mockGetRepo))
+      ),
+      graphql.query('GetOrgUploadToken', (req, res, ctx) => {
+        return res(
+          ctx.status(200),
+          ctx.data(mockGetOrgUploadToken(hasOrgUploadToken))
+        )
+      })
+    )
+
+    return { user }
+  }
+
+  describe('rendering onboarding', () => {
+    it('sends solidstart onboarding metric', async () => {
+      setup(null)
+      render(<SolidStartOnboarding />, { wrapper })
+
+      await waitFor(() =>
+        expect(Sentry.metrics.increment).toHaveBeenCalledWith(
+          'bundles_tab.onboarding.visited_page',
+          1,
+          { tags: { bundler: 'solidstart' } }
+        )
+      )
+    })
+  })
+
+  describe('step 1', () => {
+    it('renders header', async () => {
+      setup(null)
+      render(<SolidStartOnboarding />, { wrapper })
+
+      const stepText = await screen.findByText(/Step 1:/)
+      expect(stepText).toBeInTheDocument()
+
+      const headerText = await screen.findByText(
+        /Install the Codecov SolidStart Plugin/
+      )
+      expect(headerText).toBeInTheDocument()
+    })
+
+    it('renders body', async () => {
+      setup(null)
+      render(<SolidStartOnboarding />, { wrapper })
+
+      const bodyText = await screen.findByText(/To install the/)
+      expect(bodyText).toBeInTheDocument()
+
+      const pluginName = await screen.findByText('@codecov/solidstart-plugin')
+      expect(pluginName).toBeInTheDocument()
+    })
+
+    describe('code blocks', () => {
+      describe('npm', () => {
+        it('renders npm install', async () => {
+          setup(null)
+          render(<SolidStartOnboarding />, { wrapper })
+
+          const npmInstallCommand = await screen.findByText(
+            'npm install @codecov/solidstart-plugin --save-dev'
+          )
+          expect(npmInstallCommand).toBeInTheDocument()
+        })
+
+        describe('user clicks copy button', () => {
+          it('sends metric to sentry', async () => {
+            const { user } = setup(null)
+            render(<SolidStartOnboarding />, { wrapper })
+
+            const npmInstall = await screen.findByTestId(
+              'solidstart-npm-install'
+            )
+            const npmInstallCopy = await within(npmInstall).findByTestId(
+              'clipboard-code-snippet'
+            )
+
+            await user.click(npmInstallCopy)
+
+            await waitFor(() =>
+              expect(Sentry.metrics.increment).toHaveBeenCalledWith(
+                'bundles_tab.onboarding.copied.install_command',
+                1,
+                { tags: { package_manager: 'npm', bundler: 'solidstart' } }
+              )
+            )
+          })
+        })
+      })
+
+      describe('yarn', () => {
+        it('renders yarn install', async () => {
+          setup(null)
+          render(<SolidStartOnboarding />, { wrapper })
+
+          const yarnInstallCommand = await screen.findByText(
+            'yarn add @codecov/solidstart-plugin --dev'
+          )
+          expect(yarnInstallCommand).toBeInTheDocument()
+        })
+
+        describe('user clicks copy button', () => {
+          it('sends metric to sentry', async () => {
+            const { user } = setup(null)
+            render(<SolidStartOnboarding />, { wrapper })
+
+            const yarnInstall = await screen.findByTestId(
+              'solidstart-yarn-install'
+            )
+            const yarnInstallCopy = await within(yarnInstall).findByTestId(
+              'clipboard-code-snippet'
+            )
+
+            await user.click(yarnInstallCopy)
+
+            await waitFor(() =>
+              expect(Sentry.metrics.increment).toHaveBeenCalledWith(
+                'bundles_tab.onboarding.copied.install_command',
+                1,
+                { tags: { package_manager: 'yarn', bundler: 'solidstart' } }
+              )
+            )
+          })
+        })
+      })
+
+      describe('pnpm', () => {
+        it('renders pnpm install', async () => {
+          setup(null)
+          render(<SolidStartOnboarding />, { wrapper })
+
+          const pnpmInstallCommand = await screen.findByText(
+            'pnpm add @codecov/solidstart-plugin --save-dev'
+          )
+          expect(pnpmInstallCommand).toBeInTheDocument()
+        })
+
+        describe('user clicks copy button', () => {
+          it('sends metric to sentry', async () => {
+            const { user } = setup(null)
+            render(<SolidStartOnboarding />, { wrapper })
+
+            const pnpmInstall = await screen.findByTestId(
+              'solidstart-pnpm-install'
+            )
+            const pnpmInstallCopy = await within(pnpmInstall).findByTestId(
+              'clipboard-code-snippet'
+            )
+
+            await user.click(pnpmInstallCopy)
+
+            await waitFor(() =>
+              expect(Sentry.metrics.increment).toHaveBeenCalledWith(
+                'bundles_tab.onboarding.copied.install_command',
+                1,
+                { tags: { package_manager: 'pnpm', bundler: 'solidstart' } }
+              )
+            )
+          })
+        })
+      })
+    })
+  })
+
+  describe('step 2', () => {
+    it('renders header', async () => {
+      setup(null)
+      render(<SolidStartOnboarding />, { wrapper })
+
+      const stepText = await screen.findByText(/Step 2:/)
+      expect(stepText).toBeInTheDocument()
+
+      const headerText = await screen.findByText(/Copy Codecov token/)
+      expect(headerText).toBeInTheDocument()
+    })
+
+    it('renders body', async () => {
+      setup(null)
+      render(<SolidStartOnboarding />, { wrapper })
+
+      const bodyText = await screen.findByText(
+        /Set an environment variable in your build environment with the following upload token./
+      )
+      expect(bodyText).toBeInTheDocument()
+    })
+
+    describe('there is an org token', () => {
+      it('renders code block with org token', async () => {
+        setup(true)
+        render(<SolidStartOnboarding />, { wrapper })
+
+        const token = await screen.findByText(
+          /9e6a6189-20f1-482d-ab62-ecfaa2629290/
+        )
+        expect(token).toBeInTheDocument()
+      })
+    })
+
+    describe('there is no org token', () => {
+      it('renders code block with repo token', async () => {
+        setup(false)
+        render(<SolidStartOnboarding />, { wrapper })
+
+        const token = await screen.findByText(
+          /9e6a6189-20f1-482d-ab62-ecfaa2629295/
+        )
+        expect(token).toBeInTheDocument()
+      })
+    })
+
+    describe('user clicks copy button', () => {
+      it('sends metric to sentry', async () => {
+        const { user } = setup(true)
+        render(<SolidStartOnboarding />, { wrapper })
+
+        const uploadToken = await screen.findByTestId('solidstart-upload-token')
+        const uploadTokenCopy = await within(uploadToken).findByTestId(
+          'clipboard-code-snippet'
+        )
+
+        await user.click(uploadTokenCopy)
+
+        await waitFor(() =>
+          expect(Sentry.metrics.increment).toHaveBeenCalledWith(
+            'bundles_tab.onboarding.copied.token',
+            1,
+            { tags: { bundler: 'solidstart' } }
+          )
+        )
+      })
+    })
+  })
+
+  describe('step 3', () => {
+    it('renders header', async () => {
+      setup(null)
+      render(<SolidStartOnboarding />, { wrapper })
+
+      const stepText = await screen.findByText(/Step 3:/)
+      expect(stepText).toBeInTheDocument()
+
+      const headerText = await screen.findByText(/Configure the bundler plugin/)
+      expect(headerText).toBeInTheDocument()
+    })
+
+    it('renders body', async () => {
+      setup(null)
+      render(<SolidStartOnboarding />, { wrapper })
+
+      const bodyText = await screen.findByText(
+        /Add the plugin to the end of your modules array found inside your/
+      )
+      expect(bodyText).toBeInTheDocument()
+
+      const solidstartConfig = await screen.findByText('app.config.ts')
+      expect(solidstartConfig).toBeInTheDocument()
+    })
+
+    it('renders plugin config', async () => {
+      setup(null)
+      render(<SolidStartOnboarding />, { wrapper })
+
+      const pluginText = await screen.findByText(/\/\/ app.config.ts/)
+      expect(pluginText).toBeInTheDocument()
+    })
+
+    describe('user clicks copy button', () => {
+      it('sends metric to sentry', async () => {
+        const { user } = setup(true)
+        render(<SolidStartOnboarding />, { wrapper })
+
+        const pluginConfig = await screen.findByTestId(
+          'solidstart-plugin-config'
+        )
+        const pluginConfigCopy = await within(pluginConfig).findByTestId(
+          'clipboard-code-snippet'
+        )
+
+        await user.click(pluginConfigCopy)
+
+        await waitFor(() =>
+          expect(Sentry.metrics.increment).toHaveBeenCalledWith(
+            'bundles_tab.onboarding.copied.config',
+            1,
+            { tags: { bundler: 'solidstart' } }
+          )
+        )
+      })
+    })
+  })
+
+  describe('step 4', () => {
+    it('renders header', async () => {
+      setup(null)
+      render(<SolidStartOnboarding />, { wrapper })
+
+      const stepText = await screen.findByText(/Step 4:/)
+      expect(stepText).toBeInTheDocument()
+
+      const headerText = await screen.findByText(
+        /Commit and push your latest changes/
+      )
+      expect(headerText).toBeInTheDocument()
+    })
+
+    it('renders body', async () => {
+      setup(null)
+      render(<SolidStartOnboarding />, { wrapper })
+
+      const bodyText = await screen.findByText(
+        'The plugin requires at least one commit to be made to properly upload bundle analysis information up to Codecov.'
+      )
+      expect(bodyText).toBeInTheDocument()
+    })
+
+    it('renders git commit', async () => {
+      setup(null)
+      render(<SolidStartOnboarding />, { wrapper })
+
+      const gitCommit = await screen.findByText(
+        'git add -A && git commit -m "Add Codecov bundler plugin" && git push'
+      )
+      expect(gitCommit).toBeInTheDocument()
+    })
+
+    describe('user clicks copy button', () => {
+      it('sends metric to sentry', async () => {
+        const { user } = setup(true)
+        render(<SolidStartOnboarding />, { wrapper })
+
+        const commitCommand = await screen.findByTestId(
+          'solidstart-commit-command'
+        )
+        const commitCommandCopy = await within(commitCommand).findByTestId(
+          'clipboard-code-snippet'
+        )
+
+        await user.click(commitCommandCopy)
+
+        await waitFor(() =>
+          expect(Sentry.metrics.increment).toHaveBeenCalledWith(
+            'bundles_tab.onboarding.copied.commit',
+            1,
+            { tags: { bundler: 'solidstart' } }
+          )
+        )
+      })
+    })
+  })
+
+  describe('step 5', () => {
+    it('renders header', async () => {
+      setup(null)
+      render(<SolidStartOnboarding />, { wrapper })
+
+      const stepText = await screen.findByText(/Step 5:/)
+      expect(stepText).toBeInTheDocument()
+
+      const headerText = await screen.findByText(/Build the application/)
+      expect(headerText).toBeInTheDocument()
+    })
+
+    it('renders body', async () => {
+      setup(null)
+      render(<SolidStartOnboarding />, { wrapper })
+
+      const bodyText = await screen.findByText(
+        'When building your application the plugin will automatically upload the stats information to Codecov.'
+      )
+      expect(bodyText).toBeInTheDocument()
+    })
+
+    describe('renders code block', () => {
+      describe('npm', () => {
+        it('renders npm build', async () => {
+          setup(null)
+          render(<SolidStartOnboarding />, { wrapper })
+
+          const npmBuild = await screen.findByText('npm run build')
+          expect(npmBuild).toBeInTheDocument()
+        })
+
+        describe('user clicks copy button', () => {
+          it('sends metric to sentry', async () => {
+            const { user } = setup(true)
+            render(<SolidStartOnboarding />, { wrapper })
+
+            const buildCommand = await screen.findByTestId(
+              'solidstart-npm-build'
+            )
+            const buildCommandCopy = await within(buildCommand).findByTestId(
+              'clipboard-code-snippet'
+            )
+
+            await user.click(buildCommandCopy)
+
+            await waitFor(() =>
+              expect(Sentry.metrics.increment).toHaveBeenCalledWith(
+                'bundles_tab.onboarding.copied.build_command',
+                1,
+                { tags: { package_manager: 'npm', bundler: 'solidstart' } }
+              )
+            )
+          })
+        })
+      })
+
+      describe('yarn', () => {
+        it('renders yarn build', async () => {
+          setup(null)
+          render(<SolidStartOnboarding />, { wrapper })
+
+          const yarnBuild = await screen.findByText('yarn run build')
+          expect(yarnBuild).toBeInTheDocument()
+        })
+
+        describe('user clicks copy button', () => {
+          it('sends metric to sentry', async () => {
+            const { user } = setup(true)
+            render(<SolidStartOnboarding />, { wrapper })
+
+            const buildCommand = await screen.findByTestId(
+              'solidstart-yarn-build'
+            )
+            const buildCommandCopy = await within(buildCommand).findByTestId(
+              'clipboard-code-snippet'
+            )
+
+            await user.click(buildCommandCopy)
+
+            await waitFor(() =>
+              expect(Sentry.metrics.increment).toHaveBeenCalledWith(
+                'bundles_tab.onboarding.copied.build_command',
+                1,
+                { tags: { package_manager: 'yarn', bundler: 'solidstart' } }
+              )
+            )
+          })
+        })
+      })
+
+      describe('pnpm', () => {
+        it('renders pnpm build', async () => {
+          setup(null)
+          render(<SolidStartOnboarding />, { wrapper })
+
+          const pnpmBuild = await screen.findByText('pnpm run build')
+          expect(pnpmBuild).toBeInTheDocument()
+        })
+
+        describe('user clicks copy button', () => {
+          it('sends metric to sentry', async () => {
+            const { user } = setup(true)
+            render(<SolidStartOnboarding />, { wrapper })
+
+            const buildCommand = await screen.findByTestId(
+              'solidstart-pnpm-build'
+            )
+            const buildCommandCopy = await within(buildCommand).findByTestId(
+              'clipboard-code-snippet'
+            )
+
+            await user.click(buildCommandCopy)
+
+            await waitFor(() =>
+              expect(Sentry.metrics.increment).toHaveBeenCalledWith(
+                'bundles_tab.onboarding.copied.build_command',
+                1,
+                { tags: { package_manager: 'pnpm', bundler: 'solidstart' } }
+              )
+            )
+          })
+        })
+      })
+    })
+  })
+
+  describe('linking out to setup feedback', () => {
+    it('renders correct preview text', async () => {
+      setup(null)
+      render(<SolidStartOnboarding />, { wrapper })
+
+      const text = await screen.findByText(/How was your setup experience\?/)
+      expect(text).toBeInTheDocument()
+
+      const letUsKnow = await screen.findByText(/Let us know in/)
+      expect(letUsKnow).toBeInTheDocument()
+    })
+
+    it('renders link', async () => {
+      setup(null)
+      render(<SolidStartOnboarding />, { wrapper })
+
+      const link = await screen.findByText('this issue')
+      expect(link).toBeInTheDocument()
+      expect(link).toHaveAttribute(
+        'href',
+        'https://github.com/codecov/feedback/issues/270'
+      )
+    })
+  })
+
+  describe('learn more blurb', () => {
+    it('renders body', async () => {
+      setup(null)
+      render(<SolidStartOnboarding />, { wrapper })
+
+      const body = await screen.findByText(/Visit our guide to/)
+      expect(body).toBeInTheDocument()
+
+      const link = await screen.findByRole('link', { name: /learn more/ })
+      expect(link).toBeInTheDocument()
+      expect(link).toHaveAttribute(
+        'href',
+        'https://docs.codecov.com/docs/javascript-bundle-analysis'
+      )
+    })
+  })
+})

--- a/src/pages/RepoPage/BundlesTab/BundleOnboarding/SolidStartOnboarding/SolidStartOnboarding.tsx
+++ b/src/pages/RepoPage/BundlesTab/BundleOnboarding/SolidStartOnboarding/SolidStartOnboarding.tsx
@@ -1,0 +1,278 @@
+import React, { useEffect } from 'react'
+import { useParams } from 'react-router-dom'
+
+import { useOrgUploadToken } from 'services/orgUploadToken'
+import { useRepo } from 'services/repo'
+import A from 'ui/A'
+import { Card } from 'ui/Card'
+import { CodeSnippet } from 'ui/CodeSnippet'
+
+import LearnMoreBlurb from '../LearnMoreBlurb'
+import {
+  copiedBuildCommandMetric,
+  copiedCommitMetric,
+  copiedConfigMetric,
+  copiedInstallCommandMetric,
+  copiedTokenMetric,
+  visitedOnboardingMetric,
+} from '../metricHelpers'
+
+const npmInstall = `npm install @codecov/solidstart-plugin --save-dev`
+const yarnInstall = `yarn add @codecov/solidstart-plugin --dev`
+const pnpmInstall = `pnpm add @codecov/solidstart-plugin --save-dev`
+
+const pluginConfig = `// app.config.ts
+import { defineConfig } from "@solidjs/start/config";
+import solidPlugin from "vite-plugin-solid";
+import { codecovSolidStartPlugin } from "@codecov/solidstart-plugin";
+
+export default defineConfig({
+  vite: {
+    plugins: [
+      // Put the Codecov SolidStart plugin after all other plugins
+      solidPlugin(),
+      codecovSolidStartPlugin({
+        enableBundleAnalysis: true,
+        bundleName: "example-solidstart-bundle",
+        uploadToken: process.env.CODECOV_TOKEN,
+      }),
+    ],
+  },
+});`
+
+const commitString = `git add -A && git commit -m "Add Codecov bundler plugin" && git push`
+
+const npmBuild = `npm run build`
+const yarnBuild = `yarn run build`
+const pnpmBuild = `pnpm run build`
+
+const StepOne: React.FC = () => {
+  return (
+    <Card>
+      <Card.Header>
+        <Card.Title size="base">
+          Step 1: Install the Codecov SolidStart Plugin
+        </Card.Title>
+      </Card.Header>
+      <Card.Content className="flex flex-col gap-4">
+        <p>
+          To install the{' '}
+          <span className="bg-ds-gray-primary px-1 font-mono">
+            @codecov/solidstart-plugin
+          </span>{' '}
+          to your project, use one of the following commands.
+        </p>
+        <CodeSnippet
+          clipboard={npmInstall}
+          clipboardOnClick={() => {
+            copiedInstallCommandMetric('npm', 'solidstart')
+          }}
+          data-testid="solidstart-npm-install"
+        >
+          {npmInstall}
+        </CodeSnippet>
+        <CodeSnippet
+          clipboard={yarnInstall}
+          clipboardOnClick={() => {
+            copiedInstallCommandMetric('yarn', 'solidstart')
+          }}
+          data-testid="solidstart-yarn-install"
+        >
+          {yarnInstall}
+        </CodeSnippet>
+        <CodeSnippet
+          clipboard={pnpmInstall}
+          clipboardOnClick={() => {
+            copiedInstallCommandMetric('pnpm', 'solidstart')
+          }}
+          data-testid="solidstart-pnpm-install"
+        >
+          {pnpmInstall}
+        </CodeSnippet>
+      </Card.Content>
+    </Card>
+  )
+}
+
+const StepTwo: React.FC<{ uploadToken: string }> = ({ uploadToken }) => {
+  return (
+    <Card>
+      <Card.Header>
+        <Card.Title size="base">Step 2: Copy Codecov token</Card.Title>
+      </Card.Header>
+      <Card.Content className="flex flex-col gap-4">
+        <p>
+          Set an environment variable in your build environment with the
+          following upload token.
+        </p>
+        <div className="flex gap-4">
+          <CodeSnippet className="basis-1/3" clipboard="CODECOV_TOKEN">
+            CODECOV_TOKEN
+          </CodeSnippet>
+          <CodeSnippet
+            className="basis-2/3"
+            clipboard={uploadToken}
+            clipboardOnClick={() => {
+              copiedTokenMetric('solidstart')
+            }}
+            data-testid="solidstart-upload-token"
+          >
+            {uploadToken}
+          </CodeSnippet>
+        </div>
+      </Card.Content>
+    </Card>
+  )
+}
+
+const StepThree: React.FC = () => {
+  return (
+    <Card>
+      <Card.Header>
+        <Card.Title size="base">
+          Step 3: Configure the bundler plugin
+        </Card.Title>
+      </Card.Header>
+      <Card.Content className="flex flex-col gap-4">
+        <p>
+          Add the plugin to the end of your modules array found inside your{' '}
+          <span className="bg-ds-gray-primary px-1 font-mono">
+            app.config.ts
+          </span>{' '}
+          file, and pass your configuration.
+        </p>
+        <CodeSnippet
+          clipboard={pluginConfig}
+          clipboardOnClick={() => {
+            copiedConfigMetric('solidstart')
+          }}
+          data-testid="solidstart-plugin-config"
+        >
+          {pluginConfig}
+        </CodeSnippet>
+      </Card.Content>
+    </Card>
+  )
+}
+
+const StepFour: React.FC = () => {
+  return (
+    <Card>
+      <Card.Header>
+        <Card.Title size="base">
+          Step 4: Commit and push your latest changes
+        </Card.Title>
+      </Card.Header>
+      <Card.Content className="flex flex-col gap-4">
+        <p>
+          The plugin requires at least one commit to be made to properly upload
+          bundle analysis information up to Codecov.
+        </p>
+        <CodeSnippet
+          clipboard={commitString}
+          clipboardOnClick={() => {
+            copiedCommitMetric('solidstart')
+          }}
+          data-testid="solidstart-commit-command"
+        >
+          {commitString}
+        </CodeSnippet>
+      </Card.Content>
+    </Card>
+  )
+}
+
+const StepFive: React.FC = () => {
+  return (
+    <Card>
+      <Card.Header>
+        <Card.Title size="base">Step 5: Build the application</Card.Title>
+      </Card.Header>
+      <Card.Content className="flex flex-col gap-4">
+        <p>
+          When building your application the plugin will automatically upload
+          the stats information to Codecov.
+        </p>
+        <CodeSnippet
+          clipboard={npmBuild}
+          clipboardOnClick={() => {
+            copiedBuildCommandMetric('npm', 'solidstart')
+          }}
+          data-testid="solidstart-npm-build"
+        >
+          {npmBuild}
+        </CodeSnippet>
+        <CodeSnippet
+          clipboard={yarnBuild}
+          clipboardOnClick={() => {
+            copiedBuildCommandMetric('yarn', 'solidstart')
+          }}
+          data-testid="solidstart-yarn-build"
+        >
+          {yarnBuild}
+        </CodeSnippet>
+        <CodeSnippet
+          clipboard={pnpmBuild}
+          clipboardOnClick={() => {
+            copiedBuildCommandMetric('pnpm', 'solidstart')
+          }}
+          data-testid="solidstart-pnpm-build"
+        >
+          {pnpmBuild}
+        </CodeSnippet>
+      </Card.Content>
+    </Card>
+  )
+}
+
+function FeedbackCTA() {
+  return (
+    <Card>
+      <Card.Content>
+        <p>
+          <span className="font-semibold">How was your setup experience?</span>{' '}
+          Let us know in{' '}
+          <A
+            to={{ pageName: 'bundleConfigFeedback' }}
+            isExternal
+            hook="repo-config-feedback"
+          >
+            this issue
+          </A>
+        </p>
+      </Card.Content>
+    </Card>
+  )
+}
+
+interface URLParams {
+  provider: string
+  owner: string
+  repo: string
+}
+
+const SolidStartOnboarding: React.FC = () => {
+  const { provider, owner, repo } = useParams<URLParams>()
+  const { data: repoData } = useRepo({ provider, owner, repo })
+  const { data: orgUploadToken } = useOrgUploadToken({ provider, owner })
+
+  const uploadToken = orgUploadToken ?? repoData?.repository?.uploadToken ?? ''
+
+  useEffect(() => {
+    visitedOnboardingMetric('solidstart')
+  }, [])
+
+  return (
+    <div className="flex flex-col gap-6">
+      <StepOne />
+      <StepTwo uploadToken={uploadToken} />
+      <StepThree />
+      <StepFour />
+      <StepFive />
+      <FeedbackCTA />
+      <LearnMoreBlurb />
+    </div>
+  )
+}
+
+export default SolidStartOnboarding

--- a/src/pages/RepoPage/BundlesTab/BundleOnboarding/SolidStartOnboarding/SolidStartOnboarding.tsx
+++ b/src/pages/RepoPage/BundlesTab/BundleOnboarding/SolidStartOnboarding/SolidStartOnboarding.tsx
@@ -166,7 +166,7 @@ const StepFour: React.FC = () => {
       <Card.Content className="flex flex-col gap-4">
         <p>
           The plugin requires at least one commit to be made to properly upload
-          bundle analysis information up to Codecov.
+          bundle analysis information to Codecov.
         </p>
         <CodeSnippet
           clipboard={commitString}

--- a/src/pages/RepoPage/BundlesTab/BundleOnboarding/SolidStartOnboarding/index.ts
+++ b/src/pages/RepoPage/BundlesTab/BundleOnboarding/SolidStartOnboarding/index.ts
@@ -1,0 +1,1 @@
+export { default } from './SolidStartOnboarding'

--- a/src/pages/RepoPage/BundlesTab/BundleOnboarding/SvelteKitOnboarding/SvelteKitOnboarding.spec.tsx
+++ b/src/pages/RepoPage/BundlesTab/BundleOnboarding/SvelteKitOnboarding/SvelteKitOnboarding.spec.tsx
@@ -1,0 +1,596 @@
+import * as Sentry from '@sentry/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { render, screen, waitFor, within } from '@testing-library/react'
+import { userEvent } from '@testing-library/user-event'
+import { graphql } from 'msw'
+import { setupServer } from 'msw/node'
+import { MemoryRouter, Route } from 'react-router-dom'
+
+import SvelteKitOnboarding from './SvelteKitOnboarding'
+
+const mockGetRepo = {
+  owner: {
+    isCurrentUserPartOfOrg: true,
+    orgUploadToken: '9e6a6189-20f1-482d-ab62-ecfaa2629290',
+    isAdmin: null,
+    isCurrentUserActivated: null,
+    repository: {
+      __typename: 'Repository',
+      private: false,
+      uploadToken: '9e6a6189-20f1-482d-ab62-ecfaa2629295',
+      defaultBranch: 'main',
+      yaml: '',
+      activated: false,
+      oldestCommitAt: '',
+      active: true,
+      isFirstPullRequest: false,
+    },
+  },
+}
+
+const mockGetOrgUploadToken = (hasOrgUploadToken: boolean | null) => ({
+  owner: {
+    orgUploadToken: hasOrgUploadToken
+      ? '9e6a6189-20f1-482d-ab62-ecfaa2629290'
+      : null,
+  },
+})
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      suspense: true,
+      retry: false,
+    },
+  },
+})
+const server = setupServer()
+
+const wrapper: React.FC<React.PropsWithChildren> = ({ children }) => (
+  <QueryClientProvider client={queryClient}>
+    <MemoryRouter initialEntries={['/gh/codecov/test-repo/bundles/new']}>
+      <Route path="/:provider/:owner/:repo/bundles/new">{children}</Route>
+    </MemoryRouter>
+  </QueryClientProvider>
+)
+
+beforeAll(() => {
+  server.listen()
+})
+
+afterEach(() => {
+  queryClient.clear()
+  server.resetHandlers()
+})
+
+afterAll(() => {
+  server.close()
+})
+
+describe('SvelteKitOnboarding', () => {
+  function setup(hasOrgUploadToken: boolean | null) {
+    // mock out to clear error
+    window.prompt = jest.fn()
+    const user = userEvent.setup()
+
+    server.use(
+      graphql.query('GetRepo', (req, res, ctx) =>
+        res(ctx.status(200), ctx.data(mockGetRepo))
+      ),
+      graphql.query('GetOrgUploadToken', (req, res, ctx) => {
+        return res(
+          ctx.status(200),
+          ctx.data(mockGetOrgUploadToken(hasOrgUploadToken))
+        )
+      })
+    )
+
+    return { user }
+  }
+
+  describe('rendering onboarding', () => {
+    it('sends sveltekit onboarding metric', async () => {
+      setup(null)
+      render(<SvelteKitOnboarding />, { wrapper })
+
+      await waitFor(() =>
+        expect(Sentry.metrics.increment).toHaveBeenCalledWith(
+          'bundles_tab.onboarding.visited_page',
+          1,
+          { tags: { bundler: 'sveltekit' } }
+        )
+      )
+    })
+  })
+
+  describe('step 1', () => {
+    it('renders header', async () => {
+      setup(null)
+      render(<SvelteKitOnboarding />, { wrapper })
+
+      const stepText = await screen.findByText(/Step 1:/)
+      expect(stepText).toBeInTheDocument()
+
+      const headerText = await screen.findByText(
+        /Install the Codecov SvelteKit Plugin/
+      )
+      expect(headerText).toBeInTheDocument()
+    })
+
+    it('renders body', async () => {
+      setup(null)
+      render(<SvelteKitOnboarding />, { wrapper })
+
+      const bodyText = await screen.findByText(/To install the/)
+      expect(bodyText).toBeInTheDocument()
+
+      const pluginName = await screen.findByText('@codecov/sveltekit-plugin')
+      expect(pluginName).toBeInTheDocument()
+    })
+
+    describe('code blocks', () => {
+      describe('npm', () => {
+        it('renders npm install', async () => {
+          setup(null)
+          render(<SvelteKitOnboarding />, { wrapper })
+
+          const npmInstallCommand = await screen.findByText(
+            'npm install @codecov/sveltekit-plugin --save-dev'
+          )
+          expect(npmInstallCommand).toBeInTheDocument()
+        })
+
+        describe('user clicks copy button', () => {
+          it('sends metric to sentry', async () => {
+            const { user } = setup(null)
+            render(<SvelteKitOnboarding />, { wrapper })
+
+            const npmInstall = await screen.findByTestId(
+              'sveltekit-npm-install'
+            )
+            const npmInstallCopy = await within(npmInstall).findByTestId(
+              'clipboard-code-snippet'
+            )
+
+            await user.click(npmInstallCopy)
+
+            await waitFor(() =>
+              expect(Sentry.metrics.increment).toHaveBeenCalledWith(
+                'bundles_tab.onboarding.copied.install_command',
+                1,
+                { tags: { package_manager: 'npm', bundler: 'sveltekit' } }
+              )
+            )
+          })
+        })
+      })
+
+      describe('yarn', () => {
+        it('renders yarn install', async () => {
+          setup(null)
+          render(<SvelteKitOnboarding />, { wrapper })
+
+          const yarnInstallCommand = await screen.findByText(
+            'yarn add @codecov/sveltekit-plugin --dev'
+          )
+          expect(yarnInstallCommand).toBeInTheDocument()
+        })
+
+        describe('user clicks copy button', () => {
+          it('sends metric to sentry', async () => {
+            const { user } = setup(null)
+            render(<SvelteKitOnboarding />, { wrapper })
+
+            const yarnInstall = await screen.findByTestId(
+              'sveltekit-yarn-install'
+            )
+            const yarnInstallCopy = await within(yarnInstall).findByTestId(
+              'clipboard-code-snippet'
+            )
+
+            await user.click(yarnInstallCopy)
+
+            await waitFor(() =>
+              expect(Sentry.metrics.increment).toHaveBeenCalledWith(
+                'bundles_tab.onboarding.copied.install_command',
+                1,
+                { tags: { package_manager: 'yarn', bundler: 'sveltekit' } }
+              )
+            )
+          })
+        })
+      })
+
+      describe('pnpm', () => {
+        it('renders pnpm install', async () => {
+          setup(null)
+          render(<SvelteKitOnboarding />, { wrapper })
+
+          const pnpmInstallCommand = await screen.findByText(
+            'pnpm add @codecov/sveltekit-plugin --save-dev'
+          )
+          expect(pnpmInstallCommand).toBeInTheDocument()
+        })
+
+        describe('user clicks copy button', () => {
+          it('sends metric to sentry', async () => {
+            const { user } = setup(null)
+            render(<SvelteKitOnboarding />, { wrapper })
+
+            const pnpmInstall = await screen.findByTestId(
+              'sveltekit-pnpm-install'
+            )
+            const pnpmInstallCopy = await within(pnpmInstall).findByTestId(
+              'clipboard-code-snippet'
+            )
+
+            await user.click(pnpmInstallCopy)
+
+            await waitFor(() =>
+              expect(Sentry.metrics.increment).toHaveBeenCalledWith(
+                'bundles_tab.onboarding.copied.install_command',
+                1,
+                { tags: { package_manager: 'pnpm', bundler: 'sveltekit' } }
+              )
+            )
+          })
+        })
+      })
+    })
+  })
+
+  describe('step 2', () => {
+    it('renders header', async () => {
+      setup(null)
+      render(<SvelteKitOnboarding />, { wrapper })
+
+      const stepText = await screen.findByText(/Step 2:/)
+      expect(stepText).toBeInTheDocument()
+
+      const headerText = await screen.findByText(/Copy Codecov token/)
+      expect(headerText).toBeInTheDocument()
+    })
+
+    it('renders body', async () => {
+      setup(null)
+      render(<SvelteKitOnboarding />, { wrapper })
+
+      const bodyText = await screen.findByText(
+        /Set an environment variable in your build environment with the following upload token./
+      )
+      expect(bodyText).toBeInTheDocument()
+    })
+
+    describe('there is an org token', () => {
+      it('renders code block with org token', async () => {
+        setup(true)
+        render(<SvelteKitOnboarding />, { wrapper })
+
+        const token = await screen.findByText(
+          /9e6a6189-20f1-482d-ab62-ecfaa2629290/
+        )
+        expect(token).toBeInTheDocument()
+      })
+    })
+
+    describe('there is no org token', () => {
+      it('renders code block with repo token', async () => {
+        setup(false)
+        render(<SvelteKitOnboarding />, { wrapper })
+
+        const token = await screen.findByText(
+          /9e6a6189-20f1-482d-ab62-ecfaa2629295/
+        )
+        expect(token).toBeInTheDocument()
+      })
+    })
+
+    describe('user clicks copy button', () => {
+      it('sends metric to sentry', async () => {
+        const { user } = setup(true)
+        render(<SvelteKitOnboarding />, { wrapper })
+
+        const uploadToken = await screen.findByTestId('sveltekit-upload-token')
+        const uploadTokenCopy = await within(uploadToken).findByTestId(
+          'clipboard-code-snippet'
+        )
+
+        await user.click(uploadTokenCopy)
+
+        await waitFor(() =>
+          expect(Sentry.metrics.increment).toHaveBeenCalledWith(
+            'bundles_tab.onboarding.copied.token',
+            1,
+            { tags: { bundler: 'sveltekit' } }
+          )
+        )
+      })
+    })
+  })
+
+  describe('step 3', () => {
+    it('renders header', async () => {
+      setup(null)
+      render(<SvelteKitOnboarding />, { wrapper })
+
+      const stepText = await screen.findByText(/Step 3:/)
+      expect(stepText).toBeInTheDocument()
+
+      const headerText = await screen.findByText(/Configure the bundler plugin/)
+      expect(headerText).toBeInTheDocument()
+    })
+
+    it('renders body', async () => {
+      setup(null)
+      render(<SvelteKitOnboarding />, { wrapper })
+
+      const bodyText = await screen.findByText(
+        /Add the plugin to the end of your modules array found inside your/
+      )
+      expect(bodyText).toBeInTheDocument()
+
+      const sveltekitConfig = await screen.findByText('vite.config.ts')
+      expect(sveltekitConfig).toBeInTheDocument()
+    })
+
+    it('renders plugin config', async () => {
+      setup(null)
+      render(<SvelteKitOnboarding />, { wrapper })
+
+      const pluginText = await screen.findByText(/\/\/ vite.config.ts/)
+      expect(pluginText).toBeInTheDocument()
+    })
+
+    describe('user clicks copy button', () => {
+      it('sends metric to sentry', async () => {
+        const { user } = setup(true)
+        render(<SvelteKitOnboarding />, { wrapper })
+
+        const pluginConfig = await screen.findByTestId(
+          'sveltekit-plugin-config'
+        )
+        const pluginConfigCopy = await within(pluginConfig).findByTestId(
+          'clipboard-code-snippet'
+        )
+
+        await user.click(pluginConfigCopy)
+
+        await waitFor(() =>
+          expect(Sentry.metrics.increment).toHaveBeenCalledWith(
+            'bundles_tab.onboarding.copied.config',
+            1,
+            { tags: { bundler: 'sveltekit' } }
+          )
+        )
+      })
+    })
+  })
+
+  describe('step 4', () => {
+    it('renders header', async () => {
+      setup(null)
+      render(<SvelteKitOnboarding />, { wrapper })
+
+      const stepText = await screen.findByText(/Step 4:/)
+      expect(stepText).toBeInTheDocument()
+
+      const headerText = await screen.findByText(
+        /Commit and push your latest changes/
+      )
+      expect(headerText).toBeInTheDocument()
+    })
+
+    it('renders body', async () => {
+      setup(null)
+      render(<SvelteKitOnboarding />, { wrapper })
+
+      const bodyText = await screen.findByText(
+        'The plugin requires at least one commit to be made to properly upload bundle analysis information up to Codecov.'
+      )
+      expect(bodyText).toBeInTheDocument()
+    })
+
+    it('renders git commit', async () => {
+      setup(null)
+      render(<SvelteKitOnboarding />, { wrapper })
+
+      const gitCommit = await screen.findByText(
+        'git add -A && git commit -m "Add Codecov bundler plugin" && git push'
+      )
+      expect(gitCommit).toBeInTheDocument()
+    })
+
+    describe('user clicks copy button', () => {
+      it('sends metric to sentry', async () => {
+        const { user } = setup(true)
+        render(<SvelteKitOnboarding />, { wrapper })
+
+        const commitCommand = await screen.findByTestId(
+          'sveltekit-commit-command'
+        )
+        const commitCommandCopy = await within(commitCommand).findByTestId(
+          'clipboard-code-snippet'
+        )
+
+        await user.click(commitCommandCopy)
+
+        await waitFor(() =>
+          expect(Sentry.metrics.increment).toHaveBeenCalledWith(
+            'bundles_tab.onboarding.copied.commit',
+            1,
+            { tags: { bundler: 'sveltekit' } }
+          )
+        )
+      })
+    })
+  })
+
+  describe('step 5', () => {
+    it('renders header', async () => {
+      setup(null)
+      render(<SvelteKitOnboarding />, { wrapper })
+
+      const stepText = await screen.findByText(/Step 5:/)
+      expect(stepText).toBeInTheDocument()
+
+      const headerText = await screen.findByText(/Build the application/)
+      expect(headerText).toBeInTheDocument()
+    })
+
+    it('renders body', async () => {
+      setup(null)
+      render(<SvelteKitOnboarding />, { wrapper })
+
+      const bodyText = await screen.findByText(
+        'When building your application the plugin will automatically upload the stats information to Codecov.'
+      )
+      expect(bodyText).toBeInTheDocument()
+    })
+
+    describe('renders code block', () => {
+      describe('npm', () => {
+        it('renders npm build', async () => {
+          setup(null)
+          render(<SvelteKitOnboarding />, { wrapper })
+
+          const npmBuild = await screen.findByText('npm run build')
+          expect(npmBuild).toBeInTheDocument()
+        })
+
+        describe('user clicks copy button', () => {
+          it('sends metric to sentry', async () => {
+            const { user } = setup(true)
+            render(<SvelteKitOnboarding />, { wrapper })
+
+            const buildCommand = await screen.findByTestId(
+              'sveltekit-npm-build'
+            )
+            const buildCommandCopy = await within(buildCommand).findByTestId(
+              'clipboard-code-snippet'
+            )
+
+            await user.click(buildCommandCopy)
+
+            await waitFor(() =>
+              expect(Sentry.metrics.increment).toHaveBeenCalledWith(
+                'bundles_tab.onboarding.copied.build_command',
+                1,
+                { tags: { package_manager: 'npm', bundler: 'sveltekit' } }
+              )
+            )
+          })
+        })
+      })
+
+      describe('yarn', () => {
+        it('renders yarn build', async () => {
+          setup(null)
+          render(<SvelteKitOnboarding />, { wrapper })
+
+          const yarnBuild = await screen.findByText('yarn run build')
+          expect(yarnBuild).toBeInTheDocument()
+        })
+
+        describe('user clicks copy button', () => {
+          it('sends metric to sentry', async () => {
+            const { user } = setup(true)
+            render(<SvelteKitOnboarding />, { wrapper })
+
+            const buildCommand = await screen.findByTestId(
+              'sveltekit-yarn-build'
+            )
+            const buildCommandCopy = await within(buildCommand).findByTestId(
+              'clipboard-code-snippet'
+            )
+
+            await user.click(buildCommandCopy)
+
+            await waitFor(() =>
+              expect(Sentry.metrics.increment).toHaveBeenCalledWith(
+                'bundles_tab.onboarding.copied.build_command',
+                1,
+                { tags: { package_manager: 'yarn', bundler: 'sveltekit' } }
+              )
+            )
+          })
+        })
+      })
+
+      describe('pnpm', () => {
+        it('renders pnpm build', async () => {
+          setup(null)
+          render(<SvelteKitOnboarding />, { wrapper })
+
+          const pnpmBuild = await screen.findByText('pnpm run build')
+          expect(pnpmBuild).toBeInTheDocument()
+        })
+
+        describe('user clicks copy button', () => {
+          it('sends metric to sentry', async () => {
+            const { user } = setup(true)
+            render(<SvelteKitOnboarding />, { wrapper })
+
+            const buildCommand = await screen.findByTestId(
+              'sveltekit-pnpm-build'
+            )
+            const buildCommandCopy = await within(buildCommand).findByTestId(
+              'clipboard-code-snippet'
+            )
+
+            await user.click(buildCommandCopy)
+
+            await waitFor(() =>
+              expect(Sentry.metrics.increment).toHaveBeenCalledWith(
+                'bundles_tab.onboarding.copied.build_command',
+                1,
+                { tags: { package_manager: 'pnpm', bundler: 'sveltekit' } }
+              )
+            )
+          })
+        })
+      })
+    })
+  })
+
+  describe('linking out to setup feedback', () => {
+    it('renders correct preview text', async () => {
+      setup(null)
+      render(<SvelteKitOnboarding />, { wrapper })
+
+      const text = await screen.findByText(/How was your setup experience\?/)
+      expect(text).toBeInTheDocument()
+
+      const letUsKnow = await screen.findByText(/Let us know in/)
+      expect(letUsKnow).toBeInTheDocument()
+    })
+
+    it('renders link', async () => {
+      setup(null)
+      render(<SvelteKitOnboarding />, { wrapper })
+
+      const link = await screen.findByText('this issue')
+      expect(link).toBeInTheDocument()
+      expect(link).toHaveAttribute(
+        'href',
+        'https://github.com/codecov/feedback/issues/270'
+      )
+    })
+  })
+
+  describe('learn more blurb', () => {
+    it('renders body', async () => {
+      setup(null)
+      render(<SvelteKitOnboarding />, { wrapper })
+
+      const body = await screen.findByText(/Visit our guide to/)
+      expect(body).toBeInTheDocument()
+
+      const link = await screen.findByRole('link', { name: /learn more/ })
+      expect(link).toBeInTheDocument()
+      expect(link).toHaveAttribute(
+        'href',
+        'https://docs.codecov.com/docs/javascript-bundle-analysis'
+      )
+    })
+  })
+})

--- a/src/pages/RepoPage/BundlesTab/BundleOnboarding/SvelteKitOnboarding/SvelteKitOnboarding.spec.tsx
+++ b/src/pages/RepoPage/BundlesTab/BundleOnboarding/SvelteKitOnboarding/SvelteKitOnboarding.spec.tsx
@@ -385,7 +385,7 @@ describe('SvelteKitOnboarding', () => {
       render(<SvelteKitOnboarding />, { wrapper })
 
       const bodyText = await screen.findByText(
-        'The plugin requires at least one commit to be made to properly upload bundle analysis information up to Codecov.'
+        'The plugin requires at least one commit to be made to properly upload bundle analysis information to Codecov.'
       )
       expect(bodyText).toBeInTheDocument()
     })

--- a/src/pages/RepoPage/BundlesTab/BundleOnboarding/SvelteKitOnboarding/SvelteKitOnboarding.tsx
+++ b/src/pages/RepoPage/BundlesTab/BundleOnboarding/SvelteKitOnboarding/SvelteKitOnboarding.tsx
@@ -164,7 +164,7 @@ const StepFour: React.FC = () => {
       <Card.Content className="flex flex-col gap-4">
         <p>
           The plugin requires at least one commit to be made to properly upload
-          bundle analysis information up to Codecov.
+          bundle analysis information to Codecov.
         </p>
         <CodeSnippet
           clipboard={commitString}

--- a/src/pages/RepoPage/BundlesTab/BundleOnboarding/SvelteKitOnboarding/SvelteKitOnboarding.tsx
+++ b/src/pages/RepoPage/BundlesTab/BundleOnboarding/SvelteKitOnboarding/SvelteKitOnboarding.tsx
@@ -1,0 +1,276 @@
+import React, { useEffect } from 'react'
+import { useParams } from 'react-router-dom'
+
+import { useOrgUploadToken } from 'services/orgUploadToken'
+import { useRepo } from 'services/repo'
+import A from 'ui/A'
+import { Card } from 'ui/Card'
+import { CodeSnippet } from 'ui/CodeSnippet'
+
+import LearnMoreBlurb from '../LearnMoreBlurb'
+import {
+  copiedBuildCommandMetric,
+  copiedCommitMetric,
+  copiedConfigMetric,
+  copiedInstallCommandMetric,
+  copiedTokenMetric,
+  visitedOnboardingMetric,
+} from '../metricHelpers'
+
+const npmInstall = `npm install @codecov/sveltekit-plugin --save-dev`
+const yarnInstall = `yarn add @codecov/sveltekit-plugin --dev`
+const pnpmInstall = `pnpm add @codecov/sveltekit-plugin --save-dev`
+
+const pluginConfig = `// vite.config.ts
+import { sveltekit } from "@sveltejs/kit/vite";
+import { defineConfig } from "vite";
+import { codecovSvelteKitPlugin } from "@codecov/sveltekit-plugin";
+
+export default defineConfig({
+  plugins: [
+    sveltekit(),
+    // Put the Codecov SvelteKit plugin after all other plugins
+    codecovSvelteKitPlugin({
+      enableBundleAnalysis: true,
+      bundleName: "example-sveltekit-bundle",
+      uploadToken: process.env.CODECOV_TOKEN,
+    }),
+  ],
+});`
+
+const commitString = `git add -A && git commit -m "Add Codecov bundler plugin" && git push`
+
+const npmBuild = `npm run build`
+const yarnBuild = `yarn run build`
+const pnpmBuild = `pnpm run build`
+
+const StepOne: React.FC = () => {
+  return (
+    <Card>
+      <Card.Header>
+        <Card.Title size="base">
+          Step 1: Install the Codecov SvelteKit Plugin
+        </Card.Title>
+      </Card.Header>
+      <Card.Content className="flex flex-col gap-4">
+        <p>
+          To install the{' '}
+          <span className="bg-ds-gray-primary px-1 font-mono">
+            @codecov/sveltekit-plugin
+          </span>{' '}
+          to your project, use one of the following commands.
+        </p>
+        <CodeSnippet
+          clipboard={npmInstall}
+          clipboardOnClick={() => {
+            copiedInstallCommandMetric('npm', 'sveltekit')
+          }}
+          data-testid="sveltekit-npm-install"
+        >
+          {npmInstall}
+        </CodeSnippet>
+        <CodeSnippet
+          clipboard={yarnInstall}
+          clipboardOnClick={() => {
+            copiedInstallCommandMetric('yarn', 'sveltekit')
+          }}
+          data-testid="sveltekit-yarn-install"
+        >
+          {yarnInstall}
+        </CodeSnippet>
+        <CodeSnippet
+          clipboard={pnpmInstall}
+          clipboardOnClick={() => {
+            copiedInstallCommandMetric('pnpm', 'sveltekit')
+          }}
+          data-testid="sveltekit-pnpm-install"
+        >
+          {pnpmInstall}
+        </CodeSnippet>
+      </Card.Content>
+    </Card>
+  )
+}
+
+const StepTwo: React.FC<{ uploadToken: string }> = ({ uploadToken }) => {
+  return (
+    <Card>
+      <Card.Header>
+        <Card.Title size="base">Step 2: Copy Codecov token</Card.Title>
+      </Card.Header>
+      <Card.Content className="flex flex-col gap-4">
+        <p>
+          Set an environment variable in your build environment with the
+          following upload token.
+        </p>
+        <div className="flex gap-4">
+          <CodeSnippet className="basis-1/3" clipboard="CODECOV_TOKEN">
+            CODECOV_TOKEN
+          </CodeSnippet>
+          <CodeSnippet
+            className="basis-2/3"
+            clipboard={uploadToken}
+            clipboardOnClick={() => {
+              copiedTokenMetric('sveltekit')
+            }}
+            data-testid="sveltekit-upload-token"
+          >
+            {uploadToken}
+          </CodeSnippet>
+        </div>
+      </Card.Content>
+    </Card>
+  )
+}
+
+const StepThree: React.FC = () => {
+  return (
+    <Card>
+      <Card.Header>
+        <Card.Title size="base">
+          Step 3: Configure the bundler plugin
+        </Card.Title>
+      </Card.Header>
+      <Card.Content className="flex flex-col gap-4">
+        <p>
+          Add the plugin to the end of your modules array found inside your{' '}
+          <span className="bg-ds-gray-primary px-1 font-mono">
+            vite.config.ts
+          </span>{' '}
+          file, and pass your configuration.
+        </p>
+        <CodeSnippet
+          clipboard={pluginConfig}
+          clipboardOnClick={() => {
+            copiedConfigMetric('sveltekit')
+          }}
+          data-testid="sveltekit-plugin-config"
+        >
+          {pluginConfig}
+        </CodeSnippet>
+      </Card.Content>
+    </Card>
+  )
+}
+
+const StepFour: React.FC = () => {
+  return (
+    <Card>
+      <Card.Header>
+        <Card.Title size="base">
+          Step 4: Commit and push your latest changes
+        </Card.Title>
+      </Card.Header>
+      <Card.Content className="flex flex-col gap-4">
+        <p>
+          The plugin requires at least one commit to be made to properly upload
+          bundle analysis information up to Codecov.
+        </p>
+        <CodeSnippet
+          clipboard={commitString}
+          clipboardOnClick={() => {
+            copiedCommitMetric('sveltekit')
+          }}
+          data-testid="sveltekit-commit-command"
+        >
+          {commitString}
+        </CodeSnippet>
+      </Card.Content>
+    </Card>
+  )
+}
+
+const StepFive: React.FC = () => {
+  return (
+    <Card>
+      <Card.Header>
+        <Card.Title size="base">Step 5: Build the application</Card.Title>
+      </Card.Header>
+      <Card.Content className="flex flex-col gap-4">
+        <p>
+          When building your application the plugin will automatically upload
+          the stats information to Codecov.
+        </p>
+        <CodeSnippet
+          clipboard={npmBuild}
+          clipboardOnClick={() => {
+            copiedBuildCommandMetric('npm', 'sveltekit')
+          }}
+          data-testid="sveltekit-npm-build"
+        >
+          {npmBuild}
+        </CodeSnippet>
+        <CodeSnippet
+          clipboard={yarnBuild}
+          clipboardOnClick={() => {
+            copiedBuildCommandMetric('yarn', 'sveltekit')
+          }}
+          data-testid="sveltekit-yarn-build"
+        >
+          {yarnBuild}
+        </CodeSnippet>
+        <CodeSnippet
+          clipboard={pnpmBuild}
+          clipboardOnClick={() => {
+            copiedBuildCommandMetric('pnpm', 'sveltekit')
+          }}
+          data-testid="sveltekit-pnpm-build"
+        >
+          {pnpmBuild}
+        </CodeSnippet>
+      </Card.Content>
+    </Card>
+  )
+}
+
+function FeedbackCTA() {
+  return (
+    <Card>
+      <Card.Content>
+        <p>
+          <span className="font-semibold">How was your setup experience?</span>{' '}
+          Let us know in{' '}
+          <A
+            to={{ pageName: 'bundleConfigFeedback' }}
+            isExternal
+            hook="repo-config-feedback"
+          >
+            this issue
+          </A>
+        </p>
+      </Card.Content>
+    </Card>
+  )
+}
+
+interface URLParams {
+  provider: string
+  owner: string
+  repo: string
+}
+
+const SvelteKitOnboarding: React.FC = () => {
+  const { provider, owner, repo } = useParams<URLParams>()
+  const { data: repoData } = useRepo({ provider, owner, repo })
+  const { data: orgUploadToken } = useOrgUploadToken({ provider, owner })
+
+  const uploadToken = orgUploadToken ?? repoData?.repository?.uploadToken ?? ''
+
+  useEffect(() => {
+    visitedOnboardingMetric('sveltekit')
+  }, [])
+
+  return (
+    <div className="flex flex-col gap-6">
+      <StepOne />
+      <StepTwo uploadToken={uploadToken} />
+      <StepThree />
+      <StepFour />
+      <StepFive />
+      <FeedbackCTA />
+      <LearnMoreBlurb />
+    </div>
+  )
+}
+
+export default SvelteKitOnboarding

--- a/src/pages/RepoPage/BundlesTab/BundleOnboarding/SvelteKitOnboarding/index.ts
+++ b/src/pages/RepoPage/BundlesTab/BundleOnboarding/SvelteKitOnboarding/index.ts
@@ -1,0 +1,1 @@
+export { default } from './SvelteKitOnboarding'

--- a/src/pages/RepoPage/BundlesTab/BundleOnboarding/ViteOnboarding/ViteOnboarding.spec.tsx
+++ b/src/pages/RepoPage/BundlesTab/BundleOnboarding/ViteOnboarding/ViteOnboarding.spec.tsx
@@ -377,7 +377,7 @@ describe('ViteOnboarding', () => {
       render(<ViteOnboarding />, { wrapper })
 
       const bodyText = await screen.findByText(
-        'The plugin requires at least one commit to be made to properly upload bundle analysis information up to Codecov.'
+        'The plugin requires at least one commit to be made to properly upload bundle analysis information to Codecov.'
       )
       expect(bodyText).toBeInTheDocument()
     })

--- a/src/pages/RepoPage/BundlesTab/BundleOnboarding/ViteOnboarding/ViteOnboarding.tsx
+++ b/src/pages/RepoPage/BundlesTab/BundleOnboarding/ViteOnboarding/ViteOnboarding.tsx
@@ -163,7 +163,7 @@ const StepFour: React.FC = () => {
       <Card.Content className="flex flex-col gap-4">
         <p>
           The plugin requires at least one commit to be made to properly upload
-          bundle analysis information up to Codecov.
+          bundle analysis information to Codecov.
         </p>
         <CodeSnippet
           clipboard={commitString}

--- a/src/pages/RepoPage/BundlesTab/BundleOnboarding/WebpackOnboarding/WebpackOnboarding.spec.tsx
+++ b/src/pages/RepoPage/BundlesTab/BundleOnboarding/WebpackOnboarding/WebpackOnboarding.spec.tsx
@@ -381,7 +381,7 @@ describe('WebpackOnboarding', () => {
       render(<WebpackOnboarding />, { wrapper })
 
       const bodyText = await screen.findByText(
-        'The plugin requires at least one commit to be made to properly upload bundle analysis information up to Codecov.'
+        'The plugin requires at least one commit to be made to properly upload bundle analysis information to Codecov.'
       )
       expect(bodyText).toBeInTheDocument()
     })

--- a/src/pages/RepoPage/BundlesTab/BundleOnboarding/WebpackOnboarding/WebpackOnboarding.tsx
+++ b/src/pages/RepoPage/BundlesTab/BundleOnboarding/WebpackOnboarding/WebpackOnboarding.tsx
@@ -179,7 +179,7 @@ const StepFour: React.FC = () => {
       <Card.Content className="flex flex-col gap-4">
         <p>
           The plugin requires at least one commit to be made to properly upload
-          bundle analysis information up to Codecov.
+          bundle analysis information to Codecov.
         </p>
         <CodeSnippet
           clipboard={commitString}

--- a/src/pages/RepoPage/BundlesTab/BundleOnboarding/metricHelpers.ts
+++ b/src/pages/RepoPage/BundlesTab/BundleOnboarding/metricHelpers.ts
@@ -1,7 +1,14 @@
 /* eslint-disable camelcase */
 import { metrics } from 'shared/utils/metrics'
 
-type Bundlers = 'rollup' | 'vite' | 'webpack'
+type Bundlers =
+  | 'rollup'
+  | 'vite'
+  | 'webpack'
+  | 'remix'
+  | 'nuxt'
+  | 'sveltekit'
+  | 'solidstart'
 type PackageManagers = 'npm' | 'yarn' | 'pnpm'
 
 export const copiedInstallCommandMetric = (

--- a/src/pages/RepoPage/RepoPage.tsx
+++ b/src/pages/RepoPage/RepoPage.tsx
@@ -220,7 +220,6 @@ function Routes({
         </SentryRoute>
       ) : null}
       {jsOrTsPresent ? (
-        // TODO
         <SentryRoute
           path={[
             `${path}/bundles/new`,

--- a/src/pages/RepoPage/RepoPage.tsx
+++ b/src/pages/RepoPage/RepoPage.tsx
@@ -123,6 +123,10 @@ function Routes({
               `${path}/bundles/new`,
               `${path}/bundles/new/rollup`,
               `${path}/bundles/new/webpack`,
+              `${path}/bundles/new/remix-vite`,
+              `${path}/bundles/new/nuxt`,
+              `${path}/bundles/new/sveltekit`,
+              `${path}/bundles/new/solidstart`,
             ]}
             exact
           >
@@ -216,11 +220,16 @@ function Routes({
         </SentryRoute>
       ) : null}
       {jsOrTsPresent ? (
+        // TODO
         <SentryRoute
           path={[
             `${path}/bundles/new`,
             `${path}/bundles/new/rollup`,
             `${path}/bundles/new/webpack`,
+            `${path}/bundles/new/remix-vite`,
+            `${path}/bundles/new/nuxt`,
+            `${path}/bundles/new/sveltekit`,
+            `${path}/bundles/new/solidstart`,
           ]}
           exact
         >

--- a/src/services/navigation/useNavLinks/useNavLinks.js
+++ b/src/services/navigation/useNavLinks/useNavLinks.js
@@ -765,6 +765,46 @@ export function useNavLinks() {
       ) => `/${provider}/${owner}/${repo}/bundles/new/webpack`,
       text: 'Webpack',
     },
+    bundleRemixOnboarding: {
+      path: (
+        { provider = p, owner = o, repo = r } = {
+          provider: p,
+          owner: o,
+          repo: r,
+        }
+      ) => `/${provider}/${owner}/${repo}/bundles/new/remix-vite`,
+      text: 'Remix (Vite)',
+    },
+    bundleNuxtOnboarding: {
+      path: (
+        { provider = p, owner = o, repo = r } = {
+          provider: p,
+          owner: o,
+          repo: r,
+        }
+      ) => `/${provider}/${owner}/${repo}/bundles/new/nuxt`,
+      text: 'Nuxt',
+    },
+    bundleSvelteKitOnboarding: {
+      path: (
+        { provider = p, owner = o, repo = r } = {
+          provider: p,
+          owner: o,
+          repo: r,
+        }
+      ) => `/${provider}/${owner}/${repo}/bundles/new/sveltekit`,
+      text: 'SvelteKit',
+    },
+    bundleSolidStartOnboarding: {
+      path: (
+        { provider = p, owner = o, repo = r } = {
+          provider: p,
+          owner: o,
+          repo: r,
+        }
+      ) => `/${provider}/${owner}/${repo}/bundles/new/solidstart`,
+      text: 'SolidStart',
+    },
     failedTests: {
       path: (
         { provider = p, owner = o, repo = r, branch = undefined } = {

--- a/src/services/navigation/useNavLinks/useNavLinks.spec.js
+++ b/src/services/navigation/useNavLinks/useNavLinks.spec.js
@@ -1894,6 +1894,102 @@ describe('useNavLinks', () => {
     })
   })
 
+  describe('nuxt onboarding', () => {
+    it('returns the correct link with nothing passed', () => {
+      const { result } = renderHook(() => useNavLinks(), {
+        wrapper: wrapper('/gh/codecov/cool-repo'),
+      })
+
+      const path = result.current.bundleNuxtOnboarding.path()
+      expect(path).toBe('/gh/codecov/cool-repo/bundles/new/nuxt')
+    })
+
+    it('can override the params', () => {
+      const { result } = renderHook(() => useNavLinks(), {
+        wrapper: wrapper('/gh/codecov/cool-repo'),
+      })
+
+      const path = result.current.bundleNuxtOnboarding.path({
+        provider: 'bb',
+        owner: 'test-owner',
+        repo: 'test-repo',
+      })
+      expect(path).toBe('/bb/test-owner/test-repo/bundles/new/nuxt')
+    })
+  })
+
+  describe('remix vite onboarding', () => {
+    it('returns the correct link with nothing passed', () => {
+      const { result } = renderHook(() => useNavLinks(), {
+        wrapper: wrapper('/gh/codecov/cool-repo'),
+      })
+
+      const path = result.current.bundleRemixOnboarding.path()
+      expect(path).toBe('/gh/codecov/cool-repo/bundles/new/remix-vite')
+    })
+
+    it('can override the params', () => {
+      const { result } = renderHook(() => useNavLinks(), {
+        wrapper: wrapper('/gh/codecov/cool-repo'),
+      })
+
+      const path = result.current.bundleRemixOnboarding.path({
+        provider: 'bb',
+        owner: 'test-owner',
+        repo: 'test-repo',
+      })
+      expect(path).toBe('/bb/test-owner/test-repo/bundles/new/remix-vite')
+    })
+  })
+
+  describe('sveltekit onboarding', () => {
+    it('returns the correct link with nothing passed', () => {
+      const { result } = renderHook(() => useNavLinks(), {
+        wrapper: wrapper('/gh/codecov/cool-repo'),
+      })
+
+      const path = result.current.bundleSvelteKitOnboarding.path()
+      expect(path).toBe('/gh/codecov/cool-repo/bundles/new/sveltekit')
+    })
+
+    it('can override the params', () => {
+      const { result } = renderHook(() => useNavLinks(), {
+        wrapper: wrapper('/gh/codecov/cool-repo'),
+      })
+
+      const path = result.current.bundleSvelteKitOnboarding.path({
+        provider: 'bb',
+        owner: 'test-owner',
+        repo: 'test-repo',
+      })
+      expect(path).toBe('/bb/test-owner/test-repo/bundles/new/sveltekit')
+    })
+  })
+
+  describe('solidstart onboarding', () => {
+    it('returns the correct link with nothing passed', () => {
+      const { result } = renderHook(() => useNavLinks(), {
+        wrapper: wrapper('/gh/codecov/cool-repo'),
+      })
+
+      const path = result.current.bundleSolidStartOnboarding.path()
+      expect(path).toBe('/gh/codecov/cool-repo/bundles/new/solidstart')
+    })
+
+    it('can override the params', () => {
+      const { result } = renderHook(() => useNavLinks(), {
+        wrapper: wrapper('/gh/codecov/cool-repo'),
+      })
+
+      const path = result.current.bundleSolidStartOnboarding.path({
+        provider: 'bb',
+        owner: 'test-owner',
+        repo: 'test-repo',
+      })
+      expect(path).toBe('/bb/test-owner/test-repo/bundles/new/solidstart')
+    })
+  })
+
   describe('Failed tests tab', () => {
     it('returns the correct link with nothing passed', () => {
       const { result } = renderHook(() => useNavLinks(), {


### PR DESCRIPTION
# Description

Closes all at https://github.com/codecov/engineering-team/issues/2174

# Code Example

# Notable Changes
Added routes for all 4 new meta-frameworks and buttons to switch in onboarding

# Screenshots

<img width="1098" alt="Screenshot 2024-08-15 at 7 43 02 AM" src="https://github.com/user-attachments/assets/97d64e10-906e-498d-874d-0406be94212a">


# Link to Sample Entry

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.