### PR TITLE
feat: Add bundle analysis feedback survey banner

### DIFF
--- a/src/services/navigation/useNavLinks/useNavLinks.js
+++ b/src/services/navigation/useNavLinks/useNavLinks.js
@@ -765,17 +765,6 @@ export function useNavLinks() {
       ) => `/${provider}/${owner}/${repo}/bundles/new/webpack`,
       text: 'Webpack',
     },
-    teamPlanFeedbackSurvey: {
-      path: () =>
-        `https://docs.google.com/forms/d/e/1FAIpQLSeoMHPyECewV7X3UaT-uUxZCmYy1T6hEX_aecCD2ppPHGSvUw/viewform`,
-      text: 'Team plan feedback survey',
-      isExternalLink: true,
-    },
-    proPlanFeedbackSurvey: {
-      path: () => `https://forms.gle/nf37sRAtyQeXVTdr8`,
-      text: 'Pro plan feedback survey',
-      isExternalLink: true,
-    },
     failedTests: {
       path: (
         { provider = p, owner = o, repo = r, branch = undefined } = {

--- a/src/services/navigation/useNavLinks/useStaticNavLinks.js
+++ b/src/services/navigation/useNavLinks/useStaticNavLinks.js
@@ -482,5 +482,10 @@ export function useStaticNavLinks() {
       text: 'Pro plan feedback survey',
       isExternalLink: true,
     },
+    bundleFeedbackSurvey: {
+      path: () => `https://forms.gle/8fzZrwWEaBRz4ufD9`,
+      text: 'Bundle analysis feedback survey',
+      isExternalLink: true,
+    },
   }
 }

--- a/src/services/navigation/useNavLinks/useStaticNavLinks.spec.js
+++ b/src/services/navigation/useNavLinks/useStaticNavLinks.spec.js
@@ -88,6 +88,7 @@ describe('useStaticNavLinks', () => {
       ${links.demoRepo}                      | ${'/github/codecov/gazebo'}
       ${links.teamPlanFeedbackSurvey}        | ${'https://docs.google.com/forms/d/e/1FAIpQLSeoMHPyECewV7X3UaT-uUxZCmYy1T6hEX_aecCD2ppPHGSvUw/viewform'}
       ${links.proPlanFeedbackSurvey}         | ${'https://forms.gle/nf37sRAtyQeXVTdr8'}
+      ${links.bundleFeedbackSurvey}          | ${'https://forms.gle/8fzZrwWEaBRz4ufD9'}
     `('static links return path', ({ link, outcome }) => {
       it(`${link.text}: Returns the correct link`, () => {
         expect(link.path()).toBe(outcome)

--- a/src/shared/GlobalTopBanners/BundleFeedbackBanner/BundleFeedbackBanner.spec.tsx
+++ b/src/shared/GlobalTopBanners/BundleFeedbackBanner/BundleFeedbackBanner.spec.tsx
@@ -1,0 +1,162 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { graphql } from 'msw'
+import { setupServer } from 'msw/node'
+import React from 'react'
+import { MemoryRouter, Route } from 'react-router-dom'
+
+import BundleFeedbackBanner from './BundleFeedbackBanner'
+
+const mockOverview = {
+  owner: {
+    repository: {
+      __typename: 'Repository',
+      private: false,
+      defaultBranch: 'main',
+      oldestCommitAt: '2022-10-10T11:59:59',
+      coverageEnabled: true,
+      bundleAnalysisEnabled: true,
+      languages: ['typescript'],
+      testAnalyticsEnabled: true,
+    },
+  },
+}
+
+const queryClient = new QueryClient({
+  defaultOptions: { queries: { retry: false } },
+})
+
+const server = setupServer()
+
+beforeAll(() => server.listen())
+afterEach(() => {
+  queryClient.clear()
+  server.resetHandlers()
+  jest.resetAllMocks()
+})
+afterAll(() => server.close())
+
+const wrapper =
+  (initialEntries = ''): React.FC<React.PropsWithChildren> =>
+  ({ children }) => (
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={[initialEntries]}>
+        <Route path="/:provider/:owner/:repo">{children}</Route>
+        <Route path="*">{children}</Route>
+      </MemoryRouter>
+    </QueryClientProvider>
+  )
+
+describe('BundleFeedbackBanner', () => {
+  function setup() {
+    const user = userEvent.setup()
+    const mockSetItem = jest.spyOn(window.localStorage.__proto__, 'setItem')
+    const mockGetItem = jest.spyOn(window.localStorage.__proto__, 'getItem')
+
+    server.use(
+      graphql.query('GetRepoOverview', (req, res, ctx) =>
+        res(ctx.status(200), ctx.data(mockOverview))
+      )
+    )
+
+    return {
+      user,
+      mockSetItem,
+      mockGetItem,
+    }
+  }
+
+  describe('rendering banner', () => {
+    it('renders left side text', async () => {
+      setup()
+      render(<BundleFeedbackBanner />, {
+        wrapper: wrapper('/gh/codecov/cool-repo'),
+      })
+
+      const leftText = await screen.findByText(/Looks like your org tried/)
+      expect(leftText).toBeInTheDocument()
+    })
+
+    it('renders bundle tab link', async () => {
+      setup()
+      render(<BundleFeedbackBanner />, {
+        wrapper: wrapper('/gh/codecov/cool-repo'),
+      })
+
+      const link = await screen.findByRole('link', { name: 'bundle analysis' })
+      expect(link).toBeInTheDocument()
+      expect(link).toHaveAttribute('href', '/gh/codecov/cool-repo/bundles')
+    })
+
+    it('renders the link to the survey', async () => {
+      setup()
+      render(<BundleFeedbackBanner />, {
+        wrapper: wrapper('/gh/codecov/cool-repo'),
+      })
+
+      const link = await screen.findByRole('link', { name: '1 minute survey.' })
+      expect(link).toBeInTheDocument()
+      expect(link).toHaveAttribute(
+        'href',
+        'https://forms.gle/8fzZrwWEaBRz4ufD9'
+      )
+    })
+  })
+
+  describe('user dismisses banner', () => {
+    it('calls local storage', async () => {
+      const { user, mockGetItem, mockSetItem } = setup()
+      render(<BundleFeedbackBanner />, {
+        wrapper: wrapper('/gh/codecov/cool-repo'),
+      })
+
+      mockGetItem.mockReturnValue(null)
+
+      const dismissBtn = await screen.findByText(/Dismiss/)
+      expect(dismissBtn).toBeInTheDocument()
+      await user.click(dismissBtn)
+
+      await waitFor(() =>
+        expect(mockSetItem).toHaveBeenCalledWith(
+          'dismissed-top-banners',
+          JSON.stringify({ 'bundle-feedback-banner': 'true' })
+        )
+      )
+    })
+
+    it('hides the banner', async () => {
+      const { user, mockGetItem } = setup()
+      const { container } = render(<BundleFeedbackBanner />, {
+        wrapper: wrapper('/gh/codecov/cool-repo'),
+      })
+
+      mockGetItem.mockReturnValue(null)
+
+      const dismissBtn = await screen.findByText(/Dismiss/)
+      expect(dismissBtn).toBeInTheDocument()
+      await user.click(dismissBtn)
+
+      await waitFor(() => expect(container).toBeEmptyDOMElement())
+    })
+  })
+
+  describe('user is not on the repo page', () => {
+    it('does not render banner', async () => {
+      setup()
+      const { container } = render(<BundleFeedbackBanner />, {
+        wrapper: wrapper('/gh/codecov'),
+      })
+      expect(container).toBeEmptyDOMElement()
+    })
+  })
+
+  describe('user does not have BA enabled', () => {
+    it('does not render banner', async () => {
+      const { container } = render(<BundleFeedbackBanner />, {
+        wrapper: wrapper('/gh/codecov/cool-repo'),
+      })
+      expect(container).toBeEmptyDOMElement()
+    })
+  })
+})

--- a/src/shared/GlobalTopBanners/BundleFeedbackBanner/BundleFeedbackBanner.tsx
+++ b/src/shared/GlobalTopBanners/BundleFeedbackBanner/BundleFeedbackBanner.tsx
@@ -1,0 +1,65 @@
+import { useParams } from 'react-router-dom'
+
+import { useRepoOverview } from 'services/repo'
+import A from 'ui/A'
+import TopBanner from 'ui/TopBanner'
+
+const BUNDLE_FEEDBACK_BANNER_KEY = 'bundle-feedback-banner'
+
+interface URLParams {
+  provider: string
+  owner: string
+  repo?: string
+}
+
+const BundleFeedbackBanner = () => {
+  const { provider, owner, repo } = useParams<URLParams>()
+  const { data: repoOverview, isSuccess } = useRepoOverview({
+    provider,
+    owner,
+    repo: repo || '', // if repo undefined, query is disabled
+    opts: { enabled: !!repo },
+  })
+
+  const showBanner = repo && isSuccess && repoOverview?.bundleAnalysisEnabled
+
+  if (!showBanner) {
+    return null
+  }
+
+  return (
+    <TopBanner localStorageKey={BUNDLE_FEEDBACK_BANNER_KEY}>
+      <TopBanner.Start>
+        <p className="items-center gap-1 md:flex">
+          &#127775;{' '}
+          <span className="font-semibold">
+            Looks like your org tried{' '}
+            <A
+              to={{ pageName: 'bundles' }}
+              isExternal={false}
+              hook="bundle-feedback-BA-link"
+            >
+              bundle analysis
+            </A>
+            !
+          </span>
+          We&apos;d love your thoughts and feedback in this
+          <A
+            to={{ pageName: 'bundleFeedbackSurvey' }}
+            isExternal
+            hook="bundle-feedback-link"
+          >
+            1 minute survey.
+          </A>
+        </p>
+      </TopBanner.Start>
+      <TopBanner.End>
+        <TopBanner.DismissButton>
+          <span className="opacity-100"> Dismiss </span>
+        </TopBanner.DismissButton>
+      </TopBanner.End>
+    </TopBanner>
+  )
+}
+
+export default BundleFeedbackBanner

--- a/src/shared/GlobalTopBanners/BundleFeedbackBanner/index.ts
+++ b/src/shared/GlobalTopBanners/BundleFeedbackBanner/index.ts
@@ -1,0 +1,1 @@
+export { default } from './BundleFeedbackBanner'

--- a/src/shared/GlobalTopBanners/GlobalTopBanners.spec.tsx
+++ b/src/shared/GlobalTopBanners/GlobalTopBanners.spec.tsx
@@ -6,6 +6,7 @@ jest.mock('./RequestInstallBanner', () => () => 'RequestInstallBanner')
 jest.mock('./TrialBanner', () => () => 'TrialBanner')
 jest.mock('./TeamPlanFeedbackBanner', () => () => 'TeamPlanFeedbackBanner')
 jest.mock('./ProPlanFeedbackBanner', () => () => 'ProPlanFeedbackBanner')
+jest.mock('./BundleFeedbackBanner', () => () => 'BundleFeedbackBanner')
 jest.mock('./OktaBanners', () => () => 'OktaBanners')
 
 describe('GlobalTopBanners', () => {
@@ -31,6 +32,13 @@ describe('GlobalTopBanners', () => {
   })
 
   it('renders pro plan feedback banner', async () => {
+    render(<GlobalTopBanners />)
+
+    const banner = await screen.findByText(/ProPlanFeedbackBanner/)
+    expect(banner).toBeInTheDocument()
+  })
+
+  it('renders bundle feedback banner', async () => {
     render(<GlobalTopBanners />)
 
     const banner = await screen.findByText(/ProPlanFeedbackBanner/)

--- a/src/shared/GlobalTopBanners/GlobalTopBanners.tsx
+++ b/src/shared/GlobalTopBanners/GlobalTopBanners.tsx
@@ -2,6 +2,7 @@ import { lazy } from 'react'
 
 import SilentNetworkErrorWrapper from 'layouts/shared/SilentNetworkErrorWrapper'
 
+const BundleFeedbackBanner = lazy(() => import('./BundleFeedbackBanner'))
 const RequestInstallBanner = lazy(() => import('./RequestInstallBanner'))
 const TrialBanner = lazy(() => import('./TrialBanner'))
 const TeamPlanFeedbackBanner = lazy(() => import('./TeamPlanFeedbackBanner'))
@@ -11,11 +12,15 @@ const OktaBanners = lazy(() => import('./OktaBanners'))
 const GlobalTopBanners: React.FC = () => {
   return (
     <SilentNetworkErrorWrapper>
-      <OktaBanners />
-      <RequestInstallBanner />
-      <TrialBanner />
-      <TeamPlanFeedbackBanner />
-      <ProPlanFeedbackBanner />
+      {/* These are listed in priority order: if multiple banners are rendering, only the bottommost will display. */}
+      <div className="[&>*:last-child]:block [&>*]:hidden">
+        <OktaBanners />
+        <RequestInstallBanner />
+        <TrialBanner />
+        <TeamPlanFeedbackBanner />
+        <ProPlanFeedbackBanner />
+        <BundleFeedbackBanner />
+      </div>
     </SilentNetworkErrorWrapper>
   )
 }

--- a/src/shared/GlobalTopBanners/TeamPlanFeedbackBanner/TeamPlanFeedbackBanner.tsx
+++ b/src/shared/GlobalTopBanners/TeamPlanFeedbackBanner/TeamPlanFeedbackBanner.tsx
@@ -25,28 +25,26 @@ const TeamPlanFeedbackBanner = () => {
   }
 
   return (
-    <>
-      <TopBanner localStorageKey={TEAM_PLAN_FEEDBACK_BANNER_KEY}>
-        <TopBanner.Start>
-          <p className="items-center gap-1 md:flex">
-            &#127775; We&apos;d love your thoughts and feedback about Codecov in
-            this
-            <A
-              to={{ pageName: 'teamPlanFeedbackSurvey' }}
-              isExternal
-              hook="team-plan-feedback-link"
-            >
-              1 minute survey.
-            </A>
-          </p>
-        </TopBanner.Start>
-        <TopBanner.End>
-          <TopBanner.DismissButton>
-            <span className="opacity-100"> Dismiss </span>
-          </TopBanner.DismissButton>
-        </TopBanner.End>
-      </TopBanner>
-    </>
+    <TopBanner localStorageKey={TEAM_PLAN_FEEDBACK_BANNER_KEY}>
+      <TopBanner.Start>
+        <p className="items-center gap-1 md:flex">
+          &#127775; We&apos;d love your thoughts and feedback about Codecov in
+          this
+          <A
+            to={{ pageName: 'teamPlanFeedbackSurvey' }}
+            isExternal
+            hook="team-plan-feedback-link"
+          >
+            1 minute survey.
+          </A>
+        </p>
+      </TopBanner.Start>
+      <TopBanner.End>
+        <TopBanner.DismissButton>
+          <span className="opacity-100"> Dismiss </span>
+        </TopBanner.DismissButton>
+      </TopBanner.End>
+    </TopBanner>
   )
 }
 

--- a/src/ui/TopBanner/TopBanner.tsx
+++ b/src/ui/TopBanner/TopBanner.tsx
@@ -146,14 +146,16 @@ const TopBannerRoot: React.FC<React.PropsWithChildren<TopBannerProps>> = ({
     <TopBannerContext.Provider
       value={{ variant, localStorageKey, setHideBanner }}
     >
-      <div
-        data-testid="top-banner-root"
-        className={cs(
-          'h-fit w-full px-4 py-2 lg:inline-flex lg:min-h-[38px]',
-          variants[variant].bgColor
-        )}
-      >
-        {children}
+      <div>
+        <div
+          data-testid="top-banner-root"
+          className={cs(
+            'h-fit w-full px-4 py-2 lg:inline-flex lg:min-h-[38px]',
+            variants[variant].bgColor
+          )}
+        >
+          {children}
+        </div>
       </div>
     </TopBannerContext.Provider>
   )


### PR DESCRIPTION
Adds bundle analysis feedback survey banner. Also, adjusts GlobalTopBanners to only render at most one banner. Was scratching my head for a bit on how to only show max one banner, but just had to use my whole brain and realize could do with CSS 😄 

[Design](https://www.figma.com/design/7UXH8qTtbsX5Vz0yYYEZVr/GH-1065?node-id=82-52&t=2dzfE0WcH3arnvss-0)

Closes https://github.com/codecov/engineering-team/issues/2030

![Screenshot 2024-08-16 at 15 12 01](https://github.com/user-attachments/assets/781d706a-0f44-4b6c-a11f-573f04e691fe)
