### PR TITLE
[fix] Relocate the upload widget to the bottom on small screens

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ package-lock.json
 .DS_Store
 .env.local
 .env.development.local
+.env.local.development
 .env.test.local
 .env.production.local
 

--- a/src/pages/CommitDetailPage/CommitCoverage/CommitCoverage.jsx
+++ b/src/pages/CommitDetailPage/CommitCoverage/CommitCoverage.jsx
@@ -204,15 +204,15 @@ function CommitCoverage() {
       {/**we are currently capturing a single error*/}
       <CommitErrorBanners />
       {rateLimit?.isGithubRateLimited && <GitHubRateLimitExceededBanner />}
-      <div className="flex flex-col gap-4 lg:flex-row-reverse lg:gap-8">
+      <div className="flex flex-col gap-4 lg:flex-row lg:gap-8">
+        <article className="flex flex-1 flex-col">
+          <CommitCoverageRoutes />
+        </article>
         <aside className="flex w-full flex-1 flex-col gap-6 self-start py-3 lg:sticky lg:top-16 lg:max-w-sm">
           <Suspense fallback={<Loader />}>
             <UploadsCard />
           </Suspense>
         </aside>
-        <article className="flex flex-1 flex-col">
-          <CommitCoverageRoutes />
-        </article>
       </div>
     </div>
   )


### PR DESCRIPTION
# Description

This closes https://github.com/codecov/engineering-team/issues/2499. 

Before

![image](https://github.com/user-attachments/assets/fbb1b145-a4ca-406d-8c58-8a4016cae22e)


After

<img width="694" alt="Screenshot 2024-10-03 at 10 39 28 AM" src="https://github.com/user-attachments/assets/e17137de-006e-4731-b3b4-4f8206d5c4a8">



<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.