### PR TITLE
feat: Creating new tests analytics columns / fix styles 

### DIFF
--- a/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/FailedTestsTable/FailedTestsTable.spec.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/FailedTestsTable/FailedTestsTable.spec.tsx
@@ -166,7 +166,7 @@ describe('FailedTestsTable', () => {
       const nameColumn = await screen.findByText('Test name')
       expect(nameColumn).toBeInTheDocument()
 
-      const durationColumn = await screen.findByText('Average duration')
+      const durationColumn = await screen.findByText('Last duration')
       expect(durationColumn).toBeInTheDocument()
 
       const failureRateColumn = await screen.findByText('Failure rate')
@@ -226,7 +226,7 @@ describe('FailedTestsTable', () => {
         wrapper: wrapper(queryClient),
       })
 
-      const durationColumn = await screen.findByText('Average duration')
+      const durationColumn = await screen.findByText('Last duration')
       await user.click(durationColumn)
 
       await waitFor(() => {

--- a/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/FailedTestsTable/FailedTestsTable.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/FailedTestsTable/FailedTestsTable.tsx
@@ -15,6 +15,7 @@ import { useParams } from 'react-router-dom'
 import { formatTimeToNow } from 'shared/utils/dates'
 import Icon from 'ui/Icon'
 import Spinner from 'ui/Spinner'
+import { Tooltip } from 'ui/Tooltip'
 
 import {
   OrderingDirection,
@@ -84,12 +85,14 @@ export function getSortingOption(
 const isNumericValue = (value: string) =>
   value === 'avgDuration' ||
   value === 'failureRate' ||
-  value === 'commitsFailed'
+  value === 'commitsFailed' ||
+  value === 'flakeRate'
 
 interface FailedTestsColumns {
   name: string
   avgDuration: number | null
   failureRate: number | null
+  flakeRate?: number | null
   commitsFailed: number | null
   updatedAt: string
 }
@@ -102,7 +105,7 @@ const columns = [
     cell: (info) => info.renderValue(),
   }),
   columnHelper.accessor('avgDuration', {
-    header: () => 'Average duration',
+    header: () => 'Last duration',
     cell: (info) => `${(info.renderValue() ?? 0).toFixed(3)}s`,
   }),
   columnHelper.accessor('failureRate', {
@@ -111,6 +114,38 @@ const columns = [
       const value = (info.renderValue() ?? 0) * 100
       const isInt = Number.isInteger(info.renderValue())
       return isInt ? `${value}%` : `${value.toFixed(2)}%`
+    },
+  }),
+  columnHelper.accessor('flakeRate', {
+    header: () => (
+      <div className="flex items-center gap-1">
+        Flake rate
+        <Icon
+          name="informationCircle"
+          size="sm"
+          className="text-ds-gray-tertiary"
+        />
+      </div>
+    ),
+    cell: (info) => {
+      return (
+        <Tooltip delayDuration={0} skipDelayDuration={100}>
+          <Tooltip.Root>
+            <Tooltip.Trigger className="underline decoration-dotted decoration-1 underline-offset-4">
+              {info.renderValue() ? `${info.renderValue()}%` : '9%'}
+            </Tooltip.Trigger>
+            <Tooltip.Portal>
+              <Tooltip.Content
+                className="bg-ds-gray-primary p-2 text-xs text-ds-gray-octonary"
+                side="right"
+              >
+                Passed 2,999, failed 100
+                <Tooltip.Arrow className="size-4 fill-ds-gray-primary" />
+              </Tooltip.Content>
+            </Tooltip.Portal>
+          </Tooltip.Root>
+        </Tooltip>
+      )
     },
   }),
   columnHelper.accessor('commitsFailed', {

--- a/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/MetricsSection/MetricsSection.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/MetricsSection/MetricsSection.tsx
@@ -15,7 +15,7 @@ const TooltipWithIcon = ({ children }: { children: React.ReactNode }) => {
         <Tooltip.Portal>
           <Tooltip.Content
             side="right"
-            className="w-64 rounded-md bg-ds-gray-primary p-3 text-xs text-gray-700"
+            className="w-64 rounded-md bg-ds-gray-primary p-3 text-xs text-ds-gray-octonary"
           >
             {children}
             <Tooltip.Arrow className="size-4 fill-gray-100" />
@@ -159,8 +159,8 @@ const TotalSkippedTestsCard = () => {
 
 function MetricsSection() {
   return (
-    <div className="flex">
-      <div className="flex flex-col gap-3 border-r-2">
+    <div className="overflow-x-auto overflow-y-hidden md:flex">
+      <div className="mb-6 flex flex-col gap-3 border-r-2 md:mb-0">
         <p className="pl-4 text-xs font-semibold text-ds-gray-quaternary">
           Improve CI Run Efficiency
         </p>


### PR DESCRIPTION
# Description
Updating avg to last duration, adding new flake rate + tooltip. 
Updating styles and support dark mode in the tooltip used in metrics section.

issues: [[Gazebo] Create flake rate new column](https://github.com/codecov/engineering-team/issues/2428) 
[[Gazebo] Update avg duration to last duration in the table](https://github.com/codecov/engineering-team/issues/2426)

# Screensho
<img width="1476" alt="Screenshot 2024-09-10 at 3 47 45 PM" src="https://github.com/user-attachments/assets/ba1c2138-3a9c-4e71-87ce-3427ce1498ee">
<img width="1476" alt="Screenshot 2024-09-10 at 3 47 51 PM" src="https://github.com/user-attachments/assets/d3ad4560-bd4a-4515-9d63-049265531364">
<img width="1476" alt="Screenshot 2024-09-10 at 3 47 55 PM" src="https://github.com/user-attachments/assets/70d5ca02-d692-496f-99b2-57480e2eb3b2">


<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.