### PR TITLE
chore: Add and configure Vite plugins

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,6 +105,7 @@
   "devDependencies": {
     "@babel/plugin-proposal-private-property-in-object": "^7.21.11",
     "@chromatic-com/storybook": "^1",
+    "@codecov/vite-plugin": "^1.0.1",
     "@codecov/webpack-plugin": "^1.0.0",
     "@craco/craco": "^7.1.0",
     "@sentry/webpack-plugin": "^2.22.2",

--- a/package.json
+++ b/package.json
@@ -108,6 +108,7 @@
     "@codecov/vite-plugin": "^1.0.1",
     "@codecov/webpack-plugin": "^1.0.0",
     "@craco/craco": "^7.1.0",
+    "@sentry/vite-plugin": "^2.22.4",
     "@sentry/webpack-plugin": "^2.22.2",
     "@storybook/addon-a11y": "^8.2.6",
     "@storybook/addon-actions": "^8.2.6",

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -1,6 +1,7 @@
+import { codecovVitePlugin } from '@codecov/vite-plugin'
+import react from '@vitejs/plugin-react'
 import { defineConfig, loadEnv } from 'vite'
 import tsconfigPaths from 'vite-tsconfig-paths'
-import react from '@vitejs/plugin-react'
 import { ViteEjsPlugin } from 'vite-plugin-ejs'
 import svgr from 'vite-plugin-svgr'
 
@@ -9,6 +10,18 @@ export default defineConfig((config) => {
 
   const envWithProcessPrefix = {
     'process.env': `${JSON.stringify(env)}`,
+  }
+
+  const plugins = []
+  if (process.env.CODECOV_ORG_TOKEN && process.env.CODECOV_API_URL) {
+    plugins.push(
+      codecovVitePlugin({
+        enableBundleAnalysis: true,
+        bundleName: process.env.CODECOV_BUNDLE_NAME,
+        apiUrl: process.env.CODECOV_API_URL,
+        uploadToken: process.env.CODECOV_ORG_TOKEN,
+      })
+    )
   }
 
   return {

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -15,9 +15,9 @@ export default defineConfig((config) => {
 
   const plugins = []
   if (
-    process.env.UPLOAD_CODECOV_BUNDLE_STATS &&
     process.env.CODECOV_API_URL &&
-    process.env.CODECOV_ORG_TOKEN
+    process.env.CODECOV_ORG_TOKEN &&
+    process.env.UPLOAD_CODECOV_BUNDLE_STATS
   ) {
     plugins.push(
       codecovVitePlugin({
@@ -29,7 +29,9 @@ export default defineConfig((config) => {
     )
   }
 
-  if (config.mode === 'production') {
+  const runSentryPlugin =
+    config.mode === 'production' && !!process.env.SENTRY_AUTH_TOKEN
+  if (runSentryPlugin) {
     plugins.push(
       sentryVitePlugin({
         applicationKey: 'gazebo',
@@ -54,7 +56,7 @@ export default defineConfig((config) => {
     },
     build: {
       outDir: 'build',
-      sourcemap: config.mode === 'production',
+      sourcemap: runSentryPlugin,
     },
     define: envWithProcessPrefix,
     plugins: [

--- a/yarn.lock
+++ b/yarn.lock
@@ -2231,6 +2231,32 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@codecov/bundler-plugin-core@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "@codecov/bundler-plugin-core@npm:1.0.1"
+  dependencies:
+    "@actions/core": "npm:^1.10.1"
+    "@actions/github": "npm:^6.0.0"
+    chalk: "npm:4.1.2"
+    semver: "npm:^7.5.4"
+    unplugin: "npm:^1.10.1"
+    zod: "npm:^3.22.4"
+  checksum: 10c0/4a2fbcb0d33ada3c5f0335fae555cc534b46ee8e9ae4f72976b894d1d0c21954ba6309c8ee4b4d759a203674557360932c94c40f766368dfaf5195d77fe6feb8
+  languageName: node
+  linkType: hard
+
+"@codecov/vite-plugin@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "@codecov/vite-plugin@npm:1.0.1"
+  dependencies:
+    "@codecov/bundler-plugin-core": "npm:^1.0.1"
+    unplugin: "npm:^1.10.1"
+  peerDependencies:
+    vite: 4.x || 5.x
+  checksum: 10c0/e6fb5d924fd17cd4ac429c5c5279cc3ff13c25853826aa0cd70468916475d09a163df2669f3a646d7738a4659203de7ccf397ec9834813eef5e013cf4db9c72a
+  languageName: node
+  linkType: hard
+
 "@codecov/webpack-plugin@npm:^1.0.0":
   version: 1.0.0
   resolution: "@codecov/webpack-plugin@npm:1.0.0"
@@ -11268,6 +11294,7 @@ __metadata:
   dependencies:
     "@babel/plugin-proposal-private-property-in-object": "npm:^7.21.11"
     "@chromatic-com/storybook": "npm:^1"
+    "@codecov/vite-plugin": "npm:^1.0.1"
     "@codecov/webpack-plugin": "npm:^1.0.0"
     "@craco/craco": "npm:^7.1.0"
     "@hookform/resolvers": "npm:^2.8.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4294,6 +4294,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@sentry/babel-plugin-component-annotate@npm:2.22.4":
+  version: 2.22.4
+  resolution: "@sentry/babel-plugin-component-annotate@npm:2.22.4"
+  checksum: 10c0/35bd4ce07cf581ee1443e9411bf1a492ee9eb260d919c4efe70b7866adc0db77220a3c1a7941a9a24f03eb17c90d8f25226138f1d87cc82c83996565c7487a70
+  languageName: node
+  linkType: hard
+
 "@sentry/browser@npm:8.24.0":
   version: 8.24.0
   resolution: "@sentry/browser@npm:8.24.0"
@@ -4322,6 +4329,22 @@ __metadata:
     magic-string: "npm:0.30.8"
     unplugin: "npm:1.0.1"
   checksum: 10c0/e12aa15d2e7d8d06f2e260d63a84fe4e5c68375004d2d9ef6b86675796da056c158538d7f37d91aa81695dbe16663b5c2c9c9c4efa2eacdd4318d5fac16e1e57
+  languageName: node
+  linkType: hard
+
+"@sentry/bundler-plugin-core@npm:2.22.4":
+  version: 2.22.4
+  resolution: "@sentry/bundler-plugin-core@npm:2.22.4"
+  dependencies:
+    "@babel/core": "npm:^7.18.5"
+    "@sentry/babel-plugin-component-annotate": "npm:2.22.4"
+    "@sentry/cli": "npm:^2.33.1"
+    dotenv: "npm:^16.3.1"
+    find-up: "npm:^5.0.0"
+    glob: "npm:^9.3.2"
+    magic-string: "npm:0.30.8"
+    unplugin: "npm:1.0.1"
+  checksum: 10c0/abec341d5648964e99d269a87ec2c1e6b583ec6a7a8497d1da4a8c502d1348b60b0697849990f82e17987121b9eaab196f8963a203398b43680fc03d6ca6b2f8
   languageName: node
   linkType: hard
 
@@ -4449,6 +4472,16 @@ __metadata:
   dependencies:
     "@sentry/types": "npm:8.24.0"
   checksum: 10c0/5a9da3c5fbfac886a365fc48d467954a63c0d15bd049cc2a61d24d0146c8f6e8c88f1e57e2666384d834b440d6cc4abdc986d3dda57f7418a310e2032bdbecdc
+  languageName: node
+  linkType: hard
+
+"@sentry/vite-plugin@npm:^2.22.4":
+  version: 2.22.4
+  resolution: "@sentry/vite-plugin@npm:2.22.4"
+  dependencies:
+    "@sentry/bundler-plugin-core": "npm:2.22.4"
+    unplugin: "npm:1.0.1"
+  checksum: 10c0/9c1c2ef152052d634e78ed67b1d33c8313127a8904362508fe8e7a890a8d8fd9c258073f00df652b6a07f8cec925acb5a5fe58336bec25600fc76cfeae34e5c0
   languageName: node
   linkType: hard
 
@@ -11306,6 +11339,7 @@ __metadata:
     "@radix-ui/react-radio-group": "npm:^1.1.3"
     "@radix-ui/react-tooltip": "npm:^1.1.2"
     "@sentry/react": "npm:^8.24.0"
+    "@sentry/vite-plugin": "npm:^2.22.4"
     "@sentry/webpack-plugin": "npm:^2.22.2"
     "@storybook/addon-a11y": "npm:^8.2.6"
     "@storybook/addon-actions": "npm:^8.2.6"


### PR DESCRIPTION
# Description

This PR adds in the Codecov Vite plugin and Sentry Vite plugin, to upload bundle stats and source maps respectively. 

Issue: codecov/engineering-team#2125

# Notable Changes

- Add in Codecov Vite plugin
- Add in Sentry Vite plugin
- Configure plugins conditionally in Vite config