### PR TITLE
fix: useRepoCoverageTimeseries using wrong field 

### DIFF
--- a/src/pages/RepoPage/CoverageTab/OverviewTab/hooks/useRepoCoverageTimeseries.js
+++ b/src/pages/RepoPage/CoverageTab/OverviewTab/hooks/useRepoCoverageTimeseries.js
@@ -33,7 +33,7 @@ export function useRepoCoverageTimeseries({ branch }, options = {}) {
     owner,
     repo,
     branch,
-    after: queryVars?.startDate,
+    after: queryVars?.after,
     before: today,
     interval: queryVars.interval,
     opts: {


### PR DESCRIPTION
# Description

Small fix to the `useRepoCoverageTimeseries` hook as it's using the incorrect field, causing it to not re-run when a user selects a different trend. 🤦 