### PR TITLE
fix: hover styles for dark mode on selectors

### DIFF
--- a/src/pages/LoginPage/LoginButton.jsx
+++ b/src/pages/LoginPage/LoginButton.jsx
@@ -18,7 +18,7 @@ function LoginButton({ provider }) {
 
   return (
     <a
-      className="flex h-14 items-center rounded-sm border border-ds-gray-quaternary bg-ds-gray-primary font-semibold shadow hover:bg-ds-gray-secondary dark:hover:bg-ds-gray-quaternary"
+      className="flex h-14 items-center rounded-sm border border-ds-gray-quaternary bg-ds-gray-primary font-semibold shadow hover:bg-ds-gray-secondary"
       href={signIn.path({ to, provider })}
       data-cy={'login-button'}
     >

--- a/src/pages/SyncProviderPage/SyncButton.tsx
+++ b/src/pages/SyncProviderPage/SyncButton.tsx
@@ -12,7 +12,7 @@ const SyncButton: React.FC<SyncButtonProps> = ({ provider }) => {
   return (
     <div className="flex h-14 items-center rounded-sm border border-ds-gray-quaternary bg-ds-gray-primary text-left shadow">
       <a
-        className="flex h-full grow items-center font-semibold hover:bg-ds-gray-secondary dark:hover:bg-ds-gray-quaternary"
+        className="flex h-full grow items-center font-semibold hover:bg-ds-gray-secondary"
         href={signIn.path({ to, provider })}
         data-cy={'login-button'}
       >

--- a/src/ui/Button/Button.jsx
+++ b/src/ui/Button/Button.jsx
@@ -25,7 +25,6 @@ const variantClasses = {
     border-solid border shadow
 
     hover:bg-ds-gray-secondary
-    dark:hover:bg-ds-gray-quaternary
   `,
   primary: `
     justify-center font-semibold

--- a/src/ui/ContextSwitcher/ContextSwitcher.jsx
+++ b/src/ui/ContextSwitcher/ContextSwitcher.jsx
@@ -40,7 +40,7 @@ function ContextItem({ context, defaultOrgUsername, setToggle, owner }) {
 
   return (
     <li
-      className="cursor-pointer select-none py-2 text-gray-900 hover:bg-ds-gray-secondary dark:hover:bg-ds-gray-quaternary"
+      className="cursor-pointer select-none py-2 text-gray-900 hover:bg-ds-gray-secondary"
       id="listbox-option-0"
     >
       <Button

--- a/src/ui/Dropdown/Dropdown.tsx
+++ b/src/ui/Dropdown/Dropdown.tsx
@@ -120,7 +120,7 @@ const Content = React.forwardRef<
 Content.displayName = 'Dropdown.Content'
 
 const item = cva(
-  'focus:bg-accent focus:text-accent-foreground relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm text-ds-gray-octonary outline-none transition-colors hover:cursor-pointer hover:bg-ds-gray-secondary dark:hover:bg-ds-gray-quaternary data-[disabled]:pointer-events-none data-[disabled]:opacity-50'
+  'focus:bg-accent focus:text-accent-foreground relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm text-ds-gray-octonary outline-none transition-colors hover:cursor-pointer hover:bg-ds-gray-secondary data-[disabled]:pointer-events-none data-[disabled]:opacity-50'
 )
 
 interface ItemProps

--- a/src/ui/Select/Select.jsx
+++ b/src/ui/Select/Select.jsx
@@ -15,7 +15,7 @@ const SelectClasses = {
   root: 'relative',
   item: 'block cursor-pointer py-1 px-3 text-sm font-normal',
   button:
-    'flex justify-between items-center w-full rounded bg-ds-background text-left whitespace-nowrap disabled:text-ds-gray-quaternary disabled:bg-ds-gray-primary disabled:border-ds-gray-tertiary focus:outline-1',
+    'flex justify-between items-center w-full rounded bg-ds-container text-left whitespace-nowrap disabled:text-ds-gray-quaternary disabled:bg-ds-gray-primary disabled:border-ds-gray-tertiary focus:outline-1',
   ul: 'overflow-hidden rounded-bl rounded-br bg-ds-background border-ds-gray-tertiary absolute w-full z-40 max-h-80 min-w-fit',
   loadMoreTrigger: 'relative top-[-65px] invisible block leading-[0]',
 }


### PR DESCRIPTION
# Description

This PR aims to quick fix the hover styling on the selectors

This style is also used for the hover on regenerate button, but its a tradeoff I think we're willing to make for now

# Screenshots


https://github.com/user-attachments/assets/e708f47a-91d0-417f-b873-6eb75b5ecf00

# Link to Sample Entry

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.