### PR TITLE
chore: Resolve vulnerability vite

### DIFF
--- a/package.json
+++ b/package.json
@@ -211,8 +211,7 @@
   "resolutions": {
     "react-refresh": "^0.14.0",
     "resolve-url-loader/postcss": "8.4.31",
-    "micromatch": "^4.0.8",
-    "vite": "^5.4.8"
+    "micromatch": "^4.0.8"
   },
   "packageManager": "yarn@4.5.0",
   "engineStrict": false

--- a/package.json
+++ b/package.json
@@ -211,7 +211,8 @@
   "resolutions": {
     "react-refresh": "^0.14.0",
     "resolve-url-loader/postcss": "8.4.31",
-    "micromatch": "^4.0.8"
+    "micromatch": "^4.0.8",
+    "vite": "^5.4.8"
   },
   "packageManager": "yarn@4.5.0",
   "engineStrict": false

--- a/yarn.lock
+++ b/yarn.lock
@@ -21937,7 +21937,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vite@npm:^5.0.0, vite@npm:^5.4.8":
+"vite@npm:^5.4.8":
   version: 5.4.8
   resolution: "vite@npm:5.4.8"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -21937,7 +21937,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vite@npm:^5.4.8":
+"vite@npm:^5.0.0, vite@npm:^5.4.8":
   version: 5.4.8
   resolution: "vite@npm:5.4.8"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -17535,17 +17535,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss@npm:^8.4.41":
-  version: 8.4.41
-  resolution: "postcss@npm:8.4.41"
-  dependencies:
-    nanoid: "npm:^3.3.7"
-    picocolors: "npm:^1.0.1"
-    source-map-js: "npm:^1.2.0"
-  checksum: 10c0/c1828fc59e7ec1a3bf52b3a42f615dba53c67960ed82a81df6441b485fe43c20aba7f4e7c55425762fd99c594ecabbaaba8cf5b30fd79dfec5b52a9f63a2d690
-  languageName: node
-  linkType: hard
-
 "postcss@npm:^8.4.43":
   version: 8.4.47
   resolution: "postcss@npm:8.4.47"
@@ -21948,50 +21937,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vite@npm:^5.0.0":
-  version: 5.4.2
-  resolution: "vite@npm:5.4.2"
-  dependencies:
-    esbuild: "npm:^0.21.3"
-    fsevents: "npm:~2.3.3"
-    postcss: "npm:^8.4.41"
-    rollup: "npm:^4.20.0"
-  peerDependencies:
-    "@types/node": ^18.0.0 || >=20.0.0
-    less: "*"
-    lightningcss: ^1.21.0
-    sass: "*"
-    sass-embedded: "*"
-    stylus: "*"
-    sugarss: "*"
-    terser: ^5.4.0
-  dependenciesMeta:
-    fsevents:
-      optional: true
-  peerDependenciesMeta:
-    "@types/node":
-      optional: true
-    less:
-      optional: true
-    lightningcss:
-      optional: true
-    sass:
-      optional: true
-    sass-embedded:
-      optional: true
-    stylus:
-      optional: true
-    sugarss:
-      optional: true
-    terser:
-      optional: true
-  bin:
-    vite: bin/vite.js
-  checksum: 10c0/23e347ca8aa6f0a774227e4eb7abae228f12c6806a727b046aa75e7ee37ffc2d68cff74360e12a42c347f79adc294e2363bc723b957bf4b382b5a8fb39e4df9d
-  languageName: node
-  linkType: hard
-
-"vite@npm:^5.4.8":
+"vite@npm:^5.0.0, vite@npm:^5.4.8":
   version: 5.4.8
   resolution: "vite@npm:5.4.8"
   dependencies:


### PR DESCRIPTION
Bump vite version to resolve vulnerability for [#800](https://github.com/codecov/internal-issues/issues/800) and [#801](https://github.com/codecov/internal-issues/issues/801)

After https://github.com/codecov/gazebo/pull/3331 , I noticed that the dependabot alerts for these ([here](https://github.com/codecov/gazebo/security/dependabot/97) and [here](https://github.com/codecov/gazebo/security/dependabot/99)) were not closing and it seemed to be because I needed to pin/bump the indirect dependencies specifically (they don't get done with the direct dependency)

