### PR TITLE
feat: Render okta errors based on error param

### DIFF
--- a/src/shared/GlobalTopBanners/OktaBanners/OktaBanners.spec.tsx
+++ b/src/shared/GlobalTopBanners/OktaBanners/OktaBanners.spec.tsx
@@ -9,6 +9,7 @@ import OktaBanners from './OktaBanners'
 
 jest.mock('../OktaEnabledBanner', () => () => 'OktaEnabledBanner')
 jest.mock('../OktaEnforcedBanner', () => () => 'OktaEnforcedBanner')
+jest.mock('../OktaErrorBanners', () => () => 'OktaErrorBanners')
 
 const wrapper =
   (initialEntries = ['/gh/owner']): React.FC<React.PropsWithChildren> =>
@@ -145,6 +146,27 @@ describe('OktaBanners', () => {
           const banner = await screen.findByText(/OktaEnabledBanner/)
           expect(banner).toBeInTheDocument()
         })
+
+        it('should render OktaErrorBanners', async () => {
+          setup({
+            owner: {
+              isUserOktaAuthenticated: false,
+              account: {
+                oktaConfig: {
+                  enabled: true,
+                  enforced: false,
+                  url: 'https://okta.com',
+                  clientId: 'clientId',
+                  clientSecret: 'clientSecret',
+                },
+              },
+            },
+          })
+
+          render(<OktaBanners />, { wrapper: wrapper() })
+          const banner = await screen.findByText(/OktaErrorBanners/)
+          expect(banner).toBeInTheDocument()
+        })
       })
 
       describe('when Okta is enforced', () => {
@@ -167,6 +189,27 @@ describe('OktaBanners', () => {
           render(<OktaBanners />, { wrapper: wrapper() })
 
           const banner = await screen.findByText(/OktaEnforcedBanner/)
+          expect(banner).toBeInTheDocument()
+        })
+
+        it('should render OktaErrorBanners', async () => {
+          setup({
+            owner: {
+              isUserOktaAuthenticated: false,
+              account: {
+                oktaConfig: {
+                  enabled: true,
+                  enforced: true,
+                  url: 'https://okta.com',
+                  clientId: 'clientId',
+                  clientSecret: 'clientSecret',
+                },
+              },
+            },
+          })
+
+          render(<OktaBanners />, { wrapper: wrapper() })
+          const banner = await screen.findByText(/OktaErrorBanners/)
           expect(banner).toBeInTheDocument()
         })
       })

