### PR TITLE
[fix] Update error message copy on uploads card

### DIFF
--- a/src/pages/CommitDetailPage/CommitCoverage/UploadsCard/RenderError.tsx
+++ b/src/pages/CommitDetailPage/CommitCoverage/UploadsCard/RenderError.tsx
@@ -69,7 +69,8 @@ const ErrorMessage = ({ errorCode, count }: ErrorMessageProps) => {
       <span className="mt-3 flex items-start gap-1 text-ds-primary-red">
         {icon}
         <p className="w-11/12">
-          Upload failed. Please rerun the upload. {renderCount}
+          Processing failed. Please rerun the upload in a new commit.{' '}
+          {renderCount}
         </p>
       </span>
     )

--- a/src/pages/CommitDetailPage/CommitCoverage/UploadsCard/Upload.spec.jsx
+++ b/src/pages/CommitDetailPage/CommitCoverage/UploadsCard/Upload.spec.jsx
@@ -163,7 +163,7 @@ describe('UploadsCard', () => {
       })
 
       const processingFailed = screen.getByText(
-        /Processing failed. Please rerun the upload in a new commit../
+        /Processing failed. Please rerun the upload in a new commit./
       )
       expect(processingFailed).toBeInTheDocument()
     })

--- a/src/pages/CommitDetailPage/CommitCoverage/UploadsCard/Upload.spec.jsx
+++ b/src/pages/CommitDetailPage/CommitCoverage/UploadsCard/Upload.spec.jsx
@@ -163,7 +163,7 @@ describe('UploadsCard', () => {
       })
 
       const processingFailed = screen.getByText(
-        /Upload failed. Please rerun the upload./
+        /Processing failed. Please rerun the upload in a new commit../
       )
       expect(processingFailed).toBeInTheDocument()
     })
@@ -229,7 +229,7 @@ describe('UploadsCard', () => {
         { wrapper }
       )
 
-      const processingFailed = screen.getByText(/Upload failed/)
+      const processingFailed = screen.getByText(/Processing failed./)
       expect(processingFailed).toBeInTheDocument()
 
       const uploadExpired = screen.getByText(


### PR DESCRIPTION
# Description

This closes https://github.com/codecov/internal-issues/issues/808. 

# Screenshots

<img width="465" alt="Screenshot 2024-09-26 at 7 52 54 PM" src="https://github.com/user-attachments/assets/602173ee-02d1-4234-9f0a-d6ac11a69fe3">


# Link to Sample Entry

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.