### PR TITLE
feat: Tokenless section in global upload token tab

### DIFF
--- a/src/pages/AccountSettings/tabs/OrgUploadToken/OrgUploadToken.jsx
+++ b/src/pages/AccountSettings/tabs/OrgUploadToken/OrgUploadToken.jsx
@@ -14,8 +14,8 @@ const TokenlessSection = lazy(() => import('./TokenlessSection'))
 function OrgUploadToken() {
   const { provider, owner } = useParams()
   const { data: orgUploadToken } = useOrgUploadToken({ provider, owner })
-  const { TokenlessSection: TokenlessSectionFlag } = useFlags({
-    TokenlessSection: false,
+  const { tokenlessSection: tokenlessSectionFlag } = useFlags({
+    tokenlessSection: false,
   })
 
   return (
@@ -28,7 +28,7 @@ function OrgUploadToken() {
       </div>
       <hr />
       <div className="flex flex-col gap-6">
-        {TokenlessSectionFlag ? <TokenlessSection /> : null}
+        {tokenlessSectionFlag ? <TokenlessSection /> : null}
         <Banner>
           <h2 className="font-semibold">Sensitive credential</h2>
           <p>

--- a/src/pages/AccountSettings/tabs/OrgUploadToken/OrgUploadToken.jsx
+++ b/src/pages/AccountSettings/tabs/OrgUploadToken/OrgUploadToken.jsx
@@ -1,15 +1,22 @@
+import { lazy } from 'react'
 import { useParams } from 'react-router-dom'
 
 import { useOrgUploadToken } from 'services/orgUploadToken'
+import { useFlags } from 'shared/featureFlags'
 import A from 'ui/A'
 import Banner from 'ui/Banner'
 
 import GenerateOrgUploadToken from './GenerateOrgUploadToken'
 import RegenerateOrgUploadToken from './RegenerateOrgUploadToken'
 
+const TokenlessSection = lazy(() => import('./TokenlessSection'))
+
 function OrgUploadToken() {
   const { provider, owner } = useParams()
   const { data: orgUploadToken } = useOrgUploadToken({ provider, owner })
+  const { TokenlessSection: TokenlessSectionFlag } = useFlags({
+    TokenlessSection: false,
+  })
 
   return (
     <div className="flex flex-col gap-4 lg:w-3/4">
@@ -21,6 +28,7 @@ function OrgUploadToken() {
       </div>
       <hr />
       <div className="flex flex-col gap-6">
+        {TokenlessSectionFlag ? <TokenlessSection /> : null}
         <Banner>
           <h2 className="font-semibold">Sensitive credential</h2>
           <p>

--- a/src/pages/AccountSettings/tabs/OrgUploadToken/OrgUploadToken.test.jsx
+++ b/src/pages/AccountSettings/tabs/OrgUploadToken/OrgUploadToken.test.jsx
@@ -7,6 +7,7 @@ import { Suspense } from 'react'
 import { MemoryRouter, Route } from 'react-router-dom'
 
 import { useAddNotification } from 'services/toastNotification'
+import { useFlags } from 'shared/featureFlags'
 
 import OrgUploadToken from './OrgUploadToken'
 
@@ -146,6 +147,13 @@ describe('OrgUploadToken', () => {
         'href',
         'https://docs.codecov.com/docs/codecov-uploader#organization-upload-token'
       )
+    })
+
+    it('renders TokenlessSection component', async () => {
+      render(<OrgUploadToken />, { wrapper })
+
+      const tokenlessSection = await screen.findByText('TokenlessSection')
+      expect(tokenlessSection).toBeInTheDocument()
     })
   })
 

--- a/src/pages/AccountSettings/tabs/OrgUploadToken/OrgUploadToken.test.jsx
+++ b/src/pages/AccountSettings/tabs/OrgUploadToken/OrgUploadToken.test.jsx
@@ -12,6 +12,8 @@ import { useFlags } from 'shared/featureFlags'
 import OrgUploadToken from './OrgUploadToken'
 
 vi.mock('services/toastNotification')
+vi.mock('shared/featureFlags')
+vi.mock('./TokenlessSection', () => ({ default: () => 'TokenlessSection' }))
 
 const mockOwner = {
   owner: {
@@ -61,6 +63,7 @@ describe('OrgUploadToken', () => {
     const user = userEvent.setup()
     const mutate = vi.fn()
     const addNotification = vi.fn()
+    useFlags.mockReturnValue({ tokenlessSection: true })
 
     useAddNotification.mockReturnValue(addNotification)
 
@@ -150,6 +153,7 @@ describe('OrgUploadToken', () => {
     })
 
     it('renders TokenlessSection component', async () => {
+      setup({ orgUploadToken: 'upload-token' })
       render(<OrgUploadToken />, { wrapper })
 
       const tokenlessSection = await screen.findByText('TokenlessSection')

--- a/src/pages/AccountSettings/tabs/OrgUploadToken/TokenlessSection/TokenRequiredModal.spec.tsx
+++ b/src/pages/AccountSettings/tabs/OrgUploadToken/TokenlessSection/TokenRequiredModal.spec.tsx
@@ -1,0 +1,191 @@
+import { render, screen, waitFor } from 'custom-testing-library'
+
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter, Route } from 'react-router-dom'
+
+import TokenRequiredModal from './TokenRequiredModal'
+
+const wrapper: React.FC<React.PropsWithChildren> = ({ children }) => (
+  <MemoryRouter initialEntries={['/some-initial-path']}>
+    <Route path="/some-initial-path">{children}</Route>
+  </MemoryRouter>
+)
+
+describe('TokenRequiredModal', () => {
+  function setup(isLoading = false) {
+    return {
+      user: userEvent.setup(),
+      closeModal: jest.fn(),
+      setTokenRequired: jest.fn(),
+      isLoading,
+    }
+  }
+
+  describe('renders the modal content correctly', () => {
+    it('renders the correct modal title', async () => {
+      const { closeModal, setTokenRequired } = setup()
+
+      render(
+        <TokenRequiredModal
+          closeModal={closeModal}
+          setTokenRequired={setTokenRequired}
+          isLoading={false}
+        />,
+        { wrapper }
+      )
+
+      const title = await screen.findByText(/Require token for uploads/)
+      expect(title).toBeInTheDocument()
+    })
+
+    it('renders the correct body content part 1', async () => {
+      const { closeModal, setTokenRequired } = setup()
+
+      render(
+        <TokenRequiredModal
+          closeModal={closeModal}
+          setTokenRequired={setTokenRequired}
+          isLoading={false}
+        />,
+        { wrapper }
+      )
+
+      const messagePartOne = await screen.findByText(
+        /Enforcing token authentication for uploads/
+      )
+      expect(messagePartOne).toBeInTheDocument()
+    })
+
+    it('renders the correct body content part 2', async () => {
+      const { closeModal, setTokenRequired } = setup()
+
+      render(
+        <TokenRequiredModal
+          closeModal={closeModal}
+          setTokenRequired={setTokenRequired}
+          isLoading={false}
+        />,
+        { wrapper }
+      )
+
+      const messagePartTwo = await screen.findByText(
+        /Before proceeding, make sure all of your repositories/
+      )
+      expect(messagePartTwo).toBeInTheDocument()
+    })
+
+    it('renders the correct body content part 3', async () => {
+      const { closeModal, setTokenRequired } = setup()
+
+      render(
+        <TokenRequiredModal
+          closeModal={closeModal}
+          setTokenRequired={setTokenRequired}
+          isLoading={false}
+        />,
+        { wrapper }
+      )
+
+      const messagePartThree = await screen.findByText(
+        /to enforce the use of the global token for uploads./
+      )
+      expect(messagePartThree).toBeInTheDocument()
+    })
+
+    it('renders the cancel button', async () => {
+      const { closeModal, setTokenRequired } = setup()
+
+      render(
+        <TokenRequiredModal
+          closeModal={closeModal}
+          setTokenRequired={setTokenRequired}
+          isLoading={false}
+        />,
+        { wrapper }
+      )
+
+      const cancelButton = await screen.findByRole('button', { name: /Cancel/ })
+      expect(cancelButton).toBeInTheDocument()
+    })
+
+    it('renders the require token button', async () => {
+      const { closeModal, setTokenRequired } = setup()
+
+      render(
+        <TokenRequiredModal
+          closeModal={closeModal}
+          setTokenRequired={setTokenRequired}
+          isLoading={false}
+        />,
+        { wrapper }
+      )
+
+      const requireButton = await screen.findByRole('button', {
+        name: /Require token for upload/,
+      })
+      expect(requireButton).toBeInTheDocument()
+    })
+
+    it('renders loading state on require token button', async () => {
+      const { closeModal, setTokenRequired } = setup(true)
+
+      render(
+        <TokenRequiredModal
+          closeModal={closeModal}
+          setTokenRequired={setTokenRequired}
+          isLoading={true}
+        />,
+        { wrapper }
+      )
+
+      const requireButton = await screen.findByRole('button', {
+        name: /Require token for upload/,
+      })
+      expect(requireButton).toHaveAttribute('disabled')
+    })
+  })
+
+  describe('when clicking cancel button', () => {
+    it('closes the modal without requiring token', async () => {
+      const { user, closeModal, setTokenRequired } = setup()
+
+      render(
+        <TokenRequiredModal
+          closeModal={closeModal}
+          setTokenRequired={setTokenRequired}
+          isLoading={false}
+        />,
+        { wrapper }
+      )
+
+      const cancelButton = await screen.findByRole('button', { name: /Cancel/ })
+      await user.click(cancelButton)
+
+      expect(setTokenRequired).toHaveBeenCalledWith(false)
+      await waitFor(() => expect(closeModal).toHaveBeenCalled())
+    })
+  })
+
+  describe('when clicking require token button', () => {
+    it('sets token requirement and closes the modal', async () => {
+      const { user, closeModal, setTokenRequired } = setup()
+
+      render(
+        <TokenRequiredModal
+          closeModal={closeModal}
+          setTokenRequired={setTokenRequired}
+          isLoading={false}
+        />,
+        { wrapper }
+      )
+
+      const requireButton = await screen.findByRole('button', {
+        name: /Require token for upload/,
+      })
+      await user.click(requireButton)
+
+      expect(setTokenRequired).toHaveBeenCalledWith(true)
+      await waitFor(() => expect(closeModal).toHaveBeenCalled())
+    })
+  })
+})

--- a/src/pages/AccountSettings/tabs/OrgUploadToken/TokenlessSection/TokenRequiredModal.spec.tsx
+++ b/src/pages/AccountSettings/tabs/OrgUploadToken/TokenlessSection/TokenRequiredModal.spec.tsx
@@ -12,12 +12,11 @@ const wrapper: React.FC<React.PropsWithChildren> = ({ children }) => (
 )
 
 describe('TokenRequiredModal', () => {
-  function setup(isLoading = false) {
+  function setup() {
     return {
       user: userEvent.setup(),
       closeModal: jest.fn(),
       setTokenRequired: jest.fn(),
-      isLoading,
     }
   }
 
@@ -127,7 +126,7 @@ describe('TokenRequiredModal', () => {
     })
 
     it('renders loading state on require token button', async () => {
-      const { closeModal, setTokenRequired } = setup(true)
+      const { closeModal, setTokenRequired } = setup()
 
       render(
         <TokenRequiredModal

--- a/src/pages/AccountSettings/tabs/OrgUploadToken/TokenlessSection/TokenRequiredModal.tsx
+++ b/src/pages/AccountSettings/tabs/OrgUploadToken/TokenlessSection/TokenRequiredModal.tsx
@@ -1,0 +1,79 @@
+import Button from 'ui/Button'
+import Icon from 'ui/Icon'
+import Modal from 'ui/Modal'
+
+interface TokenlessModalProps {
+  closeModal: () => void
+  setTokenRequired: (value: boolean) => void
+  isLoading: boolean
+}
+
+const TokenlessModal = ({
+  closeModal,
+  setTokenRequired,
+  isLoading,
+}: TokenlessModalProps) => (
+  <Modal
+    isOpen={true}
+    onClose={closeModal}
+    title={
+      <p className="flex items-center gap-2 text-base">
+        <Icon
+          name="exclamationTriangle"
+          size="sm"
+          className="fill-ds-primary-yellow"
+        />
+        Require token for uploads
+      </p>
+    }
+    body={
+      <div className="flex flex-col gap-4">
+        <p>
+          Enforcing token authentication for uploads within your organization
+          will cause uploads without a token to be rejected for all of your
+          repositories.
+        </p>
+        <p>
+          Before proceeding, make sure all of your repositories can access
+          either your global upload token or a repository-specific token in your
+          CI configuration and that your CI jobs are using one of them when
+          submitting uploads.
+        </p>
+        <p>
+          Click <span className="font-semibold">Require token for upload</span>{' '}
+          to enforce the use of the global token for uploads.
+        </p>
+      </div>
+    }
+    footer={
+      <div className="flex gap-2">
+        <Button
+          hook="cancel-token-requirement"
+          onClick={() => {
+            setTokenRequired(false)
+            closeModal()
+          }}
+          to={undefined}
+          disabled={undefined}
+        >
+          Cancel
+        </Button>
+        <Button
+          isLoading={isLoading}
+          hook="require-token-upload"
+          variant="primary"
+          onClick={() => {
+            setTokenRequired(true)
+            closeModal()
+          }}
+          to={undefined}
+          disabled={undefined}
+        >
+          Require token for upload
+        </Button>
+      </div>
+    }
+  />
+)
+
+export default TokenlessModal

--- a/src/pages/AccountSettings/tabs/OrgUploadToken/TokenlessSection/TokenlessSection.spec.tsx
+++ b/src/pages/AccountSettings/tabs/OrgUploadToken/TokenlessSection/TokenlessSection.spec.tsx
@@ -124,9 +124,16 @@ describe('TokenlessSection', () => {
     const requiredOption = screen.getByLabelText('Required')
     await user.click(requiredOption)
 
-    const notRequiredOption = screen.getByLabelText('Not required')
-    await user.click(notRequiredOption)
+    const requireTokenButton = screen.getByRole('button', {
+      name: /Require token for upload/,
+    })
 
+    await user.click(requireTokenButton)
+    expect(requiredOption).toBeChecked()
+    const notRequiredOption = screen.getByLabelText('Not required')
+    expect(notRequiredOption).not.toBeChecked()
+
+    await user.click(notRequiredOption)
     expect(notRequiredOption).toBeChecked()
   })
 })

--- a/src/pages/AccountSettings/tabs/OrgUploadToken/TokenlessSection/TokenlessSection.spec.tsx
+++ b/src/pages/AccountSettings/tabs/OrgUploadToken/TokenlessSection/TokenlessSection.spec.tsx
@@ -1,0 +1,65 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter, Route } from 'react-router-dom'
+
+import TokenlessSection from './TokenlessSection'
+
+jest.mock('./TokenRequiredModal', () => () => 'Mocked TokenRequiredModal')
+
+const Wrapper: React.FC<React.PropsWithChildren> = ({ children }) => (
+  <MemoryRouter initialEntries={['/account/github/codecov/org-upload-token']}>
+    <Route path="/account/:provider/:owner/org-upload-token">{children}</Route>
+  </MemoryRouter>
+)
+
+describe('TokenlessSection', () => {
+  const setup = () => {
+    const user = userEvent.setup()
+    render(<TokenlessSection />, { wrapper: Wrapper })
+    return { user }
+  }
+
+  it('renders the token authentication title', () => {
+    setup()
+    const title = screen.getByText('Token authentication')
+    expect(title).toBeInTheDocument()
+  })
+
+  it('renders the learn more link', () => {
+    setup()
+    const learnMoreLink = screen.getByText('learn more')
+    expect(learnMoreLink).toBeInTheDocument()
+  })
+
+  it('renders the authentication option selection text', () => {
+    setup()
+    const optionText = screen.getByText('Select an authentication option')
+    expect(optionText).toBeInTheDocument()
+  })
+
+  it('renders "Not required" option description', () => {
+    setup()
+    const notRequiredDescription = screen.getByText(
+      'When a token is not required, your team can upload coverage reports without one. Existing tokens will still work, and no action is needed for past uploads. Designed for public open-source projects.'
+    )
+    expect(notRequiredDescription).toBeInTheDocument()
+  })
+
+  it('renders "Required" option description', () => {
+    setup()
+    const requiredDescription = screen.getByText(
+      'When a token is required, your team must use a global or repo-specific token for uploads. Designed for private repositories and closed-source projects.'
+    )
+    expect(requiredDescription).toBeInTheDocument()
+  })
+
+  it('renders and opens the token required modal when "Required" option is selected', async () => {
+    const { user } = setup()
+
+    const requiredOption = screen.getByLabelText('Required')
+    await user.click(requiredOption)
+
+    const modal = screen.getByText('Mocked TokenRequiredModal')
+    expect(modal).toBeInTheDocument()
+  })
+})

--- a/src/pages/AccountSettings/tabs/OrgUploadToken/TokenlessSection/TokenlessSection.spec.tsx
+++ b/src/pages/AccountSettings/tabs/OrgUploadToken/TokenlessSection/TokenlessSection.spec.tsx
@@ -4,8 +4,6 @@ import { MemoryRouter, Route } from 'react-router-dom'
 
 import TokenlessSection from './TokenlessSection'
 
-jest.mock('./TokenRequiredModal', () => () => 'Mocked TokenRequiredModal')
-
 const Wrapper: React.FC<React.PropsWithChildren> = ({ children }) => (
   <MemoryRouter initialEntries={['/account/github/codecov/org-upload-token']}>
     <Route path="/account/:provider/:owner/org-upload-token">{children}</Route>
@@ -15,30 +13,38 @@ const Wrapper: React.FC<React.PropsWithChildren> = ({ children }) => (
 describe('TokenlessSection', () => {
   const setup = () => {
     const user = userEvent.setup()
-    render(<TokenlessSection />, { wrapper: Wrapper })
+
     return { user }
   }
 
   it('renders the token authentication title', () => {
+    render(<TokenlessSection />, { wrapper: Wrapper })
     setup()
+
     const title = screen.getByText('Token authentication')
     expect(title).toBeInTheDocument()
   })
 
   it('renders the learn more link', () => {
+    render(<TokenlessSection />, { wrapper: Wrapper })
     setup()
+
     const learnMoreLink = screen.getByText('learn more')
     expect(learnMoreLink).toBeInTheDocument()
   })
 
   it('renders the authentication option selection text', () => {
+    render(<TokenlessSection />, { wrapper: Wrapper })
     setup()
+
     const optionText = screen.getByText('Select an authentication option')
     expect(optionText).toBeInTheDocument()
   })
 
   it('renders "Not required" option description', () => {
+    render(<TokenlessSection />, { wrapper: Wrapper })
     setup()
+
     const notRequiredDescription = screen.getByText(
       'When a token is not required, your team can upload coverage reports without one. Existing tokens will still work, and no action is needed for past uploads. Designed for public open-source projects.'
     )
@@ -46,24 +52,73 @@ describe('TokenlessSection', () => {
   })
 
   it('renders "Required" option description', () => {
+    render(<TokenlessSection />, { wrapper: Wrapper })
     setup()
+
     const requiredDescription = screen.getByText(
       'When a token is required, your team must use a global or repo-specific token for uploads. Designed for private repositories and closed-source projects.'
     )
     expect(requiredDescription).toBeInTheDocument()
   })
 
-  it('renders and opens the token required modal when "Required" option is selected', async () => {
-    const { user } = setup()
+  describe('when "Required" option is selected', () => {
+    it('renders the "Cancel" button', async () => {
+      render(<TokenlessSection />, { wrapper: Wrapper })
+      const { user } = setup()
 
-    const requiredOption = screen.getByLabelText('Required')
-    await user.click(requiredOption)
+      const requiredOption = screen.getByLabelText('Required')
+      await user.click(requiredOption)
 
-    const modal = screen.getByText('Mocked TokenRequiredModal')
-    expect(modal).toBeInTheDocument()
+      const cancelButton = screen.getByRole('button', { name: /Cancel/ })
+      expect(cancelButton).toBeInTheDocument()
+    })
+
+    it('renders the "Require token for upload" button', async () => {
+      render(<TokenlessSection />, { wrapper: Wrapper })
+      const { user } = setup()
+
+      const requiredOption = screen.getByLabelText('Required')
+      await user.click(requiredOption)
+
+      const requireTokenButton = screen.getByRole('button', {
+        name: /Require token for upload/,
+      })
+      expect(requireTokenButton).toBeInTheDocument()
+    })
+
+    it('removes modal and defaults to not required when "Cancel" button is clicked', async () => {
+      render(<TokenlessSection />, { wrapper: Wrapper })
+      const { user } = setup()
+
+      const requiredOption = screen.getByLabelText('Required')
+      await user.click(requiredOption)
+
+      const cancelButton = screen.getByRole('button', { name: /Cancel/ })
+      await user.click(cancelButton)
+
+      const notRequiredOption = screen.getByLabelText('Not required')
+      expect(notRequiredOption).toBeChecked()
+    })
+
+    it('removes modal and switches to required when "Require token for upload" button is clicked', async () => {
+      render(<TokenlessSection />, { wrapper: Wrapper })
+      const { user } = setup()
+
+      const requiredOption = screen.getByLabelText('Required')
+      await user.click(requiredOption)
+
+      const requireTokenButton = screen.getByRole('button', {
+        name: /Require token for upload/,
+      })
+      await user.click(requireTokenButton)
+
+      const requiredOptionAfterClick = screen.getByLabelText('Required')
+      expect(requiredOptionAfterClick).toBeChecked()
+    })
   })
 
   it("switches to 'Not required' option when not required is selected", async () => {
+    render(<TokenlessSection />, { wrapper: Wrapper })
     const { user } = setup()
 
     const requiredOption = screen.getByLabelText('Required')

--- a/src/pages/AccountSettings/tabs/OrgUploadToken/TokenlessSection/TokenlessSection.spec.tsx
+++ b/src/pages/AccountSettings/tabs/OrgUploadToken/TokenlessSection/TokenlessSection.spec.tsx
@@ -62,4 +62,16 @@ describe('TokenlessSection', () => {
     const modal = screen.getByText('Mocked TokenRequiredModal')
     expect(modal).toBeInTheDocument()
   })
+
+  it("switches to 'Not required' option when not required is selected", async () => {
+    const { user } = setup()
+
+    const requiredOption = screen.getByLabelText('Required')
+    await user.click(requiredOption)
+
+    const notRequiredOption = screen.getByLabelText('Not required')
+    await user.click(notRequiredOption)
+
+    expect(notRequiredOption).toBeChecked()
+  })
 })

--- a/src/pages/AccountSettings/tabs/OrgUploadToken/TokenlessSection/TokenlessSection.tsx
+++ b/src/pages/AccountSettings/tabs/OrgUploadToken/TokenlessSection/TokenlessSection.tsx
@@ -42,11 +42,6 @@ function TokenlessSection() {
       <Card.Content>
         <p className="mb-3">Select an authentication option</p>
         <RadioTileGroup
-          defaultValue={
-            tokenRequired
-              ? AUTHENTICATION_OPTIONS.Required
-              : AUTHENTICATION_OPTIONS.NotRequired
-          }
           value={
             tokenRequired
               ? AUTHENTICATION_OPTIONS.Required

--- a/src/pages/AccountSettings/tabs/OrgUploadToken/TokenlessSection/TokenlessSection.tsx
+++ b/src/pages/AccountSettings/tabs/OrgUploadToken/TokenlessSection/TokenlessSection.tsx
@@ -1,0 +1,94 @@
+import { useState } from 'react'
+
+import A from 'ui/A'
+import { Card } from 'ui/Card'
+import { RadioTileGroup } from 'ui/RadioTileGroup'
+
+import TokenlessModal from './TokenRequiredModal'
+
+const AUTHENTICATION_OPTIONS = {
+  NotRequired: 'not-required',
+  Required: 'required',
+} as const
+
+function TokenlessSection() {
+  const [showModal, setShowModal] = useState(false)
+  const [tokenRequired, setTokenRequired] = useState(false) // TODO: get from API
+
+  const handleValueChange = (value: string) => {
+    if (value === AUTHENTICATION_OPTIONS.Required) {
+      setShowModal(true)
+    } else {
+      setTokenRequired(false)
+    }
+  }
+
+  return (
+    <Card>
+      <Card.Header>
+        <div className="flex items-center gap-2">
+          <h2 className="text-sm font-semibold">Token authentication</h2>
+          <A
+            to={{
+              pageName: 'aboutCodeCoverage', // TODO: replace with actual pageName
+            }}
+            hook="tokenless-docs"
+            isExternal={true}
+          >
+            <span className="text-ds-primary">learn more</span>
+          </A>
+        </div>
+      </Card.Header>
+      <Card.Content>
+        <p className="mb-3">Select an authentication option</p>
+        <RadioTileGroup
+          defaultValue={
+            tokenRequired
+              ? AUTHENTICATION_OPTIONS.Required
+              : AUTHENTICATION_OPTIONS.NotRequired
+          }
+          value={
+            tokenRequired
+              ? AUTHENTICATION_OPTIONS.Required
+              : AUTHENTICATION_OPTIONS.NotRequired
+          }
+          name="token-authentication"
+          onValueChange={handleValueChange}
+        >
+          <RadioTileGroup.Item
+            value={AUTHENTICATION_OPTIONS.NotRequired}
+            data-testid="token-not-required-radio"
+          >
+            <RadioTileGroup.Label>Not required</RadioTileGroup.Label>
+            <RadioTileGroup.Description>
+              When a token is not required, your team can upload coverage
+              reports without one. Existing tokens will still work, and no
+              action is needed for past uploads. Designed for public open-source
+              projects.
+            </RadioTileGroup.Description>
+          </RadioTileGroup.Item>
+          <RadioTileGroup.Item
+            value={AUTHENTICATION_OPTIONS.Required}
+            data-testid="token-required-radio"
+          >
+            <RadioTileGroup.Label>Required</RadioTileGroup.Label>
+            <RadioTileGroup.Description>
+              When a token is required, your team must use a global or
+              repo-specific token for uploads. Designed for private repositories
+              and closed-source projects.
+            </RadioTileGroup.Description>
+          </RadioTileGroup.Item>
+        </RadioTileGroup>
+        {showModal && (
+          <TokenlessModal
+            closeModal={() => setShowModal(false)}
+            setTokenRequired={setTokenRequired}
+            isLoading={false} // TODO: get from API
+          />
+        )}
+      </Card.Content>
+    </Card>
+  )
+}
+
+export default TokenlessSection

--- a/src/pages/AccountSettings/tabs/OrgUploadToken/TokenlessSection/index.ts
+++ b/src/pages/AccountSettings/tabs/OrgUploadToken/TokenlessSection/index.ts
@@ -1,0 +1,1 @@
+export { default } from './TokenlessSection'


### PR DESCRIPTION
# Description
No api work, tokenless section in global upload token, hidden behind a feature flag. 

# Notable Changes
- New modal for required token 
- New component for the radio buttons of tokenless 

# Screenshots

![Screenshot 2024-09-20 at 1 46 48 PM](https://github.com/user-attachments/assets/c89ed4c6-3092-47ce-b2fd-6e46319f6740)
![Screenshot 2024-09-20 at 1 46 43 PM](https://github.com/user-attachments/assets/3ae49f39-4731-4d12-954e-6258859bdd5c)
![Screenshot 2024-09-20 at 1 46 39 PM](https://github.com/user-attachments/assets/298e35e0-d4e0-415e-82d3-91e62ab9ba17)

issue: [[Frontend] Add new toggle switch to org settings page](https://github.com/codecov/engineering-team/issues/2302)

# Link to Sample Entry

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.