### PR TITLE
chore: Modify our Sentry ignore errors

### DIFF
--- a/src/sentry.ts
+++ b/src/sentry.ts
@@ -4,6 +4,17 @@ import { Route } from 'react-router-dom'
 
 import config from './config'
 
+// Custom ignored errors
+const customIgnoredErrors = [
+  /*
+   * LD could fail for a multiple reasons, network issues, server issues, rate
+   * limiting, etc. We can't really help if if LD fails to fetch, so we ignore
+   * it. We also provide a fallback value to our feature flags so if this
+   * fails the app won't break.
+   */
+  'LaunchDarklyFlagFetchError',
+]
+
 // common ignore errors / URLs to de-clutter Sentry
 // https://docs.sentry.io/platforms/javascript/guides/react/configuration/filtering/#decluttering-sentry
 const deClutterConfig = {
@@ -29,6 +40,7 @@ const deClutterConfig = {
     'EBCallBackMessageReceived',
     // See http://toolbar.conduit.com/Developer/HtmlAndGadget/Methods/JSInjection.aspx
     'conduitPage',
+    ...customIgnoredErrors,
   ],
   denyUrls: [
     // Facebook flakiness

--- a/src/sentry.ts
+++ b/src/sentry.ts
@@ -13,6 +13,13 @@ const customIgnoredErrors = [
    * fails the app won't break.
    */
   'LaunchDarklyFlagFetchError',
+  /*
+   * App throwing an error if it can't find a module. We have resolved this
+   * with two different methods, we're storing assets from previous builds, as
+   * well when this error is triggered we automatically refresh the users
+   * window to load in the new data (which is triggered by this error).
+   */
+  'Failed to fetch dynamically imported module',
 ]
 
 // common ignore errors / URLs to de-clutter Sentry


### PR DESCRIPTION
# Description

This PR adds in a way for us to add in custom ignored errors to our Sentry config. As well, this PR adds in two errors to ignore to start off with `LaunchDarklyFlagFetchError` and `Failed to fetch dynamically imported module`.