### PR TITLE
fix: Add script in the index.html if unable to dynamically load asset

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,6 +56,13 @@
     <link rel="manifest" href="/manifest.json" />
 
     <title>Codecov</title>
+
+    <script>
+      window.addEventListener('vite:preloadError', (event) => {
+        window.location.reload()
+      })
+    </script>
+
     <% if(isProduction) { %>
     <script>
       ;(function (apiKey) {


### PR DESCRIPTION
# Description

Basically we're seeing a lot of failing to load assets in Sentry, this is because of the way our infra is setup, and old versions of the app are not there for the user to request. This is how Vite recommends resolving the issue: [load-error-handling](https://vite.dev/guide/build#load-error-handling).

This PR adds this script into the `index.html` so it is unaffected by new deployments as the index.html is the file that is consistently served and not cached in the same manner.