### PR TITLE
fix: Add host flag to vite start script

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev:vite": "yarn start:vite",
+    "dev:vite": "yarn start:vite --host",
     "start:vite": "yarn generate-icons:vite && vite",
     "build:vite": "yarn generate-icons:vite && tsc -b && vite build",
     "dev": "yarn start",

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev:vite": "yarn start:vite --host",
-    "start:vite": "yarn generate-icons:vite && vite",
+    "dev:vite": "yarn start:vite",
+    "start:vite": "yarn generate-icons:vite && vite --host",
     "build:vite": "yarn generate-icons:vite && tsc -b && vite build",
     "dev": "yarn start",
     "start": "craco start",


### PR DESCRIPTION
For whatever reason starting yesterday, my vite dev server was not getting detected by umbrella hat's codecov-gateway. A port scan on localhost revealed no port 3000. Not sure how vite is accepting connections from browser, but clearly by some magic lol. Adding the `--host` flag properly exposes the port to localhost, making the devserver visible to the gateway container.
