### PR TITLE
fix: Format date for durations in TA

### DIFF
--- a/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/MetricsSection/MetricsSection.test.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/MetricsSection/MetricsSection.test.tsx
@@ -135,7 +135,7 @@ describe('MetricsSection', () => {
       })
 
       const title = await screen.findByText('Test run time')
-      const context = await screen.findByText('24 minutes 50 seconds')
+      const context = await screen.findByText('24m 50s')
 
       expect(title).toBeInTheDocument()
       expect(context).toBeInTheDocument()
@@ -150,7 +150,7 @@ describe('MetricsSection', () => {
       const title = await screen.findByText('Slowest tests')
       const context = await screen.findByText(6)
       const description = await screen.findByText(
-        'The slowest 6 tests take 1 minute 51 seconds to run.'
+        'The slowest 6 tests take 1m 51s to run.'
       )
 
       expect(title).toBeInTheDocument()

--- a/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/MetricsSection/MetricsSection.test.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/MetricsSection/MetricsSection.test.tsx
@@ -21,7 +21,7 @@ const mockAggResponse = (
       private: isPrivate,
       testAnalytics: {
         testResultsAggregates: {
-          totalDuration: 1.1,
+          totalDuration: 1490,
           totalDurationPercentChange: 25.0,
           slowestTestsDuration: 111.11,
           slowestTestsDurationPercentChange: 0.0,
@@ -135,14 +135,10 @@ describe('MetricsSection', () => {
       })
 
       const title = await screen.findByText('Test run time')
-      const context = await screen.findByText(1.1)
-      const description = await screen.findByText(
-        'Increased by [12.5hr] in the last [30 days]'
-      )
+      const context = await screen.findByText('24 minutes 50 seconds')
 
       expect(title).toBeInTheDocument()
       expect(context).toBeInTheDocument()
-      expect(description).toBeInTheDocument()
     })
 
     it('renders slowest tests card', async () => {
@@ -154,7 +150,7 @@ describe('MetricsSection', () => {
       const title = await screen.findByText('Slowest tests')
       const context = await screen.findByText(6)
       const description = await screen.findByText(
-        'The slowest 6 tests take 111.11 to run.'
+        'The slowest 6 tests take 1 minute 51 seconds to run.'
       )
 
       expect(title).toBeInTheDocument()
@@ -171,7 +167,7 @@ describe('MetricsSection', () => {
       const title = await screen.findByText('Flaky tests')
       const context = await screen.findByText(88)
       const description = await screen.findByText(
-        '*The total rerun time for flaky tests is [50hr].'
+        'The number of flaky tests in your test suite.'
       )
 
       expect(title).toBeInTheDocument()
@@ -188,7 +184,7 @@ describe('MetricsSection', () => {
       const title = await screen.findByText('Avg. flake rate')
       const context = await screen.findByText('8%')
       const description = await screen.findByText(
-        'On average, a flaky test ran [20] times before it passed.'
+        'The average flake rate across all branches.'
       )
 
       expect(title).toBeInTheDocument()

--- a/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/MetricsSection/MetricsSection.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/MetricsSection/MetricsSection.tsx
@@ -275,7 +275,7 @@ function MetricsSection() {
           <p className="pl-4 text-xs font-semibold text-ds-gray-quaternary">
             Improve CI Run Efficiency
           </p>
-          <div className="flex">
+          <div className="grid grid-cols-2">
             <TotalTestsRunTimeCard
               totalDuration={aggregates?.totalDuration}
               totalDurationPercentChange={

--- a/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/MetricsSection/MetricsSection.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/MetricsSection/MetricsSection.tsx
@@ -1,6 +1,8 @@
 import { useParams } from 'react-router-dom'
 
 import { isFreePlan, isTeamPlan } from 'shared/utils/billing'
+import { cn } from 'shared/utils/cn'
+import { formatTimeFromSeconds } from 'shared/utils/dates'
 import Badge from 'ui/Badge'
 import Icon from 'ui/Icon'
 import { MetricCard } from 'ui/MetricCard'
@@ -72,14 +74,11 @@ const TotalTestsRunTimeCard = ({
       </MetricCard.Header>
 
       <MetricCard.Content>
-        {totalDuration}
+        {formatTimeFromSeconds(totalDuration)}
         {totalDurationPercentChange ? (
           <PercentBadge value={totalDurationPercentChange} />
         ) : null}
       </MetricCard.Content>
-      <MetricCard.Description>
-        Increased by [12.5hr] in the last [30 days]
-      </MetricCard.Description>
     </MetricCard>
   )
 }
@@ -104,7 +103,8 @@ const SlowestTestsCard = ({
 
       <MetricCard.Content>{slowestTests}</MetricCard.Content>
       <MetricCard.Description>
-        The slowest {slowestTests} tests take {slowestTestsDuration} to run.
+        The slowest {slowestTests} tests take{' '}
+        {formatTimeFromSeconds(slowestTestsDuration)} to run.
       </MetricCard.Description>
     </MetricCard>
   )
@@ -135,7 +135,7 @@ const TotalFlakyTestsCard = ({
         ) : null}
       </MetricCard.Content>
       <MetricCard.Description>
-        *The total rerun time for flaky tests is [50hr].
+        The number of flaky tests in your test suite.
       </MetricCard.Description>
     </MetricCard>
   )
@@ -167,7 +167,7 @@ const AverageFlakeRateCard = ({
         ) : null}
       </MetricCard.Content>
       <MetricCard.Description>
-        On average, a flaky test ran [20] times before it passed.
+        The average flake rate across all branches.
       </MetricCard.Description>
     </MetricCard>
   )
@@ -292,7 +292,12 @@ function MetricsSection() {
           <p className="pl-4 text-xs font-semibold text-ds-gray-quaternary">
             Improve Test Performance
           </p>
-          <div className="flex">
+          <div
+            className={cn(
+              'grid',
+              !!flakeAggregates ? 'grid-cols-4' : 'grid-cols-2'
+            )}
+          >
             {!!flakeAggregates ? (
               <>
                 <TotalFlakyTestsCard

--- a/src/shared/utils/dates.js
+++ b/src/shared/utils/dates.js
@@ -1,7 +1,6 @@
 import {
   format,
   formatDistanceToNow,
-  formatDuration,
   fromUnixTime,
   intervalToDuration,
   parseISO,
@@ -31,5 +30,15 @@ export const formatTimeFromSeconds = (totalSeconds) => {
   if (!totalSeconds) return 'N/A'
 
   const duration = intervalToDuration({ start: 0, end: totalSeconds * 1000 })
-  return formatDuration(duration)
+
+  const { days, hours, minutes, seconds } = duration
+
+  return [
+    days ? `${days}d` : '',
+    hours ? `${hours}h` : '',
+    minutes ? `${minutes}m` : '',
+    seconds ? `${seconds}s` : '',
+  ]
+    .filter(Boolean)
+    .join(' ')
 }

--- a/src/shared/utils/dates.js
+++ b/src/shared/utils/dates.js
@@ -1,4 +1,11 @@
-import { format, formatDistanceToNow, fromUnixTime, parseISO } from 'date-fns'
+import {
+  format,
+  formatDistanceToNow,
+  formatDuration,
+  fromUnixTime,
+  intervalToDuration,
+  parseISO,
+} from 'date-fns'
 import { useMemo } from 'react'
 
 export function useDateFormatted(date, formatDescription = 'MMMM do yyyy') {
@@ -17,4 +24,12 @@ export function formatTimeToNow(date) {
   return formatDistanceToNow(parsedDate, {
     addSuffix: true,
   })
+}
+
+export const formatTimeFromSeconds = (totalSeconds) => {
+  if (totalSeconds === 0) return '0s'
+  if (!totalSeconds) return 'N/A'
+
+  const duration = intervalToDuration({ start: 0, end: totalSeconds * 1000 })
+  return formatDuration(duration)
 }

--- a/src/shared/utils/dates.test.js
+++ b/src/shared/utils/dates.test.js
@@ -87,6 +87,6 @@ describe('formatTimeFromSeconds', () => {
   })
 
   it('returns the correct time format when totalSeconds is greater than 0', () => {
-    expect(formatTimeFromSeconds(3661)).toBe('1hr 1min 1s')
+    expect(formatTimeFromSeconds(3661)).toBe('1 hour 1 minute 1 second')
   })
 })

--- a/src/shared/utils/dates.test.js
+++ b/src/shared/utils/dates.test.js
@@ -87,6 +87,6 @@ describe('formatTimeFromSeconds', () => {
   })
 
   it('returns the correct time format when totalSeconds is greater than 0', () => {
-    expect(formatTimeFromSeconds(3661)).toBe('1 hour 1 minute 1 second')
+    expect(formatTimeFromSeconds(3661)).toBe('1h 1m 1s')
   })
 })

--- a/src/shared/utils/dates.test.js
+++ b/src/shared/utils/dates.test.js
@@ -1,6 +1,10 @@
 import { renderHook } from '@testing-library/react'
 
-import { formatTimeToNow, useDateFormatted } from './dates'
+import {
+  formatTimeFromSeconds,
+  formatTimeToNow,
+  useDateFormatted,
+} from './dates'
 
 describe('useDateFormatted and formatTimeToNow functions', () => {
   let formattedDate
@@ -66,5 +70,23 @@ describe('useDateFormatted and formatTimeToNow functions', () => {
       expect(result.current).toBe('July 20th 2020')
       expect(formattedDate).toBe('about 2 years ago')
     })
+  })
+})
+
+describe('formatTimeFromSeconds', () => {
+  it('returns "N/A" when totalSeconds is null', () => {
+    expect(formatTimeFromSeconds(null)).toBe('N/A')
+  })
+
+  it('returns "N/A" when totalSeconds is undefined', () => {
+    expect(formatTimeFromSeconds(undefined)).toBe('N/A')
+  })
+
+  it('returns "0s" when totalSeconds is 0', () => {
+    expect(formatTimeFromSeconds(0)).toBe('0s')
+  })
+
+  it('returns the correct time format when totalSeconds is greater than 0', () => {
+    expect(formatTimeFromSeconds(3661)).toBe('1hr 1min 1s')
   })
 })


### PR DESCRIPTION
# Description
We need it based on days/hours/minutes/seconds.

# Notable Changes

- New function for date
- Fixed descriptions 

# Screenshots
<img width="1511" alt="Screenshot 2024-10-17 at 11 34 56 AM" src="https://github.com/user-attachments/assets/cf6638ed-63cf-4eec-808f-9d646ad45285">


# Link to Sample Entry

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.