### PR TITLE
feat: Link hook to metrics section, make percent badge dynamic

### DIFF
--- a/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/MetricsSection/MetricsSection.test.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/MetricsSection/MetricsSection.test.tsx
@@ -1,0 +1,111 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { render, screen } from '@testing-library/react'
+import { graphql, HttpResponse } from 'msw2'
+import { setupServer } from 'msw2/node'
+import { PropsWithChildren } from 'react'
+import { MemoryRouter, Route } from 'react-router-dom'
+
+import MetricsSection from './MetricsSection'
+
+const mockOverview = {
+  owner: {
+    isCurrentUserActivated: true,
+    repository: {
+      __typename: 'Repository',
+      private: false,
+      defaultBranch: 'main',
+      oldestCommitAt: '2022-10-10T11:59:59',
+      coverageEnabled: true,
+      bundleAnalysisEnabled: true,
+      languages: ['typescript'],
+      testAnalyticsEnabled: true,
+    },
+  },
+}
+
+const mockAggResponse = {
+  owner: {
+    repository: {
+      __typename: 'Repository',
+      testAnalytics: {
+        testResultsAggregates: {
+          totalDuration: 1.0,
+          totalDurationPercentChange: 25.0,
+          slowestTestsDuration: 111.11,
+          slowestTestsDurationPercentChange: 0.0,
+          totalFails: 1,
+          totalFailsPercentChange: 100.0,
+          totalSkips: 20,
+          totalSkipsPercentChange: 0.0,
+        },
+      },
+    },
+  },
+}
+
+const server = setupServer()
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      retry: false,
+      suspense: false,
+    },
+  },
+})
+
+const wrapper: (initialEntries?: string) => React.FC<PropsWithChildren> =
+  (initialEntries = '/gh/codecov/cool-repo/tests') =>
+  ({ children }) => (
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={[initialEntries]}>
+        <Route path="/:provider/:owner/:repo/tests" exact>
+          {children}
+        </Route>
+        <Route path="/:provider/:owner/:repo/tests/:branch" exact>
+          {children}
+        </Route>
+      </MemoryRouter>
+    </QueryClientProvider>
+  )
+
+beforeAll(() => {
+  server.listen()
+})
+
+afterEach(() => {
+  server.resetHandlers()
+  queryClient.clear()
+})
+
+afterAll(() => {
+  server.close()
+})
+
+describe('MetricsSection', () => {
+  function setup() {
+    server.use(
+      graphql.query('GetRepoOverview', (info) => {
+        console.log('Mock for GetRepoOverview called')
+        return HttpResponse.json({ data: mockOverview })
+      }),
+      graphql.query('GetTestResultsAggregates', (info) => {
+        console.log('Mock for GetTestResultsAggregates called')
+        return HttpResponse.json({ data: mockAggResponse })
+      })
+    )
+  }
+
+  describe('when on default branch', () => {
+    it('renders subheaders', () => {
+      setup()
+      render(<MetricsSection />, {
+        wrapper: wrapper('/gh/owner/repo/tests/main'),
+      })
+
+      const runEfficiency = screen.getByText('Improve CI Run Efficiency')
+      const testPerf = screen.getByText('Improve Test Performance')
+      expect(runEfficiency).toBeInTheDocument()
+      expect(testPerf).toBeInTheDocument()
+    })
+  })
+})

