### PR TITLE
fix: Guard when calling match() on undefined

### DIFF
--- a/src/pages/DefaultOrgSelector/DefaultOrgSelector.jsx
+++ b/src/pages/DefaultOrgSelector/DefaultOrgSelector.jsx
@@ -47,7 +47,7 @@ const renderItem = ({ item }) => {
   if (item?.isProvider) {
     return (
       <div className="flex h-8 items-center gap-2">
-        <A pathname={{ pageName: 'codecovAppInstallation' }}>
+        <A to={{ pageName: 'codecovAppInstallation' }}>
           <Icon name="plus-circle" />
           <span>Install Codecov GitHub app</span>
         </A>

--- a/src/pages/DefaultOrgSelector/DefaultOrgSelector.spec.jsx
+++ b/src/pages/DefaultOrgSelector/DefaultOrgSelector.spec.jsx
@@ -330,8 +330,8 @@ describe('DefaultOrgSelector', () => {
       const selfOrg = screen.getByRole('option', { name: 'Rula' })
       expect(selfOrg).toBeInTheDocument()
 
-      const addNewOrg = screen.getByRole('option', {
-        name: 'plus-circle.svg Install Codecov GitHub app',
+      const addNewOrg = screen.getByRole('link', {
+        name: 'plus-circle.svg Install Codecov GitHub app external-link.svg',
       })
       expect(addNewOrg).toBeInTheDocument()
     })
@@ -378,8 +378,8 @@ describe('DefaultOrgSelector', () => {
       const selfOrg = screen.queryByRole('option', { name: 'janedoe' })
       expect(selfOrg).not.toBeInTheDocument()
 
-      const addNewOrg = screen.getByRole('option', {
-        name: 'plus-circle.svg Install Codecov GitHub app',
+      const addNewOrg = screen.getByRole('link', {
+        name: 'plus-circle.svg Install Codecov GitHub app external-link.svg',
       })
       expect(addNewOrg).toBeInTheDocument()
     })
@@ -417,8 +417,8 @@ describe('DefaultOrgSelector', () => {
       const noOrgsFound = screen.getByText(/No organizations found/)
       expect(noOrgsFound).toBeInTheDocument()
 
-      const addNewOrg = screen.getByRole('option', {
-        name: 'plus-circle.svg Install Codecov GitHub app',
+      const addNewOrg = screen.getByRole('link', {
+        name: 'plus-circle.svg Install Codecov GitHub app external-link.svg',
       })
       expect(addNewOrg).toBeInTheDocument()
     })
@@ -458,8 +458,8 @@ describe('DefaultOrgSelector', () => {
       const orgInList = screen.getByRole('option', { name: 'criticalRole' })
       expect(orgInList).toBeInTheDocument()
 
-      const addNewOrg = screen.queryByRole('option', {
-        name: 'plus-circle.svg Install Codecov GitHub app',
+      const addNewOrg = screen.queryByRole('link', {
+        name: 'plus-circle.svg Install Codecov GitHub app external-link.svg',
       })
       expect(addNewOrg).not.toBeInTheDocument()
     })
@@ -496,8 +496,8 @@ describe('DefaultOrgSelector', () => {
 
       await user.click(selectOrg)
 
-      const addNewOrg = screen.getByRole('option', {
-        name: 'plus-circle.svg Install Codecov GitHub app',
+      const addNewOrg = screen.getByRole('link', {
+        name: 'plus-circle.svg Install Codecov GitHub app external-link.svg',
       })
 
       await user.click(addNewOrg)

--- a/src/ui/A/A.jsx
+++ b/src/ui/A/A.jsx
@@ -30,7 +30,10 @@ const variantClasses = {
   configure: `rounded bg-ds-blue-default px-4 py-1 font-semibold text-ds-gray-primary dark:text-white dark:bg-ds-blue-nonary`,
 }
 
-const getHostnameFromRegex = (url) => {
+export const getHostnameFromRegex = (url) => {
+  if (!url) {
+    return 'app.codecov.io'
+  }
   // run against regex
   const matches = url.match(/^https?:\/\/([^/?#]+)(?:[/?#]|$)/i)
   // extract hostname (will be null if no match is found)

--- a/src/ui/A/A.spec.jsx
+++ b/src/ui/A/A.spec.jsx
@@ -1,7 +1,7 @@
 import { render, screen } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 
-import A from '.'
+import A, { getHostnameFromRegex } from './A'
 
 describe('A', () => {
   function setup(props = {}) {
@@ -9,6 +9,17 @@ describe('A', () => {
       wrapper: MemoryRouter,
     })
   }
+
+  describe('hostnameWithoutRegex', () => {
+    it('returns to home if no url passed', () => {
+      expect(getHostnameFromRegex(undefined)).toBe('https://app.codecov.io')
+    })
+    it('scrubs URL if one exists', () => {
+      expect(getHostnameFromRegex('https://app.codecov.io')).toBe(
+        'app.codecov.io'
+      )
+    })
+  })
 
   describe('when rendered with the prop `to`', () => {
     beforeEach(() => {

--- a/src/ui/A/A.spec.jsx
+++ b/src/ui/A/A.spec.jsx
@@ -12,7 +12,7 @@ describe('A', () => {
 
   describe('hostnameWithoutRegex', () => {
     it('returns to home if no url passed', () => {
-      expect(getHostnameFromRegex(undefined)).toBe('https://app.codecov.io')
+      expect(getHostnameFromRegex(undefined)).toBe('app.codecov.io')
     })
     it('scrubs URL if one exists', () => {
       expect(getHostnameFromRegex('https://app.codecov.io')).toBe(

--- a/src/ui/CodeRenderer/CodeRendererProgressHeader/CodeRendererProgressHeader.jsx
+++ b/src/ui/CodeRenderer/CodeRendererProgressHeader/CodeRendererProgressHeader.jsx
@@ -12,7 +12,7 @@ function CodeRendererProgressHeader({ path, fileCoverage, change }) {
    * Header component that shows progress bar for the Code Renderer component.
    * @param {[String]} treePaths path of file from root directory. Only used in standalone file viewer
    * @param {Float} fileCoverage total coverage of current file
-   * @param {Float} change difference between head and base coverage. Only used in commmit based file viewer
+   * @param {Float} change difference between head and base coverage. Only used in commit based file viewer
    */
 
   const isUnsupportedFileType = unsupportedExtensionsMapper({ path })


### PR DESCRIPTION
# Description

Aiming to fix: https://codecov.sentry.io/issues/5616514924

Not sure exactly where this sentry issue is coming from, but my hunch is it's from the only place we're calling .match() on something here: https://github.com/codecov/gazebo/blob/7a43fe74ff12c04adefdbb971009a9282e79cc37/src/ui/A/A.jsx#L37-L38

Tracing that function up though, even weirder because we have a guard checking for if href exists here:
https://github.com/codecov/gazebo/blob/7a43fe74ff12c04adefdbb971009a9282e79cc37/src/ui/A/A.jsx#L78-L80

Technically it will resolve to true for _any_ truthy value, such as true, 1, '', etc. In those cases, we also wouldn't be throwing an error saying "can't read properties of undefined" either, but something more like these:

<img width="981" alt="Screenshot 2024-09-18 at 9 36 24 AM" src="https://github.com/user-attachments/assets/5bb90983-38aa-4d46-a66d-133e7afa738b">

In any case, I don't think this PR "hurts" us. If the URL doesn't exist, we should nav the user back to the top of the application.

**TESTING**

- Went through and clicked around everywhere to try and reproduce, couldn't find anything 
- The app still functions correctly

# Link to Sample Entry

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.