### PR TITLE
fix: Re-render issue with AssetsTable

### DIFF
--- a/src/pages/RepoPage/BundlesTab/BundleContent/AssetsTable/AssetsTable.tsx
+++ b/src/pages/RepoPage/BundlesTab/BundleContent/AssetsTable/AssetsTable.tsx
@@ -250,20 +250,29 @@ export const AssetsTable: React.FC = () => {
   }, [fetchNextPage, hasNextPage, inView])
 
   const tableData: Array<Column> = useMemo(() => {
-    // filtering like this will remove any null values, TS just has trouble with it
-    return data.assets.filter(Boolean).map((asset) => ({
-      name: asset!.name,
-      extension: asset!.extension,
-      size: asset!.bundleData.size.uncompress,
-      loadTime: asset!.bundleData.loadTime.threeG,
-      changeOverTime: asset!.measurements ?? undefined,
-    }))
+    if (data) {
+      return data?.pages
+        .map((page) => page.assets)
+        .flat()
+        .filter(Boolean)
+        .map((asset) => ({
+          name: asset!.name,
+          extension: asset!.extension,
+          size: asset!.bundleData.size.uncompress,
+          loadTime: asset!.bundleData.loadTime.threeG,
+          changeOverTime: asset!.measurements ?? undefined,
+        }))
+    }
+
+    return []
   }, [data])
 
