### PR TITLE
chore: Fix tailwind config

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -316,7 +316,7 @@ module.exports = {
     },
     tailwindcss: {
       callees: ['classnames', 'clsx', 'ctl', 'cn'],
-      config: 'tailwind.config.js',
+      config: 'tailwind.config.mjs',
       cssFiles: ['src/**/*.css'],
       cssFilesRefreshRate: 5000,
       removeDuplicates: true,


### PR DESCRIPTION
I was getting lint warnings such as attached screenshot. This will fix the reference to the new file name (after craco removal [pr](https://github.com/codecov/gazebo/pull/3393)). Note I had to delete `node_modules` then re- `yarn install` to get it to go away with this fix

![Screenshot 2024-10-16 at 4 41 55 PM](https://github.com/user-attachments/assets/7fbb32d8-e25a-486b-a0a5-9baf3cb2ca54)

