### PR TITLE
feat: Fire Pendo event on RepoPage for JS and TS users

### DIFF
--- a/src/App.spec.tsx
+++ b/src/App.spec.tsx
@@ -94,6 +94,21 @@ const user = {
   },
 }
 
+const mockRepoOverview = {
+  owner: {
+    repository: {
+      __typename: 'Repository',
+      private: false,
+      defaultBranch: 'main',
+      oldestCommitAt: '2022-10-10T11:59:59',
+      coverageEnabled: true,
+      bundleAnalysisEnabled: true,
+      testAnalyticsEnabled: true,
+      languages: ['JavaScript'],
+    },
+  },
+}
+
 const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
@@ -196,6 +211,9 @@ describe('App', () => {
       }),
       graphql.mutation('updateDefaultOrganization', (req, res, ctx) => {
         return res(ctx.status(200), ctx.data({}))
+      }),
+      graphql.query('GetRepoOverview', (req, res, ctx) => {
+        return res(ctx.status(200), ctx.data(mockRepoOverview))
       })
     )
   }

--- a/src/pages/RepoPage/RepoPage.spec.tsx
+++ b/src/pages/RepoPage/RepoPage.spec.tsx
@@ -85,6 +85,58 @@ const mockRepoOverview = ({
   }
 }
 
+const mockOwner = {
+  ownerid: 123,
+  username: 'test-owner',
+  avatarUrl: 'http://127.0.0.1/avatar-url',
+  isCurrentUserPartOfOrg: true,
+  isAdmin: true,
+}
+
+const mockUser = {
+  me: {
+    owner: {
+      defaultOrgUsername: 'codecov',
+    },
+    email: 'jane.doe@codecov.io',
+    privateAccess: true,
+    onboardingCompleted: true,
+    businessEmail: 'jane.doe@codecov.io',
+    termsAgreement: true,
+    user: {
+      name: 'Jane Doe',
+      username: 'janedoe',
+      avatarUrl: 'http://127.0.0.1/avatar-url',
+      avatar: 'http://127.0.0.1/avatar-url',
+      student: false,
+      studentCreatedAt: null,
+      studentUpdatedAt: null,
+      customerIntent: 'PERSONAL',
+    },
+    trackingMetadata: {
+      service: 'github',
+      ownerid: 123,
+      serviceId: '123',
+      plan: 'users-basic',
+      staff: false,
+      hasYaml: false,
+      bot: null,
+      delinquent: null,
+      didTrial: null,
+      planProvider: null,
+      planUserCount: 1,
+      createdAt: 'timestamp',
+      updatedAt: 'timestamp',
+      profile: {
+        createdAt: 'timestamp',
+        otherGoal: null,
+        typeProjects: [],
+        goals: [],
+      },
+    },
+  },
+}
+
 const server = setupServer()
 let testLocation: ReturnType<typeof useLocation>
 
@@ -245,6 +297,12 @@ describe('RepoPage', () => {
             })
           )
         )
+      }),
+      graphql.query('DetailOwner', (req, res, ctx) => {
+        return res(ctx.data({ owner: mockOwner }))
+      }),
+      graphql.query('CurrentUser', (req, res, ctx) => {
+        return res(ctx.status(200), ctx.data(mockUser))
       })
     )
 

--- a/src/pages/RepoPage/RepoPage.tsx
+++ b/src/pages/RepoPage/RepoPage.tsx
@@ -11,6 +11,7 @@ import LoadingLogo from 'ui/LoadingLogo'
 import ActivationAlert from './ActivationAlert'
 import { useCrumbs } from './context'
 import DeactivatedRepo from './DeactivatedRepo'
+import { useJSorTSPendoTracking } from './hooks/useJSorTSPendoTracking'
 import RepoPageTabs from './RepoPageTabs'
 
 const BundlesTab = lazy(() => import('./BundlesTab'))
@@ -251,6 +252,8 @@ function RepoPage() {
     },
   })
   const { setBaseCrumbs } = useCrumbs()
