### PR TITLE
feat: Plan specific details, flake rate related stuff

### DIFF
--- a/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/FailedTestsTable/FailedTestsTable.test.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/FailedTestsTable/FailedTestsTable.test.tsx
@@ -105,7 +105,13 @@ describe('FailedTestsTable', () => {
     planValue = 'users-enterprisem',
     isPrivate = false,
   }: SetupArgs) {
-    const queryClient = new QueryClient()
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: {
+          suspense: false,
+        },
+      },
+    })
 
     const user = userEvent.setup({ delay: null })
     const mockVariables = vi.fn()
@@ -174,13 +180,15 @@ describe('FailedTestsTable', () => {
     describe('when repo is private', () => {
       describe('when plan is team plan', () => {
         it('does not render flake rate column', async () => {
-          const { queryClient } = setup({ planValue: 'team' })
+          const { queryClient } = setup({
+            planValue: 'users-teamm',
+            isPrivate: true,
+          })
           render(<FailedTestsTable />, {
             wrapper: wrapper(queryClient),
           })
 
-          await waitFor(() => queryClient.isFetching)
-          await waitFor(() => !queryClient.isFetching)
+          await waitFor(() => expect(queryClient.isFetching()).toBeFalsy())
 
           const flakeRateColumn = screen.queryByText('Flake rate')
           expect(flakeRateColumn).not.toBeInTheDocument()
@@ -189,13 +197,15 @@ describe('FailedTestsTable', () => {
 
       describe('when plan is free', () => {
         it('does not render flake rate column', async () => {
-          const { queryClient } = setup({ planValue: 'free' })
+          const { queryClient } = setup({
+            planValue: 'users-free',
+            isPrivate: true,
+          })
           render(<FailedTestsTable />, {
             wrapper: wrapper(queryClient),
           })
 
-          await waitFor(() => queryClient.isFetching)
-          await waitFor(() => !queryClient.isFetching)
+          await waitFor(() => expect(queryClient.isFetching()).toBeFalsy())
 
           const flakeRateColumn = screen.queryByText('Flake rate')
           expect(flakeRateColumn).not.toBeInTheDocument()

--- a/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/FailedTestsTable/FailedTestsTable.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/FailedTestsTable/FailedTestsTable.tsx
@@ -1,4 +1,5 @@
 import {
+  CellContext,
   createColumnHelper,
   flexRender,
   getCoreRowModel,
@@ -12,6 +13,7 @@ import { useEffect, useMemo, useState } from 'react'
 import { useInView } from 'react-intersection-observer'
 import { useParams } from 'react-router-dom'
 
+import { isFreePlan, isTeamPlan } from 'shared/utils/billing'
 import { formatTimeToNow } from 'shared/utils/dates'
 import Icon from 'ui/Icon'
 import Spinner from 'ui/Spinner'
@@ -97,52 +99,61 @@ interface FailedTestsColumns {
   name: string
   avgDuration: number | null
   failureRate: number | null
-  flakeRate?: React.ReactNode
+  flakeRate?: React.ReactNode | null
   commitsFailed: number | null
   updatedAt: string
 }
 
 const columnHelper = createColumnHelper<FailedTestsColumns>()
 
-const columns = [
-  columnHelper.accessor('name', {
-    header: () => 'Test name',
-    cell: (info) => info.renderValue(),
-  }),
-  columnHelper.accessor('avgDuration', {
-    header: () => 'Avg duration',
-    cell: (info) => `${(info.renderValue() ?? 0).toFixed(3)}s`,
-  }),
-  columnHelper.accessor('failureRate', {
-    header: () => 'Failure rate',
-    cell: (info) => {
-      const value = (info.renderValue() ?? 0) * 100
-      const isInt = Number.isInteger(info.renderValue())
-      return isInt ? `${value}%` : `${value.toFixed(2)}%`
-    },
-  }),
-  columnHelper.accessor('flakeRate', {
-    header: () => (
-      <div className="flex items-center gap-1">
-        Flake rate
-        <TooltipWithIcon>
-          Shows how often a flake occurs by tracking how many times a test goes
-          from fail to pass or pass to fail on a given branch and commit within
-          the last [7] days.
-        </TooltipWithIcon>
-      </div>
-    ),
-    cell: (info) => info.renderValue(),
-  }),
-  columnHelper.accessor('commitsFailed', {
-    header: () => 'Commits failed',
-    cell: (info) => (info.renderValue() ? info.renderValue() : 0),
-  }),
-  columnHelper.accessor('updatedAt', {
-    header: () => 'Last run',
-    cell: (info) => formatTimeToNow(info.renderValue()),
-  }),
-]
+const getColumns = (hideFlakeRate: boolean) => {
+  const baseColumns = [
+    columnHelper.accessor('name', {
+      header: () => 'Test name',
+      cell: (info) => info.renderValue(),
+    }),
+    columnHelper.accessor('avgDuration', {
+      header: () => 'Avg duration',
+      cell: (info) => `${(info.renderValue() ?? 0).toFixed(3)}s`,
+    }),
+    columnHelper.accessor('failureRate', {
+      header: () => 'Failure rate',
+      cell: (info) => {
+        const value = (info.renderValue() ?? 0) * 100
+        const isInt = Number.isInteger(info.renderValue())
+        return isInt ? `${value}%` : `${value.toFixed(2)}%`
+      },
+    }),
+    columnHelper.accessor('commitsFailed', {
+      header: () => 'Commits failed',
+      cell: (info) => (info.renderValue() ? info.renderValue() : 0),
+    }),
+    columnHelper.accessor('updatedAt', {
+      header: () => 'Last run',
+      cell: (info) => formatTimeToNow(info.renderValue()),
+    }),
+  ]
+
+  if (!hideFlakeRate) {
+    baseColumns.splice(3, 0, {
+      accessorKey: 'flakeRate',
+      header: () => (
+        <div className="flex items-center gap-1">
+          Flake rate
+          <TooltipWithIcon>
+            Shows how often a flake occurs by tracking how many times a test
+            goes from fail to pass or pass to fail on a given branch and commit
+            within the last [7] days.
+          </TooltipWithIcon>
+        </div>
+      ),
+      cell: (info: CellContext<FailedTestsColumns, number | null>) =>
+        info.renderValue(),
+    })
+  }
+
+  return baseColumns
+}
 
 interface URLParams {
   provider: string
@@ -180,45 +191,53 @@ const FailedTestsTable = () => {
     },
   })
 
-  const tableData = useMemo(() => {
-    return testData?.testResults.map((result) => {
-      const value = (result.flakeRate ?? 0) * 100
-      const isFlakeInt = Number.isInteger(value)
+  const hideFlakeRate =
+    (isTeamPlan(testData?.plan) || isFreePlan(testData?.plan)) &&
+    testData?.private
 
-      return {
-        name: result.name,
-        avgDuration: result.avgDuration,
-        failureRate: result.failureRate,
-        flakeRate: (
-          <>
-            <Tooltip delayDuration={0} skipDelayDuration={100}>
-              <Tooltip.Root>
-                <Tooltip.Trigger className="underline decoration-dotted decoration-1 underline-offset-4">
-                  {isFlakeInt ? `${value}%` : `${value.toFixed(2)}%`}
-                </Tooltip.Trigger>
-                <Tooltip.Portal>
-                  <Tooltip.Content
-                    className="bg-ds-gray-primary p-2 text-xs text-ds-gray-octonary"
-                    side="right"
-                  >
-                    Passed {result.totalPassCount}, Failed{' '}
-                    {result.totalFailCount}, Skipped {result.totalSkipCount}
-                    <Tooltip.Arrow className="size-4 fill-ds-gray-primary" />
-                  </Tooltip.Content>
-                </Tooltip.Portal>
-              </Tooltip.Root>
-            </Tooltip>
-          </>
-        ),
-        commitsFailed: result.commitsFailed,
-        updatedAt: result.updatedAt,
-      }
-    })
+  const tableData = useMemo(() => {
+    return (
+      testData?.testResults.map((result) => {
+        const value = (result.flakeRate ?? 0) * 100
+        const isFlakeInt = Number.isInteger(value)
+
+        return {
+          name: result.name,
+          avgDuration: result.avgDuration,
+          failureRate: result.failureRate,
+          flakeRate: (
+            <>
+              <Tooltip delayDuration={0} skipDelayDuration={100}>
+                <Tooltip.Root>
+                  <Tooltip.Trigger className="underline decoration-dotted decoration-1 underline-offset-4">
+                    {isFlakeInt ? `${value}%` : `${value.toFixed(2)}%`}
+                  </Tooltip.Trigger>
+                  <Tooltip.Portal>
+                    <Tooltip.Content
+                      className="bg-ds-gray-primary p-2 text-xs text-ds-gray-octonary"
+                      side="right"
+                    >
+                      Passed {result.totalPassCount}, Failed{' '}
+                      {result.totalFailCount}, Skipped {result.totalSkipCount}
+                      <Tooltip.Arrow className="size-4 fill-ds-gray-primary" />
+                    </Tooltip.Content>
+                  </Tooltip.Portal>
+                </Tooltip.Root>
+              </Tooltip>
+            </>
+          ),
+          commitsFailed: result.commitsFailed,
+          updatedAt: result.updatedAt,
+        }
+      }) ?? []
+    )
   }, [testData])
+
+  const columns = getColumns(!!hideFlakeRate)
 
   const table = useReactTable({
     columns,
-    data: tableData ?? [],
+    data: tableData,
     state: {
       sorting,
     },

--- a/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/FailedTestsTable/FailedTestsTable.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/FailedTestsTable/FailedTestsTable.tsx
@@ -99,7 +99,7 @@ interface FailedTestsColumns {
   name: string
   avgDuration: number | null
   failureRate: number | null
-  flakeRate?: React.ReactNode | null
+  flakeRate?: React.ReactNode
   commitsFailed: number | null
   updatedAt: string
 }
@@ -206,25 +206,23 @@ const FailedTestsTable = () => {
           avgDuration: result.avgDuration,
           failureRate: result.failureRate,
           flakeRate: (
-            <>
-              <Tooltip delayDuration={0} skipDelayDuration={100}>
-                <Tooltip.Root>
-                  <Tooltip.Trigger className="underline decoration-dotted decoration-1 underline-offset-4">
-                    {isFlakeInt ? `${value}%` : `${value.toFixed(2)}%`}
-                  </Tooltip.Trigger>
-                  <Tooltip.Portal>
-                    <Tooltip.Content
-                      className="bg-ds-gray-primary p-2 text-xs text-ds-gray-octonary"
-                      side="right"
-                    >
-                      Passed {result.totalPassCount}, Failed{' '}
-                      {result.totalFailCount}, Skipped {result.totalSkipCount}
-                      <Tooltip.Arrow className="size-4 fill-ds-gray-primary" />
-                    </Tooltip.Content>
-                  </Tooltip.Portal>
-                </Tooltip.Root>
-              </Tooltip>
-            </>
+            <Tooltip delayDuration={0} skipDelayDuration={100}>
+              <Tooltip.Root>
+                <Tooltip.Trigger className="underline decoration-dotted decoration-1 underline-offset-4">
+                  {isFlakeInt ? `${value}%` : `${value.toFixed(2)}%`}
+                </Tooltip.Trigger>
+                <Tooltip.Portal>
+                  <Tooltip.Content
+                    className="bg-ds-gray-primary p-2 text-xs text-ds-gray-octonary"
+                    side="right"
+                  >
+                    Passed {result.totalPassCount}, Failed{' '}
+                    {result.totalFailCount}, Skipped {result.totalSkipCount}
+                    <Tooltip.Arrow className="size-4 fill-ds-gray-primary" />
+                  </Tooltip.Content>
+                </Tooltip.Portal>
+              </Tooltip.Root>
+            </Tooltip>
           ),
           commitsFailed: result.commitsFailed,
           updatedAt: result.updatedAt,

--- a/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/FailedTestsTable/FailedTestsTable.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/FailedTestsTable/FailedTestsTable.tsx
@@ -233,7 +233,7 @@ const FailedTestsTable = () => {
     )
   }, [testData])
 
-  const columns = getColumns(!!hideFlakeRate)
+  const columns = useMemo(() => getColumns(!!hideFlakeRate), [hideFlakeRate])
 
   const table = useReactTable({
     columns,

--- a/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/MetricsSection/MetricsSection.test.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/MetricsSection/MetricsSection.test.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { render, screen } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
 import { graphql, HttpResponse } from 'msw2'
 import { setupServer } from 'msw2/node'
 import { PropsWithChildren, Suspense } from 'react'
@@ -7,26 +7,18 @@ import { MemoryRouter, Route } from 'react-router-dom'
 
 import MetricsSection from './MetricsSection'
 
-const mockOverview = {
+const mockAggResponse = (
+  planValue = 'users-enterprisem',
+  isPrivate = false
+) => ({
   owner: {
-    isCurrentUserActivated: true,
-    repository: {
-      __typename: 'Repository',
-      private: false,
-      defaultBranch: 'main',
-      oldestCommitAt: '2022-10-10T11:59:59',
-      coverageEnabled: true,
-      bundleAnalysisEnabled: true,
-      languages: ['typescript'],
-      testAnalyticsEnabled: true,
+    plan: {
+      value: planValue,
     },
-  },
-}
-
-const mockAggResponse = {
-  owner: {
     repository: {
       __typename: 'Repository',
+      defaultBranch: 'main',
+      private: isPrivate,
       testAnalytics: {
         testResultsAggregates: {
           totalDuration: 1.1,
@@ -41,7 +33,7 @@ const mockAggResponse = {
       },
     },
   },
-}
+})
 
 const mockFlakeAggResponse = {
   owner: {
@@ -96,13 +88,12 @@ afterAll(() => {
 })
 
 describe('MetricsSection', () => {
-  function setup() {
+  function setup(planValue = 'users-enterprisem', isPrivate = false) {
     server.use(
-      graphql.query('GetRepoOverview', (info) => {
-        return HttpResponse.json({ data: mockOverview })
-      }),
       graphql.query('GetTestResultsAggregates', (info) => {
-        return HttpResponse.json({ data: mockAggResponse })
+        return HttpResponse.json({
+          data: mockAggResponse(planValue, isPrivate),
+        })
       }),
       graphql.query('GetFlakeAggregates', (info) => {
         return HttpResponse.json({ data: mockFlakeAggResponse })
@@ -237,6 +228,122 @@ describe('MetricsSection', () => {
       expect(title).toBeInTheDocument()
       expect(context).toBeInTheDocument()
       expect(description).toBeInTheDocument()
+    })
+  })
+
+  describe('when on team plan', () => {
+    describe('when repo is private', () => {
+      it('does not render total flaky tests card', async () => {
+        setup('users-teamm', true)
+        render(<MetricsSection />, {
+          wrapper: wrapper('/gh/owner/repo/tests/main'),
+        })
+
+        await waitFor(() => queryClient.isFetching)
+        await waitFor(() => !queryClient.isFetching)
+
+        const flakeAggregates = screen.queryByText('Flaky tests')
+        expect(flakeAggregates).not.toBeInTheDocument()
+      })
+
+      it('does not render avg flaky tests card', async () => {
+        setup('users-teamm', true)
+        render(<MetricsSection />, {
+          wrapper: wrapper('/gh/owner/repo/tests/main'),
+        })
+
+        await waitFor(() => queryClient.isFetching)
+        await waitFor(() => !queryClient.isFetching)
+
+        const flakeAggregates = screen.queryByText('Avg. flake rate')
+        expect(flakeAggregates).not.toBeInTheDocument()
+      })
+    })
+
+    describe('when repo is public', () => {
+      it('renders total flaky tests card', async () => {
+        setup('users-teamm', false)
+        render(<MetricsSection />, {
+          wrapper: wrapper('/gh/owner/repo/tests/main'),
+        })
+
+        await waitFor(() => queryClient.isFetching)
+        await waitFor(() => !queryClient.isFetching)
+
+        const flakeAggregates = screen.queryByText('Flaky tests')
+        expect(flakeAggregates).toBeInTheDocument()
+      })
+
+      it('renders avg flaky tests card', async () => {
+        setup('users-teamm', false)
+        render(<MetricsSection />, {
+          wrapper: wrapper('/gh/owner/repo/tests/main'),
+        })
+
+        await waitFor(() => queryClient.isFetching)
+        await waitFor(() => !queryClient.isFetching)
+
+        const flakeAggregates = screen.queryByText('Avg. flake rate')
+        expect(flakeAggregates).toBeInTheDocument()
+      })
+    })
+  })
+
+  describe('when on free plan', () => {
+    describe('when repo is private', () => {
+      it('does not render total flaky tests card', async () => {
+        setup('users-basic', true)
+        render(<MetricsSection />, {
+          wrapper: wrapper('/gh/owner/repo/tests/main'),
+        })
+
+        await waitFor(() => queryClient.isFetching)
+        await waitFor(() => !queryClient.isFetching)
+
+        const flakeAggregates = screen.queryByText('Flaky tests')
+        expect(flakeAggregates).not.toBeInTheDocument()
+      })
+
+      it('does not render avg flaky tests card', async () => {
+        setup('users-basic', true)
+        render(<MetricsSection />, {
+          wrapper: wrapper('/gh/owner/repo/tests/main'),
+        })
+
+        await waitFor(() => queryClient.isFetching)
+        await waitFor(() => !queryClient.isFetching)
+
+        const flakeAggregates = screen.queryByText('Avg. flake rate')
+        expect(flakeAggregates).not.toBeInTheDocument()
+      })
+    })
+
+    describe('when repo is public', () => {
+      it('renders total flaky tests card', async () => {
+        setup('users-basic', false)
+        render(<MetricsSection />, {
+          wrapper: wrapper('/gh/owner/repo/tests/main'),
+        })
+
+        await waitFor(() => queryClient.isFetching)
+        await waitFor(() => !queryClient.isFetching)
+
+        const flakeAggregates = screen.queryByText('Flaky tests')
+        expect(flakeAggregates).toBeInTheDocument()
+      })
+
+      it('renders avg flaky tests card', async () => {
+        setup('users-basic', false)
+        render(<MetricsSection />, {
+          wrapper: wrapper('/gh/owner/repo/tests/main'),
+        })
+
+        await waitFor(() => queryClient.isFetching)
+        await waitFor(() => !queryClient.isFetching)
+
+        const flakeAggregates = screen.queryByText('Avg. flake rate')
+        expect(flakeAggregates).toBeInTheDocument()
+      })
     })
   })
 })

--- a/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/MetricsSection/MetricsSection.test.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/MetricsSection/MetricsSection.test.tsx
@@ -239,8 +239,7 @@ describe('MetricsSection', () => {
           wrapper: wrapper('/gh/owner/repo/tests/main'),
         })
 
-        await waitFor(() => queryClient.isFetching)
-        await waitFor(() => !queryClient.isFetching)
+        await waitFor(() => expect(queryClient.isFetching()).toBeFalsy())
 
         const flakeAggregates = screen.queryByText('Flaky tests')
         expect(flakeAggregates).not.toBeInTheDocument()
@@ -252,8 +251,7 @@ describe('MetricsSection', () => {
           wrapper: wrapper('/gh/owner/repo/tests/main'),
         })
 
-        await waitFor(() => queryClient.isFetching)
-        await waitFor(() => !queryClient.isFetching)
+        await waitFor(() => expect(queryClient.isFetching()).toBeFalsy())
 
         const flakeAggregates = screen.queryByText('Avg. flake rate')
         expect(flakeAggregates).not.toBeInTheDocument()
@@ -267,8 +265,7 @@ describe('MetricsSection', () => {
           wrapper: wrapper('/gh/owner/repo/tests/main'),
         })
 
-        await waitFor(() => queryClient.isFetching)
-        await waitFor(() => !queryClient.isFetching)
+        await waitFor(() => expect(queryClient.isFetching()).toBeFalsy())
 
         const flakeAggregates = screen.queryByText('Flaky tests')
         expect(flakeAggregates).toBeInTheDocument()
@@ -280,8 +277,7 @@ describe('MetricsSection', () => {
           wrapper: wrapper('/gh/owner/repo/tests/main'),
         })
 
-        await waitFor(() => queryClient.isFetching)
-        await waitFor(() => !queryClient.isFetching)
+        await waitFor(() => expect(queryClient.isFetching()).toBeFalsy())
 
         const flakeAggregates = screen.queryByText('Avg. flake rate')
         expect(flakeAggregates).toBeInTheDocument()
@@ -297,8 +293,7 @@ describe('MetricsSection', () => {
           wrapper: wrapper('/gh/owner/repo/tests/main'),
         })
 
-        await waitFor(() => queryClient.isFetching)
-        await waitFor(() => !queryClient.isFetching)
+        await waitFor(() => expect(queryClient.isFetching()).toBeFalsy())
 
         const flakeAggregates = screen.queryByText('Flaky tests')
         expect(flakeAggregates).not.toBeInTheDocument()
@@ -310,8 +305,7 @@ describe('MetricsSection', () => {
           wrapper: wrapper('/gh/owner/repo/tests/main'),
         })
 
-        await waitFor(() => queryClient.isFetching)
-        await waitFor(() => !queryClient.isFetching)
+        await waitFor(() => expect(queryClient.isFetching()).toBeFalsy())
 
         const flakeAggregates = screen.queryByText('Avg. flake rate')
         expect(flakeAggregates).not.toBeInTheDocument()
@@ -325,8 +319,7 @@ describe('MetricsSection', () => {
           wrapper: wrapper('/gh/owner/repo/tests/main'),
         })
 
-        await waitFor(() => queryClient.isFetching)
-        await waitFor(() => !queryClient.isFetching)
+        await waitFor(() => expect(queryClient.isFetching()).toBeFalsy())
 
         const flakeAggregates = screen.queryByText('Flaky tests')
         expect(flakeAggregates).toBeInTheDocument()
@@ -338,8 +331,7 @@ describe('MetricsSection', () => {
           wrapper: wrapper('/gh/owner/repo/tests/main'),
         })
 
-        await waitFor(() => queryClient.isFetching)
-        await waitFor(() => !queryClient.isFetching)
+        await waitFor(() => expect(queryClient.isFetching()).toBeFalsy())
 
         const flakeAggregates = screen.queryByText('Avg. flake rate')
         expect(flakeAggregates).toBeInTheDocument()

--- a/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/hooks/useInfiniteTestResults/useInfiniteTestResults.test.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/hooks/useInfiniteTestResults/useInfiniteTestResults.test.tsx
@@ -7,8 +7,12 @@ import { useInfiniteTestResults } from './useInfiniteTestResults'
 
 const mockTestResults = {
   owner: {
+    plan: {
+      value: 'users-enterprisem',
+    },
     repository: {
       __typename: 'Repository',
+      private: false,
       testAnalytics: {
         testResults: {
           edges: [
@@ -68,11 +72,17 @@ const mockNotFoundError = {
       __typename: 'NotFoundError',
       message: 'Repository not found',
     },
+    plan: {
+      value: 'users-enterprisem',
+    },
   },
 }
 
 const mockOwnerNotActivatedError = {
   owner: {
+    plan: {
+      value: 'users-enterprisem',
+    },
     repository: {
       __typename: 'OwnerNotActivatedError',
       message: 'Owner not activated',

--- a/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/hooks/useTestResultsAggregates/useTestResultsAggregates.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/hooks/useTestResultsAggregates/useTestResultsAggregates.tsx
@@ -9,9 +9,16 @@ import { NetworkErrorObject } from 'shared/api/helpers'
 const TestResultsAggregatesSchema = z.object({
   owner: z
     .object({
+      plan: z
+        .object({
+          value: z.string(),
+        })
+        .nullable(),
       repository: z.discriminatedUnion('__typename', [
         z.object({
           __typename: z.literal('Repository'),
+          private: z.boolean().nullable(),
+          defaultBranch: z.string().nullable(),
           testAnalytics: z
             .object({
               testResultsAggregates: z.object({
@@ -39,9 +46,14 @@ const query = `
     $repo: String!
   ) {
     owner(username: $owner) {
+      plan {
+        value
+      }
       repository: repository(name: $repo) {
         __typename
         ... on Repository {
+            private
+            defaultBranch
             testAnalytics {
               testResultsAggregates {
                 totalDuration
@@ -105,7 +117,13 @@ export const useTestResultsAggregates = () => {
           } satisfies NetworkErrorObject)
         }
 
-        return data.owner?.repository.testAnalytics?.testResultsAggregates
+        return {
+          testResultsAggregates:
+            data?.owner?.repository?.testAnalytics?.testResultsAggregates,
+          plan: data?.owner?.plan?.value,
+          private: data?.owner?.repository?.private,
+          defaultBranch: data?.owner?.repository?.defaultBranch,
+        }
       }),
   })
 }

--- a/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/hooks/useTestResultsAggregates/useTestsResultsAggregates.test.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/hooks/useTestResultsAggregates/useTestsResultsAggregates.test.tsx
@@ -40,6 +40,9 @@ const mockNotFoundError = {
       __typename: 'NotFoundError',
       message: 'repo not found',
     },
+    plan: {
+      value: 'users-basic',
+    },
   },
 }
 
@@ -48,13 +51,21 @@ const mockIncorrectResponse = {
     repository: {
       invalid: 'invalid',
     },
+    plan: {
+      value: 'users-basic',
+    },
   },
 }
 
 const mockResponse = {
   owner: {
+    plan: {
+      value: 'users-basic',
+    },
     repository: {
       __typename: 'Repository',
+      private: true,
+      defaultBranch: 'main',
       testAnalytics: {
         testResultsAggregates: {
           totalDuration: 1.0,
@@ -101,14 +112,19 @@ describe('useTestResultsAggregates', () => {
 
         await waitFor(() =>
           expect(result.current.data).toEqual({
-            totalDuration: 1,
-            totalDurationPercentChange: 25,
-            slowestTestsDuration: 111.11,
-            slowestTestsDurationPercentChange: 0,
-            totalFails: 1,
-            totalFailsPercentChange: 100,
-            totalSkips: 20,
-            totalSkipsPercentChange: 0,
+            testResultsAggregates: {
+              totalDuration: 1,
+              totalDurationPercentChange: 25,
+              slowestTestsDuration: 111.11,
+              slowestTestsDurationPercentChange: 0,
+              totalFails: 1,
+              totalFailsPercentChange: 100,
+              totalSkips: 20,
+              totalSkipsPercentChange: 0,
+            },
+            plan: 'users-basic',
+            private: true,
+            defaultBranch: 'main',
           })
         )
       })


### PR DESCRIPTION
# Description
Don't show flake related components if the repo is private and plan is either team or free.

# Notable Changes
- Added required fields to the queries 
- Updated logic to hide flake related components if the repo is private and plan is either team or free
- Update tests

# Screenshots
<img width="1512" alt="Screenshot 2024-10-15 at 5 57 11 PM" src="https://github.com/user-attachments/assets/6a04463e-e2fc-4c41-a1ef-efdcc4775453">


# Link to Sample Entry

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.