### PR TITLE
chore: Resolve vulnerabilities - express, path-to-regexp

### DIFF
--- a/package.json
+++ b/package.json
@@ -213,8 +213,8 @@
     "resolve-url-loader/postcss": "8.4.31",
     "micromatch": "^4.0.8",
     "express": "^4.21.0",
-    "path-to-regexp@npm:^1.7.0": "^1.9.0",
-    "path-to-regexp@npm:^6.2.0": "^6.3.0"
+    "path-to-regexp@^1.7.0": "^1.9.0",
+    "path-to-regexp@^6.2.0": "^6.3.0"
   },
   "packageManager": "yarn@4.5.0",
   "engineStrict": false

--- a/package.json
+++ b/package.json
@@ -211,7 +211,10 @@
   "resolutions": {
     "react-refresh": "^0.14.0",
     "resolve-url-loader/postcss": "8.4.31",
-    "micromatch": "^4.0.8"
+    "micromatch": "^4.0.8",
+    "express": "^4.21.0",
+    "path-to-regexp@npm:^1.7.0": "^1.9.0",
+    "path-to-regexp@npm:^6.2.0": "^6.3.0"
   },
   "packageManager": "yarn@4.5.0",
   "engineStrict": false

--- a/yarn.lock
+++ b/yarn.lock
@@ -8081,9 +8081,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"body-parser@npm:1.20.2":
-  version: 1.20.2
-  resolution: "body-parser@npm:1.20.2"
+"body-parser@npm:1.20.3":
+  version: 1.20.3
+  resolution: "body-parser@npm:1.20.3"
   dependencies:
     bytes: "npm:3.1.2"
     content-type: "npm:~1.0.5"
@@ -8093,11 +8093,11 @@ __metadata:
     http-errors: "npm:2.0.0"
     iconv-lite: "npm:0.4.24"
     on-finished: "npm:2.4.1"
-    qs: "npm:6.11.0"
+    qs: "npm:6.13.0"
     raw-body: "npm:2.5.2"
     type-is: "npm:~1.6.18"
     unpipe: "npm:1.0.0"
-  checksum: 10c0/06f1438fff388a2e2354c96aa3ea8147b79bfcb1262dfcc2aae68ec13723d01d5781680657b74e9f83c808266d5baf52804032fbde2b7382b89bd8cdb273ace9
+  checksum: 10c0/0a9a93b7518f222885498dcecaad528cf010dd109b071bf471c93def4bfe30958b83e03496eb9c1ad4896db543d999bb62be1a3087294162a88cfa1b42c16310
   languageName: node
   linkType: hard
 
@@ -10182,6 +10182,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"encodeurl@npm:~2.0.0":
+  version: 2.0.0
+  resolution: "encodeurl@npm:2.0.0"
+  checksum: 10c0/5d317306acb13e6590e28e27924c754163946a2480de11865c991a3a7eed4315cd3fba378b543ca145829569eefe9b899f3d84bb09870f675ae60bc924b01ceb
+  languageName: node
+  linkType: hard
+
 "encoding@npm:^0.1.13":
   version: 0.1.13
   resolution: "encoding@npm:0.1.13"
@@ -11132,42 +11139,42 @@ __metadata:
   languageName: node
   linkType: hard
 
-"express@npm:^4.17.3, express@npm:^4.19.2":
-  version: 4.19.2
-  resolution: "express@npm:4.19.2"
+"express@npm:^4.21.0":
+  version: 4.21.0
+  resolution: "express@npm:4.21.0"
   dependencies:
     accepts: "npm:~1.3.8"
     array-flatten: "npm:1.1.1"
-    body-parser: "npm:1.20.2"
+    body-parser: "npm:1.20.3"
     content-disposition: "npm:0.5.4"
     content-type: "npm:~1.0.4"
     cookie: "npm:0.6.0"
     cookie-signature: "npm:1.0.6"
     debug: "npm:2.6.9"
     depd: "npm:2.0.0"
-    encodeurl: "npm:~1.0.2"
+    encodeurl: "npm:~2.0.0"
     escape-html: "npm:~1.0.3"
     etag: "npm:~1.8.1"
-    finalhandler: "npm:1.2.0"
+    finalhandler: "npm:1.3.1"
     fresh: "npm:0.5.2"
     http-errors: "npm:2.0.0"
