### PR TITLE
fix: Small issues in the Vite config, and index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -91,7 +91,7 @@
           z = e.getElementsByTagName(n)[0]
           z.parentNode.insertBefore(y, z)
         })(window, document, 'script', 'pendo')
-      })('%REACT_APP_PENDO_KEY%')
+      })('<%= REACT_APP_PENDO_KEY %>')
     </script>
     <% } %>
   </head>

--- a/index.html
+++ b/index.html
@@ -51,21 +51,10 @@
       name="description"
       content="Code coverage done right. Hosted coverage report highly integrated with GitHub, Bitbucket and GitLab. Awesome pull request comments to enhance your QA."
     />
-    <link rel="apple-touch-icon" href="/logo-192x192.png" />
-    <!--
-      manifest.json provides metadata used when your web app is installed on a
-      user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
-    -->
-    <link rel="manifest" href="/manifest.json" />
-    <!--
-      Notice the use of %PUBLIC_URL% in the tags above.
-      It will be replaced with the URL of the `public` folder during the build.
-      Only files inside the `public` folder can be referenced from the HTML.
 
-      Unlike "/favicon.ico" or "favicon.ico", "%PUBLIC_URL%/favicon.ico" will
-      work correctly both with client-side routing and a non-root public URL.
-      Learn how to configure a non-root public URL by running `yarn build`.
-    -->
+    <link rel="apple-touch-icon" href="/logo-192x192.png" />
+    <link rel="manifest" href="/manifest.json" />
+
     <title>Codecov</title>
     <% if(isProduction) { %>
     <script>

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -51,7 +51,6 @@ export default defineConfig((config) => {
   }
 
   return {
-    base: env.REACT_APP_BASE_URL,
     server: {
       port: 3000,
     },


### PR DESCRIPTION
# Description

Two small changes:

- `index.html` this is how you correctly "replace" a value with this plugin
- Removing the override of the base, this was causing cors issues because it was trying to request things from the wrong URL