### PR TITLE
fix: Change how we set isProduction in Vite config

### DIFF
--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -62,7 +62,7 @@ export default defineConfig((config) => {
     define: envWithProcessPrefix,
     plugins: [
       ViteEjsPlugin({
-        isProduction: config.mode === 'production',
+        isProduction: process.env.REACT_APP_ENV === "production",
         REACT_APP_PENDO_KEY: process.env.REACT_APP_PENDO_KEY,
       }),
       tsconfigPaths(),


### PR DESCRIPTION
# Description

In our CRACO `index.html` we determine if we add Pendo off of the set `REACT_APP_ENV`, however that's not how we currently do it in the Vite config, so this PR quickly updates that to follow that pattern.

```
// public/index.html
<% if(process.env.REACT_APP_ENV === "production") { %>
```