### PR TITLE
Persist Selected Branch Across Tabs/Pages

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -154,7 +154,19 @@ const MainAppRoutes = () => (
         <CommitDetailPage />
       </BaseLayout>
     </SentryRoute>
-    <SentryRoute path="/:provider/:owner/:repo">
+    <SentryRoute
+      path={[
+        '/:provider/:owner/:repo/commits/:branch',
+        '/:provider/:owner/:repo/tree/:branch',
+        '/:provider/:owner/:repo/flags/:branch',
+        '/:provider/:owner/:repo/components/:branch',
+        '/:provider/:owner/:repo/bundles/:branch',
+        '/:provider/:owner/:repo/tests/:branch',
+        // paths above are for grabbing branch for components in tree between here and RepoPage
+        // where there is another set of SentryRoute matching
+        '/:provider/:owner/:repo',
+      ]}
+    >
       <BaseLayout>
         <RepoPage />
       </BaseLayout>

--- a/src/pages/RepoPage/BundlesTab/BundleContent/BundleSelection/BranchSelector.tsx
+++ b/src/pages/RepoPage/BundlesTab/BundleContent/BundleSelection/BranchSelector.tsx
@@ -81,7 +81,6 @@ const BranchSelector: React.FC<BranchSelectorProps> = ({
     selection.head !== null
   ) {
     history.push(
-      // @ts-expect-error - useNavLinks needs to be typed
       bundlesLink.path({ branch: encodeURIComponent(selection?.name) })
     )
   }
@@ -104,7 +103,6 @@ const BranchSelector: React.FC<BranchSelectorProps> = ({
           onChange={(item: Branch) => {
             resetBundleSelect()
             history.push(
-              // @ts-expect-error - useNavLinks needs to be typed
               bundlesLink.path({ branch: encodeURIComponent(item?.name) })
             )
           }}

--- a/src/pages/RepoPage/BundlesTab/BundleContent/BundleSelection/BundleSelector.tsx
+++ b/src/pages/RepoPage/BundlesTab/BundleContent/BundleSelection/BundleSelector.tsx
@@ -67,7 +67,6 @@ const BundleSelector = forwardRef<any, BranchSelectorProps>(
     if (!isString(selectedBundle) && bundles.length > 0 && !bundlesIsFetching) {
       history.push(
         bundlesLink.path({
-          // @ts-expect-error - useNavLinks needs to be typed
           branch,
           // @ts-expect-error - useNavLinks needs to be typed
           bundle: encodeURIComponent(bundles[0]),
@@ -101,7 +100,6 @@ const BundleSelector = forwardRef<any, BranchSelectorProps>(
               if (branch && name) {
                 history.push(
                   bundlesLink.path({
-                    // @ts-expect-error - useNavLinks needs to be typed
                     branch,
                     // @ts-expect-error - useNavLinks needs to be typed
                     bundle: encodeURIComponent(name),

--- a/src/pages/RepoPage/CommitsTab/CommitsTab.jsx
+++ b/src/pages/RepoPage/CommitsTab/CommitsTab.jsx
@@ -2,7 +2,11 @@ import { lazy, Suspense, useEffect, useRef, useState } from 'react'
 import { useHistory, useParams } from 'react-router-dom'
 
 import { useBranchHasCommits } from 'services/branches'
-import { useLocationParams, useNavLinks } from 'services/navigation'
+import {
+  ALL_BRANCHES,
+  useLocationParams,
+  useNavLinks,
+} from 'services/navigation'
 import { useRepoOverview } from 'services/repo'
 import Icon from 'ui/Icon'
 import MultiSelect from 'ui/MultiSelect'
@@ -13,7 +17,6 @@ import Spinner from 'ui/Spinner'
 import { filterItems, statusEnum } from './enums'
 import { useCommitsTabBranchSelector } from './hooks'
 
-const ALL_BRANCHES = 'All branches'
 const CommitsTable = lazy(() => import('./CommitsTable'))
 
 const Loader = () => (

--- a/src/pages/RepoPage/CoverageTab/ComponentsTab/Header/BranchSelector/BranchSelector.tsx
+++ b/src/pages/RepoPage/CoverageTab/ComponentsTab/Header/BranchSelector/BranchSelector.tsx
@@ -32,9 +32,7 @@ const BranchSelector: React.FC<BranchSelectorProps> = ({
     owner,
     repo,
   })
-  const [selectedBranch, setSelectedBranch] = useState<string>(
-    branch ?? overview?.defaultBranch ?? ''
-  )
+  const selectedBranch = branch ?? overview?.defaultBranch ?? ''
   const [branchSearchTerm, setBranchSearchTerm] = useState<string>('')
   const history = useHistory()
   const { componentsTab } = useNavLinks()
@@ -91,7 +89,6 @@ const BranchSelector: React.FC<BranchSelectorProps> = ({
           items={branchList?.branches ?? []}
           value={decodedBranch ? { name: decodedBranch } : selection}
           onChange={(branch: Branch) => {
-            setSelectedBranch(branch?.name)
             history.push(
               componentsTab.path({
                 branch: encodeURIComponent(branch?.name),

--- a/src/pages/RepoPage/CoverageTab/ComponentsTab/Header/BranchSelector/BranchSelector.tsx
+++ b/src/pages/RepoPage/CoverageTab/ComponentsTab/Header/BranchSelector/BranchSelector.tsx
@@ -94,8 +94,7 @@ const BranchSelector: React.FC<BranchSelectorProps> = ({
             setSelectedBranch(branch?.name)
             history.push(
               componentsTab.path({
-                // @ts-expect-error - branch is not typed
-                branch: branch?.name,
+                branch: encodeURIComponent(branch?.name),
               })
             )
           }}

--- a/src/pages/RepoPage/CoverageTab/CoverageTab.tsx
+++ b/src/pages/RepoPage/CoverageTab/CoverageTab.tsx
@@ -42,7 +42,13 @@ function CoverageTab() {
       {hideNavigator ? null : <CoverageTabNavigator />}
       <Suspense fallback={<Loader />}>
         <Switch>
-          <SentryRoute path="/:provider/:owner/:repo/flags" exact>
+          <SentryRoute
+            path={[
+              '/:provider/:owner/:repo/flags',
+              '/:provider/:owner/:repo/flags/:branch',
+            ]}
+            exact
+          >
             <FlagsTab />
           </SentryRoute>
           <SentryRoute

--- a/src/pages/RepoPage/CoverageTab/CoverageTabNavigator.tsx
+++ b/src/pages/RepoPage/CoverageTab/CoverageTabNavigator.tsx
@@ -14,24 +14,25 @@ interface URLParams {
   provider: string
   owner: string
   repo: string
+  branch?: string
 }
 
 function CoverageTabNavigator() {
-  const { provider, owner, repo } = useParams<URLParams>()
+  const { provider, owner, repo, branch } = useParams<URLParams>()
   const location = useLocation()
   const history = useHistory()
   const { coverage, flagsTab, componentsTab } = useNavLinks()
 
   const urls = {
-    Overview: coverage.path({ provider, owner, repo }),
+    Overview: coverage.path({ provider, owner, repo, branch }),
     Flags: flagsTab.path({ provider, owner, repo }),
     // will probably need to add branch here as arg when we support
     // keeping same branch we are on another tab with
-    Components: componentsTab.path({ provider, owner, repo }),
+    Components: componentsTab.path({ provider, owner, repo, branch }),
   }
 
   let value: TabsValue = TABS.Overview
-  if (location.pathname === urls.Flags) {
+  if (location.pathname.startsWith(urls.Flags)) {
     value = TABS.Flags
   } else if (location.pathname.startsWith(urls.Components)) {
     value = TABS.Components

--- a/src/pages/RepoPage/FailedTestsTab/FailedTestsTable/BranchSelector/BranchSelector.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/FailedTestsTable/BranchSelector/BranchSelector.tsx
@@ -72,7 +72,6 @@ const BranchSelector = () => {
     selection.head !== null
   ) {
     history.push(
-      // @ts-expect-error - useNavLinks needs to be typed
       failedTestsLink.path({ branch: encodeURIComponent(selection?.name) })
     )
   }
@@ -94,7 +93,6 @@ const BranchSelector = () => {
           value={selection}
           onChange={(item: Branch) => {
             history.push(
-              // @ts-expect-error - useNavLinks needs to be typed
               failedTestsLink.path({ branch: encodeURIComponent(item?.name) })
             )
           }}

--- a/src/pages/RepoPage/RepoPage.tsx
+++ b/src/pages/RepoPage/RepoPage.tsx
@@ -75,6 +75,7 @@ function Routes({
             path={[
               path,
               `${path}/flags`,
+              `${path}/flags/:branch`,
               `${path}/components`,
               `${path}/components/:branch`,
               `${path}/blob/:ref/:path+`,

--- a/src/pages/RepoPage/RepoPageTabs.spec.tsx
+++ b/src/pages/RepoPage/RepoPageTabs.spec.tsx
@@ -91,7 +91,9 @@ const wrapper =
             '/:provider/:owner/:repo/blob/:ref/:path+',
             '/:provider/:owner/:repo/commits',
             '/:provider/:owner/:repo/compare',
+            '/:provider/:owner/:repo/flags/:branch',
             '/:provider/:owner/:repo/flags',
+            '/:provider/:owner/:repo/components/:branch',
             '/:provider/:owner/:repo/components',
             '/:provider/:owner/:repo/new',
             '/:provider/:owner/:repo/pulls',
@@ -523,7 +525,11 @@ describe('useRepoTabs', () => {
             useRepoTabs({
               refetchEnabled: false,
             }),
-          { wrapper: wrapper('/gh/codecov/test-repo/tree/main/src') }
+          {
+            wrapper: wrapper(
+              '/gh/codecov/test-repo/tree/selected%2fbranch/src'
+            ),
+          }
         )
 
         const expectedTab = [
@@ -531,7 +537,31 @@ describe('useRepoTabs', () => {
             children: 'Coverage',
             exact: false,
             location: {
-              pathname: '/gh/codecov/test-repo/tree',
+              pathname: '/gh/codecov/test-repo/tree/selected%2fbranch',
+            },
+            pageName: 'overview',
+          },
+        ]
+        await waitFor(() =>
+          expect(result.current).toEqual(expect.arrayContaining(expectedTab))
+        )
+      })
+      it('returns the correct tab definition when All branch is selected', async () => {
+        setup({})
+        const { result } = renderHook(
+          () =>
+            useRepoTabs({
+              refetchEnabled: false,
+            }),
+          { wrapper: wrapper('/gh/codecov/test-repo/tree/All%20branches') }
+        )
+
+        const expectedTab = [
+          {
+            children: 'Coverage',
+            exact: false,
+            location: {
+              pathname: '/gh/codecov/test-repo',
             },
             pageName: 'overview',
           },
@@ -584,6 +614,112 @@ describe('useRepoTabs', () => {
           {
             children: 'Coverage',
             exact: false,
+            pageName: 'overview',
+          },
+        ]
+        await waitFor(() =>
+          expect(result.current).toEqual(expect.arrayContaining(expectedTab))
+        )
+      })
+    })
+
+    describe('when match flags is true', () => {
+      it('returns the correct tab definition when no branch selected', async () => {
+        setup({})
+        const { result } = renderHook(
+          () =>
+            useRepoTabs({
+              refetchEnabled: false,
+            }),
+          { wrapper: wrapper('/gh/codecov/test-repo/flags') }
+        )
+
+        const expectedTab = [
+          {
+            children: 'Coverage',
+            exact: false,
+            location: {
+              pathname: '/gh/codecov/test-repo',
+            },
+            pageName: 'overview',
+          },
+        ]
+        await waitFor(() =>
+          expect(result.current).toEqual(expect.arrayContaining(expectedTab))
+        )
+      })
+      it('returns the correct tab definition when branch is selected', async () => {
+        setup({})
+        const { result } = renderHook(
+          () =>
+            useRepoTabs({
+              refetchEnabled: false,
+            }),
+          { wrapper: wrapper('/gh/codecov/test-repo/flags/selected%2fbranch') }
+        )
+
+        const expectedTab = [
+          {
+            children: 'Coverage',
+            exact: false,
+            location: {
+              pathname: '/gh/codecov/test-repo/tree/selected%2fbranch',
+            },
+            pageName: 'overview',
+          },
+        ]
+        await waitFor(() =>
+          expect(result.current).toEqual(expect.arrayContaining(expectedTab))
+        )
+      })
+    })
+
+    describe('when match components is true', () => {
+      it('returns the correct tab definition when no branch selected', async () => {
+        setup({})
+        const { result } = renderHook(
+          () =>
+            useRepoTabs({
+              refetchEnabled: false,
+            }),
+          { wrapper: wrapper('/gh/codecov/test-repo/components') }
+        )
+
+        const expectedTab = [
+          {
+            children: 'Coverage',
+            exact: false,
+            location: {
+              pathname: '/gh/codecov/test-repo',
+            },
+            pageName: 'overview',
+          },
+        ]
+        await waitFor(() =>
+          expect(result.current).toEqual(expect.arrayContaining(expectedTab))
+        )
+      })
+      it('returns the correct tab definition when branch is selected', async () => {
+        setup({})
+        const { result } = renderHook(
+          () =>
+            useRepoTabs({
+              refetchEnabled: false,
+            }),
+          {
+            wrapper: wrapper(
+              '/gh/codecov/test-repo/components/selected%2fbranch'
+            ),
+          }
+        )
+
+        const expectedTab = [
+          {
+            children: 'Coverage',
+            exact: false,
+            location: {
+              pathname: '/gh/codecov/test-repo/tree/selected%2fbranch',
+            },
             pageName: 'overview',
           },
         ]

--- a/src/pages/RepoPage/RepoPageTabs.tsx
+++ b/src/pages/RepoPage/RepoPageTabs.tsx
@@ -51,11 +51,10 @@ export const useRepoTabs = ({ refetchEnabled }: UseRepoTabsArgs) => {
   let coverageLocation = undefined
   if (matchTree) {
     coverageLocation = {
-      pathname: branch
-        ? branch === ALL_BRANCHES
+      pathname:
+        branch === ALL_BRANCHES
           ? `/${provider}/${owner}/${repo}`
-          : `/${provider}/${owner}/${repo}/tree/${branch}`
-        : `/${provider}/${owner}/${repo}/tree`,
+          : `/${provider}/${owner}/${repo}/tree/${branch}`,
     }
   } else if (matchFlags || matchComponents) {
     coverageLocation = {

--- a/src/pages/RepoPage/RepoPageTabs.tsx
+++ b/src/pages/RepoPage/RepoPageTabs.tsx
@@ -16,6 +16,7 @@ interface URLParams {
   provider: string
   owner: string
   repo: string
+  branch?: string
 }
 
 interface UseRepoTabsArgs {
@@ -30,7 +31,7 @@ interface TabArgs {
 }
 
 export const useRepoTabs = ({ refetchEnabled }: UseRepoTabsArgs) => {
-  const { provider, owner, repo } = useParams<URLParams>()
+  const { provider, owner, repo, branch } = useParams<URLParams>()
   const { data: repoOverview } = useRepoOverview({ provider, owner, repo })
   const { data: repoData } = useRepo({
     provider,
@@ -46,11 +47,23 @@ export const useRepoTabs = ({ refetchEnabled }: UseRepoTabsArgs) => {
   const matchCoverageOnboarding = useMatchCoverageOnboardingPath()
   const matchFlags = useMatchFlagsPath()
   const matchComponents = useMatchComponentsPath()
-  let location = undefined
+  let coverageLocation = undefined
   if (matchTree) {
-    location = { pathname: `/${provider}/${owner}/${repo}/tree` }
+    coverageLocation = {
+      pathname:
+        branch && branch !== 'All branches'
+          ? `/${provider}/${owner}/${repo}/tree/${branch}`
+          : `/${provider}/${owner}/${repo}/tree`,
+    }
+  } else if (matchFlags || matchComponents) {
+    coverageLocation = {
+      pathname:
+        branch && branch !== 'All branches'
+          ? `/${provider}/${owner}/${repo}/tree/${branch}`
+          : `/${provider}/${owner}/${repo}`,
+    }
   } else if (matchBlobs) {
-    location = { pathname: `/${provider}/${owner}/${repo}/blob` }
+    coverageLocation = { pathname: `/${provider}/${owner}/${repo}/blob` }
   }
 
   const tabs: TabArgs[] = []
@@ -67,7 +80,9 @@ export const useRepoTabs = ({ refetchEnabled }: UseRepoTabsArgs) => {
         matchFlags ||
         matchComponents
       ),
-      location,
+      /* if exact is false, location (or the current url if location is undefined) needs to be as
+      specific or more than the url that the tab is linking to for the underlying NavLink matching to work correctly and apply the active state. In other words, the url this tab links to is the more generic pattern */
+      location: coverageLocation,
     })
   }
 

--- a/src/pages/RepoPage/RepoPageTabs.tsx
+++ b/src/pages/RepoPage/RepoPageTabs.tsx
@@ -1,5 +1,6 @@
 import { useParams } from 'react-router-dom'
 
+import { ALL_BRANCHES } from 'services/navigation'
 import { useRepo, useRepoOverview } from 'services/repo'
 import Badge from 'ui/Badge'
 import TabNavigation from 'ui/TabNavigation'
@@ -50,15 +51,16 @@ export const useRepoTabs = ({ refetchEnabled }: UseRepoTabsArgs) => {
   let coverageLocation = undefined
   if (matchTree) {
     coverageLocation = {
-      pathname:
-        branch && branch !== 'All branches'
-          ? `/${provider}/${owner}/${repo}/tree/${branch}`
-          : `/${provider}/${owner}/${repo}/tree`,
+      pathname: branch
+        ? branch === ALL_BRANCHES
+          ? `/${provider}/${owner}/${repo}`
+          : `/${provider}/${owner}/${repo}/tree/${branch}`
+        : `/${provider}/${owner}/${repo}/tree`,
     }
   } else if (matchFlags || matchComponents) {
     coverageLocation = {
       pathname:
-        branch && branch !== 'All branches'
+        branch && branch !== ALL_BRANCHES
           ? `/${provider}/${owner}/${repo}/tree/${branch}`
           : `/${provider}/${owner}/${repo}`,
     }

--- a/src/services/navigation/useNavLinks/index.js
+++ b/src/services/navigation/useNavLinks/index.js
@@ -1,2 +1,2 @@
-export { useNavLinks } from './useNavLinks'
+export { useNavLinks, ALL_BRANCHES } from './useNavLinks'
 export { useStaticNavLinks } from './useStaticNavLinks'

--- a/src/services/navigation/useNavLinks/useNavLinks.js
+++ b/src/services/navigation/useNavLinks/useNavLinks.js
@@ -168,10 +168,9 @@ export function useNavLinks() {
         }
       ) => {
         if (branch) {
-          if (branch === ALL_BRANCHES) {
-            return `/${provider}/${owner}/${repo}/commits/${encodeURIComponent(ALL_BRANCHES)}`
-          }
-          return `/${provider}/${owner}/${repo}/commits/${branch}`
+          return branch === ALL_BRANCHES
+            ? `/${provider}/${owner}/${repo}/commits/${encodeURIComponent(ALL_BRANCHES)}`
+            : `/${provider}/${owner}/${repo}/commits/${branch}`
         }
         return `/${provider}/${owner}/${repo}/commits`
       },

--- a/src/services/navigation/useNavLinks/useNavLinks.js
+++ b/src/services/navigation/useNavLinks/useNavLinks.js
@@ -5,6 +5,7 @@ import config from 'config'
 
 // Note to Terry, when we have more time automate all paths to pass through query search params.
 
+const ALL_BRANCHES = 'All branches'
 export function useNavLinks() {
   const {
     branch: b,
@@ -167,6 +168,9 @@ export function useNavLinks() {
         }
       ) => {
         if (branch) {
+          if (branch === ALL_BRANCHES) {
+            return `/${provider}/${owner}/${repo}/commits/${encodeURIComponent(ALL_BRANCHES)}`
+          }
           return `/${provider}/${owner}/${repo}/commits/${branch}`
         }
         return `/${provider}/${owner}/${repo}/commits`
@@ -343,26 +347,33 @@ export function useNavLinks() {
     },
     overview: {
       path: (
-        { provider = p, owner = o, repo = r } = {
+        { provider = p, owner = o, repo = r, branch = b } = {
           provider: p,
           owner: o,
           repo: r,
+          branch: b,
         }
-      ) => `/${provider}/${owner}/${repo}`,
+      ) =>
+        `/${provider}/${owner}/${repo}${branch && branch !== ALL_BRANCHES ? `/tree/${branch}` : ''}`,
       text: 'Overview',
     },
     coverage: {
       path: (
-        { provider = p, owner = o, repo = r, queryParams = {} } = {
+        { provider = p, owner = o, repo = r, queryParams = {}, branch = b } = {
           provider: p,
           owner: o,
           repo: r,
           queryParams: {},
+          branch: b,
         }
       ) => {
         let query = ''
         if (queryParams && Object.keys(queryParams).length > 0) {
           query = qs.stringify(queryParams, { addQueryPrefix: true })
+        }
+
+        if (branch && branch !== ALL_BRANCHES) {
+          return `/${provider}/${owner}/${repo}/tree/${branch}${query}`
         }
 
         return `/${provider}/${owner}/${repo}${query}`
@@ -372,26 +383,28 @@ export function useNavLinks() {
     },
     flagsTab: {
       path: (
-        { provider = p, owner = o, repo = r } = {
+        { provider = p, owner = o, repo = r, branch = b } = {
           provider: p,
           owner: o,
           repo: r,
+          branch: b,
         }
-      ) => `/${provider}/${owner}/${repo}/flags`,
+      ) =>
+        `/${provider}/${owner}/${repo}/flags${branch && branch !== ALL_BRANCHES ? `/${branch}` : ''}`,
       isExternalLink: false,
       text: 'Flags',
     },
     componentsTab: {
       path: (
-        { provider = p, owner = o, repo = r, branch = undefined } = {
+        { provider = p, owner = o, repo = r, branch = b } = {
           provider: p,
           owner: o,
           repo: r,
-          branch: undefined,
+          branch: b,
         }
       ) => {
-        if (branch) {
-          return `/${provider}/${owner}/${repo}/components/${encodeURIComponent(branch)}`
+        if (branch && branch !== ALL_BRANCHES) {
+          return `/${provider}/${owner}/${repo}/components/${branch}`
         }
         return `/${provider}/${owner}/${repo}/components`
       },
@@ -723,7 +736,7 @@ export function useNavLinks() {
           provider = p,
           owner = o,
           repo = r,
-          branch = undefined,
+          branch = b,
           bundle = undefined,
         } = {
           provider: p,
@@ -731,11 +744,11 @@ export function useNavLinks() {
           repo: r,
         }
       ) => {
-        if (branch && bundle) {
+        if (branch && branch !== ALL_BRANCHES && bundle) {
           return `/${provider}/${owner}/${repo}/bundles/${branch}/${bundle}`
         }
 
-        if (branch) {
+        if (branch && branch !== ALL_BRANCHES) {
           return `/${provider}/${owner}/${repo}/bundles/${branch}`
         }
 
@@ -815,13 +828,14 @@ export function useNavLinks() {
     },
     failedTests: {
       path: (
-        { provider = p, owner = o, repo = r, branch = undefined } = {
+        { provider = p, owner = o, repo = r, branch = b } = {
           provider: p,
           owner: o,
           repo: r,
+          branch: b,
         }
       ) => {
-        if (branch) {
+        if (branch && branch !== ALL_BRANCHES) {
           return `/${provider}/${owner}/${repo}/tests/${branch}`
         }
 

--- a/src/services/navigation/useNavLinks/useNavLinks.js
+++ b/src/services/navigation/useNavLinks/useNavLinks.js
@@ -5,7 +5,7 @@ import config from 'config'
 
 // Note to Terry, when we have more time automate all paths to pass through query search params.
 
-const ALL_BRANCHES = 'All branches'
+export const ALL_BRANCHES = 'All branches'
 export function useNavLinks() {
   const {
     branch: b,

--- a/src/services/navigation/useNavLinks/useNavLinks.spec.js
+++ b/src/services/navigation/useNavLinks/useNavLinks.spec.js
@@ -560,6 +560,34 @@ describe('useNavLinks', () => {
       })
       expect(path).toBe('/bb/test-owner/test-repo?flags%5B0%5D=myFlag')
     })
+
+    it('passes branches into the url', () => {
+      const { result } = renderHook(() => useNavLinks(), {
+        wrapper: wrapper('/gl/doggo/squirrel-locator/'),
+      })
+
+      const path = result.current.coverage.path({
+        provider: 'bb',
+        owner: 'test-owner',
+        repo: 'test-repo',
+        branch: 'hello',
+      })
+      expect(path).toBe('/bb/test-owner/test-repo/tree/hello')
+    })
+
+    it('does not pass "All branches" into the url', () => {
+      const { result } = renderHook(() => useNavLinks(), {
+        wrapper: wrapper('/gl/doggo/squirrel-locator/'),
+      })
+
+      const path = result.current.coverage.path({
+        provider: 'bb',
+        owner: 'test-owner',
+        repo: 'test-repo',
+        branch: 'All branches',
+      })
+      expect(path).toBe('/bb/test-owner/test-repo')
+    })
   })
 
   describe('commits link', () => {
@@ -583,6 +611,33 @@ describe('useNavLinks', () => {
         repo: 'test-repo',
       })
       expect(path).toBe('/bb/test-owner/test-repo/commits')
+    })
+    it('passes branches into the url', () => {
+      const { result } = renderHook(() => useNavLinks(), {
+        wrapper: wrapper('/gl/doggo/squirrel-locator'),
+      })
+
+      const path = result.current.commits.path({
+        provider: 'bb',
+        owner: 'test-owner',
+        repo: 'test-repo',
+        branch: 'myBranch',
+      })
+      expect(path).toBe('/bb/test-owner/test-repo/commits/myBranch')
+    })
+
+    it('passes "All branches" into the url', () => {
+      const { result } = renderHook(() => useNavLinks(), {
+        wrapper: wrapper('/gl/doggo/squirrel-locator/'),
+      })
+
+      const path = result.current.commits.path({
+        provider: 'bb',
+        owner: 'test-owner',
+        repo: 'test-repo',
+        branch: 'All branches',
+      })
+      expect(path).toBe('/bb/test-owner/test-repo/commits/All%20branches')
     })
   })
 
@@ -920,6 +975,34 @@ describe('useNavLinks', () => {
       })
       expect(path).toBe('/bb/test-owner/gazebo/flags')
     })
+
+    it('passes branches into the url', () => {
+      const { result } = renderHook(() => useNavLinks(), {
+        wrapper: wrapper('/gh/codecov/gazebo/flags'),
+      })
+
+      const path = result.current.flagsTab.path({
+        provider: 'bb',
+        owner: 'test-owner',
+        repo: 'test-repo',
+        branch: 'hello',
+      })
+      expect(path).toBe('/bb/test-owner/test-repo/flags/hello')
+    })
+
+    it('does not pass "All branches" into the url', () => {
+      const { result } = renderHook(() => useNavLinks(), {
+        wrapper: wrapper('/gh/codecov/gazebo/flags'),
+      })
+
+      const path = result.current.flagsTab.path({
+        provider: 'bb',
+        owner: 'test-owner',
+        repo: 'test-repo',
+        branch: 'All branches',
+      })
+      expect(path).toBe('/bb/test-owner/test-repo/flags')
+    })
   })
 
   describe('repo components tab link', () => {
@@ -942,6 +1025,34 @@ describe('useNavLinks', () => {
         owner: 'test-owner',
       })
       expect(path).toBe('/bb/test-owner/gazebo/components')
+    })
+
+    it('passes branches into the url', () => {
+      const { result } = renderHook(() => useNavLinks(), {
+        wrapper: wrapper('/gh/codecov/gazebo/components'),
+      })
+
+      const path = result.current.componentsTab.path({
+        provider: 'bb',
+        owner: 'test-owner',
+        repo: 'test-repo',
+        branch: 'main',
+      })
+      expect(path).toBe('/bb/test-owner/test-repo/components/main')
+    })
+
+    it('does not pass "All branches" into the url', () => {
+      const { result } = renderHook(() => useNavLinks(), {
+        wrapper: wrapper('/gh/codecov/gazebo/components'),
+      })
+
+      const path = result.current.componentsTab.path({
+        provider: 'bb',
+        owner: 'test-owner',
+        repo: 'test-repo',
+        branch: 'All branches',
+      })
+      expect(path).toBe('/bb/test-owner/test-repo/components')
     })
   })
 
@@ -1819,6 +1930,18 @@ describe('useNavLinks', () => {
           '/gh/codecov/cool-repo/bundles/test-branch/test-bundle'
         )
       })
+
+      it('does not pass "All branches" into the url', () => {
+        const { result } = renderHook(() => useNavLinks(), {
+          wrapper: wrapper('/gh/codecov/cool-repo'),
+        })
+
+        const path = result.current.bundles.path({
+          branch: 'All branches',
+          bundle: 'test-bundle',
+        })
+        expect(path).toBe('/gh/codecov/cool-repo/bundles')
+      })
     })
   })
 
@@ -2047,6 +2170,20 @@ describe('useNavLinks', () => {
         branch: 'cool',
       })
       expect(path).toBe('/bb/test-owner/test-repo/tests/cool')
+    })
+
+    it('does not pass "All branches" into the url', () => {
+      const { result } = renderHook(() => useNavLinks(), {
+        wrapper: wrapper('/gl/codecov/cool-repo'),
+      })
+
+      const path = result.current.failedTests.path({
+        provider: 'bb',
+        owner: 'test-owner',
+        repo: 'test-repo',
+        branch: 'All branches',
+      })
+      expect(path).toBe('/bb/test-owner/test-repo/tests')
     })
   })
 


### PR DESCRIPTION
# Description

Closes https://github.com/codecov/engineering-team/issues/2188
Part 2/2 of https://www.notion.so/sentry/Branch-Selector-Mismatch-Experience-292469a7e517485b80eaf31f3f7d06d8

# Code Example

# Notable Changes

In order to share the link across page loads, I've tacked on the selected branch to the most of the Repo Page Tabs:
- Coverage
  - Overview
  - Flags
  - Components
- Bundles
- Tests
- Commits

I've excluded Pulls and Configurations as they don't really pertain to having a branch selected. If a user navigates to either of those with a selected branch, it will be wiped away and the user will need to manually switch away from the default branch when they go back to a tab that allows branch selection.

# Screenshots

# Link to Sample Entry

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.