### PR TITLE
chore: Add react source maps to our builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "zod": "^3.21.4"
   },
   "devDependencies": {
+    "@acemarke/react-prod-sourcemaps": "^0.3.1",
     "@babel/plugin-proposal-private-property-in-object": "^7.21.11",
     "@chromatic-com/storybook": "^1",
     "@codecov/vite-plugin": "^1.0.1",

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -37,7 +37,7 @@ export default defineConfig((config) => {
   if (runSentryPlugin) {
     plugins.push(
       ViteReactSourcemapsPlugin({
-        debug: true,
+        debug: false,
         preserve: false,
       }),
       sentryVitePlugin({

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -6,6 +6,7 @@ import tsconfigPaths from 'vite-tsconfig-paths'
 import { ViteEjsPlugin } from 'vite-plugin-ejs'
 import svgr from 'vite-plugin-svgr'
 import legacy from '@vitejs/plugin-legacy'
+import { ViteReactSourcemapsPlugin } from '@acemarke/react-prod-sourcemaps'
 
 export default defineConfig((config) => {
   const env = loadEnv(config.mode, process.cwd(), 'REACT_APP')
@@ -22,7 +23,8 @@ export default defineConfig((config) => {
   ) {
     plugins.push(
       codecovVitePlugin({
-        enableBundleAnalysis: process.env.UPLOAD_CODECOV_BUNDLE_STATS === 'true',
+        enableBundleAnalysis:
+          process.env.UPLOAD_CODECOV_BUNDLE_STATS === 'true',
         bundleName: process.env.CODECOV_BUNDLE_NAME,
         apiUrl: process.env.CODECOV_API_URL,
         uploadToken: process.env.CODECOV_ORG_TOKEN,
@@ -34,6 +36,10 @@ export default defineConfig((config) => {
     config.mode === 'production' && !!process.env.SENTRY_AUTH_TOKEN
   if (runSentryPlugin) {
     plugins.push(
+      ViteReactSourcemapsPlugin({
+        debug: false,
+        preserve: false,
+      }),
       sentryVitePlugin({
         applicationKey: 'gazebo',
         org: process.env.SENTRY_ORG || 'codecov',

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -37,7 +37,7 @@ export default defineConfig((config) => {
   if (runSentryPlugin) {
     plugins.push(
       ViteReactSourcemapsPlugin({
-        debug: false,
+        debug: true,
         preserve: false,
       }),
       sentryVitePlugin({

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,6 +5,22 @@ __metadata:
   version: 8
   cacheKey: 10c0
 
+"@acemarke/react-prod-sourcemaps@npm:^0.3.1":
+  version: 0.3.1
+  resolution: "@acemarke/react-prod-sourcemaps@npm:0.3.1"
+  dependencies:
+    "@ampproject/remapping": "npm:^2.2.1"
+    "@jridgewell/resolve-uri": "npm:^3.1.1"
+    glob: "npm:^10.3.3"
+    magic-string: "npm:^0.30.3"
+    unplugin: "npm:^1.4.0"
+    yargs: "npm:^17.7.2"
+  bin:
+    react-prod-sourcemaps: lib/index.cjs
+  checksum: 10c0/e0496a540691787ed12ddc781b5105e4719fa0a4c5a1d215b0f91156809473ad275669231cc958b62a1df3b634f788417087738d8288801d1932b35f4035bc4c
+  languageName: node
+  linkType: hard
+
 "@actions/core@npm:^1.10.1":
   version: 1.10.1
   resolution: "@actions/core@npm:1.10.1"
@@ -51,7 +67,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ampproject/remapping@npm:^2.2.0, @ampproject/remapping@npm:^2.3.0":
+"@ampproject/remapping@npm:^2.2.0, @ampproject/remapping@npm:^2.2.1, @ampproject/remapping@npm:^2.3.0":
   version: 2.3.0
   resolution: "@ampproject/remapping@npm:2.3.0"
   dependencies:
@@ -4191,7 +4207,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jridgewell/resolve-uri@npm:^3.1.0":
+"@jridgewell/resolve-uri@npm:^3.1.0, @jridgewell/resolve-uri@npm:^3.1.1":
   version: 3.1.2
   resolution: "@jridgewell/resolve-uri@npm:3.1.2"
   checksum: 10c0/d502e6fb516b35032331406d4e962c21fe77cdf1cbdb49c6142bcbd9e30507094b18972778a6e27cbad756209cfe34b1a27729e6fa08a2eb92b33943f680cf1e
@@ -8167,6 +8183,15 @@ __metadata:
   bin:
     acorn: bin/acorn
   checksum: 10c0/51fb26cd678f914e13287e886da2d7021f8c2bc0ccc95e03d3e0447ee278dd3b40b9c57dc222acd5881adcf26f3edc40901a4953403232129e3876793cd17386
+  languageName: node
+  linkType: hard
+
+"acorn@npm:^8.12.1":
+  version: 8.13.0
+  resolution: "acorn@npm:8.13.0"
+  bin:
+    acorn: bin/acorn
+  checksum: 10c0/f35dd53d68177c90699f4c37d0bb205b8abe036d955d0eb011ddb7f14a81e6fd0f18893731c457c1b5bd96754683f4c3d80d9a5585ddecaa53cdf84e0b3d68f7
   languageName: node
   linkType: hard
 
@@ -12522,6 +12547,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "gazebo@workspace:."
   dependencies:
+    "@acemarke/react-prod-sourcemaps": "npm:^0.3.1"
     "@babel/plugin-proposal-private-property-in-object": "npm:^7.21.11"
     "@chromatic-com/storybook": "npm:^1"
     "@codecov/vite-plugin": "npm:^1.0.1"
@@ -12800,7 +12826,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"glob@npm:^10.2.2, glob@npm:^10.3.10, glob@npm:^10.4.1":
+"glob@npm:^10.2.2, glob@npm:^10.3.10, glob@npm:^10.3.3, glob@npm:^10.4.1":
   version: 10.4.5
   resolution: "glob@npm:10.4.5"
   dependencies:
@@ -15468,6 +15494,15 @@ __metadata:
   dependencies:
     "@jridgewell/sourcemap-codec": "npm:^1.5.0"
   checksum: 10c0/b9eb370773d0bd90ca11a848753409d8e5309b1ad56d2a1aa49d6649da710a6d2fe7237ad1a643c5a5d3800de2b9946ed9690acdfc00e6cc1aeafff3ab1752c4
+  languageName: node
+  linkType: hard
+
+"magic-string@npm:^0.30.3":
+  version: 0.30.12
+  resolution: "magic-string@npm:0.30.12"
+  dependencies:
+    "@jridgewell/sourcemap-codec": "npm:^1.5.0"
+  checksum: 10c0/469f457d18af37dfcca8617086ea8a65bcd8b60ba8a1182cb024ce43e470ace3c9d1cb6bee58d3b311768fb16bc27bd50bdeebcaa63dadd0fd46cac4d2e11d5f
   languageName: node
   linkType: hard
 
@@ -21744,6 +21779,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"unplugin@npm:^1.4.0":
+  version: 1.14.1
+  resolution: "unplugin@npm:1.14.1"
+  dependencies:
+    acorn: "npm:^8.12.1"
+    webpack-virtual-modules: "npm:^0.6.2"
+  peerDependencies:
+    webpack-sources: ^3
+  peerDependenciesMeta:
+    webpack-sources:
+      optional: true
+  checksum: 10c0/a74342b8f0cbbdc7b1da1f78f1898c0c915e3f67b22281fcd61a5495a585f4a1fd0fc270a7e59643a41c138c94c852cb69ea17af72965fb15f86f18ee76c2ed1
+  languageName: node
+  linkType: hard
+
 "unquote@npm:~1.1.1":
   version: 1.1.1
   resolution: "unquote@npm:1.1.1"
@@ -22761,7 +22811,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"webpack-virtual-modules@npm:^0.6.1":
+"webpack-virtual-modules@npm:^0.6.1, webpack-virtual-modules@npm:^0.6.2":
   version: 0.6.2
   resolution: "webpack-virtual-modules@npm:0.6.2"
   checksum: 10c0/5ffbddf0e84bf1562ff86cf6fcf039c74edf09d78358a6904a09bbd4484e8bb6812dc385fe14330b715031892dcd8423f7a88278b57c9f5002c84c2860179add


### PR DESCRIPTION
# Description

This PR adds in a package that provides the sourcemaps for React, since they're not included by default. This should hopefully help when we look into Sentry at errors that are being thrown by React.