### PR TITLE
fix: Show enable button in components/flags for activated users only

### DIFF
--- a/src/pages/CommitDetailPage/CommitCoverage/CommitCoverage.spec.jsx
+++ b/src/pages/CommitDetailPage/CommitCoverage/CommitCoverage.spec.jsx
@@ -165,6 +165,7 @@ const mockErroredUploads = {
 
 const mockRepoSettingsTeamData = (isPrivate = false) => ({
   owner: {
+    isCurrentUserActivated: null,
     repository: {
       __typename: 'Repository',
       defaultBranch: 'master',

--- a/src/pages/CommitDetailPage/CommitCoverage/CommitCoverage.spec.jsx
+++ b/src/pages/CommitDetailPage/CommitCoverage/CommitCoverage.spec.jsx
@@ -165,7 +165,7 @@ const mockErroredUploads = {
 
 const mockRepoSettingsTeamData = (isPrivate = false) => ({
   owner: {
-    isCurrentUserActivated: null,
+    isCurrentUserPartOfOrg: null,
     repository: {
       __typename: 'Repository',
       defaultBranch: 'master',

--- a/src/pages/CommitDetailPage/CommitCoverage/CommitCoverageTabs/CommitCoverageTabs.spec.jsx
+++ b/src/pages/CommitDetailPage/CommitCoverage/CommitCoverageTabs/CommitCoverageTabs.spec.jsx
@@ -12,6 +12,7 @@ import CommitCoverageTabs from './CommitCoverageTabs'
 
 const mockRepoSettings = (isPrivate) => ({
   owner: {
+    isCurrentUserActivated: true,
     repository: {
       __typename: 'Repository',
       defaultBranch: 'main',

--- a/src/pages/CommitDetailPage/CommitCoverage/CommitCoverageTabs/CommitCoverageTabs.spec.jsx
+++ b/src/pages/CommitDetailPage/CommitCoverage/CommitCoverageTabs/CommitCoverageTabs.spec.jsx
@@ -12,7 +12,7 @@ import CommitCoverageTabs from './CommitCoverageTabs'
 
 const mockRepoSettings = (isPrivate) => ({
   owner: {
-    isCurrentUserActivated: true,
+    isCurrentUserPartOfOrg: true,
     repository: {
       __typename: 'Repository',
       defaultBranch: 'main',

--- a/src/pages/CommitDetailPage/CommitCoverage/routes/FilesChangedTab/FilesChangedTab.spec.tsx
+++ b/src/pages/CommitDetailPage/CommitCoverage/routes/FilesChangedTab/FilesChangedTab.spec.tsx
@@ -33,7 +33,7 @@ const mockProTier = {
 
 const mockRepoSettings = (isPrivate: boolean) => ({
   owner: {
-    isCurrentUserActivated: true,
+    isCurrentUserPartOfOrg: true,
     repository: {
       __typename: 'Repository',
       defaultBranch: 'master',

--- a/src/pages/CommitDetailPage/CommitCoverage/routes/FilesChangedTab/FilesChangedTab.spec.tsx
+++ b/src/pages/CommitDetailPage/CommitCoverage/routes/FilesChangedTab/FilesChangedTab.spec.tsx
@@ -33,6 +33,7 @@ const mockProTier = {
 
 const mockRepoSettings = (isPrivate: boolean) => ({
   owner: {
+    isCurrentUserActivated: true,
     repository: {
       __typename: 'Repository',
       defaultBranch: 'master',

--- a/src/pages/CommitDetailPage/Header/Header.spec.tsx
+++ b/src/pages/CommitDetailPage/Header/Header.spec.tsx
@@ -17,7 +17,7 @@ const mockedUseFlags = useFlags as jest.Mock<{ multipleTiers: boolean }>
 
 const mockRepoSettings = (isPrivate = false) => ({
   owner: {
-    isCurrentUserActivated: true,
+    isCurrentUserPartOfOrg: true,
     repository: {
       __typename: 'Repository',
       defaultBranch: 'master',

--- a/src/pages/CommitDetailPage/Header/Header.spec.tsx
+++ b/src/pages/CommitDetailPage/Header/Header.spec.tsx
@@ -17,6 +17,7 @@ const mockedUseFlags = useFlags as jest.Mock<{ multipleTiers: boolean }>
 
 const mockRepoSettings = (isPrivate = false) => ({
   owner: {
+    isCurrentUserActivated: true,
     repository: {
       __typename: 'Repository',
       defaultBranch: 'master',

--- a/src/pages/PullRequestPage/Header/Header.spec.tsx
+++ b/src/pages/PullRequestPage/Header/Header.spec.tsx
@@ -17,7 +17,7 @@ const mockedUseFlags = useFlags as jest.Mock<{ multipleTiers: boolean }>
 
 const mockRepoSettings = (isPrivate = false) => ({
   owner: {
-    isCurrentUserActivated: true,
+    isCurrentUserPartOfOrg: true,
     repository: {
       __typename: 'Repository',
       defaultBranch: 'master',

--- a/src/pages/PullRequestPage/Header/Header.spec.tsx
+++ b/src/pages/PullRequestPage/Header/Header.spec.tsx
@@ -17,6 +17,7 @@ const mockedUseFlags = useFlags as jest.Mock<{ multipleTiers: boolean }>
 
 const mockRepoSettings = (isPrivate = false) => ({
   owner: {
+    isCurrentUserActivated: true,
     repository: {
       __typename: 'Repository',
       defaultBranch: 'master',

--- a/src/pages/PullRequestPage/PullCoverage/Summary/Summary.spec.tsx
+++ b/src/pages/PullRequestPage/PullCoverage/Summary/Summary.spec.tsx
@@ -81,7 +81,7 @@ describe('Summary', () => {
           ctx.status(200),
           ctx.data({
             owner: {
-              isCurrentUserActivated: true,
+              isCurrentUserPartOfOrg: true,
               repository: {
                 __typename: 'Repository',
                 defaultBranch: 'master',

--- a/src/pages/PullRequestPage/PullCoverage/Summary/Summary.spec.tsx
+++ b/src/pages/PullRequestPage/PullCoverage/Summary/Summary.spec.tsx
@@ -81,6 +81,7 @@ describe('Summary', () => {
           ctx.status(200),
           ctx.data({
             owner: {
+              isCurrentUserActivated: true,
               repository: {
                 __typename: 'Repository',
                 defaultBranch: 'master',

--- a/src/pages/PullRequestPage/PullCoverage/routes/FileExplorer/FileExplorer.spec.tsx
+++ b/src/pages/PullRequestPage/PullCoverage/routes/FileExplorer/FileExplorer.spec.tsx
@@ -159,6 +159,7 @@ const mockTreeData = {
 
 const mockRepoSettings = {
   owner: {
+    isCurrentUserActivated: true,
     repository: {
       __typename: 'Repository',
       activated: true,

--- a/src/pages/PullRequestPage/PullCoverage/routes/FileExplorer/FileExplorer.spec.tsx
+++ b/src/pages/PullRequestPage/PullCoverage/routes/FileExplorer/FileExplorer.spec.tsx
@@ -159,7 +159,7 @@ const mockTreeData = {
 
 const mockRepoSettings = {
   owner: {
-    isCurrentUserActivated: true,
+    isCurrentUserPartOfOrg: true,
     repository: {
       __typename: 'Repository',
       activated: true,

--- a/src/pages/PullRequestPage/PullCoverage/routes/FilesChangedTab/FilesChangedTab.spec.tsx
+++ b/src/pages/PullRequestPage/PullCoverage/routes/FilesChangedTab/FilesChangedTab.spec.tsx
@@ -128,7 +128,7 @@ describe('FilesChangedTab', () => {
           ctx.status(200),
           ctx.data({
             owner: {
-              isCurrentUserActivated: true,
+              isCurrentUserPartOfOrg: true,
               repository: {
                 __typename: 'Repository',
                 activated: true,

--- a/src/pages/PullRequestPage/PullCoverage/routes/FilesChangedTab/FilesChangedTab.spec.tsx
+++ b/src/pages/PullRequestPage/PullCoverage/routes/FilesChangedTab/FilesChangedTab.spec.tsx
@@ -128,6 +128,7 @@ describe('FilesChangedTab', () => {
           ctx.status(200),
           ctx.data({
             owner: {
+              isCurrentUserActivated: true,
               repository: {
                 __typename: 'Repository',
                 activated: true,

--- a/src/pages/RepoPage/CommitsTab/CommitsTab.spec.jsx
+++ b/src/pages/RepoPage/CommitsTab/CommitsTab.spec.jsx
@@ -137,7 +137,7 @@ const mockBranch = (branchName) => ({
 
 const mockRepoSettings = (isPrivate = false) => ({
   owner: {
-    isCurrentUserActivated: true,
+    isCurrentUserPartOfOrg: true,
     repository: {
       __typename: 'Repository',
       activated: true,

--- a/src/pages/RepoPage/CommitsTab/CommitsTab.spec.jsx
+++ b/src/pages/RepoPage/CommitsTab/CommitsTab.spec.jsx
@@ -137,6 +137,7 @@ const mockBranch = (branchName) => ({
 
 const mockRepoSettings = (isPrivate = false) => ({
   owner: {
+    isCurrentUserActivated: true,
     repository: {
       __typename: 'Repository',
       activated: true,

--- a/src/pages/RepoPage/ConfigTab/tabs/GeneralTab/Tokens/TokensTeam/TokensTeam.spec.js
+++ b/src/pages/RepoPage/ConfigTab/tabs/GeneralTab/Tokens/TokensTeam/TokensTeam.spec.js
@@ -37,6 +37,7 @@ describe('TokensTeam', () => {
           ctx.status(200),
           ctx.data({
             owner: {
+              isCurrentUserActivated: true,
               repository: {
                 __typename: 'Repository',
                 activated: true,

--- a/src/pages/RepoPage/ConfigTab/tabs/GeneralTab/Tokens/TokensTeam/TokensTeam.spec.js
+++ b/src/pages/RepoPage/ConfigTab/tabs/GeneralTab/Tokens/TokensTeam/TokensTeam.spec.js
@@ -37,7 +37,7 @@ describe('TokensTeam', () => {
           ctx.status(200),
           ctx.data({
             owner: {
-              isCurrentUserActivated: true,
+              isCurrentUserPartOfOrg: true,
               repository: {
                 __typename: 'Repository',
                 activated: true,

--- a/src/pages/RepoPage/CoverageTab/ComponentsTab/ComponentsTab.spec.tsx
+++ b/src/pages/RepoPage/CoverageTab/ComponentsTab/ComponentsTab.spec.tsx
@@ -30,6 +30,7 @@ jest.mock('./Header', () => ({ children }: { children: React.ReactNode }) => (
 
 const mockRepoSettings = (isPrivate = false) => ({
   owner: {
+    isCurrentUserActivated: true,
     repository: {
       __typename: 'Repository',
       activated: true,

--- a/src/pages/RepoPage/CoverageTab/ComponentsTab/ComponentsTab.spec.tsx
+++ b/src/pages/RepoPage/CoverageTab/ComponentsTab/ComponentsTab.spec.tsx
@@ -30,10 +30,10 @@ jest.mock('./Header', () => ({ children }: { children: React.ReactNode }) => (
 
 const mockRepoSettings = (
   isPrivate = false,
-  isCurrentUserActivated = true
+  isCurrentUserPartOfOrg = true
 ) => ({
   owner: {
-    isCurrentUserActivated,
+    isCurrentUserPartOfOrg,
     repository: {
       __typename: 'Repository',
       activated: true,
@@ -158,13 +158,13 @@ describe('Components Tab', () => {
     flags = [nextPageFlagData, initialFlagData],
     tierValue = TierNames.PRO,
     isPrivate = false,
-    isCurrentUserActivated = true,
+    isCurrentUserPartOfOrg = true,
   }: {
     data?: object
     flags?: any[]
     tierValue?: TTierNames
     isPrivate?: boolean
-    isCurrentUserActivated?: boolean
+    isCurrentUserPartOfOrg?: boolean
   }) {
     server.use(
       graphql.query('OwnerTier', (req, res, ctx) => {
@@ -182,7 +182,7 @@ describe('Components Tab', () => {
       graphql.query('GetRepoSettingsTeam', (req, res, ctx) => {
         return res(
           ctx.status(200),
-          ctx.data(mockRepoSettings(isPrivate, isCurrentUserActivated))
+          ctx.data(mockRepoSettings(isPrivate, isCurrentUserPartOfOrg))
         )
       }),
       graphql.query('BackfillComponentMemberships', (req, res, ctx) =>
@@ -338,7 +338,7 @@ describe('Components Tab', () => {
     })
   })
 
-  describe('when current user is not activated and data is not enabled', () => {
+  describe('when current user is not part of org and data is not enabled', () => {
     beforeEach(() => {
       setup({
         data: {
@@ -353,13 +353,15 @@ describe('Components Tab', () => {
             },
           },
         },
-        isCurrentUserActivated: false,
+        isCurrentUserPartOfOrg: false,
       })
     })
 
     it('renders empty state message', async () => {
       render(<ComponentsTab />, { wrapper })
-      const componentsText = await screen.findByText(/No data to display/)
+      const componentsText = await screen.findByText(
+        /Component analytics is disabled./
+      )
       expect(componentsText).toBeInTheDocument()
     })
   })

--- a/src/pages/RepoPage/CoverageTab/ComponentsTab/ComponentsTab.spec.tsx
+++ b/src/pages/RepoPage/CoverageTab/ComponentsTab/ComponentsTab.spec.tsx
@@ -28,9 +28,12 @@ jest.mock('./Header', () => ({ children }: { children: React.ReactNode }) => (
   <p>Components Header Component {children}</p>
 ))
 
-const mockRepoSettings = (isPrivate = false) => ({
+const mockRepoSettings = (
+  isPrivate = false,
+  isCurrentUserActivated = true
+) => ({
   owner: {
-    isCurrentUserActivated: true,
+    isCurrentUserActivated,
     repository: {
       __typename: 'Repository',
       activated: true,
@@ -155,11 +158,13 @@ describe('Components Tab', () => {
     flags = [nextPageFlagData, initialFlagData],
     tierValue = TierNames.PRO,
     isPrivate = false,
+    isCurrentUserActivated = true,
   }: {
     data?: object
     flags?: any[]
     tierValue?: TTierNames
     isPrivate?: boolean
+    isCurrentUserActivated?: boolean
   }) {
     server.use(
       graphql.query('OwnerTier', (req, res, ctx) => {
@@ -175,7 +180,10 @@ describe('Components Tab', () => {
         )
       }),
       graphql.query('GetRepoSettingsTeam', (req, res, ctx) => {
-        return res(ctx.status(200), ctx.data(mockRepoSettings(isPrivate)))
+        return res(
+          ctx.status(200),
+          ctx.data(mockRepoSettings(isPrivate, isCurrentUserActivated))
+        )
       }),
       graphql.query('BackfillComponentMemberships', (req, res, ctx) =>
         res(ctx.status(200), ctx.data(data))
@@ -327,6 +335,32 @@ describe('Components Tab', () => {
         /enable components in your infrastructure today/
       )
       expect(enableText).toBeInTheDocument()
+    })
+  })
+
+  describe('when current user is not activated and data is not enabled', () => {
+    beforeEach(() => {
+      setup({
+        data: {
+          config: {
+            isTimescaleEnabled: true,
+          },
+          owner: {
+            repository: {
+              __typename: 'Repository',
+              componentsMeasurementsActive: false,
+              componentsMeasurementsBackfilled: false,
+            },
+          },
+        },
+        isCurrentUserActivated: false,
+      })
+    })
+
+    it('renders empty state message', async () => {
+      render(<ComponentsTab />, { wrapper })
+      const componentsText = await screen.findByText(/No data to display/)
+      expect(componentsText).toBeInTheDocument()
     })
   })
 })

--- a/src/pages/RepoPage/CoverageTab/ComponentsTab/ComponentsTab.tsx
+++ b/src/pages/RepoPage/CoverageTab/ComponentsTab/ComponentsTab.tsx
@@ -66,12 +66,12 @@ function ComponentsTab() {
           })
         }
       >
-        {repoSettings?.isCurrentUserActivated ? (
+        {repoSettings?.isCurrentUserPartOfOrg ? (
           <BackfillBanners />
         ) : (
           <div className="mt-3 text-center">
             <hr />
-            <p className="mt-4 p-3">No data to display</p>
+            <p className="mt-4 p-3">Component analytics is disabled.</p>
           </div>
         )}
       </Header>

--- a/src/pages/RepoPage/CoverageTab/ComponentsTab/ComponentsTab.tsx
+++ b/src/pages/RepoPage/CoverageTab/ComponentsTab/ComponentsTab.tsx
@@ -69,9 +69,9 @@ function ComponentsTab() {
         {repoSettings?.isCurrentUserActivated ? (
           <BackfillBanners />
         ) : (
-          <div className="mt-3">
+          <div className="mt-3 text-center">
             <hr />
-            <p className="p-3">No data to display</p>
+            <p className="mt-4 p-3">No data to display</p>
           </div>
         )}
       </Header>

--- a/src/pages/RepoPage/CoverageTab/ComponentsTab/ComponentsTab.tsx
+++ b/src/pages/RepoPage/CoverageTab/ComponentsTab/ComponentsTab.tsx
@@ -66,7 +66,14 @@ function ComponentsTab() {
           })
         }
       >
-        <BackfillBanners />
+        {repoSettings?.isCurrentUserActivated ? (
+          <BackfillBanners />
+        ) : (
+          <div className="mt-3">
+            <hr />
+            <p className="p-3">No data to display</p>
+          </div>
+        )}
       </Header>
       <div className="flex flex-1 flex-col gap-4">
         {showComponentsTable({

--- a/src/pages/RepoPage/CoverageTab/CoverageTab.spec.tsx
+++ b/src/pages/RepoPage/CoverageTab/CoverageTab.spec.tsx
@@ -12,7 +12,7 @@ import CoverageTab from './CoverageTab'
 
 const mockRepoSettingsTeam = {
   owner: {
-    isCurrentUserActivated: true,
+    isCurrentUserPartOfOrg: true,
     repository: {
       __typename: 'Repository',
       defaultBranch: 'master',

--- a/src/pages/RepoPage/CoverageTab/CoverageTab.spec.tsx
+++ b/src/pages/RepoPage/CoverageTab/CoverageTab.spec.tsx
@@ -12,6 +12,7 @@ import CoverageTab from './CoverageTab'
 
 const mockRepoSettingsTeam = {
   owner: {
+    isCurrentUserActivated: true,
     repository: {
       __typename: 'Repository',
       defaultBranch: 'master',

--- a/src/pages/RepoPage/CoverageTab/FlagsTab/FlagsTab.jsx
+++ b/src/pages/RepoPage/CoverageTab/FlagsTab/FlagsTab.jsx
@@ -61,12 +61,12 @@ function FlagsTab() {
           isRepoBackfilling,
         })}
       >
-        {repoSettings?.isCurrentUserActivated ? (
+        {repoSettings?.isCurrentUserPartOfOrg ? (
           <BackfillBanners />
         ) : (
           <div className="mt-3 text-center">
             <hr />
-            <p className="mt-4 p-3">No data to display</p>
+            <p className="mt-4 p-3">Flag analytics is disabled.</p>
           </div>
         )}
       </Header>

--- a/src/pages/RepoPage/CoverageTab/FlagsTab/FlagsTab.jsx
+++ b/src/pages/RepoPage/CoverageTab/FlagsTab/FlagsTab.jsx
@@ -61,7 +61,14 @@ function FlagsTab() {
           isRepoBackfilling,
         })}
       >
-        <BackfillBanners />
+        {repoSettings?.isCurrentUserActivated ? (
+          <BackfillBanners />
+        ) : (
+          <div className="mt-3 text-center">
+            <hr />
+            <p className="mt-4 p-3">No data to display</p>
+          </div>
+        )}
       </Header>
       <div className="flex flex-1 flex-col gap-4">
         {showFlagsTable({

--- a/src/pages/RepoPage/CoverageTab/FlagsTab/FlagsTab.spec.jsx
+++ b/src/pages/RepoPage/CoverageTab/FlagsTab/FlagsTab.spec.jsx
@@ -38,10 +38,10 @@ const flagsData = [
 
 const mockRepoSettings = (
   isPrivate = false,
-  isCurrentUserActivated = true
+  isCurrentUserPartOfOrg = true
 ) => ({
   owner: {
-    isCurrentUserActivated,
+    isCurrentUserPartOfOrg,
     repository: {
       __typename: 'Repository',
       activated: true,
@@ -98,7 +98,7 @@ describe('Flags Tab', () => {
     flags = flagsData,
     tierValue = TierNames.PRO,
     isPrivate = false,
-    isCurrentUserActivated = true,
+    isCurrentUserPartOfOrg = true,
   }) {
     useRepoFlagsSelect.mockReturnValue({ data: flags })
     useRepoBackfilled.mockReturnValue(data)
@@ -119,7 +119,7 @@ describe('Flags Tab', () => {
       graphql.query('GetRepoSettingsTeam', (req, res, ctx) => {
         return res(
           ctx.status(200),
-          ctx.data(mockRepoSettings(isPrivate, isCurrentUserActivated))
+          ctx.data(mockRepoSettings(isPrivate, isCurrentUserPartOfOrg))
         )
       })
     )
@@ -330,7 +330,7 @@ describe('Flags Tab', () => {
     })
   })
 
-  describe('when current user is not activated and data is not enabled', () => {
+  describe('when current user is not part of org and data is not enabled', () => {
     beforeEach(() => {
       setup({
         data: {
@@ -348,13 +348,13 @@ describe('Flags Tab', () => {
             name: 'flag2',
           },
         ],
-        isCurrentUserActivated: false,
+        isCurrentUserPartOfOrg: false,
       })
     })
 
     it('renders empty state message', async () => {
       render(<FlagsTab />, { wrapper })
-      const flagsText = await screen.findByText(/No data to display/)
+      const flagsText = await screen.findByText(/Flag analytics is disabled./)
       expect(flagsText).toBeInTheDocument()
     })
   })

--- a/src/pages/RepoPage/CoverageTab/FlagsTab/FlagsTab.spec.jsx
+++ b/src/pages/RepoPage/CoverageTab/FlagsTab/FlagsTab.spec.jsx
@@ -36,9 +36,12 @@ const flagsData = [
   },
 ]
 
-const mockRepoSettings = (isPrivate = false) => ({
+const mockRepoSettings = (
+  isPrivate = false,
+  isCurrentUserActivated = true
+) => ({
   owner: {
-    isCurrentUserActivated: true,
+    isCurrentUserActivated,
     repository: {
       __typename: 'Repository',
       activated: true,
@@ -95,6 +98,7 @@ describe('Flags Tab', () => {
     flags = flagsData,
     tierValue = TierNames.PRO,
     isPrivate = false,
+    isCurrentUserActivated = true,
   }) {
     useRepoFlagsSelect.mockReturnValue({ data: flags })
     useRepoBackfilled.mockReturnValue(data)
@@ -113,7 +117,10 @@ describe('Flags Tab', () => {
         )
       }),
       graphql.query('GetRepoSettingsTeam', (req, res, ctx) => {
-        return res(ctx.status(200), ctx.data(mockRepoSettings(isPrivate)))
+        return res(
+          ctx.status(200),
+          ctx.data(mockRepoSettings(isPrivate, isCurrentUserActivated))
+        )
       })
     )
   }
@@ -320,6 +327,35 @@ describe('Flags Tab', () => {
         /enable flags in your infrastructure today/
       )
       expect(enableText).toBeInTheDocument()
+    })
+  })
+
+  describe('when current user is not activated and data is not enabled', () => {
+    beforeEach(() => {
+      setup({
+        data: {
+          data: {
+            flagsMeasurementsActive: true,
+            flagsMeasurementsBackfilled: true,
+            isTimescaleEnabled: true,
+          },
+        },
+        flags: [
+          {
+            name: 'flag1',
+          },
+          {
+            name: 'flag2',
+          },
+        ],
+        isCurrentUserActivated: false,
+      })
+    })
+
+    it('renders empty state message', async () => {
+      render(<FlagsTab />, { wrapper })
+      const flagsText = await screen.findByText(/No data to display/)
+      expect(flagsText).toBeInTheDocument()
     })
   })
 })

--- a/src/pages/RepoPage/CoverageTab/FlagsTab/FlagsTab.spec.jsx
+++ b/src/pages/RepoPage/CoverageTab/FlagsTab/FlagsTab.spec.jsx
@@ -38,6 +38,7 @@ const flagsData = [
 
 const mockRepoSettings = (isPrivate = false) => ({
   owner: {
+    isCurrentUserActivated: true,
     repository: {
       __typename: 'Repository',
       activated: true,

--- a/src/pages/RepoPage/CoverageTab/OverviewTab/OverviewTab.spec.tsx
+++ b/src/pages/RepoPage/CoverageTab/OverviewTab/OverviewTab.spec.tsx
@@ -19,7 +19,7 @@ jest.mock('./subroute/Fileviewer', () => () => 'FileViewer')
 
 const mockRepoSettings = (isPrivate = false) => ({
   owner: {
-    isCurrentUserActivated: true,
+    isCurrentUserPartOfOrg: true,
     repository: {
       defaultBranch: 'master',
       private: isPrivate,

--- a/src/pages/RepoPage/CoverageTab/OverviewTab/OverviewTab.spec.tsx
+++ b/src/pages/RepoPage/CoverageTab/OverviewTab/OverviewTab.spec.tsx
@@ -19,6 +19,7 @@ jest.mock('./subroute/Fileviewer', () => () => 'FileViewer')
 
 const mockRepoSettings = (isPrivate = false) => ({
   owner: {
+    isCurrentUserActivated: true,
     repository: {
       defaultBranch: 'master',
       private: isPrivate,

--- a/src/pages/RepoPage/CoverageTab/OverviewTab/subroute/FileExplorer/FlagMultiSelect.spec.jsx
+++ b/src/pages/RepoPage/CoverageTab/OverviewTab/subroute/FileExplorer/FlagMultiSelect.spec.jsx
@@ -14,6 +14,7 @@ jest.mock('react-use/lib/useIntersection')
 
 const mockRepoSettings = (isPrivate) => ({
   owner: {
+    isCurrentUserActivated: true,
     repository: {
       __typename: 'Repository',
       activated: true,

--- a/src/pages/RepoPage/CoverageTab/OverviewTab/subroute/FileExplorer/FlagMultiSelect.spec.jsx
+++ b/src/pages/RepoPage/CoverageTab/OverviewTab/subroute/FileExplorer/FlagMultiSelect.spec.jsx
@@ -14,7 +14,7 @@ jest.mock('react-use/lib/useIntersection')
 
 const mockRepoSettings = (isPrivate) => ({
   owner: {
-    isCurrentUserActivated: true,
+    isCurrentUserPartOfOrg: true,
     repository: {
       __typename: 'Repository',
       activated: true,

--- a/src/pages/RepoPage/CoverageTab/OverviewTab/subroute/Fileviewer/Fileviewer.spec.jsx
+++ b/src/pages/RepoPage/CoverageTab/OverviewTab/subroute/Fileviewer/Fileviewer.spec.jsx
@@ -13,7 +13,7 @@ jest.mock('ui/CodeRenderer/hooks/useScrollToLine')
 
 const mockRepoSettings = (isPrivate) => ({
   owner: {
-    isCurrentUserActivated: true,
+    isCurrentUserPartOfOrg: true,
     repository: {
       __typename: 'Repository',
       activated: true,

--- a/src/pages/RepoPage/CoverageTab/OverviewTab/subroute/Fileviewer/Fileviewer.spec.jsx
+++ b/src/pages/RepoPage/CoverageTab/OverviewTab/subroute/Fileviewer/Fileviewer.spec.jsx
@@ -13,6 +13,7 @@ jest.mock('ui/CodeRenderer/hooks/useScrollToLine')
 
 const mockRepoSettings = (isPrivate) => ({
   owner: {
+    isCurrentUserActivated: true,
     repository: {
       __typename: 'Repository',
       activated: true,

--- a/src/services/repo/useRepoSettingsTeam.spec.tsx
+++ b/src/services/repo/useRepoSettingsTeam.spec.tsx
@@ -31,7 +31,7 @@ afterAll(() => server.close())
 
 const mockNotFoundError = {
   owner: {
-    isCurrentUserActivated: null,
+    isCurrentUserPartOfOrg: null,
     repository: {
       __typename: 'NotFoundError',
       message: 'repo not found',
@@ -41,7 +41,7 @@ const mockNotFoundError = {
 
 const mockIncorrectResponse = {
   owner: {
-    isCurrentUserActivated: false,
+    isCurrentUserPartOfOrg: false,
     repository: {
       invalid: 'invalid',
     },
@@ -50,7 +50,7 @@ const mockIncorrectResponse = {
 
 const mockResponse = {
   owner: {
-    isCurrentUserActivated: true,
+    isCurrentUserPartOfOrg: true,
     repository: {
       __typename: 'Repository',
       defaultBranch: 'master',
@@ -100,7 +100,7 @@ describe('useRepoSettingsTeam', () => {
 
         await waitFor(() =>
           expect(result.current.data).toEqual({
-            isCurrentUserActivated: true,
+            isCurrentUserPartOfOrg: true,
             repository: {
               __typename: 'Repository',
               defaultBranch: 'master',

--- a/src/services/repo/useRepoSettingsTeam.tsx
+++ b/src/services/repo/useRepoSettingsTeam.tsx
@@ -32,7 +32,7 @@ interface FetchRepoSettingsTeamArgs {
 const RequestSchema = z.object({
   owner: z
     .object({
-      isCurrentUserActivated: z.boolean().nullable(),
+      isCurrentUserPartOfOrg: z.boolean().nullable(),
       repository: z
         .discriminatedUnion('__typename', [
           RepositorySchema,
@@ -46,7 +46,7 @@ const RequestSchema = z.object({
 const query = `
 query GetRepoSettingsTeam($name: String!, $repo: String!) {
   owner(username:$name) {
-    isCurrentUserActivated
+    isCurrentUserPartOfOrg
     repository(name:$repo) {
       __typename
       ... on Repository {
@@ -106,7 +106,7 @@ function fetchRepoSettingsDetails({
 
     return {
       repository,
-      isCurrentUserActivated: data?.owner?.isCurrentUserActivated,
+      isCurrentUserPartOfOrg: data?.owner?.isCurrentUserPartOfOrg,
     }
   })
 }

--- a/src/services/repo/useRepoSettingsTeam.tsx
+++ b/src/services/repo/useRepoSettingsTeam.tsx
@@ -4,10 +4,8 @@ import { z } from 'zod'
 
 import Api from 'shared/api'
 import { NetworkErrorObject } from 'shared/api/helpers'
-import A from 'ui/A'
 
 import { RepoNotFoundErrorSchema } from './schemas/RepoNotFoundError'
-import { RepoOwnerNotActivatedErrorSchema } from './schemas/RepoOwnerNotActivatedError'
 
 const RepositorySchema = z.object({
   __typename: z.literal('Repository'),
@@ -34,11 +32,11 @@ interface FetchRepoSettingsTeamArgs {
 const RequestSchema = z.object({
   owner: z
     .object({
+      isCurrentUserActivated: z.boolean().nullable(),
       repository: z
         .discriminatedUnion('__typename', [
           RepositorySchema,
           RepoNotFoundErrorSchema,
-          RepoOwnerNotActivatedErrorSchema,
         ])
         .nullable(),
     })
@@ -48,6 +46,7 @@ const RequestSchema = z.object({
 const query = `
 query GetRepoSettingsTeam($name: String!, $repo: String!) {
   owner(username:$name) {
+    isCurrentUserActivated
     repository(name:$repo) {
       __typename
       ... on Repository {
@@ -62,9 +61,6 @@ query GetRepoSettingsTeam($name: String!, $repo: String!) {
         }
       }
       ... on NotFoundError {
-        message
-      }
-      ... on OwnerNotActivatedError {
         message
       }
     }
@@ -106,27 +102,11 @@ function fetchRepoSettingsDetails({
       })
     }
 
-    if (data?.owner?.repository?.__typename === 'OwnerNotActivatedError') {
-      return Promise.reject({
-        status: 403,
-        data: {
-          detail: (
-            <p>
-              Activation is required to view this repo, please{' '}
-              {/* @ts-expect-error */}
-              <A to={{ pageName: 'membersTab' }}>click here </A> to activate
-              your account.
-            </p>
-          ),
-        },
-        dev: 'useRepoSettingsTeam - 403 owner not activated error',
-      })
-    }
-
     const repository = data.owner?.repository
 
     return {
       repository,
+      isCurrentUserActivated: data?.owner?.isCurrentUserActivated,
     }
   })
 }


### PR DESCRIPTION
# Description
We show `enable  anayltics` button for non logged in users, this fixes so that if current user is not part of org, we don't show the enabled button.

issue: https://github.com/codecov/feedback/issues/452

# Notable Changes
- Update to reflect is current user part of the org 
- Fix tests 

# Screenshots
<img width="1505" alt="Screenshot 2024-08-26 at 5 19 45 PM" src="https://github.com/user-attachments/assets/25ccc5c8-182d-46e3-852f-9731fb607eb4">
<img width="1505" alt="Screenshot 2024-08-26 at 5 19 39 PM" src="https://github.com/user-attachments/assets/1226446b-db34-422b-89a4-527fa0ebfab0">


<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.