### PR TITLE
fix: Destruct isDirty directly from formstate object

### DIFF
--- a/src/pages/AccountSettings/tabs/OktaAccess/OktaConfigForm/OktaConfigForm.tsx
+++ b/src/pages/AccountSettings/tabs/OktaAccess/OktaConfigForm/OktaConfigForm.tsx
@@ -92,13 +92,13 @@ export function OktaConfigForm() {
                 Client ID
               </label>
               <TextInput
+                defaultValue={oktaConfig?.clientId}
                 {...register('clientId', {
                   required: true,
                 })}
                 type="text"
                 id="clientId"
                 placeholder="Enter Client ID"
-                defaultValue={oktaConfig?.clientId}
               />
               {formState.errors.clientId ? (
                 <p className="mt-1 text-codecov-red">
@@ -112,11 +112,11 @@ export function OktaConfigForm() {
               </label>
               <div className="relative">
                 <TextInput
+                  defaultValue={oktaConfig?.clientSecret}
                   {...register('clientSecret', { required: true })}
                   type={showPassword ? 'text' : 'password'}
                   id="clientSecret"
                   placeholder="Enter Client Secret"
-                  defaultValue={oktaConfig?.clientSecret}
                 />
                 <button
                   type="button"
@@ -141,11 +141,11 @@ export function OktaConfigForm() {
                 Redirect URI
               </label>
               <TextInput
+                defaultValue={oktaConfig?.url}
                 {...register('redirectUri', { required: true })}
                 type="text"
                 id="redirectUri"
                 placeholder="Enter Redirect URI"
-                defaultValue={oktaConfig?.url}
               />
               {formState.errors.redirectUri ? (
                 <p className="mt-1 text-codecov-red">

--- a/src/pages/AccountSettings/tabs/OktaAccess/OktaConfigForm/OktaConfigForm.tsx
+++ b/src/pages/AccountSettings/tabs/OktaAccess/OktaConfigForm/OktaConfigForm.tsx
@@ -27,17 +27,23 @@ interface URLParams {
 }
 
 export function OktaConfigForm() {
-  const { register, handleSubmit, formState, reset } = useForm<FormValues>({
-    resolver: zodResolver(FormSchema),
-    mode: 'onChange',
-  })
-
   const { provider, owner } = useParams<URLParams>()
 
   const { data } = useOktaConfig({
     provider,
     username: owner,
   })
+
+  const { register, handleSubmit, formState, reset } = useForm<FormValues>({
+    resolver: zodResolver(FormSchema),
+    mode: 'onSubmit',
+    defaultValues: {
+      clientId: data?.owner?.account?.oktaConfig?.clientId,
+      clientSecret: data?.owner?.account?.oktaConfig?.clientSecret,
+      redirectUri: data?.owner?.account?.oktaConfig?.url,
+    },
+  })
+  const { isDirty, isValid } = formState
   const oktaConfig = data?.owner?.account?.oktaConfig
   const { mutate } = useUpdateOktaConfig({ provider, owner })
 
@@ -86,7 +92,6 @@ export function OktaConfigForm() {
                 Client ID
               </label>
               <TextInput
-                defaultValue={oktaConfig?.clientId}
                 {...register('clientId', {
                   required: true,
                 })}
@@ -106,7 +111,6 @@ export function OktaConfigForm() {
               </label>
               <div className="relative">
                 <TextInput
-                  defaultValue={oktaConfig?.clientSecret}
                   {...register('clientSecret', { required: true })}
                   type={showPassword ? 'text' : 'password'}
                   id="clientSecret"
@@ -135,7 +139,6 @@ export function OktaConfigForm() {
                 Redirect URI
               </label>
               <TextInput
-                defaultValue={oktaConfig?.url}
                 {...register('redirectUri', { required: true })}
                 type="text"
                 id="redirectUri"
@@ -150,9 +153,7 @@ export function OktaConfigForm() {
             <div>
               <Button
                 type="submit"
-                disabled={
-                  !formState.isValid || !formState.isDirty || isSubmitting
-                }
+                disabled={!isValid || !isDirty || isSubmitting}
                 to={undefined}
                 hook="save okta form changes"
               >

--- a/src/pages/AccountSettings/tabs/OktaAccess/OktaConfigForm/OktaConfigForm.tsx
+++ b/src/pages/AccountSettings/tabs/OktaAccess/OktaConfigForm/OktaConfigForm.tsx
@@ -36,7 +36,7 @@ export function OktaConfigForm() {
 
   const { register, handleSubmit, formState, reset } = useForm<FormValues>({
     resolver: zodResolver(FormSchema),
-    mode: 'onSubmit',
+    mode: 'onChange',
     defaultValues: {
       clientId: data?.owner?.account?.oktaConfig?.clientId,
       clientSecret: data?.owner?.account?.oktaConfig?.clientSecret,
@@ -98,6 +98,7 @@ export function OktaConfigForm() {
                 type="text"
                 id="clientId"
                 placeholder="Enter Client ID"
+                defaultValue={oktaConfig?.clientId}
               />
               {formState.errors.clientId ? (
                 <p className="mt-1 text-codecov-red">
@@ -115,6 +116,7 @@ export function OktaConfigForm() {
                   type={showPassword ? 'text' : 'password'}
                   id="clientSecret"
                   placeholder="Enter Client Secret"
+                  defaultValue={oktaConfig?.clientSecret}
                 />
                 <button
                   type="button"
@@ -143,6 +145,7 @@ export function OktaConfigForm() {
                 type="text"
                 id="redirectUri"
                 placeholder="Enter Redirect URI"
+                defaultValue={oktaConfig?.url}
               />
               {formState.errors.redirectUri ? (
                 <p className="mt-1 text-codecov-red">

--- a/src/pages/AccountSettings/tabs/OktaAccess/OktaConfigForm/OktaConfigForm.tsx
+++ b/src/pages/AccountSettings/tabs/OktaAccess/OktaConfigForm/OktaConfigForm.tsx
@@ -33,18 +33,18 @@ export function OktaConfigForm() {
     provider,
     username: owner,
   })
+  const oktaConfig = data?.owner?.account?.oktaConfig
 
   const { register, handleSubmit, formState, reset } = useForm<FormValues>({
     resolver: zodResolver(FormSchema),
     mode: 'onChange',
     defaultValues: {
-      clientId: data?.owner?.account?.oktaConfig?.clientId,
-      clientSecret: data?.owner?.account?.oktaConfig?.clientSecret,
-      redirectUri: data?.owner?.account?.oktaConfig?.url,
+      clientId: oktaConfig?.clientId,
+      clientSecret: oktaConfig?.clientSecret,
+      redirectUri: oktaConfig?.url,
     },
   })
   const { isDirty, isValid } = formState
-  const oktaConfig = data?.owner?.account?.oktaConfig
   const { mutate } = useUpdateOktaConfig({ provider, owner })
 
   const [oktaEnabled, setOktaEnabled] = useState(oktaConfig?.enabled)


### PR DESCRIPTION
# Description
According to https://react-hook-form.com/docs/useform/formstate:

> // ❌ formState.isValid is accessed conditionally, 
> // so the Proxy does not subscribe to changes of that state
> return <button disabled={!formState.isDirty || !formState.isValid} />;
>   
> // ✅ read all formState values to subscribe to changes
> const { isDirty, isValid } = formState;
> return <button disabled={!isDirty || !isValid} />;

This is fixing the following issue:

https://github.com/user-attachments/assets/1c2b366b-1465-47c0-8cf3-d9647256f3c5


Now its:

https://github.com/user-attachments/assets/06ed06c4-69b8-4822-8a8e-bb54df8da1ba


<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.