### PR TITLE
fix: Dark mode colors on Message component

### DIFF
--- a/src/old_ui/Message/Message.jsx
+++ b/src/old_ui/Message/Message.jsx
@@ -5,27 +5,23 @@ import Icon from 'old_ui/Icon'
 
 const typeToStyle = {
   success: {
-    text: 'text-success-900',
-    background: 'bg-success-500',
-    backgroundIcon: 'bg-success-100',
+    background: 'bg-green-100 dark:bg-opacity-20',
+    backgroundIcon: 'bg-green-100 dark:bg-opacity-20',
     icon: 'check',
   },
   warning: {
-    text: 'text-warning-900',
-    background: 'bg-codecov-orange',
-    backgroundIcon: 'bg-error-100',
+    background: 'bg-orange-100 dark:bg-opacity-20',
+    backgroundIcon: 'bg-error-100 dark:bg-opacity-20',
     icon: 'exclamationCircle',
   },
   info: {
-    text: 'text-info-900',
-    background: 'bg-info-500',
-    backgroundIcon: 'bg-info-100',
+    background: 'bg-ds-blue-nonary  dark:bg-opacity-20',
+    backgroundIcon: 'bg-ds-blue-nonary  dark:bg-opacity-20',
     icon: 'infoCircle',
   },
   error: {
-    text: 'text-error-900',
-    background: 'bg-error-500',
-    backgroundIcon: 'bg-error-100',
+    background: 'bg-error-100 dark:bg-opacity-20',
+    backgroundIcon: 'bg-error-100 dark:bg-opacity-20',
     icon: 'ban',
   },
 }


### PR DESCRIPTION
# Description

Just a short term fix for the dark mode colors that I saw while testing out some stripe stuff

Long term we want to remove these altogether for the new Alert component so this is just a stop gap until we have bandwidth for that

I just copied over the colors from Alert.tsx to this file and confirmed it looked alright in UI. Pictures below

# Screenshots

**BEFORE**
![Screenshot 2024-09-11 at 4 49 03 PM](https://github.com/user-attachments/assets/89dfba86-d744-4b00-a75f-3446065c0a53)
![Screenshot 2024-09-11 at 4 55 21 PM](https://github.com/user-attachments/assets/b3d7ee36-77cf-4fd1-9459-8a76d5216029)

**AFTER**
![Screenshot 2024-09-11 at 4 57 51 PM](https://github.com/user-attachments/assets/2840f6f8-853a-44b0-b6a4-169ff6e2c797)

**OTHERS UPDATED**
![Screenshot 2024-09-11 at 5 01 17 PM](https://github.com/user-attachments/assets/af82fc78-d72f-4ea6-bb7e-6b537ecc18da)
![Screenshot 2024-09-11 at 5 01 31 PM](https://github.com/user-attachments/assets/aab399d7-c004-4990-ba4f-63b1dfe33a04)
![Screenshot 2024-09-11 at 5 01 38 PM](https://github.com/user-attachments/assets/1c9764a3-8c99-48a7-af0f-3d71b37a6a02)
![Screenshot 2024-09-11 at 5 06 58 PM](https://github.com/user-attachments/assets/677c1d5e-4f5e-4a74-8e5c-4f7d540a984f)




# Link to Sample Entry

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.