-    merge-descriptors: "npm:1.0.1"
+    merge-descriptors: "npm:1.0.3"
     methods: "npm:~1.1.2"
     on-finished: "npm:2.4.1"
     parseurl: "npm:~1.3.3"
-    path-to-regexp: "npm:0.1.7"
+    path-to-regexp: "npm:0.1.10"
     proxy-addr: "npm:~2.0.7"
-    qs: "npm:6.11.0"
+    qs: "npm:6.13.0"
     range-parser: "npm:~1.2.1"
     safe-buffer: "npm:5.2.1"
-    send: "npm:0.18.0"
-    serve-static: "npm:1.15.0"
+    send: "npm:0.19.0"
+    serve-static: "npm:1.16.2"
     setprototypeof: "npm:1.2.0"
     statuses: "npm:2.0.1"
     type-is: "npm:~1.6.18"
     utils-merge: "npm:1.0.1"
     vary: "npm:~1.1.2"
-  checksum: 10c0/e82e2662ea9971c1407aea9fc3c16d6b963e55e3830cd0ef5e00b533feda8b770af4e3be630488ef8a752d7c75c4fcefb15892868eeaafe7353cb9e3e269fdcb
+  checksum: 10c0/4cf7ca328f3fdeb720f30ccb2ea7708bfa7d345f9cc460b64a82bf1b2c91e5b5852ba15a9a11b2a165d6089acf83457fc477dc904d59cd71ed34c7a91762c6cc
   languageName: node
   linkType: hard
 
@@ -11382,18 +11389,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"finalhandler@npm:1.2.0":
-  version: 1.2.0
-  resolution: "finalhandler@npm:1.2.0"
+"finalhandler@npm:1.3.1":
+  version: 1.3.1
+  resolution: "finalhandler@npm:1.3.1"
   dependencies:
     debug: "npm:2.6.9"
-    encodeurl: "npm:~1.0.2"
+    encodeurl: "npm:~2.0.0"
     escape-html: "npm:~1.0.3"
     on-finished: "npm:2.4.1"
     parseurl: "npm:~1.3.3"
     statuses: "npm:2.0.1"
     unpipe: "npm:~1.0.0"
-  checksum: 10c0/64b7e5ff2ad1fcb14931cd012651631b721ce657da24aedb5650ddde9378bf8e95daa451da43398123f5de161a81e79ff5affe4f9f2a6d2df4a813d6d3e254b7
+  checksum: 10c0/d38035831865a49b5610206a3a9a9aae4e8523cbbcd01175d0480ffbf1278c47f11d89be3ca7f617ae6d94f29cf797546a4619cd84dd109009ef33f12f69019f
   languageName: node
   linkType: hard
 
@@ -15051,10 +15058,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"merge-descriptors@npm:1.0.1":
-  version: 1.0.1
-  resolution: "merge-descriptors@npm:1.0.1"
-  checksum: 10c0/b67d07bd44cfc45cebdec349bb6e1f7b077ee2fd5beb15d1f7af073849208cb6f144fe403e29a36571baf3f4e86469ac39acf13c318381e958e186b2766f54ec
+"merge-descriptors@npm:1.0.3":
+  version: 1.0.3
+  resolution: "merge-descriptors@npm:1.0.3"
+  checksum: 10c0/866b7094afd9293b5ea5dcd82d71f80e51514bed33b4c4e9f516795dc366612a4cbb4dc94356e943a8a6914889a914530badff27f397191b9b75cda20b6bae93
   languageName: node
   linkType: hard
 
@@ -16500,26 +16507,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"path-to-regexp@npm:0.1.7":
-  version: 0.1.7
-  resolution: "path-to-regexp@npm:0.1.7"
-  checksum: 10c0/50a1ddb1af41a9e68bd67ca8e331a705899d16fb720a1ea3a41e310480948387daf603abb14d7b0826c58f10146d49050a1291ba6a82b78a382d1c02c0b8f905
+"path-to-regexp@npm:0.1.10":
+  version: 0.1.10
+  resolution: "path-to-regexp@npm:0.1.10"
+  checksum: 10c0/34196775b9113ca6df88e94c8d83ba82c0e1a2063dd33bfe2803a980da8d49b91db8104f49d5191b44ea780d46b8670ce2b7f4a5e349b0c48c6779b653f1afe4
   languageName: node
   linkType: hard
 
