### PR TITLE
chore: Small fixes to file viewer

### DIFF
--- a/src/ui/VirtualFileRenderer/ColorBar.test.tsx
+++ b/src/ui/VirtualFileRenderer/ColorBar.test.tsx
@@ -31,7 +31,7 @@ describe('ColorBar', () => {
 
       const bar = screen.getByTestId('covered-bar')
       expect(bar).toBeInTheDocument()
-      expect(bar).toHaveClass('bg-ds-coverage-covered')
+      expect(bar).toHaveClass('bg-ds-coverage-covered/50')
     })
   })
 
@@ -41,7 +41,7 @@ describe('ColorBar', () => {
 
       const bar = screen.getByTestId('uncovered-bar')
       expect(bar).toBeInTheDocument()
-      expect(bar).toHaveClass('bg-ds-coverage-uncovered')
+      expect(bar).toHaveClass('bg-ds-coverage-uncovered/75')
     })
   })
 
@@ -51,7 +51,7 @@ describe('ColorBar', () => {
 
       const bar = screen.getByTestId('partial-bar')
       expect(bar).toBeInTheDocument()
-      expect(bar).toHaveClass('bg-ds-coverage-partial')
+      expect(bar).toHaveClass('bg-ds-coverage-partial/50')
     })
   })
 
@@ -61,7 +61,7 @@ describe('ColorBar', () => {
 
       const bar = screen.getByTestId('highlighted-bar')
       expect(bar).toBeInTheDocument()
-      expect(bar).toHaveClass('bg-ds-blue-medium')
+      expect(bar).toHaveClass('bg-ds-blue-medium/25')
     })
   })
 

--- a/src/ui/VirtualFileRenderer/ColorBar.tsx
+++ b/src/ui/VirtualFileRenderer/ColorBar.tsx
@@ -36,7 +36,7 @@ export const ColorBar = ({
     return (
       <div
         data-testid="highlighted-bar"
-        className="pointer-events-none absolute left-[-72px] h-full w-[calc(100%+72px)] bg-ds-blue-medium opacity-25"
+        className="pointer-events-none absolute left-[-72px] h-full w-[calc(100%+72px)] bg-ds-blue-medium/25"
       />
     )
   }
@@ -55,10 +55,10 @@ export const ColorBar = ({
             : 'partial-bar'
       }
       className={cn(
-        'pointer-events-none absolute left-[-72px] h-full w-[calc(100%+72px)] opacity-25',
-        coverageType === 'H' && 'bg-ds-coverage-covered',
-        coverageType === 'M' && 'bg-ds-coverage-uncovered',
-        coverageType === 'P' && 'bg-ds-coverage-partial'
+        'pointer-events-none absolute left-[-72px] h-full w-[calc(100%+72px)]',
+        coverageType === 'H' && 'bg-ds-coverage-covered/50',
+        coverageType === 'M' && 'bg-ds-coverage-uncovered/75',
+        coverageType === 'P' && 'bg-ds-coverage-partial/50'
       )}
     />
   )

--- a/src/ui/VirtualFileRenderer/VirtualFileRenderer.test.tsx
+++ b/src/ui/VirtualFileRenderer/VirtualFileRenderer.test.tsx
@@ -424,7 +424,7 @@ describe('VirtualFileRenderer', () => {
 
         const bar = await screen.findByTestId('highlighted-bar')
         expect(bar).toBeInTheDocument()
-        await waitFor(() => expect(bar).toHaveClass('bg-ds-blue-medium'))
+        await waitFor(() => expect(bar).toHaveClass('bg-ds-blue-medium/25'))
       })
 
       it('removes highlighting when clicking on highlighted line', async () => {

--- a/src/ui/VirtualFileRenderer/VirtualFileRenderer.tsx
+++ b/src/ui/VirtualFileRenderer/VirtualFileRenderer.tsx
@@ -245,22 +245,26 @@ const CodeBody = ({
               }}
               className="absolute left-0 top-0 pl-[94px]"
             >
-              <ColorBar
-                lineNumber={lineNumber}
-                locationHash={location.hash}
-                coverage={coverage?.[lineNumber]}
-              />
-              <div
-                className="w-full"
-                style={{
-                  ...lineStyle,
-                  height: `${LINE_ROW_HEIGHT}px`,
-                  lineHeight: `${LINE_ROW_HEIGHT}px`,
-                }}
-              >
-                {tokens[item.index]?.map((token: Token, key: React.Key) => (
-                  <span {...getTokenProps({ token, key })} key={key} />
-                ))}
+              <div className="grid">
+                <div className="z-[-1] col-start-1 row-start-1">
+                  <ColorBar
+                    lineNumber={lineNumber}
+                    locationHash={location.hash}
+                    coverage={coverage?.[lineNumber]}
+                  />
+                </div>
+                <div
+                  className="col-start-1 row-start-1"
+                  style={{
+                    ...lineStyle,
+                    height: `${LINE_ROW_HEIGHT}px`,
+                    lineHeight: `${LINE_ROW_HEIGHT}px`,
+                  }}
+                >
+                  {tokens[item.index]?.map((token: Token, key: React.Key) => (
+                    <span {...getTokenProps({ token, key })} key={key} />
+                  ))}
+                </div>
               </div>
             </div>
           )
@@ -434,7 +438,7 @@ function VirtualFileRendererComponent({
           overscrollBehaviorX: 'none',
           lineHeight: `${LINE_ROW_HEIGHT}px`,
         }}
-        className="absolute z-[1] size-full resize-none overflow-y-hidden whitespace-pre bg-[unset] pl-[94px] pt-px font-mono text-transparent outline-none"
+        className="absolute z-[1] size-full resize-none overflow-y-hidden whitespace-pre bg-[unset] pl-[94px] font-mono text-transparent outline-none"
         // Directly setting the value of the text area to the code content
         value={code}
         // need to set to true since we're setting a value without an onChange handler


### PR DESCRIPTION
# Description

This PR makes a slight change to how we display the colour bar in the `VirtualFileRenderer`, before they were laid atop the code, whereas now it is behind the code, so the full colour of the code highlighting now comes through. There was also a small padding top being applied to `textarea` that needed to be removed.

# Notable Changes

- Rework how the overlaying `ColorBar` is renderer
- Remove missed padding top of 1px on the `textarea`

# Screenshots

Before:

![Screenshot 2024-10-04 at 07 32 46](https://github.com/user-attachments/assets/5c912acb-9671-4435-a18e-f4b6833ebc51)

After:

![Screenshot 2024-10-04 at 07 32 04](https://github.com/user-attachments/assets/6a53ff72-a2b5-47c6-84ef-2ddc55bdaac8)