### PR TITLE
chore: Update commit page indirect changes to use new diff viewer

### DIFF
--- a/src/pages/CommitDetailPage/CommitCoverage/routes/IndirectChangesTab/IndirectChangesTable/CommitFileDiff/CommitFileDiff.jsx
+++ b/src/pages/CommitDetailPage/CommitCoverage/routes/IndirectChangesTab/IndirectChangesTable/CommitFileDiff/CommitFileDiff.jsx
@@ -36,98 +36,6 @@ const Loader = () => (
   </div>
 )
 
-const NewDiffRenderer = ({
-  headName,
-  hashedPath,
-  segments,
-  ignoredUploadIds,
-}) => {
-  return segments?.map((segment, segmentIndex) => {
-    let content = ''
-    const lineData = []
-    segment.lines.forEach((line, lineIndex) => {
-      content += line.content
-
-      if (lineIndex < segment.lines.length - 1) {
-        content += '\n'
-      }
-
-      lineData.push({
-        headNumber: line?.headNumber,
-        baseNumber: line?.baseNumber,
-        headCoverage: line?.headCoverage,
-        baseCoverage: line?.baseCoverage,
-        hitCount: without(line?.coverageInfo?.hitUploadIds, ...ignoredUploadIds)
-          .length,
-      })
-    })
-
-    return (
-      <VirtualDiffRenderer
-        key={segmentIndex}
-        code={content}
-        fileName={headName}
-        hashedPath={hashedPath}
-        lineData={lineData}
-      />
-    )
-  })
-}
-
-const OldDiffRenderer = ({
-  headName,
-  fileLabel,
-  fullFilePath,
-  segments,
-  ignoredUploadIds,
-  stickyPadding,
-  comparisonData,
-}) => {
-  return segments?.map((segment, segmentIndex) => {
-    const content = segment.lines.map((line) => line.content).join('\n')
-    return (
-      <Fragment key={`${headName}-${segmentIndex}`}>
-        <CodeRendererInfoRow>
-          <div className="flex w-full justify-between">
-            <div className="flex gap-1">
-              <span data-testid="patch">{segment?.header}</span>
-              {fileLabel && (
-                <span className="border-l-2 pl-2">{fileLabel}</span>
-              )}
-            </div>
-            <A href={fullFilePath} isExternal hook="commit full file">
-              View full file
-            </A>
-          </div>
-        </CodeRendererInfoRow>
-        <CodeRenderer
-          code={content}
-          fileName={headName}
-          rendererType={CODE_RENDERER_TYPE.DIFF}
-          LineComponent={({ i, line, ...props }) => (
-            <DiffLine
-              // If this line one of the first 3 or last three lines of the segment
-              key={i + 1}
-              lineContent={line}
-              edgeOfFile={i <= 2 || i >= segment.lines.length - 3}
-              path={comparisonData?.hashedPath}
-              hitCount={
-                without(
-                  segment?.lines?.[i]?.coverageInfo?.hitUploadIds,
-                  ...ignoredUploadIds
-                ).length
-              }
-              stickyPadding={stickyPadding}
-              {...props}
-              {...segment.lines[i]}
-            />
-          )}
-        />
-      </Fragment>
-    )
-  })
-}
-
 function CommitFileDiff({ path }) {
   const { commitFileDiff } = useNavLinks()
   const { owner, repo, provider, commit } = useParams()
@@ -172,24 +80,83 @@ function CommitFileDiff({ path }) {
   return (
     <>
       {isCriticalFile && <CriticalFileLabel variant="borderTop" />}
-      {virtualDiffRenderer ? (
-        <NewDiffRenderer
-          headName={headName}
-          hashedPath={comparisonData.hashedPath}
-          segments={segments}
-          ignoredUploadIds={ignoredUploadIds}
-        />
-      ) : (
-        <OldDiffRenderer
-          headName={headName}
-          fileLabel={fileLabel}
-          fullFilePath={fullFilePath}
-          segments={segments}
-          ignoredUploadIds={ignoredUploadIds}
-          stickyPadding={stickyPadding}
-          comparisonData={comparisonData}
-        />
-      )}
+      {segments?.map((segment, segmentIndex) => {
+        const content = segment.lines.map((line) => line.content).join('\n')
+
+        let newDiffContent = ''
+        const lineData = []
+        if (virtualDiffRenderer) {
+          segment.lines.forEach((line, lineIndex) => {
+            newDiffContent += line.content
+
+            if (lineIndex < segment.lines.length - 1) {
+              newDiffContent += '\n'
+            }
+
+            lineData.push({
+              headNumber: line?.headNumber,
+              baseNumber: line?.baseNumber,
+              headCoverage: line?.headCoverage,
+              baseCoverage: line?.baseCoverage,
+              hitCount: without(
+                line?.coverageInfo?.hitUploadIds,
+                ...ignoredUploadIds
+              ).length,
+            })
+          })
+        }
+
+        return (
+          <Fragment key={`${headName}-${segmentIndex}`}>
+            <CodeRendererInfoRow>
+              <div className="flex w-full justify-between">
+                <div className="flex gap-1">
+                  <span data-testid="patch">{segment?.header}</span>
+                  {fileLabel && (
+                    <span className="border-l-2 pl-2">{fileLabel}</span>
+                  )}
+                </div>
+                <A href={fullFilePath} isExternal hook="commit full file">
+                  View full file
+                </A>
+              </div>
+            </CodeRendererInfoRow>
+            {virtualDiffRenderer ? (
+              <VirtualDiffRenderer
+                key={segmentIndex}
+                code={newDiffContent}
+                fileName={headName}
+                hashedPath={comparisonData?.hashedPath}
+                lineData={lineData}
+              />
+            ) : (
+              <CodeRenderer
+                code={content}
+                fileName={headName}
+                rendererType={CODE_RENDERER_TYPE.DIFF}
+                LineComponent={({ i, line, ...props }) => (
+                  <DiffLine
+                    // If this line one of the first 3 or last three lines of the segment
+                    key={i + 1}
+                    lineContent={line}
+                    edgeOfFile={i <= 2 || i >= segment.lines.length - 3}
+                    path={comparisonData?.hashedPath}
+                    hitCount={
+                      without(
+                        segment?.lines?.[i]?.coverageInfo?.hitUploadIds,
+                        ...ignoredUploadIds
+                      ).length
+                    }
+                    stickyPadding={stickyPadding}
+                    {...props}
+                    {...segment.lines[i]}
+                  />
+                )}
+              />
+            )}
+          </Fragment>
+        )
+      })}
     </>
   )
 }

--- a/src/pages/CommitDetailPage/CommitCoverage/routes/IndirectChangesTab/IndirectChangesTable/CommitFileDiff/CommitFileDiff.jsx
+++ b/src/pages/CommitDetailPage/CommitCoverage/routes/IndirectChangesTab/IndirectChangesTable/CommitFileDiff/CommitFileDiff.jsx
@@ -8,6 +8,7 @@ import { useComparisonForCommitAndParent } from 'services/comparison/useComparis
 import { transformImpactedFileData } from 'services/comparison/utils'
 import { useNavLinks } from 'services/navigation'
 import { useRepoOverview } from 'services/repo'
+import { useFlags } from 'shared/featureFlags'
 import {
   CODE_RENDERER_TYPE,
   STICKY_PADDING_SIZES,
@@ -18,6 +19,7 @@ import CodeRendererInfoRow from 'ui/CodeRenderer/CodeRendererInfoRow'
 import CriticalFileLabel from 'ui/CodeRenderer/CriticalFileLabel'
 import DiffLine from 'ui/CodeRenderer/DiffLine'
 import Spinner from 'ui/Spinner'
+import { VirtualDiffRenderer } from 'ui/VirtualFileRenderer'
 
 function ErrorDisplayMessage() {
   return (
@@ -34,11 +36,103 @@ const Loader = () => (
   </div>
 )
 
+const NewDiffRenderer = ({
+  headName,
+  hashedPath,
+  segments,
+  ignoredUploadIds,
+}) => {
+  return segments?.map((segment, segmentIndex) => {
+    let content = ''
+    const lineData = []
+    segment.lines.forEach((line, lineIndex) => {
+      content += line.content
+
+      if (lineIndex < segment.lines.length - 1) {
+        content += '\n'
+      }
+
+      lineData.push({
+        headNumber: line?.headNumber,
+        baseNumber: line?.baseNumber,
+        headCoverage: line?.headCoverage,
+        baseCoverage: line?.baseCoverage,
+        hitCount: without(line?.coverageInfo?.hitUploadIds, ...ignoredUploadIds)
+          .length,
+      })
+    })
+
+    return (
+      <VirtualDiffRenderer
+        key={segmentIndex}
+        code={content}
+        fileName={headName}
+        hashedPath={hashedPath}
+        lineData={lineData}
+      />
+    )
+  })
+}
+
+const OldDiffRenderer = ({
+  headName,
+  fileLabel,
+  fullFilePath,
+  segments,
+  ignoredUploadIds,
+  stickyPadding,
+  comparisonData,
+}) => {
+  return segments?.map((segment, segmentIndex) => {
+    const content = segment.lines.map((line) => line.content).join('\n')
+    return (
+      <Fragment key={`${headName}-${segmentIndex}`}>
+        <CodeRendererInfoRow>
+          <div className="flex w-full justify-between">
+            <div className="flex gap-1">
+              <span data-testid="patch">{segment?.header}</span>
+              {fileLabel && (
+                <span className="border-l-2 pl-2">{fileLabel}</span>
+              )}
+            </div>
+            <A href={fullFilePath} isExternal hook="commit full file">
+              View full file
+            </A>
+          </div>
+        </CodeRendererInfoRow>
+        <CodeRenderer
+          code={content}
+          fileName={headName}
+          rendererType={CODE_RENDERER_TYPE.DIFF}
+          LineComponent={({ i, line, ...props }) => (
+            <DiffLine
+              // If this line one of the first 3 or last three lines of the segment
+              key={i + 1}
+              lineContent={line}
+              edgeOfFile={i <= 2 || i >= segment.lines.length - 3}
+              path={comparisonData?.hashedPath}
+              hitCount={
+                without(
+                  segment?.lines?.[i]?.coverageInfo?.hitUploadIds,
+                  ...ignoredUploadIds
+                ).length
+              }
+              stickyPadding={stickyPadding}
+              {...props}
+              {...segment.lines[i]}
+            />
+          )}
+        />
+      </Fragment>
+    )
+  })
+}
+
 function CommitFileDiff({ path }) {
   const { commitFileDiff } = useNavLinks()
   const { owner, repo, provider, commit } = useParams()
   const { data: overview } = useRepoOverview({ provider, owner, repo })
-
+  const { virtualDiffRenderer } = useFlags({ virtualDiffRenderer: false })
   const { data: ignoredUploadIds } = useIgnoredIds()
 
   const { data: comparisonData, isLoading } = useComparisonForCommitAndParent({
@@ -69,10 +163,7 @@ function CommitFileDiff({ path }) {
   const { fileLabel, headName, isCriticalFile, segments } = comparisonData
 
   let stickyPadding = undefined
-  let fullFilePath = commitFileDiff.path({
-    commit,
-    tree: path,
-  })
+  let fullFilePath = commitFileDiff.path({ commit, tree: path })
   if (overview?.coverageEnabled && overview?.bundleAnalysisEnabled) {
     stickyPadding = STICKY_PADDING_SIZES.DIFF_LINE_DROPDOWN_PADDING
     fullFilePath = `${fullFilePath}?dropdown=coverage`
@@ -81,49 +172,24 @@ function CommitFileDiff({ path }) {
   return (
     <>
       {isCriticalFile && <CriticalFileLabel variant="borderTop" />}
-      {segments?.map((segment, segmentIndex) => {
-        const content = segment.lines.map((line) => line.content).join('\n')
-        return (
-          <Fragment key={`${headName}-${segmentIndex}`}>
-            <CodeRendererInfoRow>
-              <div className="flex w-full justify-between">
-                <div className="flex gap-1">
-                  <span data-testid="patch">{segment?.header}</span>
-                  {fileLabel && (
-                    <span className="border-l-2 pl-2">{fileLabel}</span>
-                  )}
-                </div>
-                <A href={fullFilePath} isExternal hook="commit full file">
-                  View full file
-                </A>
-              </div>
-            </CodeRendererInfoRow>
-            <CodeRenderer
-              code={content}
-              fileName={headName}
-              rendererType={CODE_RENDERER_TYPE.DIFF}
-              LineComponent={({ i, line, ...props }) => (
-                <DiffLine
-                  // If this line one of the first 3 or last three lines of the segment
-                  key={i + 1}
-                  lineContent={line}
-                  edgeOfFile={i <= 2 || i >= segment.lines.length - 3}
-                  path={comparisonData?.hashedPath}
-                  hitCount={
-                    without(
-                      segment?.lines?.[i]?.coverageInfo?.hitUploadIds,
-                      ...ignoredUploadIds
-                    ).length
-                  }
-                  stickyPadding={stickyPadding}
-                  {...props}
-                  {...segment.lines[i]}
-                />
-              )}
-            />
-          </Fragment>
-        )
-      })}
+      {virtualDiffRenderer ? (
+        <NewDiffRenderer
+          headName={headName}
+          hashedPath={comparisonData.hashedPath}
+          segments={segments}
+          ignoredUploadIds={ignoredUploadIds}
+        />
+      ) : (
+        <OldDiffRenderer
+          headName={headName}
+          fileLabel={fileLabel}
+          fullFilePath={fullFilePath}
+          segments={segments}
+          ignoredUploadIds={ignoredUploadIds}
+          stickyPadding={stickyPadding}
+          comparisonData={comparisonData}
+        />
+      )}
     </>
   )
 }

--- a/src/pages/CommitDetailPage/CommitCoverage/routes/IndirectChangesTab/IndirectChangesTable/CommitFileDiff/CommitFileDiff.test.jsx
+++ b/src/pages/CommitDetailPage/CommitCoverage/routes/IndirectChangesTab/IndirectChangesTable/CommitFileDiff/CommitFileDiff.test.jsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { render, screen, waitFor } from '@testing-library/react'
+import { render, screen, waitFor, within } from '@testing-library/react'
 import { graphql, HttpResponse } from 'msw2'
 import { setupServer } from 'msw2/node'
 import { MemoryRouter, Route } from 'react-router-dom'
@@ -7,7 +7,10 @@ import { MemoryRouter, Route } from 'react-router-dom'
 import CommitFileDiff from './CommitFileDiff'
 
 const mocks = vi.hoisted(() => ({
+  useFlags: vi.fn(),
   useScrollToLine: vi.fn(),
+  withProfiler: (component) => component,
+  captureMessage: vi.fn(),
 }))
 
 vi.mock('ui/CodeRenderer/hooks', () => {
@@ -18,8 +21,55 @@ vi.mock('ui/CodeRenderer/hooks', () => {
   }
 })
 
-window.requestAnimationFrame = (cb) => cb()
+vi.mock('shared/featureFlags', () => ({
+  useFlags: mocks.useFlags,
+}))
+
+vi.mock('@sentry/react', () => {
+  const originalModule = vi.importActual('@sentry/react')
+  return {
+    ...originalModule,
+    withProfiler: mocks.withProfiler,
+    captureMessage: mocks.captureMessage,
+  }
+})
+
+window.requestAnimationFrame = (cb) => {
+  cb(1)
+  return 1
+}
 window.cancelAnimationFrame = () => {}
+
+const scrollToMock = vi.fn()
+window.scrollTo = scrollToMock
+window.scrollY = 100
+
+class ResizeObserverMock {
+  callback = (x) => null
+
+  constructor(callback) {
+    this.callback = callback
+  }
+
+  observe() {
+    this.callback([
+      {
+        contentRect: { width: 100 },
+        target: {
+          getAttribute: () => ({ scrollWidth: 100 }),
+          getBoundingClientRect: () => ({ top: 100 }),
+        },
+      },
+    ])
+  }
+  unobserve() {
+    // do nothing
+  }
+  disconnect() {
+    // do nothing
+  }
+}
+global.window.ResizeObserver = ResizeObserverMock
 
 const baseMock = (impactedFile) => ({
   owner: {
@@ -143,15 +193,24 @@ afterAll(() => server.close())
 
 describe('CommitFileDiff', () => {
   function setup(
-    { impactedFile = mockImpactedFile, bundleAnalysisEnabled = false } = {
+    {
+      impactedFile = mockImpactedFile,
+      bundleAnalysisEnabled = false,
+      featureFlag = false,
+    } = {
       impactedFile: mockImpactedFile,
       bundleAnalysisEnabled: false,
+      featureFlag: false,
     }
   ) {
     mocks.useScrollToLine.mockImplementation(() => ({
       lineRef: () => {},
       handleClick: jest.fn(),
       targeted: false,
+    }))
+
+    mocks.useFlags.mockImplementation(() => ({
+      virtualDiffRenderer: featureFlag,
     }))
 
     server.use(
@@ -171,46 +230,6 @@ describe('CommitFileDiff', () => {
 
       const changeHeader = await screen.findByText('-0,0 +1,45')
       expect(changeHeader).toBeInTheDocument()
-    })
-
-    it('renders the lines of a segment', async () => {
-      setup()
-      render(<CommitFileDiff path={'flag1/file.js'} />, { wrapper })
-
-      const calculator = await screen.findByText(/Calculator/)
-      expect(calculator).toBeInTheDocument()
-
-      const value = await screen.findByText(/value/)
-      expect(value).toBeInTheDocument()
-
-      const calcMode = await screen.findByText(/calcMode/)
-      expect(calcMode).toBeInTheDocument()
-    })
-
-    describe('rendering hit icon', () => {
-      describe('there are no ignored ids', () => {
-        it('renders hit count icon', async () => {
-          setup()
-          render(<CommitFileDiff path={'flag1/file.js'} />, { wrapper })
-
-          const hitCount = await screen.findByText('5')
-          expect(hitCount).toBeInTheDocument()
-        })
-      })
-
-      describe('there are ignored ids', () => {
-        beforeEach(() => {
-          queryClient.setQueryData(['IgnoredUploadIds'], [0])
-        })
-
-        it('renders hit count icon', async () => {
-          setup()
-          render(<CommitFileDiff path={'flag1/file.js'} />, { wrapper })
-
-          const hitCount = await screen.findByText('4')
-          expect(hitCount).toBeInTheDocument()
-        })
-      })
     })
 
     describe('when only coverage is enabled', () => {
@@ -239,30 +258,6 @@ describe('CommitFileDiff', () => {
           '/gh/codecov/gazebo/commit/123sha/blob/flag1/file.js?dropdown=coverage'
         )
       })
-    })
-  })
-
-  describe('when segment is an empty array', () => {
-    beforeEach(() => {
-      const impactedFile = {
-        isCriticalFile: false,
-        headName: 'flag1/file.js',
-        segments: [],
-      }
-
-      setup({ impactedFile })
-    })
-    it('does not render information on the code renderer', async () => {
-      render(<CommitFileDiff path={'flag1/file.js'} />, { wrapper })
-
-      await waitFor(() => queryClient.isFetching)
-      await waitFor(() => !queryClient.isFetching)
-
-      const unexpectedChange = screen.queryByText(/Unexpected Changes/i)
-      expect(unexpectedChange).not.toBeInTheDocument()
-
-      const diffLine = screen.queryByText('fv-diff-line')
-      expect(diffLine).not.toBeInTheDocument()
     })
   })
 
@@ -332,16 +327,184 @@ describe('CommitFileDiff', () => {
   })
 
   describe('when there is no data', () => {
-    beforeEach(() => {
-      setup({ impactedFile: null })
+    let consoleSpy
+
+    beforeAll(() => {
+      consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
     })
+
+    afterAll(() => {
+      consoleSpy.mockRestore()
+    })
+
     it('renders a error display message', async () => {
+      setup({ impactedFile: null })
       render(<CommitFileDiff path={'random/path'} />, { wrapper })
 
       const criticalFile = await screen.findByText(
         /There was a problem getting the source code from your provider. Unable to show line by line coverage/i
       )
       expect(criticalFile).toBeInTheDocument()
+    })
+  })
+
+  describe('code renderer', () => {
+    describe('feature flag is true', () => {
+      it('renders the text area', async () => {
+        setup({ featureFlag: true })
+        render(<CommitFileDiff path={'flag1/file.js'} />, { wrapper })
+
+        const textArea = await screen.findByTestId(
+          'virtual-file-renderer-text-area'
+        )
+        expect(textArea).toBeInTheDocument()
+
+        const calculator = await await within(textArea).findByText(/Calculator/)
+        expect(calculator).toBeInTheDocument()
+
+        const value = await await within(textArea).findByText(/value/)
+        expect(value).toBeInTheDocument()
+
+        const calcMode = await await within(textArea).findByText(/calcMode/)
+        expect(calcMode).toBeInTheDocument()
+      })
+
+      it('renders the lines of a segment', async () => {
+        setup({ featureFlag: true })
+        render(<CommitFileDiff path={'flag1/file.js'} />, { wrapper })
+
+        const codeDisplayOverlay = await screen.findByTestId(
+          'virtual-file-renderer-overlay'
+        )
+
+        const calculator =
+          await within(codeDisplayOverlay).findByText(/Calculator/)
+        expect(calculator).toBeInTheDocument()
+
+        const value = await within(codeDisplayOverlay).findByText(/value/)
+        expect(value).toBeInTheDocument()
+
+        const calcMode = await within(codeDisplayOverlay).findByText(/calcMode/)
+        expect(calcMode).toBeInTheDocument()
+      })
+
+      describe('rendering hit icon', () => {
+        describe('there are no ignored ids', () => {
+          it('renders hit count icon', async () => {
+            setup({ featureFlag: true })
+            render(<CommitFileDiff path={'flag1/file.js'} />, { wrapper })
+
+            const hitCount = await screen.findByText('5')
+            expect(hitCount).toBeInTheDocument()
+          })
+        })
+
+        describe('there are ignored ids', () => {
+          beforeEach(() => {
+            queryClient.setQueryData(['IgnoredUploadIds'], [0])
+          })
+
+          it('renders hit count icon', async () => {
+            setup({ featureFlag: true })
+            render(<CommitFileDiff path={'flag1/file.js'} />, { wrapper })
+
+            const hitCount = await screen.findByText('4')
+            expect(hitCount).toBeInTheDocument()
+          })
+        })
+      })
+
+      describe('when segment is an empty array', () => {
+        const impactedFile = {
+          ...mockImpactedFile,
+          isCriticalFile: false,
+          headName: 'flag1/file.js',
+          segments: {
+            results: [],
+          },
+        }
+
+        it('does not render information on the code renderer', async () => {
+          setup({ impactedFile, featureFlag: true })
+          render(<CommitFileDiff path={'flag1/file.js'} />, { wrapper })
+
+          await waitFor(() => queryClient.isFetching)
+          await waitFor(() => !queryClient.isFetching)
+
+          const unexpectedChange = screen.queryByText(/Unexpected Changes/i)
+          expect(unexpectedChange).not.toBeInTheDocument()
+
+          const diffLine = screen.queryByText('fv-diff-line')
+          expect(diffLine).not.toBeInTheDocument()
+        })
+      })
+    })
+
+    describe('feature flag is false', () => {
+      it('renders the lines of a segment', async () => {
+        setup()
+        render(<CommitFileDiff path={'flag1/file.js'} />, { wrapper })
+
+        const calculator = await screen.findByText(/Calculator/)
+        expect(calculator).toBeInTheDocument()
+
+        const value = await screen.findByText(/value/)
+        expect(value).toBeInTheDocument()
+
+        const calcMode = await screen.findByText(/calcMode/)
+        expect(calcMode).toBeInTheDocument()
+      })
+
+      describe('rendering hit icon', () => {
+        describe('there are no ignored ids', () => {
+          it('renders hit count icon', async () => {
+            setup()
+            render(<CommitFileDiff path={'flag1/file.js'} />, { wrapper })
+
+            const hitCount = await screen.findByText('5')
+            expect(hitCount).toBeInTheDocument()
+          })
+        })
+
+        describe('there are ignored ids', () => {
+          beforeEach(() => {
+            queryClient.setQueryData(['IgnoredUploadIds'], [0])
+          })
+
+          it('renders hit count icon', async () => {
+            setup()
+            render(<CommitFileDiff path={'flag1/file.js'} />, { wrapper })
+
+            const hitCount = await screen.findByText('4')
+            expect(hitCount).toBeInTheDocument()
+          })
+        })
+      })
+
+      describe('when segment is an empty array', () => {
+        const impactedFile = {
+          ...mockImpactedFile,
+          isCriticalFile: false,
+          headName: 'flag1/file.js',
+          segments: {
+            results: [],
+          },
+        }
+
+        it('does not render information on the code renderer', async () => {
+          setup({ impactedFile })
+          render(<CommitFileDiff path={'flag1/file.js'} />, { wrapper })
+
+          await waitFor(() => queryClient.isFetching)
+          await waitFor(() => !queryClient.isFetching)
+
+          const unexpectedChange = screen.queryByText(/Unexpected Changes/i)
+          expect(unexpectedChange).not.toBeInTheDocument()
+
+          const diffLine = screen.queryByText('fv-diff-line')
+          expect(diffLine).not.toBeInTheDocument()
+        })
+      })
     })
   })
 })

--- a/src/pages/CommitDetailPage/CommitCoverage/routes/IndirectChangesTab/IndirectChangesTable/CommitFileDiff/CommitFileDiff.test.jsx
+++ b/src/pages/CommitDetailPage/CommitCoverage/routes/IndirectChangesTab/IndirectChangesTable/CommitFileDiff/CommitFileDiff.test.jsx
@@ -359,13 +359,13 @@ describe('CommitFileDiff', () => {
         )
         expect(textArea).toBeInTheDocument()
 
-        const calculator = await await within(textArea).findByText(/Calculator/)
+        const calculator = await within(textArea).findByText(/Calculator/)
         expect(calculator).toBeInTheDocument()
 
-        const value = await await within(textArea).findByText(/value/)
+        const value = await within(textArea).findByText(/value/)
         expect(value).toBeInTheDocument()
 
-        const calcMode = await await within(textArea).findByText(/calcMode/)
+        const calcMode = await within(textArea).findByText(/calcMode/)
         expect(calcMode).toBeInTheDocument()
       })
 


### PR DESCRIPTION
# Description

This PR updates the diff viewer on the commit detail page indirect changes tab, to use the new virtual diff viewer.

Ticket: codecov/engineering-team#2590

# Notable Changes

- Update `CommitFileDiff` to conditionally use new diff renderer
- Update tests

# Screenshots

![Screenshot 2024-10-07 at 09 18 33](https://github.com/user-attachments/assets/cd315cd1-d269-4e40-a963-f6963591f07b)