### PR TITLE
chore: Add new diff viewer to commit files changed

### DIFF
--- a/src/pages/CommitDetailPage/CommitCoverage/routes/FilesChangedTab/shared/CommitFileDiff/CommitFileDiff.jsx
+++ b/src/pages/CommitDetailPage/CommitCoverage/routes/FilesChangedTab/shared/CommitFileDiff/CommitFileDiff.jsx
@@ -50,98 +50,6 @@ const Loader = () => (
   </div>
 )
 
-const NewDiffRenderer = ({
-  headName,
-  hashedPath,
-  segments,
-  ignoredUploadIds,
-}) => {
-  return segments?.map((segment, segmentIndex) => {
-    let content = ''
-    const lineData = []
-    segment.lines.forEach((line, lineIndex) => {
-      content += line.content
-
-      if (lineIndex < segment.lines.length - 1) {
-        content += '\n'
-      }
-
-      lineData.push({
-        headNumber: line?.headNumber,
-        baseNumber: line?.baseNumber,
-        headCoverage: line?.headCoverage,
-        baseCoverage: line?.baseCoverage,
-        hitCount: without(line?.coverageInfo?.hitUploadIds, ...ignoredUploadIds)
-          .length,
-      })
-    })
-
-    return (
-      <VirtualDiffRenderer
-        key={segmentIndex}
-        code={content}
-        fileName={headName}
-        hashedPath={hashedPath}
-        lineData={lineData}
-      />
-    )
-  })
-}
-
-const OldDiffRenderer = ({
-  headName,
-  fileLabel,
-  fullFilePath,
-  segments,
-  ignoredUploadIds,
-  stickyPadding,
-  comparisonData,
-}) => {
-  return segments?.map((segment, segmentIndex) => {
-    const content = segment.lines.map((line) => line.content).join('\n')
-    return (
-      <Fragment key={`${headName}-${segmentIndex}`}>
-        <CodeRendererInfoRow>
-          <div className="flex w-full justify-between">
-            <div className="flex gap-1">
-              <span data-testid="patch">{segment?.header}</span>
-              {fileLabel && (
-                <span className="border-l-2 pl-2">{fileLabel}</span>
-              )}
-            </div>
-            <A href={fullFilePath} isExternal hook="commit full file">
-              View full file
-            </A>
-          </div>
-        </CodeRendererInfoRow>
-        <CodeRenderer
-          code={content}
-          fileName={headName}
-          rendererType={CODE_RENDERER_TYPE.DIFF}
-          LineComponent={({ i, line, ...props }) => (
-            <DiffLine
-              // If this line one of the first 3 or last three lines of the segment
-              key={i + 1}
-              lineContent={line}
-              edgeOfFile={i <= 2 || i >= segment.lines.length - 3}
-              path={comparisonData?.hashedPath}
-              hitCount={
-                without(
-                  segment?.lines?.[i]?.coverageInfo?.hitUploadIds,
-                  ...ignoredUploadIds
-                ).length
-              }
-              stickyPadding={stickyPadding}
-              {...props}
-              {...segment.lines[i]}
-            />
-          )}
-        />
-      </Fragment>
-    )
-  })
-}
-
 function CommitFileDiff({ path }) {
   const { commitFileDiff } = useNavLinks()
   const { owner, repo, provider, commit } = useParams()
@@ -184,24 +92,83 @@ function CommitFileDiff({ path }) {
   return (
     <>
       {isCriticalFile && <CriticalFileLabel variant="borderTop" />}
-      {virtualDiffRenderer ? (
-        <NewDiffRenderer
-          headName={headName}
-          hashedPath={comparisonData.hashedPath}
-          segments={segments}
-          ignoredUploadIds={ignoredUploadIds}
-        />
-      ) : (
-        <OldDiffRenderer
-          headName={headName}
-          fileLabel={fileLabel}
-          fullFilePath={fullFilePath}
-          segments={segments}
-          ignoredUploadIds={ignoredUploadIds}
-          stickyPadding={stickyPadding}
-          comparisonData={comparisonData}
-        />
-      )}
+      {segments?.map((segment, segmentIndex) => {
+        const content = segment.lines.map((line) => line.content).join('\n')
+
+        let newDiffContent = ''
+        const lineData = []
+        if (virtualDiffRenderer) {
+          segment.lines.forEach((line, lineIndex) => {
+            newDiffContent += line.content
+
+            if (lineIndex < segment.lines.length - 1) {
+              newDiffContent += '\n'
+            }
+
+            lineData.push({
+              headNumber: line?.headNumber,
+              baseNumber: line?.baseNumber,
+              headCoverage: line?.headCoverage,
+              baseCoverage: line?.baseCoverage,
+              hitCount: without(
+                line?.coverageInfo?.hitUploadIds,
+                ...ignoredUploadIds
+              ).length,
+            })
+          })
+        }
+
+        return (
+          <Fragment key={`${headName}-${segmentIndex}`}>
+            <CodeRendererInfoRow>
+              <div className="flex w-full justify-between">
+                <div className="flex gap-1">
+                  <span data-testid="patch">{segment?.header}</span>
+                  {fileLabel && (
+                    <span className="border-l-2 pl-2">{fileLabel}</span>
+                  )}
+                </div>
+                <A href={fullFilePath} isExternal hook="commit full file">
+                  View full file
+                </A>
+              </div>
+            </CodeRendererInfoRow>
+            {virtualDiffRenderer ? (
+              <VirtualDiffRenderer
+                key={segmentIndex}
+                code={newDiffContent}
+                fileName={headName}
+                hashedPath={comparisonData?.hashedPath}
+                lineData={lineData}
+              />
+            ) : (
+              <CodeRenderer
+                code={content}
+                fileName={headName}
+                rendererType={CODE_RENDERER_TYPE.DIFF}
+                LineComponent={({ i, line, ...props }) => (
+                  <DiffLine
+                    // If this line one of the first 3 or last three lines of the segment
+                    key={i + 1}
+                    lineContent={line}
+                    edgeOfFile={i <= 2 || i >= segment.lines.length - 3}
+                    path={comparisonData?.hashedPath}
+                    hitCount={
+                      without(
+                        segment?.lines?.[i]?.coverageInfo?.hitUploadIds,
+                        ...ignoredUploadIds
+                      ).length
+                    }
+                    stickyPadding={stickyPadding}
+                    {...props}
+                    {...segment.lines[i]}
+                  />
+                )}
+              />
+            )}
+          </Fragment>
+        )
+      })}
     </>
   )
 }

--- a/src/pages/CommitDetailPage/CommitCoverage/routes/FilesChangedTab/shared/CommitFileDiff/CommitFileDiff.jsx
+++ b/src/pages/CommitDetailPage/CommitCoverage/routes/FilesChangedTab/shared/CommitFileDiff/CommitFileDiff.jsx
@@ -8,6 +8,7 @@ import { useComparisonForCommitAndParent } from 'services/comparison/useComparis
 import { transformImpactedFileData } from 'services/comparison/utils'
 import { useNavLinks } from 'services/navigation'
 import { useRepoOverview } from 'services/repo'
+import { useFlags } from 'shared/featureFlags'
 import {
   CODE_RENDERER_TYPE,
   STICKY_PADDING_SIZES,
@@ -18,6 +19,7 @@ import CodeRendererInfoRow from 'ui/CodeRenderer/CodeRendererInfoRow'
 import CriticalFileLabel from 'ui/CodeRenderer/CriticalFileLabel'
 import DiffLine from 'ui/CodeRenderer/DiffLine'
 import Spinner from 'ui/Spinner'
+import { VirtualDiffRenderer } from 'ui/VirtualFileRenderer'
 
 function ErrorDisplayMessage() {
   return (
@@ -48,11 +50,103 @@ const Loader = () => (
   </div>
 )
 
+const NewDiffRenderer = ({
+  headName,
+  hashedPath,
+  segments,
+  ignoredUploadIds,
+}) => {
+  return segments?.map((segment, segmentIndex) => {
+    let content = ''
+    const lineData = []
+    segment.lines.forEach((line, lineIndex) => {
+      content += line.content
+
+      if (lineIndex < segment.lines.length - 1) {
+        content += '\n'
+      }
+
+      lineData.push({
+        headNumber: line?.headNumber,
+        baseNumber: line?.baseNumber,
+        headCoverage: line?.headCoverage,
+        baseCoverage: line?.baseCoverage,
+        hitCount: without(line?.coverageInfo?.hitUploadIds, ...ignoredUploadIds)
+          .length,
+      })
+    })
+
+    return (
+      <VirtualDiffRenderer
+        key={segmentIndex}
+        code={content}
+        fileName={headName}
+        hashedPath={hashedPath}
+        lineData={lineData}
+      />
+    )
+  })
+}
+
+const OldDiffRenderer = ({
+  headName,
+  fileLabel,
+  fullFilePath,
+  segments,
+  ignoredUploadIds,
+  stickyPadding,
+  comparisonData,
+}) => {
+  return segments?.map((segment, segmentIndex) => {
+    const content = segment.lines.map((line) => line.content).join('\n')
+    return (
+      <Fragment key={`${headName}-${segmentIndex}`}>
+        <CodeRendererInfoRow>
+          <div className="flex w-full justify-between">
+            <div className="flex gap-1">
+              <span data-testid="patch">{segment?.header}</span>
+              {fileLabel && (
+                <span className="border-l-2 pl-2">{fileLabel}</span>
+              )}
+            </div>
+            <A href={fullFilePath} isExternal hook="commit full file">
+              View full file
+            </A>
+          </div>
+        </CodeRendererInfoRow>
+        <CodeRenderer
+          code={content}
+          fileName={headName}
+          rendererType={CODE_RENDERER_TYPE.DIFF}
+          LineComponent={({ i, line, ...props }) => (
+            <DiffLine
+              // If this line one of the first 3 or last three lines of the segment
+              key={i + 1}
+              lineContent={line}
+              edgeOfFile={i <= 2 || i >= segment.lines.length - 3}
+              path={comparisonData?.hashedPath}
+              hitCount={
+                without(
+                  segment?.lines?.[i]?.coverageInfo?.hitUploadIds,
+                  ...ignoredUploadIds
+                ).length
+              }
+              stickyPadding={stickyPadding}
+              {...props}
+              {...segment.lines[i]}
+            />
+          )}
+        />
+      </Fragment>
+    )
+  })
+}
+
 function CommitFileDiff({ path }) {
   const { commitFileDiff } = useNavLinks()
   const { owner, repo, provider, commit } = useParams()
   const { data: overview } = useRepoOverview({ provider, owner, repo })
-
+  const { virtualDiffRenderer } = useFlags({ virtualDiffRenderer: false })
   const { data: ignoredUploadIds } = useIgnoredIds()
 
   const { data: comparisonData, isLoading } = useComparisonForCommitAndParent({
@@ -81,10 +175,7 @@ function CommitFileDiff({ path }) {
   const { fileLabel, headName, isCriticalFile, segments } = comparisonData
 
   let stickyPadding = undefined
-  let fullFilePath = commitFileDiff.path({
-    commit,
-    tree: path,
-  })
+  let fullFilePath = commitFileDiff.path({ commit, tree: path })
   if (overview?.coverageEnabled && overview?.bundleAnalysisEnabled) {
     stickyPadding = STICKY_PADDING_SIZES.DIFF_LINE_DROPDOWN_PADDING
     fullFilePath = `${fullFilePath}?dropdown=coverage`
@@ -93,49 +184,24 @@ function CommitFileDiff({ path }) {
   return (
     <>
       {isCriticalFile && <CriticalFileLabel variant="borderTop" />}
-      {segments?.map((segment, segmentIndex) => {
-        const content = segment.lines.map((line) => line.content).join('\n')
-        return (
-          <Fragment key={`${headName}-${segmentIndex}`}>
-            <CodeRendererInfoRow>
-              <div className="flex w-full justify-between">
-                <div className="flex gap-1">
-                  <span data-testid="patch">{segment?.header}</span>
-                  {fileLabel && (
-                    <span className="border-l-2 pl-2">{fileLabel}</span>
-                  )}
-                </div>
-                <A href={fullFilePath} isExternal hook="commit full file">
-                  View full file
-                </A>
-              </div>
-            </CodeRendererInfoRow>
-            <CodeRenderer
-              code={content}
-              fileName={headName}
-              rendererType={CODE_RENDERER_TYPE.DIFF}
-              LineComponent={({ i, line, ...props }) => (
-                <DiffLine
-                  // If this line one of the first 3 or last three lines of the segment
-                  key={i + 1}
-                  lineContent={line}
-                  edgeOfFile={i <= 2 || i >= segment.lines.length - 3}
-                  path={comparisonData?.hashedPath}
-                  hitCount={
-                    without(
-                      segment?.lines?.[i]?.coverageInfo?.hitUploadIds,
-                      ...ignoredUploadIds
-                    ).length
-                  }
-                  stickyPadding={stickyPadding}
-                  {...props}
-                  {...segment.lines[i]}
-                />
-              )}
-            />
-          </Fragment>
-        )
-      })}
+      {virtualDiffRenderer ? (
+        <NewDiffRenderer
+          headName={headName}
+          hashedPath={comparisonData.hashedPath}
+          segments={segments}
+          ignoredUploadIds={ignoredUploadIds}
+        />
+      ) : (
+        <OldDiffRenderer
+          headName={headName}
+          fileLabel={fileLabel}
+          fullFilePath={fullFilePath}
+          segments={segments}
+          ignoredUploadIds={ignoredUploadIds}
+          stickyPadding={stickyPadding}
+          comparisonData={comparisonData}
+        />
+      )}
     </>
   )
 }

--- a/src/pages/CommitDetailPage/CommitCoverage/routes/FilesChangedTab/shared/CommitFileDiff/CommitFileDiff.test.jsx
+++ b/src/pages/CommitDetailPage/CommitCoverage/routes/FilesChangedTab/shared/CommitFileDiff/CommitFileDiff.test.jsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { render, screen, waitFor } from '@testing-library/react'
+import { render, screen, waitFor, within } from '@testing-library/react'
 import { graphql, HttpResponse } from 'msw'
 import { setupServer } from 'msw/node'
 import { MemoryRouter, Route } from 'react-router-dom'

--- a/src/services/comparison/useComparisonForCommitAndParent/useComparisonForCommitAndParent.tsx
+++ b/src/services/comparison/useComparisonForCommitAndParent/useComparisonForCommitAndParent.tsx
@@ -76,7 +76,7 @@ export type ImpactedFileType = z.infer<typeof ImpactedFileSchema>
 
 const ComparisonSchema = z.object({
   __typename: z.literal('Comparison'),
-  impactedFile: ImpactedFileSchema,
+  impactedFile: ImpactedFileSchema.nullable(),
 })
 
 const CompareWithParentSchema = z


### PR DESCRIPTION
# Description

This PR updates the commit detail page files changed commit diff viewer to conditionally use the new virtual diff renderer.

Ticket: codecov/engineering-team#2590

# Notable Changes

- Add `nullable` to `impactedFile` in `useComparisonForCommitAndParent` as it was missing
- Setup `CommitFileDiff` to conditionally render old viewer vs new viewer based off of a feature flag
- Update tests

# Screenshots

![Screenshot 2024-10-07 at 07 47 24](https://github.com/user-attachments/assets/e060b0a9-f3e1-42c9-9df4-d204c56869b0)