### PR TITLE
chore: Remove old lint rules

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -29,9 +29,6 @@
     "testing-library/prefer-user-event": "warn",
     "testing-library/prefer-wait-for": "warn",
     "testing-library/prefer-explicit-assert": "warn",
-    "complexity": "off",
-    "max-statements": "off",
-    "max-nested-callbacks": ["error", 2],
     "react/prefer-stateless-function": ["error"],
     "react/prop-types": [
       "warn",
@@ -259,7 +256,6 @@
         "*.test.tsx"
       ],
       "rules": {
-        "max-nested-callbacks": "off",
         "react/display-name": "off",
         "camelcase": "off"
       }

--- a/README.md
+++ b/README.md
@@ -58,13 +58,6 @@ We are using the [Testing Library](https://testing-library.com/docs/react-testin
 
 will lint the whole project.
 
-We have some extra rules to keep the code more maintainable:
-
-- Complexity of max 5 per function: to prevent functions with a lot of of different outcome
-- 10 max statements per function: to prevent a function doing too much
-- 2 level of nested callbacks: to prevent complexity within nested functions
-- Mandatory prop-types: as we don't have a Type system, this rule will help us have documented components
-
 ## Build the application for production
 
 ```bash

--- a/src/pages/RepoPage/CoverageTab/ComponentsTab/subroute/ComponentsTable/ComponentsTable.tsx
+++ b/src/pages/RepoPage/CoverageTab/ComponentsTab/subroute/ComponentsTable/ComponentsTable.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable max-nested-callbacks */
 import {
   createColumnHelper,
   flexRender,

--- a/src/pages/RepoPage/CoverageTab/FlagsTab/subroute/FlagsTable/FlagsTable.tsx
+++ b/src/pages/RepoPage/CoverageTab/FlagsTab/subroute/FlagsTable/FlagsTable.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable max-nested-callbacks */
 import {
   createColumnHelper,
   flexRender,

--- a/src/ui/Dropdown/Dropdown.tsx
+++ b/src/ui/Dropdown/Dropdown.tsx
@@ -62,7 +62,6 @@ const Trigger = React.forwardRef<
   React.useEffect(() => {
     if (!isOpen) {
       setWasJustClosed(true)
-      // eslint-disable-next-line max-nested-callbacks
       setTimeout(() => {
         ref.current?.blur()
         setWasJustClosed(false)


### PR DESCRIPTION
# Description

We had disabled some of these rules a while ago, and everything has been going on smoothly ever since, so we might as well get rid of them once and for all. As well we're getting rid of the nested callback lint rule, as it was being used in the same way as the others and really only hinders development over providing any really meaningful value.