### PR TITLE
chore: Vitest config tweaks

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -8,9 +8,12 @@
     "plugin:import/recommended",
     "prettier",
     "plugin:storybook/recommended",
-    "plugin:tailwindcss/recommended",
-    "plugin:@vitest"
+    "plugin:tailwindcss/recommended"
   ],
+  "plugins": ["@vitest"],
+  "globals": {
+    "vi": true
+  },
   "ignorePatterns": [
     "!src/**/*.{js,jsx,ts,tsx}",
     "src/old_ui/Icon/svg/*.jsx",

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -8,7 +8,8 @@
     "plugin:import/recommended",
     "prettier",
     "plugin:storybook/recommended",
-    "plugin:tailwindcss/recommended"
+    "plugin:tailwindcss/recommended",
+    "@vitest"
   ],
   "ignorePatterns": [
     "!src/**/*.{js,jsx,ts,tsx}",

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -9,7 +9,7 @@
     "prettier",
     "plugin:storybook/recommended",
     "plugin:tailwindcss/recommended",
-    "@vitest"
+    "plugin:@vitest"
   ],
   "ignorePatterns": [
     "!src/**/*.{js,jsx,ts,tsx}",

--- a/package.json
+++ b/package.json
@@ -151,6 +151,7 @@
     "@vitejs/plugin-react": "^4.3.1",
     "@vitest/coverage-istanbul": "^2.1.1",
     "@vitest/coverage-v8": "^2.1.1",
+    "@vitest/eslint-plugin": "^1.1.4",
     "@vitest/ui": "^2.1.1",
     "autoprefixer": "^10.4.14",
     "eslint": "^8.39.0",

--- a/src/layouts/BaseLayout/InstallationHelpBanner/InstallationHelpBanner.test.jsx
+++ b/src/layouts/BaseLayout/InstallationHelpBanner/InstallationHelpBanner.test.jsx
@@ -4,7 +4,6 @@ import userEvent from '@testing-library/user-event'
 import { graphql, HttpResponse } from 'msw2'
 import { setupServer } from 'msw2/node'
 import { MemoryRouter, Route, Switch } from 'react-router-dom'
-import { vi } from 'vitest'
 
 import InstallationHelpBanner from './InstallationHelpBanner'
 

--- a/src/layouts/Footer/Footer.test.tsx
+++ b/src/layouts/Footer/Footer.test.tsx
@@ -1,6 +1,5 @@
 import { render, screen } from '@testing-library/react'
 import { MemoryRouter, Route } from 'react-router-dom'
-import { vi } from 'vitest'
 
 import config from 'config'
 

--- a/src/old_ui/Message/Message.test.jsx
+++ b/src/old_ui/Message/Message.test.jsx
@@ -1,6 +1,5 @@
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { vi } from 'vitest'
 
 import Message from '.'
 

--- a/src/vitest.setup.ts
+++ b/src/vitest.setup.ts
@@ -1,6 +1,5 @@
 import * as matchers from '@testing-library/jest-dom/matchers'
 import { cleanup } from '@testing-library/react'
-import { vi } from 'vitest'
 import '@testing-library/jest-dom/vitest'
 
 // not sure why this lint is being fired here so I'm disabling it

--- a/yarn.lock
+++ b/yarn.lock
@@ -6871,6 +6871,25 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@vitest/eslint-plugin@npm:^1.1.4":
+  version: 1.1.4
+  resolution: "@vitest/eslint-plugin@npm:1.1.4"
+  peerDependencies:
+    "@typescript-eslint/utils": ">= 8.0"
+    eslint: ">= 8.57.0"
+    typescript: ">= 5.0.0"
+    vitest: "*"
+  peerDependenciesMeta:
+    "@typescript-eslint/utils":
+      optional: true
+    typescript:
+      optional: true
+    vitest:
+      optional: true
+  checksum: 10c0/e1de76593acefa063498081978746750fcd4906f9de31a463e7675b98d44b0e600c1b9d54d1873f6c01efcf2230184f414d3a4e9a7933e7105ae60c0ea18591c
+  languageName: node
+  linkType: hard
+
 "@vitest/expect@npm:2.1.1":
   version: 2.1.1
   resolution: "@vitest/expect@npm:2.1.1"
@@ -11736,6 +11755,7 @@ __metadata:
     "@vitejs/plugin-react": "npm:^4.3.1"
     "@vitest/coverage-istanbul": "npm:^2.1.1"
     "@vitest/coverage-v8": "npm:^2.1.1"
+    "@vitest/eslint-plugin": "npm:^1.1.4"
     "@vitest/ui": "npm:^2.1.1"
     autoprefixer: "npm:^10.4.14"
     classnames: "npm:^2.3.1"


### PR DESCRIPTION
# Description

This PR fixes some linting issues with Vitest, and we no longer have to import `vi` only for JS files.