-  const columns = useMemo(
-    () => createColumns(data?.bundleData?.size?.uncompress ?? null),
-    [data?.bundleData?.size?.uncompress]
+  const bundleSize = useMemo(
+    () => data?.pages?.[0]?.bundleData?.size?.uncompress ?? null,
+    [data?.pages]
   )
+
+  const columns = useMemo(() => createColumns(bundleSize), [bundleSize])
 
   const table = useReactTable({
     columns,
@@ -279,7 +288,7 @@ export const AssetsTable: React.FC = () => {
     getExpandedRowModel: getExpandedRowModel(),
   })
 
-  if (data?.assets?.length === 0 && !isInitialLoading) {
+  if (tableData.length === 0 && !isInitialLoading) {
     return <EmptyTable />
   }
 
@@ -392,8 +401,7 @@ export const AssetsTable: React.FC = () => {
                                 <span className="font-mono">
                                   {genSizeColumn({
                                     size: row.original.size,
-                                    totalBundleSize:
-                                      data?.bundleData?.size?.uncompress,
+                                    totalBundleSize: bundleSize,
                                   })}
                                 </span>
                               </div>

--- a/src/pages/RepoPage/BundlesTab/BundleContent/AssetsTable/useBundleAssetsTable.spec.tsx
+++ b/src/pages/RepoPage/BundlesTab/BundleContent/AssetsTable/useBundleAssetsTable.spec.tsx
@@ -153,40 +153,49 @@ describe('useBundleAssetsTable', () => {
     )
 
     const expectedResult = {
-      assets: [
+      pageParams: [undefined],
+      pages: [
         {
+          assets: [
+            {
+              bundleData: {
+                loadTime: {
+                  highSpeed: 2,
+                  threeG: 1,
+                },
+                size: {
+                  gzip: 4,
+                  uncompress: 3,
+                },
+              },
+              extension: 'js',
+              measurements: {
+                change: {
+                  size: {
+                    uncompress: 5,
+                  },
+                },
+                measurements: [
+                  {
+                    avg: 6,
+                    timestamp: '2022-10-10T11:59:59',
+                  },
+                ],
+              },
+              name: 'asset-1',
+            },
+          ],
           bundleData: {
-            loadTime: {
-              highSpeed: 2,
-              threeG: 1,
-            },
             size: {
-              gzip: 4,
-              uncompress: 3,
+              uncompress: 12,
             },
           },
-          extension: 'js',
-          measurements: {
-            change: {
-              size: {
-                uncompress: 5,
-              },
-            },
-            measurements: [
-              {
-                avg: 6,
-                timestamp: '2022-10-10T11:59:59',
-              },
-            ],
+          pageInfo: {
+            endCursor: null,
+            hasNextPage: false,
           },
-          name: 'asset-1',
         },
       ],
-      bundleData: {
-        size: {
-          uncompress: 12,
-        },
-      },
     }
     await waitFor(() => expect(result.current.data).toEqual(expectedResult))
   })

--- a/src/services/bundleAnalysis/useBundleAssets.spec.tsx
+++ b/src/services/bundleAnalysis/useBundleAssets.spec.tsx
@@ -202,8 +202,8 @@ describe('useBundleAssets', () => {
                               ? false
                               : true,
                             endCursor: req.variables.assetsAfter
-                              ? 'aa'
-                              : 'MjAyMC0wOC0xMSAxNzozMDowMiswMDowMHwxMDA=',
+                              ? 'cursor-1'
+                              : 'cursor-2',
                           },
                         },
                       },
@@ -238,7 +238,19 @@ describe('useBundleAssets', () => {
       )
 
       await waitFor(() => {
-        expect(result.current.data?.assets).toEqual([node1, node2])
+        expect(result.current.data).toEqual({
+          pageParams: [undefined],
+          pages: [
+            {
+              assets: [node1, node2],
+              bundleData: { size: { uncompress: 12 } },
+              pageInfo: {
+                hasNextPage: true,
+                endCursor: 'cursor-2',
+              },
+            },
+          ],
+        })
       })
     })
 
@@ -261,8 +273,17 @@ describe('useBundleAssets', () => {
 
         await waitFor(() => {
           expect(result.current.data).toEqual({
-            assets: [node1, node2],
-            bundleData: { size: { uncompress: 12 } },
+            pageParams: [undefined],
+            pages: [
+              {
+                assets: [node1, node2],
+                bundleData: { size: { uncompress: 12 } },
+                pageInfo: {
+                  hasNextPage: true,
+                  endCursor: 'cursor-2',
+                },
+              },
+            ],
           })
         })
 
@@ -273,8 +294,25 @@ describe('useBundleAssets', () => {
 
         await waitFor(() =>
           expect(result.current.data).toEqual({
-            assets: [node1, node2, node3],
-            bundleData: { size: { uncompress: 12 } },
+            pageParams: [undefined, 'cursor-2'],
+            pages: [
+              {
+                assets: [node1, node2],
+                bundleData: { size: { uncompress: 12 } },
+                pageInfo: {
+                  endCursor: 'cursor-2',
+                  hasNextPage: true,
+                },
+              },
+              {
+                assets: [node3],
+                bundleData: { size: { uncompress: 12 } },
+                pageInfo: {
+                  endCursor: 'cursor-1',
+                  hasNextPage: false,
+                },
+              },
+            ],
           })
         )
       })
@@ -301,7 +339,16 @@ describe('useBundleAssets', () => {
         await waitFor(() => expect(result.current.isLoading).toBeFalsy())
 
         await waitFor(() => {
-          expect(result.current.data).toEqual({ assets: [], bundleData: null })
+          expect(result.current.data).toEqual({
+            pageParams: [undefined],
+            pages: [
+              {
+                assets: [],
+                bundleData: null,
+                pageInfo: null,
+              },
+            ],
+          })
         })
       })
     })
@@ -328,7 +375,10 @@ describe('useBundleAssets', () => {
       await waitFor(() => expect(result.current.isLoading).toBeFalsy())
 
       await waitFor(() => {
-        expect(result.current.data).toEqual({ assets: [], bundleData: null })
+        expect(result.current.data).toEqual({
+          pageParams: [undefined],
+          pages: [{ assets: [], bundleData: null, pageInfo: null }],
+        })
       })
     })
   })

--- a/src/services/bundleAnalysis/useBundleAssets.tsx
+++ b/src/services/bundleAnalysis/useBundleAssets.tsx
@@ -231,7 +231,7 @@ export const useBundleAssets = ({
   ordering,
   opts,
 }: UseBundleAssetsArgs) => {
-  const { data, ...rest } = useInfiniteQuery({
+  return useInfiniteQuery({
     queryKey: [
       'BundleAssets',
       provider,
@@ -333,12 +333,4 @@ export const useBundleAssets = ({
     enabled: opts?.enabled !== undefined ? opts.enabled : true,
     suspense: !!opts?.suspense,
   })
-
-  return {
-    data: {
-      assets: data?.pages.map((page) => page.assets).flat() ?? [],
-      bundleData: data?.pages?.[0]?.bundleData ?? null,
-    },
-    ...rest,
-  }
 }


### PR DESCRIPTION
# Description

When moving the AssetsTable over to the paginated hook, I missed some memo'ing which was causing a slow but infinite re-render blocking the expanding of an assets modules. This PR fixes up the re-render issues, allowing people to view their modules properly.

# Notable Changes

- Return infinite query directly
- Process and memo the data directly in the table
- Update tests