### PR TITLE
fix: Set correct scroll margin in new file renderer

### DIFF
--- a/src/shared/RawFileViewer/RawFileViewer.spec.tsx
+++ b/src/shared/RawFileViewer/RawFileViewer.spec.tsx
@@ -45,6 +45,7 @@ window.cancelAnimationFrame = () => {}
 
 const scrollToMock = jest.fn()
 window.scrollTo = scrollToMock
+window.scrollX = 100
 
 class ResizeObserverMock {
   callback = (x: any) => null
@@ -59,6 +60,7 @@ class ResizeObserverMock {
         contentRect: { width: 100 },
         target: {
           getAttribute: () => ({ scrollWidth: 100 }),
+          getBoundingClientRect: () => ({ top: 100 }),
         },
       },
     ])

--- a/src/ui/VirtualFileRenderer/VirtualFileRenderer.spec.tsx
+++ b/src/ui/VirtualFileRenderer/VirtualFileRenderer.spec.tsx
@@ -29,6 +29,7 @@ window.cancelAnimationFrame = () => {}
 
 const scrollToMock = jest.fn()
 window.scrollTo = scrollToMock
+window.scrollY = 100
 
 class ResizeObserverMock {
   callback = (x: any) => null
@@ -43,6 +44,7 @@ class ResizeObserverMock {
         contentRect: { width: 100 },
         target: {
           getAttribute: () => ({ scrollWidth: 100 }),
+          getBoundingClientRect: () => ({ top: 100 }),
         },
       },
     ])

--- a/src/ui/VirtualFileRenderer/VirtualFileRenderer.tsx
+++ b/src/ui/VirtualFileRenderer/VirtualFileRenderer.tsx
@@ -72,12 +72,15 @@ const CodeBody = ({
     scrollMargin: scrollMargin ?? 0,
   })
 
