### PR TITLE
feat: Add useInfiniteAccountOrganizations hook

### DIFF
--- a/src/pages/PlanPage/subRoutes/CurrentOrgPlan/hooks/useInfiniteAccountOrganizations.test.tsx
+++ b/src/pages/PlanPage/subRoutes/CurrentOrgPlan/hooks/useInfiniteAccountOrganizations.test.tsx
@@ -1,0 +1,224 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { renderHook, waitFor } from '@testing-library/react'
+import { graphql, HttpResponse } from 'msw2'
+import { setupServer } from 'msw2/node'
+import { MemoryRouter, Route } from 'react-router'
+
+import { useInfiniteAccountOrganizations } from './useInfiniteAccountOrganizations'
+
+const org1 = {
+  username: 'org1',
+  activatedUserCount: 7,
+  isCurrentUserPartOfOrg: true,
+}
+
+const org2 = {
+  username: 'org2',
+  activatedUserCount: 4,
+  isCurrentUserPartOfOrg: false,
+}
+
+const org3 = {
+  username: 'org3',
+  activatedUserCount: 2,
+  isCurrentUserPartOfOrg: true,
+}
+
+const mockPageOne = {
+  owner: {
+    account: {
+      organizations: {
+        edges: [
+          {
+            node: org1,
+          },
+          {
+            node: org2,
+          },
+        ],
+        pageInfo: {
+          hasNextPage: true,
+          endCursor: 'asdf',
+        },
+      },
+    },
+  },
+}
+
+const mockPageTwo = {
+  owner: {
+    account: {
+      organizations: {
+        edges: [
+          {
+            node: org3,
+          },
+        ],
+        pageInfo: {
+          hasNextPage: false,
+          endCursor: null,
+        },
+      },
+    },
+  },
+}
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      retry: false,
+    },
+  },
+})
+const wrapper: React.FC<React.PropsWithChildren> = ({ children }) => (
+  <QueryClientProvider client={queryClient}>
+    <MemoryRouter initialEntries={['/gh/codecov/plan']}>
+      <Route path="/:provider/:owner/plan">{children}</Route>
+    </MemoryRouter>
+  </QueryClientProvider>
+)
+
+const server = setupServer()
+
+beforeAll(() => server.listen())
+afterEach(() => {
+  queryClient.clear()
+  server.resetHandlers()
+})
+afterAll(() => server.close())
+
+interface SetupArgs {
+  invalidResponse?: boolean
+  noAccount?: boolean
+}
+
+describe('useInfiniteAccountOrganizations', () => {
+  function setup({ invalidResponse = false, noAccount = false }: SetupArgs) {
+    server.use(
+      graphql.query('InfiniteAccountOrganizations', (info) => {
+        if (invalidResponse) {
+          return HttpResponse.json({ data: {} })
+        } else if (noAccount) {
+          return HttpResponse.json({
+            data: {
+              owner: {
+                account: null,
+              },
+            },
+          })
+        } else if (info.variables.after) {
+          return HttpResponse.json({
+            data: mockPageTwo,
+          })
+        }
+        return HttpResponse.json({
+          data: mockPageOne,
+        })
+      })
+    )
+  }
+
+  const provider = 'gh'
+  const owner = 'codecov'
+
+  it('returns 404 when bad response from api', async () => {
+    setup({ invalidResponse: true })
+    const { result } = renderHook(
+      () => useInfiniteAccountOrganizations({ provider, owner }),
+      { wrapper }
+    )
+
+    console.error = () => {}
+
+    await waitFor(() => expect(result.current.status).toBe('error'))
+
+    await waitFor(() =>
+      expect(result.current.failureReason).toMatchObject({
+        status: 404,
+        data: {},
+        dev: 'useInfiniteAccountOrganizations - 404 Failed to parse data',
+      })
+    )
+  })
+
+  it('returns 404 when no account for owner', async () => {
+    setup({ noAccount: true })
+    const { result } = renderHook(
+      () => useInfiniteAccountOrganizations({ provider, owner }),
+      { wrapper }
+    )
+
+    console.error = () => {}
+
+    await waitFor(() => expect(result.current.status).toBe('error'))
+
+    await waitFor(() =>
+      expect(result.current.failureReason).toMatchObject({
+        status: 404,
+        data: {},
+        dev: 'useInfiniteAccountOrganizations - 404 Cannot find Account for Owner',
+      })
+    )
+  })
+
+  it('returns organizations for account', async () => {
+    setup({})
+    const { result } = renderHook(
+      () => useInfiniteAccountOrganizations({ provider, owner }),
+      { wrapper }
+    )
+
+    await waitFor(() =>
+      expect(result.current.data?.pages).toEqual([
+        {
+          organizations: [org1, org2],
+          pageInfo: {
+            hasNextPage: true,
+            endCursor: 'asdf',
+          },
+        },
+      ])
+    )
+  })
+
+  it('returns second page of orgs for account', async () => {
+    setup({})
+    const { result } = renderHook(
+      () => useInfiniteAccountOrganizations({ provider, owner }),
+      { wrapper }
+    )
+
+    await waitFor(() =>
+      expect(result.current.data?.pages).toEqual([
+        {
+          organizations: [org1, org2],
+          pageInfo: {
+            hasNextPage: true,
+            endCursor: 'asdf',
+          },
+        },
+      ])
+    )
+
+    await result.current.fetchNextPage()
+
+    await waitFor(() =>
+      expect(result.current.data?.pages).toEqual([
+        {
+          organizations: [org1, org2],
+          pageInfo: {
+            hasNextPage: true,
+            endCursor: 'asdf',
+          },
+        },
+        {
+          organizations: [org3],
+          pageInfo: {
+            hasNextPage: false,
+            endCursor: null,
+          },
+        },
+      ])
+    )
+  })
+})

