### PR TITLE
add new UploadErrorEnum values

### DIFF
--- a/src/shared/utils/commit.ts
+++ b/src/shared/utils/commit.ts
@@ -17,6 +17,9 @@ export const ErrorCodeEnum = {
   fileNotFoundInStorage: 'FILE_NOT_IN_STORAGE',
   reportExpired: 'REPORT_EXPIRED',
   reportEmpty: 'REPORT_EMPTY',
+
+  unknownProcessing: 'UNKNOWN_PROCESSING',
+  unknownStorage: 'UNKNOWN_STORAGE',
 } as const
 
 export const UploadTypeEnum = {


### PR DESCRIPTION
as title

- issue https://github.com/codecov/engineering-team/issues/1520
- worker PR https://github.com/codecov/worker/pull/703
- API PR https://github.com/codecov/codecov-api/pull/820

https://github.com/codecov/gazebo/tree/main/src/pages/CommitDetailPage/CommitCoverage/UploadsCard/RenderError.tsx appears to be where we would reference these codes to decide what to display in the UI. i am not going to touch that, but i'll let folks know when i add new codes so appropriate text can be worked out

i fixed some plumbing around error handling in upload processing. everything that used to be "unknown" will still be "unknown" for now but now there's a catchall for any exceptions we have not already assigned an error code. we can watch logs for exceptions we have not already made an error code for