### PR TITLE
fix: Add tooltip and correct styling to flake rate column header

### DIFF
--- a/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/FailedTestsTable/FailedTestsTable.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/FailedTestsTable/FailedTestsTable.tsx
@@ -22,6 +22,7 @@ import {
   OrderingParameter,
   useInfiniteTestResults,
 } from '../hooks'
+import { TooltipWithIcon } from '../MetricsSection/MetricsSection'
 
 const getDecodedBranch = (branch?: string) =>
   !!branch ? decodeURIComponent(branch) : undefined
@@ -120,11 +121,11 @@ const columns = [
     header: () => (
       <div className="flex items-center gap-1">
         Flake rate
-        <Icon
-          name="informationCircle"
-          size="sm"
-          className="text-ds-gray-tertiary"
-        />
+        <TooltipWithIcon>
+          Shows how often a flake occurs by tracking how many times a test goes
+          from fail to pass or pass to fail on a given branch and commit within
+          the last [7] days.
+        </TooltipWithIcon>
       </div>
     ),
     cell: (info) => {

--- a/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/MetricsSection/MetricsSection.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/MetricsSection/MetricsSection.tsx
@@ -3,7 +3,11 @@ import Icon from 'ui/Icon'
 import { MetricCard } from 'ui/MetricCard'
 import { Tooltip } from 'ui/Tooltip'
 
-const TooltipWithIcon = ({ children }: { children: React.ReactNode }) => {
+export const TooltipWithIcon = ({
+  children,
+}: {
+  children: React.ReactNode
+}) => {
   return (
     <Tooltip delayDuration={0} skipDelayDuration={100}>
       <Tooltip.Root>


### PR DESCRIPTION
# Description

This PR aims to fix the styling issue on the flake rate tooltip, and adds the copy and tooltip aspect to the column as well

# Screenshots

![Screenshot 2024-09-19 at 4 02 33 PM](https://github.com/user-attachments/assets/8489eb6b-fa39-42a4-badf-c6ffd1a2aa10)

# Link to Sample Entry

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.