### PR TITLE
Add type checking for codecov metrics

### DIFF
--- a/src/pages/DefaultOrgSelector/DefaultOrgSelector.jsx
+++ b/src/pages/DefaultOrgSelector/DefaultOrgSelector.jsx
@@ -9,7 +9,10 @@ import config from 'config'
 import { SentryBugReporter } from 'sentry'
 
 import { TrialStatuses, usePlanData } from 'services/account'
-import { useStoreCodecovEventMetric } from 'services/codecovEventMetrics'
+import {
+  EVENT_METRICS,
+  useStoreCodecovEventMetric,
+} from 'services/codecovEventMetrics'
 import { useUpdateDefaultOrganization } from 'services/defaultOrganization'
 import { useStaticNavLinks } from 'services/navigation'
 import { useStartTrial } from 'services/trial'
@@ -126,7 +129,7 @@ function DefaultOrgSelector() {
     updateDefaultOrg({ username: selectedOrg })
     storeEventMetric({
       owner: selectedOrg,
-      event: 'CLICKED_BUTTON',
+      event: EVENT_METRICS.CLICKED_BUTTON,
       jsonPayload: { action: 'Selected Default Org' },
     })
     if (

--- a/src/pages/RepoPage/BundlesTab/BundleOnboarding/BundleOnboarding.tsx
+++ b/src/pages/RepoPage/BundlesTab/BundleOnboarding/BundleOnboarding.tsx
@@ -4,7 +4,10 @@ import { Switch, useHistory, useLocation, useParams } from 'react-router-dom'
 import { SentryRoute } from 'sentry'
 
 import NotFound from 'pages/NotFound'
-import { useStoreCodecovEventMetric } from 'services/codecovEventMetrics'
+import {
+  EVENT_METRICS,
+  useStoreCodecovEventMetric,
+} from 'services/codecovEventMetrics'
 import { useNavLinks } from 'services/navigation'
 import { useRepo } from 'services/repo'
 import { useRedirect } from 'shared/useRedirect'
@@ -201,7 +204,7 @@ const BundleOnboarding: React.FC = () => {
   useEffect(() => {
     storeEventMetric({
       owner,
-      event: 'VISITED_PAGE',
+      event: EVENT_METRICS.VISITED_PAGE,
       jsonPayload: { page: 'Bundle Onboarding' },
     })
   }, [storeEventMetric, owner])

--- a/src/pages/RepoPage/CoverageOnboarding/CircleCI/CircleCI.tsx
+++ b/src/pages/RepoPage/CoverageOnboarding/CircleCI/CircleCI.tsx
@@ -1,6 +1,9 @@
 import { useParams } from 'react-router-dom'
 
-import { useStoreCodecovEventMetric } from 'services/codecovEventMetrics'
+import {
+  EVENT_METRICS,
+  useStoreCodecovEventMetric,
+} from 'services/codecovEventMetrics'
 import { useOrgUploadToken } from 'services/orgUploadToken'
 import { useRepo } from 'services/repo'
 import { useFlags } from 'shared/featureFlags'
@@ -100,7 +103,7 @@ function Step1({ tokenCopy, uploadToken, providerName }: Step1Props) {
             clipboardOnClick={() =>
               storeEventMetric({
                 owner,
-                event: 'COPIED_TEXT',
+                event: EVENT_METRICS.COPIED_TEXT,
                 jsonPayload: { text: 'Step 1 CircleCI' },
               })
             }
@@ -147,7 +150,7 @@ function Step2({ defaultBranch }: Step2Props) {
           clipboardOnClick={() =>
             storeEventMetric({
               owner,
-              event: 'COPIED_TEXT',
+              event: EVENT_METRICS.COPIED_TEXT,
               jsonPayload: { text: 'Step 2 CircleCI' },
             })
           }

--- a/src/pages/RepoPage/CoverageOnboarding/GitHubActions/GitHubActions.tsx
+++ b/src/pages/RepoPage/CoverageOnboarding/GitHubActions/GitHubActions.tsx
@@ -1,7 +1,10 @@
 import { useState } from 'react'
 import { useParams } from 'react-router-dom'
 
-import { useStoreCodecovEventMetric } from 'services/codecovEventMetrics'
+import {
+  EVENT_METRICS,
+  useStoreCodecovEventMetric,
+} from 'services/codecovEventMetrics'
 import { useOrgUploadToken } from 'services/orgUploadToken'
 import { useRepo } from 'services/repo'
 import { useFlags } from 'shared/featureFlags'
@@ -252,7 +255,7 @@ jobs:
                 clipboardOnClick={() =>
                   storeEventMetric({
                     owner,
-                    event: 'COPIED_TEXT',
+                    event: EVENT_METRICS.COPIED_TEXT,
                     jsonPayload: { text: `coverage GHA ${framework} install` },
                   })
                 }
@@ -268,7 +271,7 @@ jobs:
             clipboardOnClick={() =>
               storeEventMetric({
                 owner,
-                event: 'COPIED_TEXT',
+                event: EVENT_METRICS.COPIED_TEXT,
                 jsonPayload: { text: `coverage GHA ${framework} run` },
               })
             }
@@ -291,7 +294,7 @@ jobs:
             clipboardOnClick={() =>
               storeEventMetric({
                 owner,
-                event: 'COPIED_TEXT',
+                event: EVENT_METRICS.COPIED_TEXT,
                 jsonPayload: { text: `coverage GHA ${framework} action` },
               })
             }
@@ -355,7 +358,7 @@ function Step2({ tokenCopy, uploadToken }: Step2Props) {
             clipboardOnClick={() =>
               storeEventMetric({
                 owner,
-                event: 'COPIED_TEXT',
+                event: EVENT_METRICS.COPIED_TEXT,
                 jsonPayload: { text: 'Step 2 GHA' },
               })
             }

--- a/src/pages/RepoPage/CoverageOnboarding/NewRepoTab.tsx
+++ b/src/pages/RepoPage/CoverageOnboarding/NewRepoTab.tsx
@@ -4,7 +4,10 @@ import { Switch, useHistory, useLocation, useParams } from 'react-router-dom'
 import { SentryRoute } from 'sentry'
 
 import NotFound from 'pages/NotFound'
-import { useStoreCodecovEventMetric } from 'services/codecovEventMetrics'
+import {
+  EVENT_METRICS,
+  useStoreCodecovEventMetric,
+} from 'services/codecovEventMetrics'
 import { useNavLinks } from 'services/navigation'
 import { useRepo } from 'services/repo'
 import { useRedirect } from 'shared/useRedirect'
@@ -135,7 +138,7 @@ function NewRepoTab() {
   useEffect(() => {
     storeEventMetric({
       owner,
-      event: 'VISITED_PAGE',
+      event: EVENT_METRICS.VISITED_PAGE,
       jsonPayload: { page: 'Coverage Onboarding' },
     })
   }, [storeEventMetric, owner])

--- a/src/services/codecovEventMetrics/useStoreCodecovEventMetric.spec.tsx
+++ b/src/services/codecovEventMetrics/useStoreCodecovEventMetric.spec.tsx
@@ -4,7 +4,10 @@ import { graphql } from 'msw'
 import { setupServer } from 'msw/node'
 import { MemoryRouter, Route } from 'react-router-dom'
 
-import { useStoreCodecovEventMetric } from './useStoreCodecovEventMetric'
+import {
+  EVENT_METRICS,
+  useStoreCodecovEventMetric,
+} from './useStoreCodecovEventMetric'
 
 const server = setupServer()
 
@@ -69,7 +72,7 @@ describe('useStoreCodecovEventMetric', () => {
 
         result.current.mutate({
           owner: 'codecov',
-          event: 'CLICKED_BUTTON',
+          event: EVENT_METRICS.CLICKED_BUTTON,
           jsonPayload: {},
         })
 
@@ -90,7 +93,7 @@ describe('useStoreCodecovEventMetric', () => {
 
         result.current.mutate({
           owner: 'codecov',
-          event: 'CLICKED_BUTTON',
+          event: EVENT_METRICS.CLICKED_BUTTON,
           jsonPayload: {},
         })
 
@@ -114,7 +117,7 @@ describe('useStoreCodecovEventMetric', () => {
 
         const metric = {
           owner: 'codecov',
-          event: 'CLICKED_BUTTON',
+          event: EVENT_METRICS.CLICKED_BUTTON,
           jsonPayload: {},
         }
         mockGetItem.mockReturnValue(JSON.stringify(metric))
@@ -140,7 +143,7 @@ describe('useStoreCodecovEventMetric', () => {
 
         const newMetric = {
           owner: 'codecov',
-          event: 'NEW_EVENT',
+          event: EVENT_METRICS.CLICKED_BUTTON,
           jsonPayload: {},
         }
 
@@ -150,7 +153,7 @@ describe('useStoreCodecovEventMetric', () => {
         await waitFor(() => {
           const updatedMetrics = [
             ...mockMetrics.slice(1),
-            'codecov|NEW_EVENT|{}',
+            'codecov|CLICKED_BUTTON|{}',
           ]
           expect(mockSetItem).toHaveBeenCalledWith(
             'UserOnboardingMetricsStored',

--- a/src/services/codecovEventMetrics/useStoreCodecovEventMetric.tsx
+++ b/src/services/codecovEventMetrics/useStoreCodecovEventMetric.tsx
@@ -21,6 +21,17 @@ const mutationQuery = `
     }
   }
 `
+// Maintain parity with list of allowed metrics here
+// https://github.com/codecov/shared/blob/main/shared/django_apps/codecov_metrics/service/codecov_metrics.py
+export const EVENT_METRICS = {
+  VISITED_PAGE: 'VISITED_PAGE',
+  CLICKED_BUTTON: 'CLICKED_BUTTON',
+  COPIED_TEXT: 'COPIED_TEXT',
+  COMPLETED_UPLOAD: 'COMPLETED_UPLOAD',
+  INSTALLED_APP: 'INSTALLED_APP',
+} as const
+
+type EventMetric = (typeof EVENT_METRICS)[keyof typeof EVENT_METRICS]
 
 interface Params {
   provider: string
@@ -28,7 +39,7 @@ interface Params {
 
 interface StoreEventMetricMutationArgs {
   owner: string
-  event: string
+  event: EventMetric
   jsonPayload: object
 }
 
@@ -37,7 +48,7 @@ const MAX_ENTRIES = 30
 
 const generateMetricString = (
   owner: string,
-  event: string,
+  event: EventMetric,
   jsonPayload: string
 ) => {
   return `${owner}|${event}|${jsonPayload}`


### PR DESCRIPTION
# Description

This closes https://github.com/orgs/codecov/projects/31/views/11?pane=issue&itemId=68552864.

We already have some validation server side. This PR adds some TS checking so that we can receive type safe messaging earlier.


<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.