### PR TITLE
fix: New diff renderer coverage off by one

### DIFF
--- a/src/ui/VirtualRenderers/VirtualDiffRenderer.tsx
+++ b/src/ui/VirtualRenderers/VirtualDiffRenderer.tsx
@@ -223,7 +223,6 @@ const CodeBody = ({
       >
         {virtualizer.getVirtualItems().map((item) => {
           const line = lineData[item.index]
-          const lineNumber = item.index + 1
           const baseHash = `#${hashedPath}-L${line?.baseNumber}`
           const headHash = `#${hashedPath}-R${line?.headNumber}`
           // get any specific things from code highlighting library for this given line
@@ -253,7 +252,7 @@ const CodeBody = ({
                     isHighlighted={
                       location.hash === headHash || location.hash === baseHash
                     }
-                    coverage={lineData?.[lineNumber]?.headCoverage}
+                    coverage={lineData?.[item.index]?.headCoverage}
                   />
                 </div>
                 <div


### PR DESCRIPTION
# Description

Quick fix adjusting how we get the coverage value for the diff viewer

![Screenshot 2024-10-17 at 13 02 12](https://github.com/user-attachments/assets/cf9f284f-ae3b-4353-b91f-4069e3039dff)