--- a/src/shared/GlobalTopBanners/OktaBanners/OktaBanners.tsx
+++ b/src/shared/GlobalTopBanners/OktaBanners/OktaBanners.tsx
@@ -10,6 +10,7 @@ interface URLParams {
 
 const OktaEnabledBanner = lazy(() => import('../OktaEnabledBanner'))
 const OktaEnforcedBanner = lazy(() => import('../OktaEnforcedBanner'))
+const OktaErrorBanners = lazy(() => import('../OktaErrorBanners'))
 
 function OktaBanners() {
   const { provider, owner } = useParams<URLParams>()
@@ -25,7 +26,17 @@ function OktaBanners() {
   if (!owner || !oktaConfig?.enabled || data?.owner?.isUserOktaAuthenticated)
     return null
 
-  return oktaConfig?.enforced ? <OktaEnforcedBanner /> : <OktaEnabledBanner />
+  return oktaConfig?.enforced ? (
+    <div className="flex flex-col gap-2">
+      <OktaEnforcedBanner />
+      <OktaErrorBanners />
+    </div>
+  ) : (
+    <div className="flex flex-col gap-2">
+      <OktaEnabledBanner />
+      <OktaErrorBanners />
+    </div>
+  )
 }
 
 export default OktaBanners

--- a/src/shared/GlobalTopBanners/OktaErrorBanners/OktaErrorBanners.spec.tsx
+++ b/src/shared/GlobalTopBanners/OktaErrorBanners/OktaErrorBanners.spec.tsx
@@ -1,0 +1,75 @@
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter, Route } from 'react-router-dom'
+
+import OktaErrorBanners from './OktaErrorBanners'
+
+const wrapper =
+  (
+    initialEntries = ['/gh/codecov'],
+    path = '/:provider/:owner'
+  ): React.FC<React.PropsWithChildren> =>
+  ({ children }) => (
+    <MemoryRouter initialEntries={initialEntries}>
+      <Route path={path}>{children}</Route>
+    </MemoryRouter>
+  )
+
+describe('OktaErrorBanners', () => {
+  it('should return null if owner is not provided', () => {
+    const { container } = render(<OktaErrorBanners />, {
+      wrapper: wrapper(['/gh/'], '/:provider'),
+    })
+
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('should return null if error is not provided', () => {
+    const { container } = render(<OktaErrorBanners />, {
+      wrapper: wrapper(['/gh/codecov']),
+    })
+
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('should render error message for invalid_request', () => {
+    render(<OktaErrorBanners />, {
+      wrapper: wrapper(['/gh/codecov?error=invalid_request']),
+    })
+
+    const content = screen.getByText(
+      /Invalid request: The request parameters aren't valid. Please try again or contact support./
+    )
+    expect(content).toBeInTheDocument()
+  })
+
+  it('should render error message for unauthorized_client', () => {
+    render(<OktaErrorBanners />, {
+      wrapper: wrapper(['/gh/codecov?error=unauthorized_client']),
+    })
+
+    const content = screen.getByText(
+      /Unauthorized client: The client isn't authorized to request an authorization code using this method. Please reach out to your administrator./
+    )
+    expect(content).toBeInTheDocument()
+  })
+
+  it('should render error message for access_denied', () => {
+    render(<OktaErrorBanners />, {
+      wrapper: wrapper(['/gh/codecov?error=access_denied']),
+    })
+
+    const content = screen.getByText(
+      /The resource owner or authorization server denied the request/
+    )
+    expect(content).toBeInTheDocument()
+  })
+
+  it('should render dismiss button', () => {
+    render(<OktaErrorBanners />, {
+      wrapper: wrapper(['/gh/codecov?error=invalid_request']),
+    })
+
+    const dismissButton = screen.getByRole('button', { name: /Dismiss/ })
+    expect(dismissButton).toBeInTheDocument()
+  })
+})

--- a/src/shared/GlobalTopBanners/OktaErrorBanners/OktaErrorBanners.tsx
+++ b/src/shared/GlobalTopBanners/OktaErrorBanners/OktaErrorBanners.tsx
@@ -1,0 +1,41 @@
+import { useLocation, useParams } from 'react-router-dom'
+
+import Icon from 'ui/Icon'
+import TopBanner from 'ui/TopBanner'
+
+import { getErrorMessage } from './enums'
+
+interface URLParams {
+  owner?: string
+}
+
+const OktaErrorBanners = () => {
+  const { owner } = useParams<URLParams>()
+  const location = useLocation()
+
+  const searchParams = new URLSearchParams(location.search)
+  const error = searchParams.get('error')
+
+  if (!owner || !error) return null
+
+  const errorMessage = getErrorMessage(error)
+
+  return (
+    <TopBanner variant="error">
+      <TopBanner.Start>
+        <p className="items-center gap-1 md:flex">
+          <span className="flex items-center gap-1 font-semibold">
+            <Icon name="exclamationCircle" />
+            Okta Authentication Error
+          </span>
+          {errorMessage}
+        </p>
+      </TopBanner.Start>
+      <TopBanner.End>
+        <TopBanner.DismissButton>Dismiss</TopBanner.DismissButton>
+      </TopBanner.End>
+    </TopBanner>
+  )
+}
+
+export default OktaErrorBanners

--- a/src/shared/GlobalTopBanners/OktaErrorBanners/enums.ts
+++ b/src/shared/GlobalTopBanners/OktaErrorBanners/enums.ts
@@ -1,0 +1,46 @@
+enum ErrorType {
+  UnauthorizedClient = 'unauthorized_client',
+  AccessDenied = 'access_denied',
+  UnsupportedResponseType = 'unsupported_response_type',
+  UnsupportedResponseMode = 'unsupported_response_mode',
+  InvalidScope = 'invalid_scope',
+  ServerError = 'server_error',
+  TemporarilyUnavailable = 'temporarily_unavailable',
+  InvalidClient = 'invalid_client',
+  LoginRequired = 'login_required',
+  InvalidRequest = 'invalid_request',
+  UserCanceledRequest = 'user_canceled_request',
+}
+
+export const errorMessages: Record<ErrorType, string> = {
+  [ErrorType.UnauthorizedClient]:
+    "Unauthorized client: The client isn't authorized to request an authorization code using this method. Please reach out to your administrator.",
+  [ErrorType.AccessDenied]:
+    'Access denied: The resource owner or authorization server denied the request. Please reach out to your administrator.',
+  [ErrorType.UnsupportedResponseType]:
+    "Unsupported response type: The authorization server doesn't support obtaining an authorization code using this method. Please reach out to your administrator.",
+  [ErrorType.UnsupportedResponseMode]:
+    "Unsupported response mode: The authorization server doesn't support the requested response mode. Please reach out to your administrator.",
+  [ErrorType.InvalidScope]:
+    'Invalid scope: The requested scope is invalid, unknown, or malformed. Please reach out to your administrator.',
+  [ErrorType.ServerError]:
+    'Server error: The authorization server encountered an unexpected condition that prevented it from fulfilling the request. Please try again later or contact support.',
+  [ErrorType.TemporarilyUnavailable]:
+    'Temporarily unavailable: The authorization server is currently unable to handle the request due to temporary overloading or maintenance. Please try again later.',
+  [ErrorType.InvalidClient]:
+    "Invalid client: The specified client isn't valid. Please reach out to your administrator.",
+  [ErrorType.LoginRequired]:
+    "Login required: The client specified not to prompt, but the user isn't signed in. Please sign in and try again.",
+  [ErrorType.InvalidRequest]:
+    "Invalid request: The request parameters aren't valid. Please try again or contact support.",
+  [ErrorType.UserCanceledRequest]:
+    'Request canceled: User canceled the social sign-in request. Please try again if this was unintentional.',
+}
+
+export const getErrorMessage = (error: string): string => {
+  const errorType = error as ErrorType
+  return (
+    errorMessages[errorType] ||
+    'An unknown error occurred. Please try again or contact support.'
+  )
+}

--- a/src/shared/GlobalTopBanners/OktaErrorBanners/index.ts
+++ b/src/shared/GlobalTopBanners/OktaErrorBanners/index.ts
@@ -1,0 +1,1 @@
+export { default } from './OktaErrorBanners'

--- a/src/ui/TopBanner/TopBanner.stories.tsx
+++ b/src/ui/TopBanner/TopBanner.stories.tsx
@@ -13,7 +13,7 @@ const meta: Meta<typeof TopBannerComponent> = {
       },
     },
     variant: {
-      options: ['default', 'warning'],
+      options: ['default', 'warning', 'error'],
       control: 'radio',
       description:
         'This prop controls the variation of top banner that is displayed',
@@ -35,7 +35,7 @@ export const TopBanner: Story = {
   },
   argTypes: {
     variant: {
-      options: ['default', 'warning'],
+      options: ['default', 'warning', 'error'],
       control: 'radio',
     },
     children: {

--- a/src/ui/TopBanner/TopBanner.tsx
+++ b/src/ui/TopBanner/TopBanner.tsx
@@ -19,12 +19,21 @@ const variants = {
     iconColor: 'text-ds-primary-yellow',
     bgColor: 'bg-orange-100',
   },
+  error: {
+    icon: 'exclamationCircle',
+    iconColor: '',
+    bgColor: 'bg-ds-primary-red',
+  },
 } as const
 
 type Variants = keyof typeof variants
 
 const topBannerContext = z.object({
-  variant: z.union([z.literal('default'), z.literal('warning')]),
+  variant: z.union([
+    z.literal('default'),
+    z.literal('warning'),
+    z.literal('error'),
+  ]),
   localStorageKey: z.string().optional(),
   setHideBanner: z.function().args(z.boolean()).returns(z.void()),
 })


### PR DESCRIPTION
# Description
Surfacing okta errors, a full list of the error codes can be found here: https://developer.okta.com/docs/reference/error-codes/#example-errors-for-openid-connect-and-social-login

issue: https://github.com/codecov/engineering-team/issues/2347 

PS. The design was discussed with Kyle and dismiss button visibility in dark mode/light will be handled in a different issue. 

# Notable Changes
- Added a new variant for the top banner 
- Created new top banners

# Screenshots
<img width="1489" alt="Screenshot 2024-09-13 at 10 45 37 AM" src="https://github.com/user-attachments/assets/cb272fe8-cb4d-4556-97ff-465a99b82e43">
<img width="1489" alt="Screenshot 2024-09-13 at 1 49 49 PM" src="https://github.com/user-attachments/assets/392de966-16f6-4c9d-8049-e5369c6e545c">


<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.