### PR TITLE
fix: Users unable to cancel when have adblock

### DIFF
--- a/src/pages/PlanPage/subRoutes/CancelPlanPage/subRoutes/DowngradePlan/CancelButton/CancelButton.jsx
+++ b/src/pages/PlanPage/subRoutes/CancelPlanPage/subRoutes/DowngradePlan/CancelButton/CancelButton.jsx
@@ -13,7 +13,7 @@ const FALLBACK_PERIOD_TEXT = 'the end of the period'
 function CancelButton({
   customerId,
   planCost,
-  upComingCancelation,
+  upComingCancellation,
   currentPeriodEnd,
 }) {
   const [isModalOpen, setIsModalOpen] = useState(false)
@@ -27,11 +27,11 @@ function CancelButton({
     // disable button if
     queryIsLoading, // request in fly
     isAlreadyFreeUser, // user is a free user
-    upComingCancelation, // the subscription is already getting cancelled
+    upComingCancellation, // the subscription is already getting cancelled
   ].some(Boolean)
   const periodEnd = getEndPeriod(currentPeriodEnd)
 
-  function completeCancelation() {
+  function completeCancellation() {
     if (baremetricsBlocked) {
       cancelPlan()
     }
@@ -86,11 +86,12 @@ function CancelButton({
               Cancel
             </Button>
             <Button
+              // This ID is needed to render the baremetrics form. DO NOT CHANGE
               id="barecancel-trigger"
               variant="danger"
               hook="continue-cancellation-button"
               disabled={isDisabled}
-              onClick={completeCancelation}
+              onClick={completeCancellation}
             >
               Confirm Cancellation
             </Button>
@@ -104,7 +105,7 @@ function CancelButton({
 CancelButton.propTypes = {
   customerId: PropType.string,
   planCost: PropType.string.isRequired,
-  upComingCancelation: PropType.bool,
+  upComingCancellation: PropType.bool,
   currentPeriodEnd: PropType.number,
 }
 

--- a/src/pages/PlanPage/subRoutes/CancelPlanPage/subRoutes/DowngradePlan/CancelButton/hooks.js
+++ b/src/pages/PlanPage/subRoutes/CancelPlanPage/subRoutes/DowngradePlan/CancelButton/hooks.js
@@ -20,14 +20,9 @@ export function useCancel({ customerId, isModalOpen }, options = {}) {
     push(`/plan/${provider}/${owner}`)
   }
 
-  console.log({ baremetricsBlocked, isLoading })
-
   function cancelPlan() {
     mutate(null, {
       onSuccess: () => {
-        console.log(
-          'This thing is not being called, callback isnt being triggered from baremetrics side'
-        )
         sendUserToPlan()
       },
       onError: () =>

--- a/src/pages/PlanPage/subRoutes/CancelPlanPage/subRoutes/DowngradePlan/CancelButton/hooks.js
+++ b/src/pages/PlanPage/subRoutes/CancelPlanPage/subRoutes/DowngradePlan/CancelButton/hooks.js
@@ -20,9 +20,14 @@ export function useCancel({ customerId, isModalOpen }, options = {}) {
     push(`/plan/${provider}/${owner}`)
   }
 
+  console.log({ baremetricsBlocked, isLoading })
+
   function cancelPlan() {
     mutate(null, {
       onSuccess: () => {
+        console.log(
+          'This thing is not being called, callback isnt being triggered from baremetrics side'
+        )
         sendUserToPlan()
       },
       onError: () =>

--- a/src/pages/PlanPage/subRoutes/CancelPlanPage/subRoutes/DowngradePlan/CancelButton/useBarecancel.js
+++ b/src/pages/PlanPage/subRoutes/CancelPlanPage/subRoutes/DowngradePlan/CancelButton/useBarecancel.js
@@ -11,25 +11,29 @@ export function useBarecancel({ customerId, callbackSend, isModalOpen }) {
   useEffect(() => {
     let unMounted = false
     if (isModalOpen) {
-      loadBaremetrics().then(() => {
-        window.barecancel.params = {
-          /* eslint-disable camelcase */
-          access_token_id: config.BAREMETRICS_TOKEN,
-          customer_oid: customerId,
-          comment_required: true,
-          callback_send: () => {
-            memoizedSuccess()
-          },
-          callback_error: (error) => {
-            // You can also catch any errors that happen when sending the cancellation event to Baremetrics.
-            // For example, if Baremetrics returns that the customer does not have an active subscription.
-            console.error(error)
-          },
-          /* eslint-enable camelcase */
-        }
-        if (unMounted) return
-        setWasBlocked(false)
-      })
+      loadBaremetrics()
+        .then(() => {
+          window.barecancel.params = {
+            /* eslint-disable camelcase */
+            access_token_id: config.BAREMETRICS_TOKEN,
+            customer_oid: customerId,
+            comment_required: true,
+            callback_send: () => {
+              memoizedSuccess()
+            },
+            callback_error: (error) => {
+              // You can also catch any errors that happen when sending the cancellation event to Baremetrics.
+              // For example, if Baremetrics returns that the customer does not have an active subscription.
+              console.error(error)
+            },
+            /* eslint-enable camelcase */
+          }
+          if (unMounted) return
+          setWasBlocked(false)
+        })
+        .catch(() => {
+          setWasBlocked(true)
+        })
     }
 
     return () => {

--- a/src/pages/PlanPage/subRoutes/CancelPlanPage/subRoutes/DowngradePlan/CancelButton/utils.js
+++ b/src/pages/PlanPage/subRoutes/CancelPlanPage/subRoutes/DowngradePlan/CancelButton/utils.js
@@ -8,7 +8,7 @@ export function getEndPeriod(unixPeriodEnd) {
 }
 
 export function loadBaremetrics() {
-  return new Promise((resolve) => {
+  return new Promise((resolve, reject) => {
     if (window.barecancel && window.barecancel.created) {
       return resolve()
     }
@@ -17,8 +17,17 @@ export function loadBaremetrics() {
     script.src =
       'https://baremetrics-barecancel.baremetrics.com/js/application.js'
     script.dataset.testid = 'baremetrics-script'
+
+    // This stuff controls the logic in useBareCancel to make sure if the script isn't loaded to cancel without Baremetrics
+    script.onload = function () {
+      return resolve()
+    }
+
+    script.onerror = function () {
+      return reject()
+    }
+
     document.body.appendChild(script)
-    return resolve()
   })
 }
 

--- a/src/pages/PlanPage/subRoutes/CancelPlanPage/subRoutes/DowngradePlan/CancelButton/utils.js
+++ b/src/pages/PlanPage/subRoutes/CancelPlanPage/subRoutes/DowngradePlan/CancelButton/utils.js
@@ -9,16 +9,12 @@ export function getEndPeriod(unixPeriodEnd) {
 
 export function loadBaremetrics() {
   return new Promise((resolve, reject) => {
-    if (window.barecancel && window.barecancel.created) {
-      return resolve()
-    }
-    window.barecancel = { created: true }
     const script = document.createElement('script')
     script.src =
       'https://baremetrics-barecancel.baremetrics.com/js/application.js'
     script.dataset.testid = 'baremetrics-script'
 
-    // This stuff controls the logic in useBareCancel to make sure if the script isn't loaded to cancel without Baremetrics
+    // These functions control the logic in useBareCancel to make sure if the script isn't loaded to cancel without Baremetrics
     script.onload = function () {
       return resolve()
     }


### PR DESCRIPTION
# Description

**PROBLEM**
- Users with adblock on weren't able to cancel their Codecov subscriptions.
- This was due to the script being correctly "injected" into the DOM, but that being the "guard" for us to signal that "baremetrics was blocked," which is actually incorrect
- Maybe that worked previously where adblockers were preventing scripts from loading altogether; but now I guess it does inject scripts but just blocks them from executing.

Today I learned that scripts have .onload() and .onerror() handlers that allow you to throw errors if they aren't injected properly into the DOM!

Previously we were relying on doing all of that on "our own" in a bit of a hacky way; and it turns out just relying on those aspects and removing the unneeded code was all we needed to get baremetrics to work with and without adblock.



**References:**
https://app.baremetrics.com/cancellations/configure/responses/widget/embed-code
https://help.baremetrics.com/en/articles/5380579-embedding-cancellation-insights-code
https://help.baremetrics.com/en/articles/5380562-cancellation-insights-your-101-setup-guide

# Link to Sample Entry

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.