-"path-to-regexp@npm:^1.7.0":
-  version: 1.8.0
-  resolution: "path-to-regexp@npm:1.8.0"
+"path-to-regexp@npm:^1.9.0":
+  version: 1.9.0
+  resolution: "path-to-regexp@npm:1.9.0"
   dependencies:
     isarray: "npm:0.0.1"
-  checksum: 10c0/7b25d6f27a8de03f49406d16195450f5ced694398adea1510b0f949d9660600d1769c5c6c83668583b7e6b503f3caf1ede8ffc08135dbe3e982f034f356fbb5c
-  languageName: node
-  linkType: hard
-
-"path-to-regexp@npm:^6.2.0":
-  version: 6.2.2
-  resolution: "path-to-regexp@npm:6.2.2"
-  checksum: 10c0/4b60852d3501fd05ca9dd08c70033d73844e5eca14e41f499f069afa8364f780f15c5098002f93bd42af8b3514de62ac6e82a53b5662de881d2b08c9ef21ea6b
+  checksum: 10c0/de9ddb01b84d9c2c8e2bed18630d8d039e2d6f60a6538595750fa08c7a6482512257464c8da50616f266ab2cdd2428387e85f3b089e4c3f25d0c537e898a0751
   languageName: node
   linkType: hard
 
@@ -17767,12 +17767,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"qs@npm:6.11.0":
-  version: 6.11.0
-  resolution: "qs@npm:6.11.0"
+"qs@npm:6.13.0":
+  version: 6.13.0
+  resolution: "qs@npm:6.13.0"
   dependencies:
-    side-channel: "npm:^1.0.4"
-  checksum: 10c0/4e4875e4d7c7c31c233d07a448e7e4650f456178b9dd3766b7cfa13158fdb24ecb8c4f059fa91e820dc6ab9f2d243721d071c9c0378892dcdad86e9e9a27c68f
+    side-channel: "npm:^1.0.6"
+  checksum: 10c0/62372cdeec24dc83a9fb240b7533c0fdcf0c5f7e0b83343edd7310f0ab4c8205a5e7c56406531f2e47e1b4878a3821d652be4192c841de5b032ca83619d8f860
   languageName: node
   linkType: hard
 
@@ -19223,9 +19223,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"send@npm:0.18.0":
-  version: 0.18.0
-  resolution: "send@npm:0.18.0"
+"send@npm:0.19.0":
+  version: 0.19.0
+  resolution: "send@npm:0.19.0"
   dependencies:
     debug: "npm:2.6.9"
     depd: "npm:2.0.0"
@@ -19240,7 +19240,7 @@ __metadata:
     on-finished: "npm:2.4.1"
     range-parser: "npm:~1.2.1"
     statuses: "npm:2.0.1"
-  checksum: 10c0/0eb134d6a51fc13bbcb976a1f4214ea1e33f242fae046efc311e80aff66c7a43603e26a79d9d06670283a13000e51be6e0a2cb80ff0942eaf9f1cd30b7ae736a
+  checksum: 10c0/ea3f8a67a8f0be3d6bf9080f0baed6d2c51d11d4f7b4470de96a5029c598a7011c497511ccc28968b70ef05508675cebff27da9151dd2ceadd60be4e6cf845e3
   languageName: node
   linkType: hard
 
@@ -19277,15 +19277,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"serve-static@npm:1.15.0":
-  version: 1.15.0
-  resolution: "serve-static@npm:1.15.0"
+"serve-static@npm:1.16.2":
+  version: 1.16.2
+  resolution: "serve-static@npm:1.16.2"
   dependencies:
-    encodeurl: "npm:~1.0.2"
+    encodeurl: "npm:~2.0.0"
     escape-html: "npm:~1.0.3"
     parseurl: "npm:~1.3.3"
-    send: "npm:0.18.0"
-  checksum: 10c0/fa9f0e21a540a28f301258dfe1e57bb4f81cd460d28f0e973860477dd4acef946a1f41748b5bd41c73b621bea2029569c935faa38578fd34cd42a9b4947088ba
+    send: "npm:0.19.0"
+  checksum: 10c0/528fff6f5e12d0c5a391229ad893910709bc51b5705962b09404a1d813857578149b8815f35d3ee5752f44cd378d0f31669d4b1d7e2d11f41e08283d5134bd1f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Resolve vulnerabilities related to express and path-to-regexp.

