### PR TITLE
fix: Small tweaks to line number column on VirtualFileRenderer

### DIFF
--- a/src/ui/VirtualFileRenderer/VirtualFileRenderer.tsx
+++ b/src/ui/VirtualFileRenderer/VirtualFileRenderer.tsx
@@ -167,15 +167,14 @@ const CodeBody = ({
                 }px)`,
               }}
               className={cn(
-                'absolute left-0 top-0 w-full select-none border-r border-ds-gray-tertiary bg-ds-container px-4 text-right text-ds-gray-senary hover:cursor-pointer hover:text-ds-secondary-text',
+                'absolute left-0 top-0 w-full select-none border-r border-ds-gray-tertiary bg-ds-container pl-2 pr-4 text-right text-ds-gray-senary hover:cursor-pointer hover:text-ds-secondary-text',
                 coverageValue === 'H' && 'bg-ds-coverage-covered',
                 coverageValue === 'M' &&
                   'bg-ds-coverage-uncovered after:absolute after:inset-y-0 after:right-0 after:border-r-2 after:border-ds-primary-red',
                 coverageValue === 'P' &&
                   'bg-ds-coverage-partial after:absolute after:inset-y-0 after:right-0 after:border-r-2 after:border-dotted after:border-ds-primary-yellow',
                 // this needs to come last as it overrides the coverage colors
-                location.hash === `#L${lineNumber}` &&
-                  'bg-ds-blue-medium/25 font-semibold'
+                location.hash === `#L${lineNumber}` && 'bg-ds-blue-medium/25'
               )}
               onClick={() => {
                 location.hash =
@@ -183,7 +182,13 @@ const CodeBody = ({
                 history.push(location)
               }}
             >
-              <div className="flex items-center justify-between">
+              <div
+                className="flex items-center justify-between"
+                style={{
+                  height: `${LINE_ROW_HEIGHT}px`,
+                  lineHeight: `${LINE_ROW_HEIGHT}px`,
+                }}
+              >
                 <span
                   className={cn({
                     'text-ds-primary-red': coverageValue === 'M',


### PR DESCRIPTION
# Description

This PR includes some small tweaks to the `VirtualFileRenderer` fixing some issues with the line number column.

# Notable Changes

- Adjust line height values to match text area and tokens
- Remove bolding when clicking
- Adjust padding values so large numbers align properly when icons are present

# Screenshots

Before:

<img width="299" alt="Screenshot 2024-09-25 at 10 11 00" src="https://github.com/user-attachments/assets/14871838-c68e-4750-8930-ce333adcefe8">

After:

<img width="299" alt="Screenshot 2024-09-25 at 10 13 01" src="https://github.com/user-attachments/assets/b3d04082-a7f2-40f7-baa6-332632555961">