### PR TITLE
Add Account usage banners to plan page

### DIFF
--- a/src/pages/PlanPage/subRoutes/CurrentOrgPlan/CurrentOrgPlan.test.tsx
+++ b/src/pages/PlanPage/subRoutes/CurrentOrgPlan/CurrentOrgPlan.test.tsx
@@ -217,6 +217,9 @@ describe('CurrentOrgPlan', () => {
         } as z.infer<typeof AccountDetailsSchema>,
       })
       render(<CurrentOrgPlan />, { wrapper: noUpdatedPlanWrapper })
+      const currentPlanCard = await screen.findByText(/CurrentPlanCard/i)
+      expect(currentPlanCard).toBeInTheDocument()
+
       expect(
         screen.queryByText('Plan successfully updated.')
       ).not.toBeInTheDocument()

--- a/src/services/navigation/useNavLinks/useStaticNavLinks.js
+++ b/src/services/navigation/useNavLinks/useStaticNavLinks.js
@@ -160,6 +160,12 @@ export function useStaticNavLinks() {
       isExternalLink: true,
       openNewTab: true,
     },
+    enterpriseSupport: {
+      text: 'Enterprise Support',
+      path: () => 'https://codecoventerprise.zendesk.com/hc/en-us',
+      isExternalLink: true,
+      openNewTab: true,
+    },
     legacyUI: {
       path: ({ pathname }) => config.BASE_URL + pathname,
       isExternalLink: true,

--- a/src/services/navigation/useNavLinks/useStaticNavLinks.test.jsx
+++ b/src/services/navigation/useNavLinks/useStaticNavLinks.test.jsx
@@ -43,6 +43,7 @@ describe('useStaticNavLinks', () => {
       ${links.termsOfService}                | ${`${config.MARKETING_BASE_URL}/terms-of-service`}
       ${links.githubMarketplace}             | ${`https://github.com/marketplace/codecov`}
       ${links.support}                       | ${`https://codecovpro.zendesk.com/hc/en-us`}
+      ${links.enterpriseSupport}             | ${`https://codecoventerprise.zendesk.com/hc/en-us`}
       ${links.docs}                          | ${`https://docs.codecov.io/`}
       ${links.oauthTroubleshoot}             | ${'https://docs.codecov.com/docs/github-oauth-application-authorization#troubleshooting'}
       ${links.teamPlanAbout}                 | ${'https://about.codecov.io/team-plan-compare'}


### PR DESCRIPTION
Adds seat usage banners for new multi org accounts using the useEnterpriseAccountDetails hook.

[Design](https://www.figma.com/design/Tytz3vo8mjlyAL8qSiXw3S/GH-1533?node-id=1-2&node-type=canvas&t=Ps6A4FQa6wLfdkve-0)

Closes https://github.com/codecov/engineering-team/issues/2561

<img width="1306" alt="Screenshot 2024-10-10 at 10 07 41" src="https://github.com/user-attachments/assets/9ad95e09-9dee-4c1b-9673-eab398a9e841">

<img width="1309" alt="Screenshot 2024-10-10 at 10 08 33" src="https://github.com/user-attachments/assets/495b1b08-096e-4c6a-bf2f-01c1294ebc5c">
