### PR TITLE
fix: Continue to show FlagsTable for flag tab with selected branch

### DIFF
--- a/src/pages/RepoPage/CoverageTab/FlagsTab/FlagsTab.jsx
+++ b/src/pages/RepoPage/CoverageTab/FlagsTab/FlagsTab.jsx
@@ -75,7 +75,13 @@ function FlagsTab() {
           flagsMeasurementsActive,
           flagsMeasurementsBackfilled,
         }) ? (
-          <SentryRoute path="/:provider/:owner/:repo/flags" exact>
+          <SentryRoute
+            path={[
+              '/:provider/:owner/:repo/flags',
+              '/:provider/:owner/:repo/flags/:branch',
+            ]}
+            exact
+          >
             <FlagsTable />
           </SentryRoute>
         ) : (

--- a/src/pages/RepoPage/RepoPage.tsx
+++ b/src/pages/RepoPage/RepoPage.tsx
@@ -75,6 +75,8 @@ function Routes({
             path={[
               path,
               `${path}/flags`,
+              /* flags tab does not actually do anything with the branch but since it is one of multiple tabs
+              in the coverage page, it is better user experience to persist the selected branch */
               `${path}/flags/:branch`,
               `${path}/components`,
               `${path}/components/:branch`,


### PR DESCRIPTION
# Description

Fixing a bug I just introduced with https://github.com/codecov/gazebo/pull/3181

The Flags table wasn't showing on Flags Tab for a url that includes a selected branch

With branch (wrong):
<img width="1728" alt="Screenshot 2024-09-11 at 1 50 22 PM" src="https://github.com/user-attachments/assets/0317323f-ce84-4fe4-bbc9-b60a404d44fb">
Without branch (normal):
<img width="1728" alt="Screenshot 2024-09-11 at 1 50 15 PM" src="https://github.com/user-attachments/assets/88eb1fa5-61d8-48cc-af69-3264f6b68fa0">


# Code Example

# Notable Changes

# Screenshots

# Link to Sample Entry

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.