--- a/src/pages/PlanPage/subRoutes/CurrentOrgPlan/hooks/useInfiniteAccountOrganizations.ts
+++ b/src/pages/PlanPage/subRoutes/CurrentOrgPlan/hooks/useInfiniteAccountOrganizations.ts
@@ -1,0 +1,132 @@
+import { useInfiniteQuery } from '@tanstack/react-query'
+import { z } from 'zod'
+
+import { OrderingDirection } from 'types'
+
+import Api from 'shared/api/api'
+import { NetworkErrorObject } from 'shared/api/helpers'
+import { mapEdges } from 'shared/utils/graphql'
+
+const RequestSchema = z.object({
+  owner: z
+    .object({
+      account: z
+        .object({
+          organizations: z.object({
+            edges: z.array(
+              z.object({
+                node: z
+                  .object({
+                    username: z.string().nullable(),
+                    activatedUserCount: z.number().nullable(),
+                    isCurrentUserPartOfOrg: z.boolean(),
+                  })
+                  .nullable(),
+              })
+            ),
+            pageInfo: z.object({
+              hasNextPage: z.boolean(),
+              endCursor: z.string().nullable(),
+            }),
+          }),
+        })
+        .nullable(),
+    })
+    .nullable(),
+})
+
+const query = `query InfiniteAccountOrganizations(
+  $owner: String!, 
+  $after: String, 
+  $first: Int!, 
+  $ordering: AccountOrganizationOrdering!, 
+  $direction: OrderingDirection!
+) {
+  owner(username: $owner) {
+    account {
+      organizations(
+        first: $first
+        after: $after
+        ordering: $ordering
+        orderingDirection: $direction
+      ) {
+        edges {
+          node {
+            username
+            activatedUserCount
+            isCurrentUserPartOfOrg
+          }
+        }
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+      }
+    }
+    activatedUserCount
+  }
+}`
+
+interface UseInfiniteAccountOrganizationsArgs {
+  provider: string
+  owner: string
+  first?: number
+  ordering?: 'NAME' | 'ACTIVATED_USERS'
+  orderingDirection?: OrderingDirection
+}
+
+export function useInfiniteAccountOrganizations({
+  provider,
+  owner,
+  first = 20,
+  ordering = 'ACTIVATED_USERS',
+  orderingDirection = 'DESC',
+}: UseInfiniteAccountOrganizationsArgs) {
+  const variables = {
+    first,
+    ordering,
+    orderingDirection,
+  }
+
+  return useInfiniteQuery({
+    queryKey: ['InfiniteAccountOrganizations', provider, owner, variables],
+    queryFn: ({ pageParam, signal }) =>
+      Api.graphql({
+        provider,
+        signal,
+        query,
+        variables: {
+          ...variables,
+          owner,
+          after: pageParam,
+        },
+      }).then((res) => {
+        const parsedRes = RequestSchema.safeParse(res.data)
+
+        if (!parsedRes.success) {
+          return Promise.reject({
+            status: 404,
+            data: {},
+            dev: 'useInfiniteAccountOrganizations - 404 Failed to parse data',
+          } satisfies NetworkErrorObject)
+        }
+
+        const account = parsedRes?.data?.owner?.account
+
+        if (!account) {
+          return Promise.reject({
+            status: 404,
+            data: {},
+            dev: 'useInfiniteAccountOrganizations - 404 Cannot find Account for Owner',
+          } satisfies NetworkErrorObject)
+        }
+
+        return {
+          organizations: mapEdges(account.organizations),
+          pageInfo: account.organizations.pageInfo,
+        }
+      }),
+    suspense: false,
+    getNextPageParam: (data) => data.pageInfo.endCursor,
+  })
+}


### PR DESCRIPTION
Implements useInfiniteAccountOrganizations hook to be used in next step of multiple orgs ui: the org list.

Closes https://github.com/codecov/engineering-team/issues/2563
