### PR TITLE
fix: URL params not being passed to pull prefetching hooks

### DIFF
--- a/src/pages/PullRequestPage/PullCoverage/routes/FilesChangedTab/FilesChanged/NameColumn/NameColumn.jsx
+++ b/src/pages/PullRequestPage/PullCoverage/routes/FilesChangedTab/FilesChanged/NameColumn/NameColumn.jsx
@@ -1,5 +1,6 @@
 import cs from 'classnames'
 import PropTypes from 'prop-types'
+import { useParams } from 'react-router-dom'
 
 import { usePrefetchSingleFileComp } from 'services/pull'
 import Icon from 'ui/Icon'
@@ -8,8 +9,13 @@ export default function NameColumn({ row, getValue }) {
   const nameColumn = row.getValue('headName')
   const [fileNames] = nameColumn?.props?.children
   const path = fileNames?.props?.children
+  const { provider, owner, repo, pullId } = useParams()
 
   const { runPrefetch } = usePrefetchSingleFileComp({
+    provider,
+    owner,
+    repo,
+    pullId,
     path,
     filters: { hasUnintendedChanges: false },
   })

--- a/src/pages/PullRequestPage/PullCoverage/routes/IndirectChangesTab/IndirectChangedFiles/NameColumn/NameColumn.jsx
+++ b/src/pages/PullRequestPage/PullCoverage/routes/IndirectChangesTab/IndirectChangedFiles/NameColumn/NameColumn.jsx
@@ -1,11 +1,17 @@
 import cs from 'classnames'
 import PropTypes from 'prop-types'
+import { useParams } from 'react-router-dom'
 
 import { usePrefetchSingleFileComp } from 'services/pull'
 import Icon from 'ui/Icon'
 
 export default function NameColumn({ row, getValue }) {
+  const { provider, owner, repo, pullId } = useParams()
   const { runPrefetch } = usePrefetchSingleFileComp({
+    provider,
+    owner,
+    repo,
+    pullId,
     path: row.original?.headName,
     filters: { hasUnintendedChanges: true },
   })


### PR DESCRIPTION
# Description

This PR updates the name columns for the files changed and indirect changes table so that they grab the URL params and pass them to the pre-fetch hook.

# Notable Changes

- Update `NameColumn` to grab params and pass them