+
+  useJSorTSPendoTracking()
 
   useLayoutEffect(() => {
     setBaseCrumbs([

--- a/src/pages/RepoPage/hooks/useJSorTSPendoTracking.spec.tsx
+++ b/src/pages/RepoPage/hooks/useJSorTSPendoTracking.spec.tsx
@@ -156,8 +156,11 @@ describe('useJSorTSPendoTracking', () => {
     const updateOptionsMock = jest.fn()
     if (enablePendo) {
       window.pendo = {
+        initialize: jest.fn(),
         updateOptions: updateOptionsMock,
       }
+    } else {
+      window.pendo = {}
     }
 
     const user = userEvent.setup()
@@ -175,7 +178,6 @@ describe('useJSorTSPendoTracking', () => {
 
         renderHook(() => useJSorTSPendoTracking(), { wrapper })
 
-        await waitFor(() => expect(updateOptionsMock).toHaveBeenCalled())
         await waitFor(() =>
           expect(updateOptionsMock).toHaveBeenCalledWith({
             account: expect.objectContaining({

--- a/src/pages/RepoPage/hooks/useJSorTSPendoTracking.spec.tsx
+++ b/src/pages/RepoPage/hooks/useJSorTSPendoTracking.spec.tsx
@@ -175,6 +175,7 @@ describe('useJSorTSPendoTracking', () => {
 
         renderHook(() => useJSorTSPendoTracking(), { wrapper })
 
+        await waitFor(() => expect(updateOptionsMock).toHaveBeenCalled())
         await waitFor(() =>
           expect(updateOptionsMock).toHaveBeenCalledWith({
             account: expect.objectContaining({
@@ -201,6 +202,7 @@ describe('useJSorTSPendoTracking', () => {
         const link = screen.getByText('ClickMe')
         await user.click(link)
 
+        await waitFor(() => expect(updateOptionsMock).toHaveBeenCalled())
         await waitFor(() =>
           expect(updateOptionsMock).toHaveBeenCalledWith({
             account: expect.objectContaining({

--- a/src/pages/RepoPage/hooks/useJSorTSPendoTracking.spec.tsx
+++ b/src/pages/RepoPage/hooks/useJSorTSPendoTracking.spec.tsx
@@ -66,8 +66,8 @@ const mockOverview = (language?: string) => {
         oldestCommitAt: '2022-10-10T11:59:59',
         coverageEnabled: true,
         bundleAnalysisEnabled: true,
-        languages,
         testAnalyticsEnabled: true,
+        languages,
       },
     },
   }
@@ -128,7 +128,7 @@ interface SetupArgs {
 }
 
 describe('useJSorTSPendoTracking', () => {
-  function setup({ enablePendo = false, language }: SetupArgs) {
+  function setup({ enablePendo = false, language = 'javascript' }: SetupArgs) {
     server.use(
       graphql.query('CurrentUser', (req, res, ctx) => {
         return res(ctx.status(200), ctx.data(mockUser))

--- a/src/pages/RepoPage/hooks/useJSorTSPendoTracking.spec.tsx
+++ b/src/pages/RepoPage/hooks/useJSorTSPendoTracking.spec.tsx
@@ -59,6 +59,7 @@ const mockOverview = (language?: string) => {
 
   return {
     owner: {
+      isCurrentUserActivated: true,
       repository: {
         __typename: 'Repository',
         private: false,

--- a/src/pages/RepoPage/hooks/useJSorTSPendoTracking.spec.tsx
+++ b/src/pages/RepoPage/hooks/useJSorTSPendoTracking.spec.tsx
@@ -178,40 +178,13 @@ describe('useJSorTSPendoTracking', () => {
         await waitFor(() => expect(updateOptionsMock).toHaveBeenCalled())
         await waitFor(() =>
           expect(updateOptionsMock).toHaveBeenCalledWith({
-            account: {
+            account: expect.objectContaining({
               id: 123,
-              is_admin: true,
-              is_current_user_part_of_org: true,
               name: 'test-owner',
-            },
-            visitor: {
-              business_email: 'jane.doe@codecov.io',
-              created_at: 'timestamp',
-              default_org: null,
-              email: 'jane.doe@codecov.io',
-              full_name: 'janedoe',
-              guest: false,
-              id: 123,
+            }),
+            visitor: expect.objectContaining({
               js_or_ts_present: true,
-              onboarding_completed: true,
-              ownerid: 123,
-              plan: 'users-basic',
-              plan_user_count: 1,
-              profile: {
-                created_at: 'timestamp',
-                goals: [],
-                other_goal: null,
-                type_projects: [],
-              },
-              profile_created_at: 'timestamp',
-              profile_goals: [],
-              profile_other_goal: null,
-              profile_type_projects: [],
-              service: 'github',
-              staff: false,
-              updated_at: 'timestamp',
-              username: 'janedoe',
-            },
+            }),
           })
         )
       })
@@ -232,40 +205,13 @@ describe('useJSorTSPendoTracking', () => {
         await waitFor(() => expect(updateOptionsMock).toHaveBeenCalled())
         await waitFor(() =>
           expect(updateOptionsMock).toHaveBeenCalledWith({
-            account: {
+            account: expect.objectContaining({
               id: 456,
-              is_admin: true,
-              is_current_user_part_of_org: true,
               name: 'second-owner',
-            },
-            visitor: {
-              business_email: 'jane.doe@codecov.io',
-              created_at: 'timestamp',
-              default_org: null,
-              email: 'jane.doe@codecov.io',
-              full_name: 'janedoe',
-              guest: false,
-              id: 123,
+            }),
+            visitor: expect.objectContaining({
               js_or_ts_present: true,
-              onboarding_completed: true,
-              ownerid: 123,
-              plan: 'users-basic',
-              plan_user_count: 1,
-              profile: {
-                created_at: 'timestamp',
-                goals: [],
-                other_goal: null,
-                type_projects: [],
-              },
-              profile_created_at: 'timestamp',
-              profile_goals: [],
-              profile_other_goal: null,
-              profile_type_projects: [],
-              service: 'github',
-              staff: false,
-              updated_at: 'timestamp',
-              username: 'janedoe',
-            },
+            }),
           })
         )
       })

--- a/src/pages/RepoPage/hooks/useJSorTSPendoTracking.spec.tsx
+++ b/src/pages/RepoPage/hooks/useJSorTSPendoTracking.spec.tsx
@@ -1,0 +1,250 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { renderHook, screen, waitFor } from '@testing-library/react'
+import { userEvent } from '@testing-library/user-event'
+import { graphql } from 'msw'
+import { setupServer } from 'msw/node'
+import { Link, MemoryRouter, Route } from 'react-router-dom'
+
+import { useJSorTSPendoTracking } from './useJSorTSPendoTracking'
+
+const mockUser = {
+  me: {
+    owner: {
+      defaultOrgUsername: 'codecov',
+    },
+    email: 'jane.doe@codecov.io',
+    privateAccess: true,
+    onboardingCompleted: true,
+    businessEmail: 'jane.doe@codecov.io',
+    termsAgreement: true,
+    user: {
+      name: 'Jane Doe',
+      username: 'janedoe',
+      avatarUrl: 'http://127.0.0.1/avatar-url',
+      avatar: 'http://127.0.0.1/avatar-url',
+      student: false,
+      studentCreatedAt: null,
+      studentUpdatedAt: null,
+      customerIntent: 'PERSONAL',
+    },
+    trackingMetadata: {
+      service: 'github',
+      ownerid: 123,
+      serviceId: '123',
+      plan: 'users-basic',
+      staff: false,
+      hasYaml: false,
+      bot: null,
+      delinquent: null,
+      didTrial: null,
+      planProvider: null,
+      planUserCount: 1,
+      createdAt: 'timestamp',
+      updatedAt: 'timestamp',
+      profile: {
+        createdAt: 'timestamp',
+        otherGoal: null,
+        typeProjects: [],
+        goals: [],
+      },
+    },
+  },
+}
+
+const mockOverview = (language?: string) => {
+  let languages: string[] = []
+  if (language) {
+    languages = [language]
+  }
+
+  return {
+    owner: {
+      repository: {
+        __typename: 'Repository',
+        private: false,
+        defaultBranch: 'main',
+        oldestCommitAt: '2022-10-10T11:59:59',
+        coverageEnabled: true,
+        bundleAnalysisEnabled: true,
+        languages,
+        testAnalyticsEnabled: true,
+      },
+    },
+  }
+}
+
+const mockOwner1 = {
+  ownerid: 123,
+  username: 'test-owner',
+  avatarUrl: 'http://127.0.0.1/avatar-url',
+  isCurrentUserPartOfOrg: true,
+  isAdmin: true,
+}
+
+const mockOwner2 = {
+  ownerid: 456,
+  username: 'second-owner',
+  avatarUrl: 'http://127.0.0.1/avatar-url',
+  isCurrentUserPartOfOrg: true,
+  isAdmin: true,
+}
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      retry: false,
+    },
+  },
+})
+
+const wrapper: React.FC<React.PropsWithChildren> = ({ children }) => (
+  <QueryClientProvider client={queryClient}>
+    <MemoryRouter initialEntries={['/github/test-owner/test-repo']}>
+      <Route path="/:provider/:owner/:repo">
+        {children}
+        <Link to="/:provider/second-owner/second-repo">ClickMe</Link>
+      </Route>
+    </MemoryRouter>
+  </QueryClientProvider>
+)
+
+const server = setupServer()
+beforeAll(() => {
+  server.listen()
+})
+
+afterEach(() => {
+  queryClient.clear()
+  server.resetHandlers()
+})
+
+afterAll(() => {
+  server.close()
+})
+
+interface SetupArgs {
+  enablePendo?: boolean
+  language?: string
+}
+
+describe('useJSorTSPendoTracking', () => {
+  function setup({ enablePendo = false, language }: SetupArgs) {
+    server.use(
+      graphql.query('CurrentUser', (req, res, ctx) => {
+        return res(ctx.status(200), ctx.data(mockUser))
+      }),
+      graphql.query('GetRepoOverview', (req, res, ctx) => {
+        return res(ctx.status(200), ctx.data(mockOverview(language)))
+      }),
+      graphql.query('DetailOwner', (req, res, ctx) => {
+        if (req.variables.username === 'second-owner') {
+          return res(
+            ctx.data({
+              owner: mockOwner2,
+            })
+          )
+        }
+
+        return res(
+          ctx.data({
+            owner: mockOwner1,
+          })
+        )
+      })
+    )
+
+    const updateOptionsMock = jest.fn()
+    if (enablePendo) {
+      window.pendo = {
+        updateOptions: updateOptionsMock,
+      }
+    }
+
+    const user = userEvent.setup()
+
+    return { updateOptionsMock, user }
+  }
+
+  describe('js or ts is present', () => {
+    describe('first render', () => {
+      it('fires the event', async () => {
+        const { updateOptionsMock } = setup({
+          enablePendo: true,
+          language: 'javascript',
+        })
+
+        renderHook(() => useJSorTSPendoTracking(), { wrapper })
+
+        await waitFor(() =>
+          expect(updateOptionsMock).toHaveBeenCalledWith({
+            account: expect.objectContaining({
+              id: 123,
+              name: 'test-owner',
+            }),
+            visitor: expect.objectContaining({
+              js_or_ts_present: true,
+            }),
+          })
+        )
+      })
+    })
+
+    describe('owner has changed', () => {
+      it('fires the event a second time', async () => {
+        const { updateOptionsMock, user } = setup({
+          enablePendo: true,
+          language: 'javascript',
+        })
+
+        renderHook(() => useJSorTSPendoTracking(), { wrapper })
+
+        const link = screen.getByText('ClickMe')
+        await user.click(link)
+
+        await waitFor(() =>
+          expect(updateOptionsMock).toHaveBeenCalledWith({
+            account: expect.objectContaining({
+              id: 456,
+              name: 'second-owner',
+            }),
+            visitor: expect.objectContaining({
+              js_or_ts_present: true,
+            }),
+          })
+        )
+      })
+    })
+  })
+
+  describe('js or ts is not present', () => {
+    it('does not call pendo.updateOptions', async () => {
+      const { updateOptionsMock } = setup({
+        enablePendo: true,
+        language: 'python',
+      })
+
+      renderHook(() => useJSorTSPendoTracking(), { wrapper })
+
+      await waitFor(() => queryClient.isFetching)
+      await waitFor(() => !queryClient.isFetching)
+
+      await waitFor(() => expect(updateOptionsMock).not.toHaveBeenCalled())
+    })
+  })
+
+  describe('pendo is not present in the window', () => {
+    it('does not call pendo.updateOptions', async () => {
+      const { updateOptionsMock } = setup({
+        enablePendo: false,
+        language: 'javascript',
+      })
+
+      renderHook(() => useJSorTSPendoTracking(), { wrapper })
+
+      await waitFor(() => queryClient.isFetching)
+      await waitFor(() => !queryClient.isFetching)
+
+      await waitFor(() => expect(updateOptionsMock).not.toHaveBeenCalled())
+    })
+  })
+})

--- a/src/pages/RepoPage/hooks/useJSorTSPendoTracking.spec.tsx
+++ b/src/pages/RepoPage/hooks/useJSorTSPendoTracking.spec.tsx
@@ -178,13 +178,40 @@ describe('useJSorTSPendoTracking', () => {
         await waitFor(() => expect(updateOptionsMock).toHaveBeenCalled())
         await waitFor(() =>
           expect(updateOptionsMock).toHaveBeenCalledWith({
-            account: expect.objectContaining({
+            account: {
               id: 123,
+              is_admin: true,
+              is_current_user_part_of_org: true,
               name: 'test-owner',
-            }),
-            visitor: expect.objectContaining({
+            },
+            visitor: {
+              business_email: 'jane.doe@codecov.io',
+              created_at: 'timestamp',
+              default_org: null,
+              email: 'jane.doe@codecov.io',
+              full_name: 'janedoe',
+              guest: false,
+              id: 123,
               js_or_ts_present: true,
-            }),
+              onboarding_completed: true,
+              ownerid: 123,
+              plan: 'users-basic',
+              plan_user_count: 1,
+              profile: {
+                created_at: 'timestamp',
+                goals: [],
+                other_goal: null,
+                type_projects: [],
+              },
+              profile_created_at: 'timestamp',
+              profile_goals: [],
+              profile_other_goal: null,
+              profile_type_projects: [],
+              service: 'github',
+              staff: false,
+              updated_at: 'timestamp',
+              username: 'janedoe',
+            },
           })
         )
       })
@@ -205,13 +232,40 @@ describe('useJSorTSPendoTracking', () => {
         await waitFor(() => expect(updateOptionsMock).toHaveBeenCalled())
         await waitFor(() =>
           expect(updateOptionsMock).toHaveBeenCalledWith({
-            account: expect.objectContaining({
+            account: {
               id: 456,
+              is_admin: true,
+              is_current_user_part_of_org: true,
               name: 'second-owner',
-            }),
-            visitor: expect.objectContaining({
+            },
+            visitor: {
+              business_email: 'jane.doe@codecov.io',
+              created_at: 'timestamp',
+              default_org: null,
+              email: 'jane.doe@codecov.io',
+              full_name: 'janedoe',
+              guest: false,
+              id: 123,
               js_or_ts_present: true,
-            }),
+              onboarding_completed: true,
+              ownerid: 123,
+              plan: 'users-basic',
+              plan_user_count: 1,
+              profile: {
+                created_at: 'timestamp',
+                goals: [],
+                other_goal: null,
+                type_projects: [],
+              },
+              profile_created_at: 'timestamp',
+              profile_goals: [],
+              profile_other_goal: null,
+              profile_type_projects: [],
+              service: 'github',
+              staff: false,
+              updated_at: 'timestamp',
+              username: 'janedoe',
+            },
           })
         )
       })

--- a/src/pages/RepoPage/hooks/useJSorTSPendoTracking.ts
+++ b/src/pages/RepoPage/hooks/useJSorTSPendoTracking.ts
@@ -41,16 +41,6 @@ export function useJSorTSPendoTracking() {
   const { data: userData } = useUser({})
 
   useEffect(() => {
-    console.error({
-      // if we don't have any data then we can't do anything
-      ownerData: !ownerData,
-      repoOverview: !repoOverview,
-      userData: !userData,
-      // no sense in firing this event if we don't have the data we need
-      jsOrTsPresent: repoOverview?.jsOrTsPresent,
-      // if the owner hasn't changed, we don't need to update the pendo options
-      owner: previousOwner.current?.ownerid === ownerData?.ownerid,
-    })
     if (
       // if we don't have any data then we can't do anything
       !ownerData ||

--- a/src/pages/RepoPage/hooks/useJSorTSPendoTracking.ts
+++ b/src/pages/RepoPage/hooks/useJSorTSPendoTracking.ts
@@ -9,8 +9,9 @@ import { snakeifyKeys } from 'shared/utils/snakeifyKeys'
 
 declare global {
   interface Window {
-    pendo: {
-      updateOptions: (options: object) => void
+    pendo?: {
+      updateOptions?: (options: object) => void
+      initialize?: (options: object) => void
     }
   }
 }
@@ -40,6 +41,16 @@ export function useJSorTSPendoTracking() {
   const { data: userData } = useUser({})
 
   useEffect(() => {
+    console.error({
+      // if we don't have any data then we can't do anything
+      ownerData,
+      repoOverview,
+      userData,
+      // no sense in firing this event if we don't have the data we need
+      jsOrTsPresent: repoOverview?.jsOrTsPresent,
+      // if the owner hasn't changed, we don't need to update the pendo options
+      owner: previousOwner.current?.ownerid === ownerData?.ownerid,
+    })
     if (
       // if we don't have any data then we can't do anything
       !ownerData ||
@@ -72,4 +83,6 @@ export function useJSorTSPendoTracking() {
       previousOwner.current = ownerData
     }
   }, [ownerData, repoOverview, userData])
+
+  return
 }

--- a/src/pages/RepoPage/hooks/useJSorTSPendoTracking.ts
+++ b/src/pages/RepoPage/hooks/useJSorTSPendoTracking.ts
@@ -43,9 +43,9 @@ export function useJSorTSPendoTracking() {
   useEffect(() => {
     console.error({
       // if we don't have any data then we can't do anything
-      ownerData,
-      repoOverview,
-      userData,
+      ownerData: !ownerData,
+      repoOverview: !repoOverview,
+      userData: !userData,
       // no sense in firing this event if we don't have the data we need
       jsOrTsPresent: repoOverview?.jsOrTsPresent,
       // if the owner hasn't changed, we don't need to update the pendo options

--- a/src/pages/RepoPage/hooks/useJSorTSPendoTracking.ts
+++ b/src/pages/RepoPage/hooks/useJSorTSPendoTracking.ts
@@ -1,0 +1,75 @@
+import { useEffect, useRef } from 'react'
+import { useParams } from 'react-router-dom'
+
+import { useRepoOverview } from 'services/repo'
+import { getCurUserInfo, pendoDefaultUser } from 'services/tracking/pendo'
+import { getUserData } from 'services/tracking/utils'
+import { useOwner, useUser } from 'services/user'
+import { snakeifyKeys } from 'shared/utils/snakeifyKeys'
+
+declare global {
+  interface Window {
+    pendo: {
+      updateOptions: (options: object) => void
+    }
+  }
+}
+
+interface URLParams {
+  provider: string
+  owner: string
+  repo: string
+}
+
+export function useJSorTSPendoTracking() {
+  const { provider, owner, repo } = useParams<URLParams>()
+
+  const { data: ownerData } = useOwner({
+    username: owner,
+  })
+
+  // track the previous owner so we can compare it to the current owner
+  const previousOwner = useRef<typeof ownerData | null>(null)
+
+  const { data: repoOverview } = useRepoOverview({
+    provider,
+    owner,
+    repo,
+  })
+
+  const { data: userData } = useUser({})
+
+  useEffect(() => {
+    if (
+      // if we don't have any data then we can't do anything
+      !ownerData ||
+      !repoOverview ||
+      !userData ||
+      // no sense in firing this event if we don't have the data we need
+      !repoOverview?.jsOrTsPresent ||
+      // if the owner hasn't changed, we don't need to update the pendo options
+      previousOwner.current?.ownerid === ownerData?.ownerid
+    ) {
+      return
+    }
+
+    if (window?.pendo?.updateOptions) {
+      const user = getUserData(userData, pendoDefaultUser)
+
+      window.pendo.updateOptions({
+        visitor: snakeifyKeys({
+          ...getCurUserInfo(user),
+          jsOrTsPresent: repoOverview?.jsOrTsPresent,
+        }),
+        account: snakeifyKeys({
+          id: ownerData?.ownerid,
+          name: ownerData?.username,
+          isCurrentUserPartOfOrg: ownerData?.isCurrentUserPartOfOrg,
+          isAdmin: ownerData?.isAdmin,
+        }),
+      })
+
+      previousOwner.current = ownerData
+    }
+  }, [ownerData, repoOverview, userData])
+}

--- a/src/services/repo/useRepoOverview.tsx
+++ b/src/services/repo/useRepoOverview.tsx
@@ -2,6 +2,7 @@ import { useQuery } from '@tanstack/react-query'
 import { z } from 'zod'
 
 import Api from 'shared/api'
+import { NetworkErrorObject } from 'shared/api/helpers'
 
 import { RepoNotFoundErrorSchema } from './schemas'
 
@@ -87,7 +88,8 @@ export function useRepoOverview({
           return Promise.reject({
             status: 404,
             data: {},
-          })
+            dev: 'useRepoOverview - 404 failed to parse',
+          } satisfies NetworkErrorObject)
         }
 
         const data = parsedData.data
@@ -96,7 +98,8 @@ export function useRepoOverview({
           return Promise.reject({
             status: 404,
             data: {},
-          })
+            dev: 'useRepoOverview - 404 NotFoundError',
+          } satisfies NetworkErrorObject)
         }
 
         if (!data?.owner?.repository) {

--- a/src/services/repo/useRepoOverview.tsx
+++ b/src/services/repo/useRepoOverview.tsx
@@ -85,6 +85,7 @@ export function useRepoOverview({
         const parsedData = RequestSchema.safeParse(res?.data)
 
         if (!parsedData.success) {
+          console.error(parsedData.error)
           return Promise.reject({
             status: 404,
             data: {},

--- a/src/services/repo/useRepoOverview.tsx
+++ b/src/services/repo/useRepoOverview.tsx
@@ -85,7 +85,6 @@ export function useRepoOverview({
         const parsedData = RequestSchema.safeParse(res?.data)
 
         if (!parsedData.success) {
-          console.error(parsedData.error)
           return Promise.reject({
             status: 404,
             data: {},

--- a/src/services/tracking/pendo.js
+++ b/src/services/tracking/pendo.js
@@ -75,4 +75,5 @@ export const pendoDefaultUser = {
   businessEmail: null,
   onboardingCompleted: null,
   plan: null,
+  jsOrTsPresent: null,
 }

--- a/src/services/tracking/pendo.js
+++ b/src/services/tracking/pendo.js
@@ -25,7 +25,7 @@ export function useUpdatePendoWithOwner(user) {
   const oldOwner = useRef()
 
   useEffect(() => {
-    if (oldOwner.current !== owner) {
+    if (oldOwner.current?.ownerid !== owner?.ownerid) {
       window?.pendo?.updateOptions({
         visitor: getCurUserInfo(currentUser),
         account: snakeifyKeys({
@@ -45,7 +45,7 @@ export function useUpdatePendoWithOwner(user) {
   }, [oldOwner, owner, currentUser, ownerData])
 }
 
-function getCurUserInfo(currentUser) {
+export function getCurUserInfo(currentUser) {
   const profile = currentUser?.profile
   const defaultOrg = localStorage.getItem('gz-defaultOrganization')
 

--- a/src/services/tracking/pendo.spec.js
+++ b/src/services/tracking/pendo.spec.js
@@ -41,11 +41,8 @@ describe('initialize pendo', () => {
     }
   }
 
-  beforeEach(() => {
-    setup()
-  })
-
   it('fires pendo initialization with expected params', () => {
+    setup()
     firePendo(curUser)
 
     expect(window.pendo.initialize).toHaveBeenCalledTimes(1)
@@ -57,17 +54,17 @@ describe('update pendo on owner change', () => {
     window.pendo = {
       updateOptions: jest.fn(),
     }
-    jest.spyOn(React, 'useRef').mockReturnValueOnce({ current: 'rula' })
+    jest
+      .spyOn(React, 'useRef')
+      .mockReturnValueOnce({ current: { ...ownerData, ownerid: 456 } })
 
     useParams.mockReturnValue({ owner: 'codecov' })
     useOwner.mockReturnValue({ data: ownerData })
   }
 
-  beforeEach(() => {
-    setup()
-  })
-
   it('fires pendo update options when pathname is different', () => {
+    setup()
+
     renderHook(() => useUpdatePendoWithOwner(curUser))
 
     expect(window.pendo.updateOptions).toHaveBeenCalledTimes(1)
@@ -85,11 +82,9 @@ describe('update pendo when owner is not changed', () => {
     useOwner.mockReturnValue({ data: ownerData })
   }
 
-  beforeEach(() => {
-    setup()
-  })
-
   it('does not fire pendo update', () => {
+    setup()
+
     renderHook(() => useUpdatePendoWithOwner(curUser))
 
     expect(window.pendo.updateOptions).toHaveBeenCalledTimes(0)


### PR DESCRIPTION
# Description

This PR adds in a new `updateOptions` call to Pendo when users navigate to the repo page, and the given repo has JS or TS present. It will only update the options once, and will only run again once the owner value has changed.

Closes codecov/engineering-team#2451

# Notable Changes

- Fix equality check between two objects in current Pendo tracking, this should reduce the amount of times we're calling Pendo, as we're now checking the diff between the owner ids instead of object references
- Add in new hook to trigger `pendo.updateOptions` when JS or TS is present for a given repo
- Create/Update tests