### PR TITLE
fix: Remove the ! when filtering duplicate CFF uploads

### DIFF
--- a/src/pages/CommitDetailPage/CommitCoverage/UploadsCard/useUploads/useUploads.spec.tsx
+++ b/src/pages/CommitDetailPage/CommitCoverage/UploadsCard/useUploads/useUploads.spec.tsx
@@ -134,7 +134,7 @@ describe('useUploads', () => {
         )
 
         expect(result.current.uploadsOverview).toEqual(
-          '2 errored, 3 started, 1 successful, 1 carried forward'
+          '2 errored, 3 started, 1 successful'
         )
       })
 
@@ -185,17 +185,6 @@ describe('useUploads', () => {
               updatedAt: '2020-08-25T16:36:25.859889+00:00',
               uploadType: 'UPLOADED',
               downloadUrl: '/test.txt',
-            },
-            {
-              createdAt: '2020-08-25T16:36:25.820340+00:00',
-              downloadUrl: '/test.txt',
-              errors: [],
-              flags: ['front-end'],
-              jobCode: '1234',
-              provider: 'github actions',
-              state: 'COMPLETE',
-              updatedAt: '2020-08-25T16:36:25.859889+00:00',
-              uploadType: 'CARRIEDFORWARD',
             },
           ],
           travis: [

--- a/src/pages/CommitDetailPage/CommitCoverage/UploadsCard/useUploads/useUploads.spec.tsx
+++ b/src/pages/CommitDetailPage/CommitCoverage/UploadsCard/useUploads/useUploads.spec.tsx
@@ -134,7 +134,7 @@ describe('useUploads', () => {
         )
 
         expect(result.current.uploadsOverview).toEqual(
-          '2 errored, 3 started, 1 successful'
+          '2 errored, 3 started, 1 successful, 1 carried forward'
         )
       })
 
@@ -184,6 +184,18 @@ describe('useUploads', () => {
               state: 'PROCESSED',
               updatedAt: '2020-08-25T16:36:25.859889+00:00',
               uploadType: 'UPLOADED',
+              downloadUrl: '/test.txt',
+            },
+            {
+              createdAt: '2020-08-25T16:36:25.820340+00:00',
+              downloadUrl: '/test.txt',
+              errors: [],
+              flags: ['front-end'],
+              jobCode: '1234',
+              provider: 'github actions',
+              state: 'COMPLETE',
+              updatedAt: '2020-08-25T16:36:25.859889+00:00',
+              uploadType: 'CARRIEDFORWARD',
             },
           ],
           travis: [

--- a/src/pages/PullRequestPage/PullCoverage/Summary/CompareSummary/CompareSummary.spec.jsx
+++ b/src/pages/PullRequestPage/PullCoverage/Summary/CompareSummary/CompareSummary.spec.jsx
@@ -30,7 +30,7 @@ const createPullData = ({ overrideCommits, overrideComparison } = {}) => {
                       message:
                         'create component to hold bundle list table for a given pull',
                       author: {
-                        username: 'nicholas-codecov',
+                        username: 'rand',
                       },
                     },
                   },
@@ -110,7 +110,7 @@ const createPullData = ({ overrideCommits, overrideComparison } = {}) => {
           title: 'feat: Create bundle analysis table for a given pull',
           state: 'OPEN',
           author: {
-            username: 'nicholas-codecov',
+            username: 'rand',
           },
           head: {
             ciPassed: true,
@@ -217,7 +217,7 @@ describe('CompareSummary', () => {
                 commitid: 'abc',
                 message: 'Pending commit',
                 author: {
-                  username: 'nicholas-codecov',
+                  username: 'rand',
                 },
               },
             },
@@ -249,7 +249,7 @@ describe('CompareSummary', () => {
                 state: 'OPEN',
                 updatestamp: '2024-01-12T12:56:18.912860',
                 author: {
-                  username: 'nicholas-codecov',
+                  username: 'rand',
                 },
                 behindBy: null,
                 behindByCommit: null,
@@ -285,7 +285,7 @@ describe('CompareSummary', () => {
                 commitid: 'c42fe217c61b007b2c17544a9d85840381857',
                 message: 'There is an error processing the coverage reports',
                 author: {
-                  username: 'nicholas-codecov',
+                  username: 'rand',
                 },
               },
             },

--- a/src/shared/utils/extractUploads.ts
+++ b/src/shared/utils/extractUploads.ts
@@ -52,10 +52,8 @@ export function deleteDuplicateCFFUploads({ uploads }: { uploads: Upload[] }) {
   // Filter out uploads that have repeated flags, returning those without duplicates
   return uploads.filter(
     (upload) =>
-      !(
-        upload?.uploadType === UploadTypeEnum.CARRIED_FORWARD &&
-        upload?.flags?.some((flag) => nonCFFlags.has(flag))
-      )
+      upload?.uploadType === UploadTypeEnum.CARRIED_FORWARD &&
+      upload?.flags?.some((flag) => nonCFFlags.has(flag))
   )
 }
 

--- a/src/shared/utils/extractUploads.ts
+++ b/src/shared/utils/extractUploads.ts
@@ -50,7 +50,6 @@ export function deleteDuplicateCFFUploads({ uploads }: { uploads: Upload[] }) {
   })
 
   // Filter out uploads that have repeated flags, returning those without duplicates
-
   let result = []
 
   for (let upload of uploads) {
@@ -61,8 +60,8 @@ export function deleteDuplicateCFFUploads({ uploads }: { uploads: Upload[] }) {
         if (nonCFFlags.has(flag)) {
           break
         }
-        result.push(upload)
       }
+      result.push(upload)
     }
   }
 

--- a/src/shared/utils/extractUploads.ts
+++ b/src/shared/utils/extractUploads.ts
@@ -95,14 +95,14 @@ const createUploadGroups = ({ uploads }: { uploads: Upload[] }) => {
     if (!providerGroups[provider]) {
       providerGroups[provider] = [upload]
     } else {
-      providerGroups[provider].push(upload)
+      providerGroups[provider]!.push(upload)
     }
 
     if (upload.state === UploadStateEnum.error) {
       if (!errorProviderGroups[provider]) {
         errorProviderGroups[provider] = [upload]
       } else {
-        errorProviderGroups[provider].push(upload)
+        errorProviderGroups[provider]!.push(upload)
       }
     }
   })

--- a/src/shared/utils/extractUploads.ts
+++ b/src/shared/utils/extractUploads.ts
@@ -56,12 +56,10 @@ export function deleteDuplicateCFFUploads({ uploads }: { uploads: Upload[] }) {
     if (upload.uploadType !== UploadTypeEnum.CARRIED_FORWARD || !upload.flags) {
       result.push(upload)
     } else {
-      for (let flag of upload.flags) {
-        if (nonCFFlags.has(flag)) {
-          break
-        }
+      let hasFlag = upload.flags.some((flag) => nonCFFlags.has(flag))
+      if (!hasFlag) {
+        result.push(upload)
       }
-      result.push(upload)
     }
   }
 


### PR DESCRIPTION
# Description

Great find from Joe for this issue, we were accidentally filtering _OUT_ the non-duplicated flag uploads instead of returning those results

# Screenshots

# Link to Sample Entry

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.