### PR TITLE
fix: missing l on cancellation

### DIFF
--- a/src/pages/PlanPage/subRoutes/CancelPlanPage/subRoutes/DowngradePlan/DowngradePlan.jsx
+++ b/src/pages/PlanPage/subRoutes/CancelPlanPage/subRoutes/DowngradePlan/DowngradePlan.jsx
@@ -69,7 +69,7 @@ function DowngradePlan() {
           <CancelButton
             customerId={accountDetails?.subscriptionDetail?.customer?.id}
             planCost={accountDetails?.plan?.value}
-            upComingCancelation={
+            upComingCancellation={
               accountDetails?.subscriptionDetail?.cancelAtPeriodEnd
             }
             currentPeriodEnd={


### PR DESCRIPTION
# Description

idk why but just saw this file didn't save the additional "l"

Component prop here:
https://github.com/codecov/gazebo/blob/1f8f9153c19c8c5802f17a9abb43c2f29dffa5c8/src/pages/PlanPage/subRoutes/CancelPlanPage/subRoutes/DowngradePlan/CancelButton/CancelButton.jsx#L16

# Code Example

# Notable Changes

# Screenshots

# Link to Sample Entry

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.