### PR TITLE
feat: Add org list for multi org setups on plan page

### DIFF
--- a/src/pages/PlanPage/subRoutes/CurrentOrgPlan/AccountOrgs/AccountOrgs.test.tsx
+++ b/src/pages/PlanPage/subRoutes/CurrentOrgPlan/AccountOrgs/AccountOrgs.test.tsx
@@ -281,17 +281,17 @@ describe('AccountOrgs', () => {
       })
     })
 
-    describe('when user clicks on an org', () => {
+    describe('when user clicks on activated user count', () => {
       describe('and they are a member of that org', () => {
         it('redirects them to the member page for that org', async () => {
           setup()
           const user = userEvent.setup()
           render(<AccountOrgs account={mockAccount} />, { wrapper })
 
-          const org1 = await screen.findByText('org1')
-          expect(org1).toBeInTheDocument()
+          const org1Members = await screen.findByRole('link', { name: '7' })
+          expect(org1Members).toBeInTheDocument()
 
-          await user.click(org1)
+          await user.click(org1Members)
 
           await waitFor(() =>
             expect(testLocation.pathname).toBe('/members/gh/org1')
@@ -305,10 +305,10 @@ describe('AccountOrgs', () => {
           const user = userEvent.setup()
           render(<AccountOrgs account={mockAccount} />, { wrapper })
 
-          const org2 = await screen.findByText('org2')
-          expect(org2).toBeInTheDocument()
+          const org2Members = await screen.findByRole('cell', { name: '4' })
+          expect(org2Members).toBeInTheDocument()
 
-          await user.click(org2)
+          await user.click(org2Members)
 
           await waitFor(() =>
             expect(testLocation.pathname).toBe('/plan/gh/codecov')

--- a/src/pages/PlanPage/subRoutes/CurrentOrgPlan/AccountOrgs/AccountOrgs.test.tsx
+++ b/src/pages/PlanPage/subRoutes/CurrentOrgPlan/AccountOrgs/AccountOrgs.test.tsx
@@ -1,5 +1,10 @@
-import { render, screen } from '@testing-library/react'
-import { MemoryRouter, Route } from 'react-router'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { render, screen, waitFor } from '@testing-library/react'
+import { userEvent } from '@testing-library/user-event'
+import { delay, graphql, HttpResponse } from 'msw'
+import { setupServer } from 'msw/node'
+import { mockAllIsIntersecting } from 'react-intersection-observer/test-utils'
+import { MemoryRouter, Route, useLocation } from 'react-router'
 
 import AccountOrgs from './AccountOrgs'
 
@@ -14,14 +19,146 @@ const mockAccount: Account = {
   },
 }
 
+const org1 = {
+  username: 'org1',
+  activatedUserCount: 7,
+  isCurrentUserPartOfOrg: true,
+}
+
+const org2 = {
+  username: 'org2',
+  activatedUserCount: 4,
+  isCurrentUserPartOfOrg: false,
+}
+
+const org3 = {
+  username: 'org3',
+  activatedUserCount: 2,
+  isCurrentUserPartOfOrg: true,
+}
+
+const mockPageOne = {
+  owner: {
+    account: {
+      organizations: {
+        edges: [
+          {
+            node: org1,
+          },
+          {
+            node: org2,
+          },
+        ],
+        pageInfo: {
+          hasNextPage: true,
+          endCursor: 'asdf',
+        },
+      },
+    },
+  },
+}
+
+const mockPageTwo = {
+  owner: {
+    account: {
+      organizations: {
+        edges: [
+          {
+            node: org3,
+          },
+          {
+            node: null,
+          },
+        ],
+        pageInfo: {
+          hasNextPage: false,
+          endCursor: null,
+        },
+      },
+    },
+  },
+}
+
+const mockReversedOrgs = {
+  owner: {
+    account: {
+      organizations: {
+        edges: [
+          {
+            node: org3,
+          },
+          {
+            node: org2,
+          },
+        ],
+        pageInfo: {
+          hasNextPage: true,
+          endCursor: 'zzzz',
+        },
+      },
+    },
+  },
+}
+
+let testLocation: ReturnType<typeof useLocation>
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      retry: false,
+      suspense: true,
+    },
+  },
+})
 const wrapper: React.FC<React.PropsWithChildren> = ({ children }) => (
-  <MemoryRouter initialEntries={['/plan/gh/codecov']}>
-    <Route path="/plan/:provider/:owner">{children}</Route>
-  </MemoryRouter>
+  <QueryClientProvider client={queryClient}>
+    <MemoryRouter initialEntries={['/plan/gh/codecov']}>
+      <Route path="/plan/:provider/:owner">{children}</Route>
+      <Route
+        path="*"
+        render={({ location }) => {
+          testLocation = location
+          return null
+        }}
+      />
+    </MemoryRouter>
+  </QueryClientProvider>
 )
 
+const server = setupServer()
+
+beforeAll(() => server.listen())
+afterEach(() => {
+  queryClient.clear()
+  server.resetHandlers()
+})
+afterAll(() => server.close())
+
 describe('AccountOrgs', () => {
+  function setup() {
+    mockAllIsIntersecting(false)
+    server.use(
+      graphql.query('InfiniteAccountOrganizations', async (info) => {
+        if (info.variables.direction === 'DESC') {
+          return HttpResponse.json({
+            data: mockReversedOrgs,
+          })
+        }
+        if (info.variables.after) {
+          await delay(100) // for testing the spinner
+          return HttpResponse.json({
+            data: mockPageTwo,
+          })
+        }
+        return HttpResponse.json({
+          data: mockPageOne,
+        })
+      })
+    )
+  }
+
   it('renders Header', async () => {
+    setup()
     render(<AccountOrgs account={mockAccount} />, { wrapper })
 
     const header = await screen.findByText('Account details')
@@ -33,6 +170,7 @@ describe('AccountOrgs', () => {
   })
 
   it('renders total orgs', async () => {
+    setup()
     render(<AccountOrgs account={mockAccount} />, { wrapper })
 
     const label = await screen.findByText('Total organizations')
@@ -43,6 +181,7 @@ describe('AccountOrgs', () => {
   })
 
   it('renders total seats', async () => {
+    setup()
     render(<AccountOrgs account={mockAccount} />, { wrapper })
 
     const label = await screen.findByText('Total seats')
@@ -53,6 +192,7 @@ describe('AccountOrgs', () => {
   })
 
   it('renders seats remaining', async () => {
+    setup()
     render(<AccountOrgs account={mockAccount} />, { wrapper })
 
     const label = await screen.findByText('Seats remaining')
@@ -62,5 +202,119 @@ describe('AccountOrgs', () => {
       mockAccount.totalSeatCount - mockAccount.activatedUserCount
     )
     expect(number).toBeInTheDocument()
+  })
+
+  describe('organization list', () => {
+    it('renders column headers', async () => {
+      setup()
+      render(<AccountOrgs account={mockAccount} />, { wrapper })
+
+      const nameHeader = await screen.findByText('Organization name')
+      expect(nameHeader).toBeInTheDocument()
+      const membersHeader = await screen.findByText('Activated members')
+      expect(membersHeader).toBeInTheDocument()
+    })
+
+    it('renders column data', async () => {
+      setup()
+      render(<AccountOrgs account={mockAccount} />, { wrapper })
+
+      const org1 = await screen.findByText('org1')
+      expect(org1).toBeInTheDocument()
+      const org1Members = await screen.findByRole('cell', { name: '7' })
+      expect(org1Members).toBeInTheDocument()
+      const org2 = await screen.findByText('org2')
+      expect(org2).toBeInTheDocument()
+      const org2Members = await screen.findByRole('cell', { name: '4' })
+      expect(org2Members).toBeInTheDocument()
+    })
+
+    it('renders not in org message', async () => {
+      setup()
+      render(<AccountOrgs account={mockAccount} />, { wrapper })
+
+      const notInOrg = await screen.findByText('Not a member')
+      expect(notInOrg).toBeInTheDocument()
+    })
+
+    describe('when another page of data is available', () => {
+      describe('and bottom of table is visible', () => {
+        it('fetches next page of data', async () => {
+          setup()
+          render(<AccountOrgs account={mockAccount} />, { wrapper })
+
+          const org1 = await screen.findByText('org1')
+          expect(org1).toBeInTheDocument()
+          let org3 = screen.queryByText('org3')
+          expect(org3).not.toBeInTheDocument()
+          let org3Members = screen.queryByRole('cell', { name: '2' })
+          expect(org3Members).not.toBeInTheDocument()
+
+          mockAllIsIntersecting(true)
+
+          org3 = await screen.findByText('org3')
+          expect(org3).toBeInTheDocument()
+          org3Members = await screen.findByRole('cell', { name: '2' })
+          expect(org3Members).toBeInTheDocument()
+        })
+      })
+    })
+
+    describe('when user clicks on the Org name header', () => {
+      it('changes the ordering direction', async () => {
+        setup()
+        render(<AccountOrgs account={mockAccount} />, { wrapper })
+        const user = userEvent.setup()
+
+        const header = await screen.findByText('Organization name')
+        expect(header).toBeInTheDocument()
+
+        let org1: HTMLElement | null = await screen.findByText('org1')
+        expect(org1).toBeInTheDocument()
+
+        await user.click(header)
+
+        const org3 = await screen.findByText('org3')
+        expect(org3).toBeInTheDocument()
+        org1 = screen.queryByText('org1')
+        expect(org1).not.toBeInTheDocument()
+      })
+    })
+
+    describe('when user clicks on an org', () => {
+      describe('and they are a member of that org', () => {
+        it('redirects them to the member page for that org', async () => {
+          setup()
+          const user = userEvent.setup()
+          render(<AccountOrgs account={mockAccount} />, { wrapper })
+
+          const org1 = await screen.findByText('org1')
+          expect(org1).toBeInTheDocument()
+
+          await user.click(org1)
+
+          await waitFor(() =>
+            expect(testLocation.pathname).toBe('/members/gh/org1')
+          )
+        })
+      })
+
+      describe('and they are not a member of that org', () => {
+        it('does nothing', async () => {
+          setup()
+          const user = userEvent.setup()
+          render(<AccountOrgs account={mockAccount} />, { wrapper })
+
+          const org2 = await screen.findByText('org2')
+          expect(org2).toBeInTheDocument()
+
+          await user.click(org2)
+
+          await waitFor(() =>
+            expect(testLocation.pathname).toBe('/plan/gh/codecov')
+          )
+        })
+      })
+    })
   })
 })

--- a/src/pages/PlanPage/subRoutes/CurrentOrgPlan/AccountOrgs/AccountOrgs.tsx
+++ b/src/pages/PlanPage/subRoutes/CurrentOrgPlan/AccountOrgs/AccountOrgs.tsx
@@ -7,9 +7,8 @@ import {
 } from '@tanstack/react-table'
 import { useEffect, useMemo, useState } from 'react'
 import { useInView } from 'react-intersection-observer'
-import { useHistory, useParams } from 'react-router'
+import { useParams } from 'react-router'
 
-import { useNavLinks } from 'services/navigation'
 import A from 'ui/A'
 import { Card } from 'ui/Card'
 import Icon from 'ui/Icon'
@@ -96,8 +95,6 @@ interface URLParams {
 }
 
 export default function AccountOrgs({ account }: AccountOrgsArgs) {
-  const history = useHistory()
-  const { membersTab } = useNavLinks()
   const { provider, owner } = useParams<URLParams>()
   const { ref, inView } = useInView()
   const [sorting, setSorting] = useState<SortingState>([
@@ -106,11 +103,6 @@ export default function AccountOrgs({ account }: AccountOrgsArgs) {
       desc: false,
     },
   ])
-
-  const linkToMembersTab = (orgOwner: string) =>
-    history.push(
-      membersTab.path({ owner: encodeURIComponent(orgOwner), provider })
-    )
 
   const { data, isLoading, hasNextPage, fetchNextPage, isFetchingNextPage } =
     useInfiniteAccountOrganizations({
@@ -223,16 +215,31 @@ export default function AccountOrgs({ account }: AccountOrgsArgs) {
               ) : (
                 table.getRowModel().rows.map((row) =>
                   row.original.isCurrentUserPartOfOrg ? (
-                    <tr
-                      key={row.id}
-                      className="h-14 hover:cursor-pointer hover:bg-ds-gray-primary"
-                      onClick={() => linkToMembersTab(row.original.name)}
-                    >
+                    <tr key={row.id} className="h-14">
                       {row.getVisibleCells().map((cell) => (
                         <td key={cell.id}>
-                          {flexRender(
-                            cell.column.columnDef.cell,
-                            cell.getContext()
+                          {cell.column.id === 'activatedUserCount' ? (
+                            <div className="flex w-full justify-end">
+                              {/* @ts-ignore-error */}
+                              <A
+                                to={{
+                                  pageName: 'membersTab',
+                                  options: {
+                                    owner: encodeURIComponent(
+                                      row.original.name
+                                    ),
+                                    provider,
+                                  },
+                                }}
+                              >
+                                {cell.getValue()}
+                              </A>
+                            </div>
+                          ) : (
+                            flexRender(
+                              cell.column.columnDef.cell,
+                              cell.getContext()
+                            )
                           )}
                         </td>
                       ))}
@@ -241,24 +248,9 @@ export default function AccountOrgs({ account }: AccountOrgsArgs) {
                     <tr key={row.id} className="h-14">
                       {row.getVisibleCells().map((cell) => (
                         <td key={cell.id}>
-                          {cell.id === 'activatedUserCount' ? (
-                            <div className="flex justify-items-end">
-                              {/* @ts-ignore-error */}
-                              <A
-                                to={{
-                                  pageName: 'membersTab',
-                                  options: {
-                                    owner: cell.getValue(),
-                                    provider,
-                                  },
-                                }}
-                              />
-                            </div>
-                          ) : (
-                            flexRender(
-                              cell.column.columnDef.cell,
-                              cell.getContext()
-                            )
+                          {flexRender(
+                            cell.column.columnDef.cell,
+                            cell.getContext()
                           )}
                         </td>
                       ))}

--- a/src/pages/PlanPage/subRoutes/CurrentOrgPlan/AccountOrgs/AccountOrgs.tsx
+++ b/src/pages/PlanPage/subRoutes/CurrentOrgPlan/AccountOrgs/AccountOrgs.tsx
@@ -85,7 +85,24 @@ const columns = [
         <ActivatedUsersTooltip />
       </div>
     ),
-    cell: ({ renderValue }) => <p className="text-right">{renderValue()}</p>,
+    cell: (info) =>
+      info.row.original.isCurrentUserPartOfOrg ? (
+        <div className="flex w-full justify-end">
+          {/* @ts-ignore-error */}
+          <A
+            to={{
+              pageName: 'membersTab',
+              options: {
+                owner: info.row.original.name,
+              },
+            }}
+          >
+            {info.cell.renderValue()}
+          </A>
+        </div>
+      ) : (
+        <p className="text-right">{info.renderValue()}</p>
+      ),
   }),
 ]
 
@@ -213,50 +230,18 @@ export default function AccountOrgs({ account }: AccountOrgsArgs) {
                   </td>
                 </tr>
               ) : (
-                table.getRowModel().rows.map((row) =>
-                  row.original.isCurrentUserPartOfOrg ? (
-                    <tr key={row.id} className="h-14">
-                      {row.getVisibleCells().map((cell) => (
-                        <td key={cell.id}>
-                          {cell.column.id === 'activatedUserCount' ? (
-                            <div className="flex w-full justify-end">
-                              {/* @ts-ignore-error */}
-                              <A
-                                to={{
-                                  pageName: 'membersTab',
-                                  options: {
-                                    owner: encodeURIComponent(
-                                      row.original.name
-                                    ),
-                                    provider,
-                                  },
-                                }}
-                              >
-                                {cell.getValue()}
-                              </A>
-                            </div>
-                          ) : (
-                            flexRender(
-                              cell.column.columnDef.cell,
-                              cell.getContext()
-                            )
-                          )}
-                        </td>
-                      ))}
-                    </tr>
-                  ) : (
-                    <tr key={row.id} className="h-14">
-                      {row.getVisibleCells().map((cell) => (
-                        <td key={cell.id}>
-                          {flexRender(
-                            cell.column.columnDef.cell,
-                            cell.getContext()
-                          )}
-                        </td>
-                      ))}
-                    </tr>
-                  )
-                )
+                table.getRowModel().rows.map((row) => (
+                  <tr key={row.id} className="h-14">
+                    {row.getVisibleCells().map((cell) => (
+                      <td key={cell.id}>
+                        {flexRender(
+                          cell.column.columnDef.cell,
+                          cell.getContext()
+                        )}
+                      </td>
+                    ))}
+                  </tr>
+                ))
               )}
               {isFetchingNextPage ? (
                 <tr>

--- a/src/pages/PlanPage/subRoutes/CurrentOrgPlan/AccountOrgs/AccountOrgs.tsx
+++ b/src/pages/PlanPage/subRoutes/CurrentOrgPlan/AccountOrgs/AccountOrgs.tsx
@@ -230,6 +230,7 @@ export default function AccountOrgs({ account }: AccountOrgsArgs) {
                       className="h-14 hover:cursor-pointer hover:bg-ds-gray-primary"
                       onClick={() => linkToMembersTab(row.original.name)}
                       tabIndex={0}
+                      role="button"
                     >
                       {row.getVisibleCells().map((cell) => (
                         <td key={cell.id}>

--- a/src/pages/PlanPage/subRoutes/CurrentOrgPlan/AccountOrgs/AccountOrgs.tsx
+++ b/src/pages/PlanPage/subRoutes/CurrentOrgPlan/AccountOrgs/AccountOrgs.tsx
@@ -30,7 +30,7 @@ interface AccountOrgRow {
 }
 
 const Loader = () => (
-  <div className="mb-4 flex justify-center pt-4">
+  <div className="mb-4 flex justify-center pt-4" data-testid="spinner">
     <Spinner />
   </div>
 )
@@ -196,9 +196,7 @@ export default function AccountOrgs({ account }: AccountOrgsArgs) {
                       key={header.id}
                       scope="col"
                       data-sortable={header.column.getCanSort()}
-                      {...(header.column.id !== 'isAdmin'
-                        ? { onClick: header.column.getToggleSortingHandler() }
-                        : {})}
+                      onClick={header.column.getToggleSortingHandler()}
                     >
                       <div className="flex">
                         {flexRender(

--- a/src/pages/PlanPage/subRoutes/CurrentOrgPlan/AccountOrgs/AccountOrgs.tsx
+++ b/src/pages/PlanPage/subRoutes/CurrentOrgPlan/AccountOrgs/AccountOrgs.tsx
@@ -229,6 +229,7 @@ export default function AccountOrgs({ account }: AccountOrgsArgs) {
                       key={row.id}
                       className="h-14 hover:cursor-pointer hover:bg-ds-gray-primary"
                       onClick={() => linkToMembersTab(row.original.name)}
+                      tabIndex={0}
                     >
                       {row.getVisibleCells().map((cell) => (
                         <td key={cell.id}>

--- a/src/pages/PlanPage/subRoutes/CurrentOrgPlan/AccountOrgs/AccountOrgs.tsx
+++ b/src/pages/PlanPage/subRoutes/CurrentOrgPlan/AccountOrgs/AccountOrgs.tsx
@@ -86,9 +86,7 @@ const columns = [
         <ActivatedUsersTooltip />
       </div>
     ),
-    cell: ({ renderValue }) => (
-      <p className="text-right text-ds-blue-default">{renderValue()}</p>
-    ),
+    cell: ({ renderValue }) => <p className="text-right">{renderValue()}</p>,
   }),
 ]
 
@@ -229,8 +227,6 @@ export default function AccountOrgs({ account }: AccountOrgsArgs) {
                       key={row.id}
                       className="h-14 hover:cursor-pointer hover:bg-ds-gray-primary"
                       onClick={() => linkToMembersTab(row.original.name)}
-                      tabIndex={0}
-                      role="button"
                     >
                       {row.getVisibleCells().map((cell) => (
                         <td key={cell.id}>
@@ -245,9 +241,24 @@ export default function AccountOrgs({ account }: AccountOrgsArgs) {
                     <tr key={row.id} className="h-14">
                       {row.getVisibleCells().map((cell) => (
                         <td key={cell.id}>
-                          {flexRender(
-                            cell.column.columnDef.cell,
-                            cell.getContext()
+                          {cell.id === 'activatedUserCount' ? (
+                            <div className="flex justify-items-end">
+                              {/* @ts-ignore-error */}
+                              <A
+                                to={{
+                                  pageName: 'membersTab',
+                                  options: {
+                                    owner: cell.getValue(),
+                                    provider,
+                                  },
+                                }}
+                              />
+                            </div>
+                          ) : (
+                            flexRender(
+                              cell.column.columnDef.cell,
+                              cell.getContext()
+                            )
                           )}
                         </td>
                       ))}

--- a/src/pages/PlanPage/subRoutes/CurrentOrgPlan/hooks/useInfiniteAccountOrganizations.test.tsx
+++ b/src/pages/PlanPage/subRoutes/CurrentOrgPlan/hooks/useInfiniteAccountOrganizations.test.tsx
@@ -72,8 +72,8 @@ const queryClient = new QueryClient({
 })
 const wrapper: React.FC<React.PropsWithChildren> = ({ children }) => (
   <QueryClientProvider client={queryClient}>
-    <MemoryRouter initialEntries={['/gh/codecov/plan']}>
-      <Route path="/:provider/:owner/plan">{children}</Route>
+    <MemoryRouter initialEntries={['/plan/gh/codecov']}>
+      <Route path="/plan/:provider/:owner">{children}</Route>
     </MemoryRouter>
   </QueryClientProvider>
 )

--- a/src/pages/PlanPage/subRoutes/CurrentOrgPlan/hooks/useInfiniteAccountOrganizations.ts
+++ b/src/pages/PlanPage/subRoutes/CurrentOrgPlan/hooks/useInfiniteAccountOrganizations.ts
@@ -39,7 +39,6 @@ const query = `query InfiniteAccountOrganizations(
   $owner: String!, 
   $after: String, 
   $first: Int!, 
-  $ordering: AccountOrganizationOrdering!, 
   $direction: OrderingDirection!
 ) {
   owner(username: $owner) {
@@ -47,7 +46,6 @@ const query = `query InfiniteAccountOrganizations(
       organizations(
         first: $first
         after: $after
-        ordering: $ordering
         orderingDirection: $direction
       ) {
         edges {
@@ -71,7 +69,6 @@ interface UseInfiniteAccountOrganizationsArgs {
   provider: string
   owner: string
   first?: number
-  ordering?: 'NAME' | 'ACTIVATED_USERS'
   orderingDirection?: OrderingDirection
 }
 
@@ -79,13 +76,11 @@ export function useInfiniteAccountOrganizations({
   provider,
   owner,
   first = 20,
-  ordering = 'ACTIVATED_USERS',
   orderingDirection = 'DESC',
 }: UseInfiniteAccountOrganizationsArgs) {
   const variables = {
     first,
-    ordering,
-    orderingDirection,
+    direction: orderingDirection,
   }
 
   return useInfiniteQuery({


### PR DESCRIPTION
Adds the last piece of this feature: the organization list! 
During development we ran into some issues with the API and not having proper access, but that has been fixed over there pending my PR getting merged.

(Minor design changes have been okayed with design folks)
[Design](https://www.figma.com/design/Tytz3vo8mjlyAL8qSiXw3S/GH-1533?node-id=1-2&node-type=canvas&t=CjY1XPbsQTDbfMSl-0)

![Screenshot 2024-10-17 at 15 19 28](https://github.com/user-attachments/assets/432e4a0e-0baa-40a1-9854-eebcee220777)

Closes https://github.com/codecov/engineering-team/issues/2564