+  // TODO-remove
+  console.debug(scrollMargin)
+
   useLayoutEffect(() => {
     if (!codeDisplayOverlayRef.current) return
     const resizeObserver = new ResizeObserver((entries) => {
       const entry = entries?.[0]
       if (entry) {
-        setScrollMargin(entry.target.getBoundingClientRect().top)
+        setScrollMargin(Math.abs(entry.contentRect.y))
       }
     })
 

--- a/src/ui/VirtualFileRenderer/VirtualFileRenderer.tsx
+++ b/src/ui/VirtualFileRenderer/VirtualFileRenderer.tsx
@@ -19,7 +19,7 @@ import { useWindowVirtualizer } from '@tanstack/react-virtual'
 import { Dictionary } from 'lodash'
 import isNaN from 'lodash/isNaN'
 import Highlight, { defaultProps } from 'prism-react-renderer'
-import { memo, useLayoutEffect, useRef, useState } from 'react'
+import { memo, useEffect, useLayoutEffect, useRef, useState } from 'react'
 import { useHistory, useLocation } from 'react-router-dom'
 
 import { requestAnimationTimeout } from 'shared/utils/animationFrameUtils'
@@ -79,7 +79,7 @@ const CodeBody = ({
    * incase the user has scrolled down the page, and resizes the window
    * afterwards.
    */
-  useLayoutEffect(() => {
+  useEffect(() => {
     if (!codeDisplayOverlayRef.current) return
     const resizeObserver = new ResizeObserver((entries) => {
       const entry = entries?.[0]

--- a/src/ui/VirtualFileRenderer/VirtualFileRenderer.tsx
+++ b/src/ui/VirtualFileRenderer/VirtualFileRenderer.tsx
@@ -64,7 +64,6 @@ const CodeBody = ({
   const initializeRender = useRef(true)
   const [wrapperRef, setWrapperRef] = useState<HTMLDivElement | null>(null)
 
-  console.debug(scrollMargin)
   const virtualizer = useWindowVirtualizer({
     count: tokens.length,
     // this is the height of each line in the code block based off of not having any line wrapping, if we add line wrapping this will need to be updated to dynamically measure the height of each line.
@@ -72,6 +71,22 @@ const CodeBody = ({
     overscan: 45, // update to be based off of the height of the window
     scrollMargin: scrollMargin ?? 0,
   })
+
+  useLayoutEffect(() => {
+    if (!codeDisplayOverlayRef.current) return
+    const resizeObserver = new ResizeObserver((entries) => {
+      const entry = entries?.[0]
+      if (entry) {
+        setScrollMargin(entry.target.getBoundingClientRect().top)
+      }
+    })
+
+    resizeObserver.observe(codeDisplayOverlayRef.current)
+
+    return () => {
+      resizeObserver.disconnect()
+    }
+  }, [codeDisplayOverlayRef, scrollMargin])
 
   useLayoutEffect(() => {
     if (!wrapperRef) return
@@ -104,9 +119,6 @@ const CodeBody = ({
     // set the parent div height to the total size of the virtualizer
     codeDisplayOverlayRef.current.style.height = `${virtualizer.getTotalSize()}px`
     codeDisplayOverlayRef.current.style.position = 'relative'
-
-    // set the scroll margin so the virtualizer knows how much to set the scroll offset by
-    setScrollMargin(codeDisplayOverlayRef.current.getBoundingClientRect().top)
 
     const index = parseInt(location.hash.slice(2), 10)
     // need to check !isNaN because parseInt return NaN if the string is not a number which is still a valid number.

--- a/src/ui/VirtualFileRenderer/VirtualFileRenderer.tsx
+++ b/src/ui/VirtualFileRenderer/VirtualFileRenderer.tsx
@@ -59,16 +59,18 @@ const CodeBody = ({
   const history = useHistory()
   const location = useLocation()
   const [wrapperWidth, setWrapperWidth] = useState<number | '100%'>('100%')
+  const [scrollMargin, setScrollMargin] = useState<number>(0)
 
   const initializeRender = useRef(true)
   const [wrapperRef, setWrapperRef] = useState<HTMLDivElement | null>(null)
 
+  console.debug(scrollMargin)
   const virtualizer = useWindowVirtualizer({
     count: tokens.length,
     // this is the height of each line in the code block based off of not having any line wrapping, if we add line wrapping this will need to be updated to dynamically measure the height of each line.
     estimateSize: () => LINE_ROW_HEIGHT,
     overscan: 45, // update to be based off of the height of the window
-    scrollMargin: codeDisplayOverlayRef.current?.offsetTop ?? 0,
+    scrollMargin: scrollMargin ?? 0,
   })
 
   useLayoutEffect(() => {
@@ -88,6 +90,8 @@ const CodeBody = ({
     }
   }, [wrapperRef])
 
+  // we're disabling this rule here because we need this effect to run on every render until the initializeRender flag is set to false
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   useLayoutEffect(() => {
     if (!initializeRender.current) {
       return
@@ -100,6 +104,9 @@ const CodeBody = ({
     // set the parent div height to the total size of the virtualizer
     codeDisplayOverlayRef.current.style.height = `${virtualizer.getTotalSize()}px`
     codeDisplayOverlayRef.current.style.position = 'relative'
+
+    // set the scroll margin so the virtualizer knows how much to set the scroll offset by
+    setScrollMargin(codeDisplayOverlayRef.current.getBoundingClientRect().top)
 
     const index = parseInt(location.hash.slice(2), 10)
     // need to check !isNaN because parseInt return NaN if the string is not a number which is still a valid number.


### PR DESCRIPTION
# Description

The current scroll margin isn't being correctly set, so this PR updates this, by setting the correct scroll margin in our once off `useEffect` that will set the correct height. This PR also includes some small tidying up things to get everything playing nicely and "properly".

# Notable Changes

- Set the correct scroll margin in the new renderer
- Tidy some things up moving to `useEffect` from `useLayoutEffect`

