### PR TITLE
feat: Add multiple flags error message to upload items

### DIFF
--- a/src/pages/CommitDetailPage/CommitCoverage/UploadsCard/RenderError.tsx
+++ b/src/pages/CommitDetailPage/CommitCoverage/UploadsCard/RenderError.tsx
@@ -111,16 +111,27 @@ const ErrorMessage = ({ errorCode, count }: ErrorMessageProps) => {
   )
 }
 
+const FlagError = () => (
+  <span className="mt-3 flex items-start gap-1 text-ds-primary-red">
+    <Icon size="sm" name="exclamation" variant="solid" className="mt-[2px]" />
+    <p className="w-11/12">
+      Multiple flags detected. Please ensure one flag per upload.
+    </p>
+  </span>
+)
+
 interface RenderErrorProps {
   errors: (UploadErrorObject | null)[]
   state: (typeof UploadStateEnum)[keyof typeof UploadStateEnum]
+  flags: string[] | null
 }
 
-const RenderError = ({ errors, state }: RenderErrorProps) => {
+const RenderError = ({ errors, state, flags }: RenderErrorProps) => {
   const filteredErrors = useDuplicatedErrors({ errors })
 
   return (
     <>
+      {flags?.length && flags.length >= 2 ? <FlagError /> : null}
       {filteredErrors?.map(({ errorCode, count }, i) => (
         <ErrorMessage
           key={`errorCode-${errorCode}-${i}`}

--- a/src/pages/CommitDetailPage/CommitCoverage/UploadsCard/UploadItem.test.tsx
+++ b/src/pages/CommitDetailPage/CommitCoverage/UploadsCard/UploadItem.test.tsx
@@ -325,6 +325,28 @@ describe('UploadsCard', () => {
       })
     })
 
+    describe('Multiple flags error', () => {
+      it('renders error message', () => {
+        render(
+          <UploadItem
+            upload={{
+              ...mockUpload,
+              flags: ['flag1', 'flag2'],
+              errors: [],
+            }}
+          />,
+          {
+            wrapper,
+          }
+        )
+
+        const multipleFlags = screen.getByText(
+          /Multiple flags detected. Please ensure one flag per upload./
+        )
+        expect(multipleFlags).toBeInTheDocument()
+      })
+    })
+
     it('all errors', () => {
       render(
         <UploadItem

--- a/src/pages/CommitDetailPage/CommitCoverage/UploadsCard/UploadItem.tsx
+++ b/src/pages/CommitDetailPage/CommitCoverage/UploadsCard/UploadItem.tsx
@@ -86,7 +86,7 @@ const UploadItem = ({
           Download
         </A>
       </div>
-      <RenderError errors={errors} state={state} />
+      <RenderError errors={errors} state={state} flags={flags} />
     </div>
   )
 }


### PR DESCRIPTION
Adds upload error when multiple flags are specified on an upload.

Closes https://github.com/codecov/engineering-team/issues/201

![Screenshot 2024-10-09 at 13 41 22](https://github.com/user-attachments/assets/b4a665c2-84e5-4973-b616-bc3d34646df3)
