### PR TITLE
Add login link to error message in fileviewer

### DIFF
--- a/src/pages/CommitDetailPage/CommitCoverage/routes/FilesChangedTab/shared/CommitFileDiff/CommitFileDiff.jsx
+++ b/src/pages/CommitDetailPage/CommitCoverage/routes/FilesChangedTab/shared/CommitFileDiff/CommitFileDiff.jsx
@@ -24,6 +24,20 @@ function ErrorDisplayMessage() {
     <p className="border border-solid border-ds-gray-tertiary p-4">
       There was a problem getting the source code from your provider. Unable to
       show line by line coverage.
+      <br />
+      <span>
+        If you continue to experience this issue, please try{' '}
+        <A
+          to={{
+            pageName: 'login',
+          }}
+          hook={undefined}
+          isExternal={undefined}
+        >
+          logging in
+        </A>{' '}
+        again to refresh your credentials.
+      </span>
     </p>
   )
 }

--- a/src/pages/CommitDetailPage/CommitCoverage/routes/FilesChangedTab/shared/CommitFileDiff/CommitFileDiff.test.jsx
+++ b/src/pages/CommitDetailPage/CommitCoverage/routes/FilesChangedTab/shared/CommitFileDiff/CommitFileDiff.test.jsx
@@ -338,5 +338,13 @@ describe('CommitFileDiff', () => {
       )
       expect(criticalFile).toBeInTheDocument()
     })
+
+    it('renders a login link', async () => {
+      render(<CommitFileDiff path={'random/path'} />, { wrapper })
+
+      const link = await screen.findByText(/logging in/)
+      expect(link).toBeVisible()
+      expect(link).toHaveAttribute('href', '/login')
+    })
   })
 })

--- a/src/pages/CommitDetailPage/CommitCoverage/routes/IndirectChangesTab/IndirectChangesTable/CommitFileDiff/CommitFileDiff.jsx
+++ b/src/pages/CommitDetailPage/CommitCoverage/routes/IndirectChangesTab/IndirectChangesTable/CommitFileDiff/CommitFileDiff.jsx
@@ -24,6 +24,20 @@ function ErrorDisplayMessage() {
     <p className="border border-solid border-ds-gray-tertiary p-4">
       There was a problem getting the source code from your provider. Unable to
       show line by line coverage.
+      <br />
+      <span>
+        If you continue to experience this issue, please try{' '}
+        <A
+          to={{
+            pageName: 'login',
+          }}
+          hook={undefined}
+          isExternal={undefined}
+        >
+          logging in
+        </A>{' '}
+        again to refresh your credentials.
+      </span>
     </p>
   )
 }

--- a/src/pages/CommitDetailPage/CommitCoverage/routes/IndirectChangesTab/IndirectChangesTable/CommitFileDiff/CommitFileDiff.test.jsx
+++ b/src/pages/CommitDetailPage/CommitCoverage/routes/IndirectChangesTab/IndirectChangesTable/CommitFileDiff/CommitFileDiff.test.jsx
@@ -343,5 +343,13 @@ describe('CommitFileDiff', () => {
       )
       expect(criticalFile).toBeInTheDocument()
     })
+
+    it('renders a login link', async () => {
+      render(<CommitFileDiff path={'random/path'} />, { wrapper })
+
+      const link = await screen.findByText(/logging in/)
+      expect(link).toBeVisible()
+      expect(link).toHaveAttribute('href', '/login')
+    })
   })
 })

--- a/src/shared/RawFileViewer/RawFileViewer.test.tsx
+++ b/src/shared/RawFileViewer/RawFileViewer.test.tsx
@@ -432,6 +432,16 @@ describe('RawFileViewer', () => {
       )
       expect(errorMessage).toBeInTheDocument()
     })
+
+    it('renders a login link', async () => {
+      render(
+        <RawFileViewer title="The FileViewer" commit="cool-commit-sha" />,
+        { wrapper: wrapper() }
+      )
+      const link = await screen.findByText(/logging in/)
+      expect(link).toBeVisible()
+      expect(link).toHaveAttribute('href', '/login')
+    })
   })
 
   describe('displaying unsupported file', () => {

--- a/src/shared/RawFileViewer/RawFileViewer.tsx
+++ b/src/shared/RawFileViewer/RawFileViewer.tsx
@@ -11,6 +11,7 @@ import { useFlags } from 'shared/featureFlags'
 import { CODE_RENDERER_TYPE } from 'shared/utils/fileviewer'
 import { unsupportedExtensionsMapper } from 'shared/utils/unsupportedExtensionsMapper'
 import { getFilenameFromFilePath } from 'shared/utils/url'
+import A from 'ui/A'
 import CodeRenderer from 'ui/CodeRenderer'
 import CodeRendererProgressHeader from 'ui/CodeRenderer/CodeRendererProgressHeader'
 import CriticalFileLabel from 'ui/CodeRenderer/CriticalFileLabel'
@@ -21,12 +22,24 @@ import { VirtualFileRenderer } from 'ui/VirtualFileRenderer'
 
 function ErrorDisplayMessage() {
   return (
-    <div className="border border-solid border-ds-gray-tertiary p-4">
-      <p>
-        There was a problem getting the source code from your provider. Unable
-        to show line by line coverage.
-      </p>
-    </div>
+    <p className="border border-solid border-ds-gray-tertiary p-4">
+      There was a problem getting the source code from your provider. Unable to
+      show line by line coverage.
+      <br />
+      <span>
+        If you continue to experience this issue, please try{' '}
+        <A
+          to={{
+            pageName: 'login',
+          }}
+          hook={undefined}
+          isExternal={undefined}
+        >
+          logging in
+        </A>{' '}
+        again to refresh your credentials.
+      </span>
+    </p>
   )
 }
 


### PR DESCRIPTION
# Description

As a temporary fix to https://github.com/codecov/internal-issues/issues/708 and https://github.com/codecov/engineering-team/issues/2580, we will add a redirect to login to remind users to login. 

A follow up will include investigating a more reliable way to refresh Github OAuth tokens so this error auto-corrects itself. 

BEFORE

![Screenshot 2024-10-09 at 2 02 07 PM](https://github.com/user-attachments/assets/9d79ebc3-16de-457d-91c7-66e2e3a7713f)


AFTER

![Screenshot 2024-10-09 at 1 40 19 PM](https://github.com/user-attachments/assets/7ac81760-4052-4b2e-969b-644973e8cbf0)


<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.