### PR TITLE
chore: Update react-intersection-observer

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "react-dom": "^18.3.1",
     "react-hook-form": "^7.43.9",
     "react-hot-toast": "^2.4.1",
-    "react-intersection-observer": "9.4.1",
+    "react-intersection-observer": "9.13.1",
     "react-modal": "^3.14.4",
     "react-router": "^5.3.3",
     "react-router-dom": "^5.2.1",

--- a/src/vitest.setup.ts
+++ b/src/vitest.setup.ts
@@ -28,13 +28,25 @@ vi.mock('@sentry/react', async () => {
 })
 
 beforeAll(() => {
-  // This is a bit of a hack to get Vitest fake timers setup to work with waitFor and findBy's
-  // GH Issue: https://github.com/testing-library/react-testing-library/issues/1197#issuecomment-1693824628
   globalThis.jest = {
     ...globalThis.jest,
-    fn: vi.fn.bind(vi),
+    // This is a bit of a hack to get Vitest fake timers setup to work with waitFor and findBy's
+    // GH Issue: https://github.com/testing-library/react-testing-library/issues/1197#issuecomment-1693824628
     // @ts-ignore-error
     advanceTimersByTime: vi.advanceTimersByTime.bind(vi),
+
+    /*
+     * Since doing this hack means we now have a jest global defined, we must also redefine jest.fn to be vi.fn,
+     * otherwise the following lines of code in react-intersection-observer/src/test-utils.ts break:
+     *
+     * // Use the exposed mock function. Currently, only supports Jest (`jest.fn`) and Vitest with globals (`vi.fn`).
+     * if (typeof jest !== "undefined") setupIntersectionMocking(jest.fn);
+     * else if (typeof vi !== "undefined") {
+     * setupIntersectionMocking(vi.fn);
+     * }
+     */
+
+    fn: vi.fn.bind(vi),
   }
 })
 

--- a/src/vitest.setup.ts
+++ b/src/vitest.setup.ts
@@ -30,20 +30,10 @@ vi.mock('@sentry/react', async () => {
 beforeAll(() => {
   // This is a bit of a hack to get Vitest fake timers setup to work with waitFor and findBy's
   // GH Issue: https://github.com/testing-library/react-testing-library/issues/1197#issuecomment-1693824628
-  // @ts-expect-error - we need to add this to the global object for some internal deps to work
   globalThis.jest = {
-    // @ts-expect-error - we need to add this to the global object for some internal deps to work
     ...globalThis.jest,
-    /**
-     * From react-intersection-observer/test-utils
-     * // Use the exposed mock function. Currently, only supports Jest (`jest.fn`) and Vitest with globals (`vi.fn`).
-     * if (typeof jest !== 'undefined')
-     *   setupIntersectionMocking(jest.fn);
-     * else if (typeof vi !== 'undefined')
-     *   setupIntersectionMocking(vi.fn);
-     */
-
     fn: vi.fn.bind(vi),
+    // @ts-ignore-error
     advanceTimersByTime: vi.advanceTimersByTime.bind(vi),
   }
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -12651,7 +12651,7 @@ __metadata:
     react-dom: "npm:^18.3.1"
     react-hook-form: "npm:^7.43.9"
     react-hot-toast: "npm:^2.4.1"
-    react-intersection-observer: "npm:9.4.1"
+    react-intersection-observer: "npm:9.13.1"
     react-modal: "npm:^3.14.4"
     react-router: "npm:^5.3.3"
     react-router-dom: "npm:^5.2.1"
@@ -18638,12 +18638,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-intersection-observer@npm:9.4.1":
-  version: 9.4.1
-  resolution: "react-intersection-observer@npm:9.4.1"
+"react-intersection-observer@npm:9.13.1":
+  version: 9.13.1
+  resolution: "react-intersection-observer@npm:9.13.1"
   peerDependencies:
-    react: ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0
-  checksum: 10c0/9beb3c765f8de451b2524bc4c0647e79136b0283bdd0d4648920eeadd8597e3ea46bf78104986ce44fa83fe061a82ae897c53ac92e727cfbdaa84a96f1acaebd
+    react: ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+    react-dom: ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+  peerDependenciesMeta:
+    react-dom:
+      optional: true
+  checksum: 10c0/c64722db407e0ca83945bf97621ab4618fa74f3a70b528ff43988818d46feee8962bd12e70203d2d92b31030889a1f813d00e0aa3d781a7bc39fb293c277ee04
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Nothing was broken here per se, but the tests using this were logging an error because the old version uses an outdated API.