--- a/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/MetricsSection/MetricsSection.test.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/MetricsSection/MetricsSection.test.tsx
@@ -29,7 +29,7 @@ const mockAggResponse = {
       __typename: 'Repository',
       testAnalytics: {
         testResultsAggregates: {
-          totalDuration: 1.0,
+          totalDuration: 1.1,
           totalDurationPercentChange: 25.0,
           slowestTestsDuration: 111.11,
           slowestTestsDurationPercentChange: 0.0,
@@ -91,6 +91,20 @@ describe('MetricsSection', () => {
     )
   }
 
+  describe('when not on default branch', () => {
+    it('does not render component', () => {
+      setup()
+      render(<MetricsSection />, {
+        wrapper: wrapper('/gh/owner/repo/tests/ight'),
+      })
+
+      const runEfficiency = screen.queryByText('Improve CI Run Efficiency')
+      const testPerf = screen.queryByText('Improve Test Performance')
+      expect(runEfficiency).not.toBeInTheDocument()
+      expect(testPerf).not.toBeInTheDocument()
+    })
+  })
+
   describe('when on default branch', () => {
     it('renders subheaders', async () => {
       setup()
@@ -102,6 +116,108 @@ describe('MetricsSection', () => {
       const testPerf = await screen.findByText('Improve Test Performance')
       expect(runEfficiency).toBeInTheDocument()
       expect(testPerf).toBeInTheDocument()
+    })
+
+    it('renders total test runtime card', async () => {
+      setup()
+      render(<MetricsSection />, {
+        wrapper: wrapper('/gh/owner/repo/tests/main'),
+      })
+
+      const title = await screen.findByText('Test run time')
+      const context = await screen.findByText(1.1)
+      const description = await screen.findByText(
+        'Increased by [12.5hr] in the last [30 days]'
+      )
+
+      expect(title).toBeInTheDocument()
+      expect(context).toBeInTheDocument()
+      expect(description).toBeInTheDocument()
+    })
+
+    it('renders slowest tests card', async () => {
+      setup()
+      render(<MetricsSection />, {
+        wrapper: wrapper('/gh/owner/repo/tests/main'),
+      })
+
+      const title = await screen.findByText('Slowest tests')
+      const context = await screen.findByText(6)
+      const description = await screen.findByText(
+        'The slowest 6 tests take 111.11 to run.'
+      )
+
+      expect(title).toBeInTheDocument()
+      expect(context).toBeInTheDocument()
+      expect(description).toBeInTheDocument()
+    })
+
+    it('renders total flaky tests card', async () => {
+      setup()
+      render(<MetricsSection />, {
+        wrapper: wrapper('/gh/owner/repo/tests/main'),
+      })
+
+      const title = await screen.findByText('Flaky tests')
+      const context = await screen.findByText(88)
+      const description = await screen.findByText(
+        '*The total rerun time for flaky tests is [50hr].'
+      )
+
+      expect(title).toBeInTheDocument()
+      expect(context).toBeInTheDocument()
+      expect(description).toBeInTheDocument()
+    })
+
+    it('renders average flake rate card', async () => {
+      setup()
+      render(<MetricsSection />, {
+        wrapper: wrapper('/gh/owner/repo/tests/main'),
+      })
+
+      const title = await screen.findByText('Avg. flake rate')
+      const context = await screen.findByText('8%')
+      const description = await screen.findByText(
+        'On average, a flaky test ran [20] times before it passed.'
+      )
+
+      expect(title).toBeInTheDocument()
+      expect(context).toBeInTheDocument()
+      expect(description).toBeInTheDocument()
+    })
+
+    it('renders total failures card', async () => {
+      setup()
+      render(<MetricsSection />, {
+        wrapper: wrapper('/gh/owner/repo/tests/main'),
+      })
+
+      const title = await screen.findByText('Failures')
+      const context = await screen.findByText(1)
+      const description = await screen.findByText(
+        'The number of test failures across all branches.'
+      )
+
+      expect(title).toBeInTheDocument()
+      expect(context).toBeInTheDocument()
+      expect(description).toBeInTheDocument()
+    })
+
+    it('renders total skips card', async () => {
+      setup()
+      render(<MetricsSection />, {
+        wrapper: wrapper('/gh/owner/repo/tests/main'),
+      })
+
+      const title = await screen.findByText('Skipped tests')
+      const context = await screen.findByText(20)
+      const description = await screen.findByText(
+        'The number of skipped tests in your test suite.'
+      )
+
+      expect(title).toBeInTheDocument()
+      expect(context).toBeInTheDocument()
+      expect(description).toBeInTheDocument()
     })
   })
 })

--- a/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/MetricsSection/MetricsSection.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/MetricsSection/MetricsSection.tsx
@@ -6,6 +6,25 @@ import Icon from 'ui/Icon'
 import { MetricCard } from 'ui/MetricCard'
 import { Tooltip } from 'ui/Tooltip'
 
+import { useTestResultsAggregates } from '../hooks/useTestResultsAggregates'
+
+const PercentBadge = ({ value }: { value: number }) => {
+  let variant: 'success' | 'danger' = 'success'
+  let prefix = ''
+
+  if (value > 0) {
+    variant = 'danger'
+    prefix = '+'
+  }
+
+  return (
+    <Badge variant={variant}>
+      {prefix}
+      {value.toFixed(2)}%
+    </Badge>
+  )
+}
+
 export const TooltipWithIcon = ({
   children,
 }: {
@@ -33,7 +52,13 @@ export const TooltipWithIcon = ({
   )
 }
 
-const TotalTestsRunTimeCard = () => {
+const TotalTestsRunTimeCard = ({
+  totalDuration,
+  totalDurationPercentChange,
+}: {
+  totalDuration?: number
+  totalDurationPercentChange?: number | null
+}) => {
   return (
     <MetricCard>
       <MetricCard.Header>
@@ -46,8 +71,10 @@ const TotalTestsRunTimeCard = () => {
       </MetricCard.Header>
 
       <MetricCard.Content>
-        125 hr
-        <Badge variant="danger">+10%</Badge>
+        {totalDuration}
+        {totalDurationPercentChange ? (
+          <PercentBadge value={totalDurationPercentChange} />
+        ) : null}
       </MetricCard.Content>
       <MetricCard.Description>
         Increased by [12.5hr] in the last [30 days]
@@ -56,7 +83,13 @@ const TotalTestsRunTimeCard = () => {
   )
 }
 
-const SlowestTestsCard = () => {
+const SlowestTestsCard = ({
+  slowestTests,
+  slowestTestsDuration,
+}: {
+  slowestTests?: number
+  slowestTestsDuration?: number | null
+}) => {
   return (
     <MetricCard>
       <MetricCard.Header>
@@ -68,9 +101,9 @@ const SlowestTestsCard = () => {
         </MetricCard.Title>
       </MetricCard.Header>
 
-      <MetricCard.Content>6</MetricCard.Content>
+      <MetricCard.Content>{slowestTests}</MetricCard.Content>
       <MetricCard.Description>
-        The slowest [6 tests] take [2.5hr] to run.
+        The slowest {slowestTests} tests take {slowestTestsDuration} to run.
       </MetricCard.Description>
     </MetricCard>
   )
@@ -123,7 +156,13 @@ const AverageFlakeRateCard = () => {
   )
 }
 
-const TotalFailuresCard = () => {
+const TotalFailuresCard = ({
+  totalFails,
+  totalFailsPercentChange,
+}: {
+  totalFails?: number
+  totalFailsPercentChange?: number | null
+}) => {
   return (
     <MetricCard>
       <MetricCard.Header>
@@ -135,7 +174,12 @@ const TotalFailuresCard = () => {
           </TooltipWithIcon>
         </MetricCard.Title>
       </MetricCard.Header>
-      <MetricCard.Content>6</MetricCard.Content>
+      <MetricCard.Content>
+        {totalFails}
+        {totalFailsPercentChange ? (
+          <PercentBadge value={totalFailsPercentChange} />
+        ) : null}
+      </MetricCard.Content>
       <MetricCard.Description>
         The number of test failures across all branches.
       </MetricCard.Description>
@@ -143,7 +187,13 @@ const TotalFailuresCard = () => {
   )
 }
 
-const TotalSkippedTestsCard = () => {
+const TotalSkippedTestsCard = ({
+  totalSkips,
+  totalSkipsPercentChange,
+}: {
+  totalSkips?: number
+  totalSkipsPercentChange?: number | null
+}) => {
   return (
     <MetricCard>
       <MetricCard.Header>
@@ -155,7 +205,12 @@ const TotalSkippedTestsCard = () => {
         </MetricCard.Title>
       </MetricCard.Header>
 
-      <MetricCard.Content>55</MetricCard.Content>
+      <MetricCard.Content>
+        {totalSkips}
+        {totalSkipsPercentChange ? (
+          <PercentBadge value={totalSkipsPercentChange} />
+        ) : null}
+      </MetricCard.Content>
       <MetricCard.Description>
         The number of skipped tests in your test suite.
       </MetricCard.Description>
@@ -182,6 +237,8 @@ function MetricsSection() {
     repo,
   })
 
+  const { data: aggregates } = useTestResultsAggregates()
+
   const decodedBranch = getDecodedBranch(branch)
   const selectedBranch = decodedBranch ?? overview?.defaultBranch ?? ''
 
@@ -198,8 +255,16 @@ function MetricsSection() {
             Improve CI Run Efficiency
           </p>
           <div className="flex">
-            <TotalTestsRunTimeCard />
-            <SlowestTestsCard />
+            <TotalTestsRunTimeCard
+              totalDuration={aggregates?.totalDuration}
+              totalDurationPercentChange={
+                aggregates?.totalDurationPercentChange
+              }
+            />
+            <SlowestTestsCard
+              slowestTests={6}
+              slowestTestsDuration={aggregates?.slowestTestsDuration}
+            />
           </div>
         </div>
         <div className="flex flex-col gap-3">
@@ -209,8 +274,14 @@ function MetricsSection() {
           <div className="flex">
             <TotalFlakyTestsCard />
             <AverageFlakeRateCard />
-            <TotalFailuresCard />
-            <TotalSkippedTestsCard />
+            <TotalFailuresCard
+              totalFails={aggregates?.totalFails}
+              totalFailsPercentChange={aggregates?.totalFailsPercentChange}
+            />
+            <TotalSkippedTestsCard
+              totalSkips={aggregates?.totalSkips}
+              totalSkipsPercentChange={aggregates?.totalSkipsPercentChange}
+            />
           </div>
         </div>
       </div>

--- a/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/MetricsSection/MetricsSection.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/MetricsSection/MetricsSection.tsx
@@ -231,7 +231,9 @@ const getDecodedBranch = (branch?: string) =>
 function MetricsSection() {
   const { provider, owner, repo, branch } = useParams<URLParams>()
 
-  const { data: overview } = useRepoOverview({
+  console.log('Params:', { provider, owner, repo, branch })
+
+  const { data: overview, error } = useRepoOverview({
     provider,
     owner,
     repo,
@@ -241,6 +243,13 @@ function MetricsSection() {
 
   const decodedBranch = getDecodedBranch(branch)
   const selectedBranch = decodedBranch ?? overview?.defaultBranch ?? ''
+
+  console.log({
+    error,
+    overview,
+    selectedBranch,
+    default: overview?.defaultBranch,
+  })
 
   if (selectedBranch !== overview?.defaultBranch) {
     return null

--- a/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/MetricsSection/MetricsSection.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/MetricsSection/MetricsSection.tsx
@@ -231,9 +231,7 @@ const getDecodedBranch = (branch?: string) =>
 function MetricsSection() {
   const { provider, owner, repo, branch } = useParams<URLParams>()
 
-  console.log('Params:', { provider, owner, repo, branch })
-
-  const { data: overview, error } = useRepoOverview({
+  const { data: overview } = useRepoOverview({
     provider,
     owner,
     repo,
@@ -243,13 +241,6 @@ function MetricsSection() {
 
   const decodedBranch = getDecodedBranch(branch)
   const selectedBranch = decodedBranch ?? overview?.defaultBranch ?? ''
-
-  console.log({
-    error,
-    overview,
-    selectedBranch,
-    default: overview?.defaultBranch,
-  })
 
   if (selectedBranch !== overview?.defaultBranch) {
     return null

--- a/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/hooks/useTestResultsAggregates/useTestResultsAggregates.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/hooks/useTestResultsAggregates/useTestResultsAggregates.tsx
@@ -85,8 +85,6 @@ export const useTestResultsAggregates = () => {
       }).then((res) => {
         const parsedData = TestResultsAggregatesSchema.safeParse(res?.data)
 
-        console.log({ parsedData })
-
         if (!parsedData.success) {
           return Promise.reject({
             status: 404,

--- a/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/hooks/useTestResultsAggregates/useTestResultsAggregates.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/hooks/useTestResultsAggregates/useTestResultsAggregates.tsx
@@ -12,18 +12,20 @@ const TestResultsAggregatesSchema = z.object({
       repository: z.discriminatedUnion('__typename', [
         z.object({
           __typename: z.literal('Repository'),
-          testAnalytics: z.object({
-            testResultsAggregates: z.object({
-              totalDuration: z.number(),
-              totalDurationPercentChange: z.number().nullable(),
-              slowestTestsDuration: z.number(),
-              slowestTestsDurationPercentChange: z.number().nullable(),
-              totalFails: z.number(),
-              totalFailsPercentChange: z.number().nullable(),
-              totalSkips: z.number(),
-              totalSkipsPercentChange: z.number().nullable(),
-            }),
-          }),
+          testAnalytics: z
+            .object({
+              testResultsAggregates: z.object({
+                totalDuration: z.number(),
+                totalDurationPercentChange: z.number().nullable(),
+                slowestTestsDuration: z.number(),
+                slowestTestsDurationPercentChange: z.number().nullable(),
+                totalFails: z.number(),
+                totalFailsPercentChange: z.number().nullable(),
+                totalSkips: z.number(),
+                totalSkipsPercentChange: z.number().nullable(),
+              }),
+            })
+            .nullable(),
         }),
         RepoNotFoundErrorSchema,
       ]),
@@ -103,7 +105,7 @@ export const useTestResultsAggregates = () => {
           } satisfies NetworkErrorObject)
         }
 
-        return data.owner?.repository.testAnalytics.testResultsAggregates
+        return data.owner?.repository.testAnalytics?.testResultsAggregates
       }),
   })
 }

--- a/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/hooks/useTestResultsAggregates/useTestResultsAggregates.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/hooks/useTestResultsAggregates/useTestResultsAggregates.tsx
@@ -85,6 +85,8 @@ export const useTestResultsAggregates = () => {
       }).then((res) => {
         const parsedData = TestResultsAggregatesSchema.safeParse(res?.data)
 
+        console.log({ parsedData })
+
         if (!parsedData.success) {
           return Promise.reject({
             status: 404,

--- a/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/hooks/useTestResultsAggregates/useTestResultsAggregates.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/hooks/useTestResultsAggregates/useTestResultsAggregates.tsx
@@ -12,15 +12,17 @@ const TestResultsAggregatesSchema = z.object({
       repository: z.discriminatedUnion('__typename', [
         z.object({
           __typename: z.literal('Repository'),
-          testResultsAggregates: z.object({
-            totalDuration: z.number(),
-            totalDurationPercentChange: z.number().nullable(),
-            slowestTestsDuration: z.number(),
-            slowestTestsDurationPercentChange: z.number().nullable(),
-            totalFails: z.number(),
-            totalFailsPercentChange: z.number().nullable(),
-            totalSkips: z.number(),
-            totalSkipsPercentChange: z.number().nullable(),
+          testAnalytics: z.object({
+            testResultsAggregates: z.object({
+              totalDuration: z.number(),
+              totalDurationPercentChange: z.number().nullable(),
+              slowestTestsDuration: z.number(),
+              slowestTestsDurationPercentChange: z.number().nullable(),
+              totalFails: z.number(),
+              totalFailsPercentChange: z.number().nullable(),
+              totalSkips: z.number(),
+              totalSkipsPercentChange: z.number().nullable(),
+            }),
           }),
         }),
         RepoNotFoundErrorSchema,
@@ -38,16 +40,18 @@ const query = `
       repository: repository(name: $repo) {
         __typename
         ... on Repository {
-          testResultsAggregates {
-            totalDuration
-            totalDurationPercentChange
-            slowestTestsDuration
-            slowestTestsDurationPercentChange
-            totalFails
-            totalFailsPercentChange
-            totalSkips
-            totalSkipsPercentChange
-            }
+            testAnalytics {
+              testResultsAggregates {
+                totalDuration
+                totalDurationPercentChange
+                slowestTestsDuration
+                slowestTestsDurationPercentChange
+                totalFails
+                totalFailsPercentChange
+                totalSkips
+                totalSkipsPercentChange
+                }
+          }
         }
         ... on NotFoundError {
           message
@@ -99,7 +103,7 @@ export const useTestResultsAggregates = () => {
           } satisfies NetworkErrorObject)
         }
 
-        return data.owner?.repository.testResultsAggregates
+        return data.owner?.repository.testAnalytics.testResultsAggregates
       }),
   })
 }

--- a/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/hooks/useTestResultsAggregates/useTestsResultsAggregates.test.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/hooks/useTestResultsAggregates/useTestsResultsAggregates.test.tsx
@@ -55,15 +55,17 @@ const mockResponse = {
   owner: {
     repository: {
       __typename: 'Repository',
-      testResultsAggregates: {
-        totalDuration: 1.0,
-        totalDurationPercentChange: 25.0,
-        slowestTestsDuration: 111.11,
-        slowestTestsDurationPercentChange: 0.0,
-        totalFails: 1,
-        totalFailsPercentChange: 100.0,
-        totalSkips: 20,
-        totalSkipsPercentChange: 0.0,
+      testAnalytics: {
+        testResultsAggregates: {
+          totalDuration: 1.0,
+          totalDurationPercentChange: 25.0,
+          slowestTestsDuration: 111.11,
+          slowestTestsDurationPercentChange: 0.0,
+          totalFails: 1,
+          totalFailsPercentChange: 100.0,
+          totalSkips: 20,
+          totalSkipsPercentChange: 0.0,
+        },
       },
     },
   },

--- a/src/services/repo/useRepoOverview.tsx
+++ b/src/services/repo/useRepoOverview.tsx
@@ -65,6 +65,7 @@ export function useRepoOverview({
   repo,
   opts = {},
 }: UseRepoOverviewArgs) {
+  console.log('ENTERING HERE')
   let enabled = true
   if (opts?.enabled !== undefined) {
     enabled = opts.enabled
@@ -73,6 +74,7 @@ export function useRepoOverview({
   return useQuery({
     queryKey: ['GetRepoOverview', provider, owner, repo],
     queryFn: ({ signal }) => {
+      console.log('STARTING QUERY', provider, owner, repo)
       return Api.graphql({
         provider,
         signal,
@@ -82,6 +84,7 @@ export function useRepoOverview({
           repo,
         },
       }).then((res) => {
+        console.log({ res })
         const parsedData = RequestSchema.safeParse(res?.data)
 
         if (!parsedData.success) {

--- a/src/services/repo/useRepoOverview.tsx
+++ b/src/services/repo/useRepoOverview.tsx
@@ -65,7 +65,6 @@ export function useRepoOverview({
   repo,
   opts = {},
 }: UseRepoOverviewArgs) {
-  console.log('ENTERING HERE')
   let enabled = true
   if (opts?.enabled !== undefined) {
     enabled = opts.enabled
@@ -74,7 +73,6 @@ export function useRepoOverview({
   return useQuery({
     queryKey: ['GetRepoOverview', provider, owner, repo],
     queryFn: ({ signal }) => {
-      console.log('STARTING QUERY', provider, owner, repo)
       return Api.graphql({
         provider,
         signal,
@@ -84,7 +82,6 @@ export function useRepoOverview({
           repo,
         },
       }).then((res) => {
-        console.log({ res })
         const parsedData = RequestSchema.safeParse(res?.data)
 
         if (!parsedData.success) {


### PR DESCRIPTION
# Description

This PR aims to glue the hook created in https://github.com/codecov/gazebo/pull/3368 with the metrics section for many of the testResultsAggregates and their respective dynamic values.

We also create a new "PercentBadge" component which will dynamically show + or - and the appropriate color depending on the percentChange that comes back from API. If there's no percent change, which there won't be for the first 30ish days anyway, we won't have any badge populated.

What's not covered here is a "pretty format" of any of the times

Closes https://github.com/codecov/engineering-team/issues/2656

# Screenshots

**Some test code**
<img width="650" alt="Screenshot 2024-10-09 at 3 43 36 PM" src="https://github.com/user-attachments/assets/fdc441bb-5537-4983-8862-eb725b4f5c3a">
<img width="1330" alt="Screenshot 2024-10-09 at 3 43 39 PM" src="https://github.com/user-attachments/assets/d7b97f03-e073-48ff-a199-77eb03e871ed">


# Link to Sample Entry

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.