### PR TITLE
feat: Adjust repo upload token settings with a new note

### DIFF
--- a/src/pages/RepoPage/ConfigTab/tabs/GeneralTab/Tokens/RepoUploadToken/RepoUploadToken.jsx
+++ b/src/pages/RepoPage/ConfigTab/tabs/GeneralTab/Tokens/RepoUploadToken/RepoUploadToken.jsx
@@ -1,7 +1,9 @@
 import PropTypes from 'prop-types'
 import { useState } from 'react'
+import { useParams } from 'react-router'
 
 import { useRegenerateRepoUploadToken } from 'services/repoUploadToken'
+import { useUploadTokenRequired } from 'services/uploadTokenRequired'
 import A from 'ui/A'
 import Button from 'ui/Button'
 import TokenWrapper from 'ui/TokenWrapper'
@@ -19,46 +21,61 @@ function useRegenerateToken() {
 }
 
 function RepoUploadToken({ uploadToken }) {
+  const { provider, owner } = useParams()
   const [showModal, setShowModal] = useState(false)
   const { mutate, isLoading } = useRegenerateToken()
+  const { data } = useUploadTokenRequired({
+    provider,
+    owner,
+    enabled: !!uploadToken,
+  })
 
   if (!uploadToken) {
     return null
   }
+
   return (
-    <div className="flex flex-col gap-2 border-2 border-ds-gray-primary p-4 sm:flex-row">
-      <div className="flex flex-1 flex-col gap-3">
-        <div className="flex flex-col">
-          <h3 className="font-semibold">Repository upload token</h3>
-          <span>
-            Used for uploading coverage reports{' '}
-            <A to={{ pageName: 'docs' }} isExternal>
-              learn more
-            </A>
-          </span>
-        </div>
-        <p>Add this token to your codecov.yml</p>
-        <TokenWrapper token={TokenFormatEnum.FIRST_FORMAT + uploadToken} />
-        <span className="font-semibold ">OR</span>
-        <p>
-          If you’d like to add the token directly to your CI/CD Environment:
+    <div className="flex flex-col gap-2">
+      {!data?.uploadTokenRequired ? (
+        <p className="mb-2">
+          Uploading with token is now not required. You can upload without a
+          token. Contact your admins to manage the global upload token settings.
         </p>
-        <TokenWrapper token={TokenFormatEnum.SECOND_FORMAT + uploadToken} />
-      </div>
-      <div>
-        <Button
-          hook="show-modal"
-          onClick={() => setShowModal(true)}
-          disabled={isLoading}
-        >
-          Regenerate
-        </Button>
-        <RegenerateTokenModal
-          showModal={showModal}
-          closeModal={() => setShowModal(false)}
-          regenerateToken={mutate}
-          isLoading={isLoading}
-        />
+      ) : null}
+      <div className="flex flex-col gap-2 border-2 border-ds-gray-primary p-4 sm:flex-row">
+        <div className="flex flex-1 flex-col gap-3">
+          <div className="flex flex-col">
+            <h3 className="font-semibold">Repository upload token</h3>
+            <span>
+              Used for uploading coverage reports{' '}
+              <A to={{ pageName: 'docs' }} isExternal>
+                learn more
+              </A>
+            </span>
+          </div>
+          <p>Add this token to your codecov.yml</p>
+          <TokenWrapper token={TokenFormatEnum.FIRST_FORMAT + uploadToken} />
+          <span className="font-semibold ">OR</span>
+          <p>
+            If you’d like to add the token directly to your CI/CD Environment:
+          </p>
+          <TokenWrapper token={TokenFormatEnum.SECOND_FORMAT + uploadToken} />
+        </div>
+        <div>
+          <Button
+            hook="show-modal"
+            onClick={() => setShowModal(true)}
+            disabled={isLoading}
+          >
+            Regenerate
+          </Button>
+          <RegenerateTokenModal
+            showModal={showModal}
+            closeModal={() => setShowModal(false)}
+            regenerateToken={mutate}
+            isLoading={isLoading}
+          />
+        </div>
       </div>
     </div>
   )


### PR DESCRIPTION
# Description
Just adding a quick note if upload token is not required in repo upload token settings. 

# Notable Changes
- New note
- Tests 

# Screenshots
<img width="1512" alt="Screenshot 2024-10-09 at 11 51 09 AM" src="https://github.com/user-attachments/assets/e9692099-e30e-45bc-a148-4b358e9513ff">

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.