Closes:
`path-to-regexp`
https://github.com/codecov/internal-issues/issues/791
https://github.com/codecov/internal-issues/issues/790
https://github.com/codecov/internal-issues/issues/789

`express`
https://github.com/codecov/internal-issues/issues/788
https://github.com/codecov/internal-issues/issues/787
https://github.com/codecov/internal-issues/issues/786

Tested by spot-check confirming no regressions in the preview deploy pages

----------------------------------------
Here are the dependency chains

`path-to-regexp`

BEFORE
```
yarn why path-to-regexp
├─ express@npm:4.19.2
│  └─ path-to-regexp@npm:0.1.7 (via npm:0.1.7)
│
├─ msw@npm:1.3.3
│  └─ path-to-regexp@npm:6.2.2 (via npm:^6.2.0)
│
├─ msw@npm:2.4.8
│  └─ path-to-regexp@npm:6.3.0 (via npm:^6.3.0)
│
├─ msw@npm:1.3.3 [6563e]
│  └─ path-to-regexp@npm:6.2.2 (via npm:^6.2.0)
│
├─ msw@npm:2.4.8 [6563e]
│  └─ path-to-regexp@npm:6.3.0 (via npm:^6.3.0)
│
├─ react-router@npm:5.3.4
│  └─ path-to-regexp@npm:1.8.0 (via npm:^1.7.0)
│
└─ react-router@npm:5.3.4 [6563e]
   └─ path-to-regexp@npm:1.8.0 (via npm:^1.7.0)
```

AFTER
```
├─ express@npm:4.21.0
│  └─ path-to-regexp@npm:0.1.10 (via npm:0.1.10)
│
├─ msw@npm:1.3.3
│  └─ path-to-regexp@npm:6.3.0 (via npm:^6.3.0)
│
├─ msw@npm:2.4.8
│  └─ path-to-regexp@npm:6.3.0 (via npm:^6.3.0)
│
├─ msw@npm:1.3.3 [6563e]
│  └─ path-to-regexp@npm:6.3.0 (via npm:^6.3.0)
│
├─ msw@npm:2.4.8 [6563e]
│  └─ path-to-regexp@npm:6.3.0 (via npm:^6.3.0)
│
├─ react-router@npm:5.3.4
│  └─ path-to-regexp@npm:1.9.0 (via npm:^1.9.0)
│
└─ react-router@npm:5.3.4 [6563e]
   └─ path-to-regexp@npm:1.9.0 (via npm:^1.9.0)
```

Fix versions
<img width="752" alt="Screenshot 2024-09-30 at 1 27 09 PM" src="https://github.com/user-attachments/assets/50828183-f01d-407f-a5a2-2c6e470c8863">


----------------------------

`express`

BEFORE
```
├─ @storybook/builder-webpack5@npm:8.2.6
│  └─ express@npm:4.19.2 (via npm:^4.19.2)
│
├─ @storybook/builder-webpack5@npm:8.2.6 [b7782]
│  └─ express@npm:4.19.2 (via npm:^4.19.2)
│
├─ @storybook/core@npm:8.2.6
│  └─ express@npm:4.19.2 (via npm:^4.19.2)
│
├─ webpack-dev-server@npm:4.15.2
│  └─ express@npm:4.19.2 (via npm:^4.17.3)
│
└─ webpack-dev-server@npm:4.15.2 [37b33]
   └─ express@npm:4.19.2 (via npm:^4.17.3)
```

AFTER
```
yarn why express
├─ @storybook/builder-webpack5@npm:8.2.6
│  └─ express@npm:4.21.0 (via npm:^4.21.0)
│
├─ @storybook/builder-webpack5@npm:8.2.6 [b7782]
│  └─ express@npm:4.21.0 (via npm:^4.21.0)
│
├─ @storybook/core@npm:8.2.6
│  └─ express@npm:4.21.0 (via npm:^4.21.0)
│
├─ webpack-dev-server@npm:4.15.2
│  └─ express@npm:4.21.0 (via npm:^4.21.0)
│
└─ webpack-dev-server@npm:4.15.2 [37b33]
   └─ express@npm:4.21.0 (via npm:^4.21.0)
```

Fix version
<img width="777" alt="Screenshot 2024-09-30 at 1 28 09 PM" src="https://github.com/user-attachments/assets/a5e478a3-2280-49f2-8fef-fe2787aa17c0">
