### PR TITLE
fix: Clean up okta feature flag

### DIFF
--- a/src/pages/AccountSettings/AccountSettings.jsx
+++ b/src/pages/AccountSettings/AccountSettings.jsx
@@ -8,7 +8,6 @@ import { SentryRoute } from 'sentry'
 import SidebarLayout from 'layouts/SidebarLayout'
 import { usePlanData } from 'services/account'
 import { useIsCurrentUserAnAdmin, useUser } from 'services/user'
-import { useFlags } from 'shared/featureFlags'
 import { isEnterprisePlan } from 'shared/utils/billing'
 import LoadingLogo from 'ui/LoadingLogo'
 
@@ -35,10 +34,7 @@ function AccountSettings() {
   const { data: currentUser } = useUser()
 
   const { data } = usePlanData({ provider, owner })
-  const { oktaSettings } = useFlags({
-    oktaSettings: false,
-  })
-  const viewOktaAccess = oktaSettings && isEnterprisePlan(data?.plan?.value)
+  const viewOktaAccess = isEnterprisePlan(data?.plan?.value)
 
   const isViewingPersonalSettings =
     currentUser?.user?.username?.toLowerCase() === owner?.toLowerCase()

--- a/src/pages/AccountSettings/AccountSettings.spec.jsx
+++ b/src/pages/AccountSettings/AccountSettings.spec.jsx
@@ -7,12 +7,9 @@ import { MemoryRouter, Route } from 'react-router-dom'
 
 import config from 'config'
 
-import { useFlags } from 'shared/featureFlags'
-
 import AccountSettings from './AccountSettings'
 
 jest.mock('config')
-jest.mock('shared/featureFlags')
 
 jest.mock('./shared/Header', () => () => 'Header')
 jest.mock('./AccountSettingsSideMenu', () => () => 'AccountSettingsSideMenu')
@@ -143,7 +140,6 @@ describe('AccountSettings', () => {
   ) {
     config.IS_SELF_HOSTED = isSelfHosted
     config.HIDE_ACCESS_TAB = hideAccessTab
-    useFlags.mockReturnValue({ oktaSettings: true })
 
     server.use(
       graphql.query('CurrentUser', (req, res, ctx) => {

--- a/src/pages/AccountSettings/AccountSettingsSideMenu.jsx
+++ b/src/pages/AccountSettings/AccountSettingsSideMenu.jsx
@@ -4,7 +4,6 @@ import config from 'config'
 
 import { usePlanData } from 'services/account'
 import { useIsCurrentUserAnAdmin, useUser } from 'services/user'
-import { useFlags } from 'shared/featureFlags'
 import { isEnterprisePlan } from 'shared/utils/billing'
 import Sidemenu from 'ui/Sidemenu'
 
@@ -67,10 +66,7 @@ function AccountSettingsSideMenu() {
     currentUser?.user?.username?.toLowerCase() === owner?.toLowerCase()
 
   const { data } = usePlanData({ provider, owner })
-  const { oktaSettings } = useFlags({
-    oktaSettings: false,
-  })
-  const viewOktaAccess = oktaSettings && isEnterprisePlan(data?.plan?.value)
+  const viewOktaAccess = isEnterprisePlan(data?.plan?.value)
 
   const links = generateLinks({
     isAdmin,

--- a/src/pages/AccountSettings/AccountSettingsSideMenu.spec.jsx
+++ b/src/pages/AccountSettings/AccountSettingsSideMenu.spec.jsx
@@ -7,12 +7,9 @@ import { MemoryRouter, Route } from 'react-router-dom'
 
 import config from 'config'
 
-import { useFlags } from 'shared/featureFlags'
-
 import AccountSettingsSideMenu from './AccountSettingsSideMenu'
 
 jest.mock('config')
-jest.mock('shared/featureFlags')
 
 const mockPlanData = {
   baseUnitPrice: 10,
@@ -132,7 +129,6 @@ describe('AccountSettingsSideMenu', () => {
   ) {
     config.IS_SELF_HOSTED = isSelfHosted
     config.HIDE_ACCESS_TAB = hideAccessTab
-    useFlags.mockReturnValue({ oktaSettings: true })
 
     server.use(
       graphql.query('CurrentUser', (req, res, ctx) => {

--- a/src/shared/GlobalTopBanners/OktaBanners/OktaBanners.spec.tsx
+++ b/src/shared/GlobalTopBanners/OktaBanners/OktaBanners.spec.tsx
@@ -5,17 +5,10 @@ import { setupServer } from 'msw/node'
 import { Suspense } from 'react'
 import { MemoryRouter, Route } from 'react-router-dom'
 
-import { useFlags } from 'shared/featureFlags'
-
 import OktaBanners from './OktaBanners'
 
 jest.mock('../OktaEnabledBanner', () => () => 'OktaEnabledBanner')
 jest.mock('../OktaEnforcedBanner', () => () => 'OktaEnforcedBanner')
-
-jest.mock('shared/featureFlags')
-const mockedUseFlags = useFlags as jest.Mock<{
-  oktaSettings: boolean
-}>
 
 const wrapper =
   (initialEntries = ['/gh/owner']): React.FC<React.PropsWithChildren> =>
@@ -43,10 +36,6 @@ afterAll(() => server.close())
 
 describe('OktaBanners', () => {
   function setup(data = {}) {
-    mockedUseFlags.mockReturnValue({
-      oktaSettings: true,
-    })
-
     server.use(
       graphql.query('GetOktaConfig', (req, res, ctx) =>
         res(ctx.status(200), ctx.data(data))

--- a/src/shared/GlobalTopBanners/OktaBanners/OktaBanners.tsx
+++ b/src/shared/GlobalTopBanners/OktaBanners/OktaBanners.tsx
@@ -2,7 +2,6 @@ import { lazy } from 'react'
 import { useParams } from 'react-router'
 
 import { useOktaConfig } from 'pages/AccountSettings/tabs/OktaAccess/hooks'
-import { useFlags } from 'shared/featureFlags'
 
 interface URLParams {
   provider: string
@@ -14,9 +13,6 @@ const OktaEnforcedBanner = lazy(() => import('../OktaEnforcedBanner'))
 
 function OktaBanners() {
   const { provider, owner } = useParams<URLParams>()
-  const { oktaSettings } = useFlags({
-    oktaSettings: false,
-  })
 
   const { data } = useOktaConfig({
     provider,
@@ -26,12 +22,7 @@ function OktaBanners() {
 
   const oktaConfig = data?.owner?.account?.oktaConfig
 
-  if (
-    !oktaSettings ||
-    !owner ||
-    !oktaConfig?.enabled ||
-    data?.owner?.isUserOktaAuthenticated
-  )
+  if (!owner || !oktaConfig?.enabled || data?.owner?.isUserOktaAuthenticated)
     return null
 
   return oktaConfig?.enforced ? <OktaEnforcedBanner /> : <OktaEnabledBanner />


### PR DESCRIPTION
# Description
Removing feature flag as it's fully released now.

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.