### PR TITLE
feat: Glue in pass/fail/skip params into tooltip via test results query

### DIFF
--- a/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/FailedTestsTable/FailedTestsTable.test.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/FailedTestsTable/FailedTestsTable.test.tsx
@@ -25,6 +25,9 @@ const node1 = {
   failureRate: 0.1,
   flakeRate: 0.0,
   avgDuration: 10,
+  totalFailCount: 5,
+  totalPassCount: 6,
+  totalSkipCount: 7,
 }
 
 const node2 = {
@@ -34,6 +37,9 @@ const node2 = {
   failureRate: 0.2,
   flakeRate: 0.2,
   avgDuration: 20,
+  totalFailCount: 8,
+  totalPassCount: 9,
+  totalSkipCount: 10,
 }
 
 const node3 = {
@@ -43,6 +49,9 @@ const node3 = {
   failureRate: 0.3,
   flakeRate: 0.1,
   avgDuration: 30,
+  totalFailCount: 11,
+  totalPassCount: 12,
+  totalSkipCount: 13,
 }
 
 const server = setupServer()
@@ -168,6 +177,9 @@ describe('FailedTestsTable', () => {
       const failureRateColumn = await screen.findByText('Failure rate')
       expect(failureRateColumn).toBeInTheDocument()
 
+      const flakeRateColumn = await screen.findByText('Flake rate')
+      expect(flakeRateColumn).toBeInTheDocument()
+
       const commitFailedColumn = await screen.findByText('Commits failed')
       expect(commitFailedColumn).toBeInTheDocument()
 
@@ -194,6 +206,9 @@ describe('FailedTestsTable', () => {
 
       const failureRateColumn = await screen.findByText('10.00%')
       expect(failureRateColumn).toBeInTheDocument()
+
+      const flakeRateColumn = await screen.findByText('0%')
+      expect(flakeRateColumn).toBeInTheDocument()
 
       const commitFailedColumn = await screen.findByText('1')
       expect(commitFailedColumn).toBeInTheDocument()

--- a/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/FailedTestsTable/FailedTestsTable.test.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/FailedTestsTable/FailedTestsTable.test.tsx
@@ -1,10 +1,5 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import {
-  render,
-  screen,
-  waitFor,
-  waitForElementToBeRemoved,
-} from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { graphql, HttpResponse } from 'msw2'
 import { setupServer } from 'msw2/node'
@@ -400,22 +395,6 @@ describe('FailedTestsTable', () => {
           })
         )
       })
-    })
-  })
-
-  describe('infinite scrolling', () => {
-    it('loads next page', async () => {
-      const { queryClient } = setup({})
-      render(<FailedTestsTable />, {
-        wrapper: wrapper(queryClient),
-      })
-
-      const loading = await screen.findByText('Loading')
-      mockIsIntersecting(loading, true)
-      await waitForElementToBeRemoved(loading)
-
-      const thirdCommit = await screen.findByText('test-3')
-      expect(thirdCommit).toBeInTheDocument()
     })
   })
 

--- a/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/SelectorSection/SelectorSection.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/SelectorSection/SelectorSection.tsx
@@ -73,7 +73,7 @@ function SelectorSection() {
               />
             </div>
             <A to="" isExternal hook={'30-day-retention'}>
-              30 day retention
+              60 day retention
             </A>
           </div>
           <div className="flex flex-col gap-1 px-4">

--- a/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/hooks/useInfiniteTestResults/useInfiniteTestResults.test.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/hooks/useInfiniteTestResults/useInfiniteTestResults.test.tsx
@@ -20,6 +20,9 @@ const mockTestResults = {
                 failureRate: 0.1,
                 flakeRate: 0.0,
                 avgDuration: 10,
+                totalFailCount: 5,
+                totalPassCount: 6,
+                totalSkipCount: 7,
               },
             },
             {
@@ -30,6 +33,9 @@ const mockTestResults = {
                 failureRate: 0.2,
                 flakeRate: 0.0,
                 avgDuration: 20,
+                totalFailCount: 8,
+                totalPassCount: 9,
+                totalSkipCount: 10,
               },
             },
             {
@@ -40,6 +46,9 @@ const mockTestResults = {
                 failureRate: 0.2,
                 flakeRate: 0.1,
                 avgDuration: 30,
+                totalFailCount: 11,
+                totalPassCount: 12,
+                totalSkipCount: 13,
               },
             },
           ],
@@ -153,6 +162,9 @@ describe('useInfiniteTestResults', () => {
                 failureRate: 0.1,
                 flakeRate: 0.0,
                 avgDuration: 10,
+                totalFailCount: 5,
+                totalPassCount: 6,
+                totalSkipCount: 7,
               },
               {
                 updatedAt: '2023-01-02T00:00:00Z',
@@ -161,6 +173,9 @@ describe('useInfiniteTestResults', () => {
                 failureRate: 0.2,
                 flakeRate: 0.0,
                 avgDuration: 20,
+                totalFailCount: 8,
+                totalPassCount: 9,
+                totalSkipCount: 10,
               },
               {
                 updatedAt: '2023-01-03T00:00:00Z',
@@ -169,6 +184,9 @@ describe('useInfiniteTestResults', () => {
                 failureRate: 0.2,
                 flakeRate: 0.1,
                 avgDuration: 30,
+                totalFailCount: 11,
+                totalPassCount: 12,
+                totalSkipCount: 13,
               },
             ])
           )

--- a/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/hooks/useInfiniteTestResults/useInfiniteTestResults.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/hooks/useInfiniteTestResults/useInfiniteTestResults.tsx
@@ -21,6 +21,9 @@ const TestResultSchema = z.object({
   failureRate: z.number().nullable(),
   flakeRate: z.number().nullable(),
   avgDuration: z.number().nullable(),
+  totalFailCount: z.number(),
+  totalSkipCount: z.number(),
+  totalPassCount: z.number(),
 })
 
 export const OrderingDirection = {
@@ -104,6 +107,9 @@ query GetTestResults(
                 failureRate
                 flakeRate
                 commitsFailed
+                totalFailCount
+                totalSkipCount
+                totalPassCount
               }
             }
             pageInfo {


### PR DESCRIPTION
# Description

This PR glues in the pass fail and skip counts from the test results query to the tooltip shown when you hover the flake rate field.
A minor refactor had to be done when generating the test results "values" to show on the table because multiple values from the query are being populated onto a single column.

I basically just moved over that component logic to the column and had the column render the value itself instead of having it on the column.

# Screenshots

<img width="1237" alt="Screenshot 2024-10-10 at 4 52 37 PM" src="https://github.com/user-attachments/assets/a5d67333-2e04-45b9-9671-2fa593d230a1">

# Link to Sample Entry

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.