### PR TITLE
fix: Move from commit SHA to 22 char hash and polyfill Promise.allSettled

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "@acemarke/react-prod-sourcemaps": "^0.3.1",
     "@babel/plugin-proposal-private-property-in-object": "^7.21.11",
     "@chromatic-com/storybook": "^1",
-    "@codecov/vite-plugin": "^1.0.1",
+    "@codecov/vite-plugin": "^1.2.1",
     "@sentry/vite-plugin": "^2.22.4",
     "@storybook/addon-a11y": "^8.3.4",
     "@storybook/addon-actions": "^8.3.4",

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -56,14 +56,6 @@ export default defineConfig((config) => {
     )
   }
 
-  // conditionally add the commit sha to the asset and chunk file names
-  let assetFileNames
-  let chunkFileNames
-  if (process.env.GAZEBO_SHA) {
-    assetFileNames = `assets/[name]-${process.env.GAZEBO_SHA}-[hash][extname]`
-    chunkFileNames = `assets/[name]-${process.env.GAZEBO_SHA}-[hash].js`
-  }
-
   return {
     server: {
       port: 3000,
@@ -72,7 +64,11 @@ export default defineConfig((config) => {
       outDir: 'build',
       sourcemap: runSentryPlugin,
       rollupOptions: {
-        output: { assetFileNames, chunkFileNames },
+        output: {
+          entryFileNames: 'assets/[name].[hash:22].js',
+          chunkFileNames: 'assets/[name].[hash:22].js',
+          assetFileNames: 'assets/[name].[hash:22][extname]',
+        },
       },
     },
     define: envWithProcessPrefix,
@@ -83,7 +79,10 @@ export default defineConfig((config) => {
       }),
       tsconfigPaths(),
       legacy({
+        // which legacy browsers to support
         targets: ['>0.2%', 'not dead', 'not op_mini all'],
+        // which polyfills to include in the modern build
+        modernPolyfills: ['es.promise.all-settled'],
       }),
       react(),
       svgr(),

--- a/yarn.lock
+++ b/yarn.lock
@@ -3358,9 +3358,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@codecov/bundler-plugin-core@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "@codecov/bundler-plugin-core@npm:1.0.1"
+"@codecov/bundler-plugin-core@npm:^1.2.1":
+  version: 1.2.1
+  resolution: "@codecov/bundler-plugin-core@npm:1.2.1"
   dependencies:
     "@actions/core": "npm:^1.10.1"
     "@actions/github": "npm:^6.0.0"
@@ -3368,19 +3368,19 @@ __metadata:
     semver: "npm:^7.5.4"
     unplugin: "npm:^1.10.1"
     zod: "npm:^3.22.4"
-  checksum: 10c0/4a2fbcb0d33ada3c5f0335fae555cc534b46ee8e9ae4f72976b894d1d0c21954ba6309c8ee4b4d759a203674557360932c94c40f766368dfaf5195d77fe6feb8
+  checksum: 10c0/ec051dbfea8003b17676d0a0b24c006cfccaa9eb2a790357a5d504d214025d2b3209445d0c5889b56c4729259da4fd0845069ba6e08cd1e271706dd3da1788c6
   languageName: node
   linkType: hard
 
-"@codecov/vite-plugin@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "@codecov/vite-plugin@npm:1.0.1"
+"@codecov/vite-plugin@npm:^1.2.1":
+  version: 1.2.1
+  resolution: "@codecov/vite-plugin@npm:1.2.1"
   dependencies:
-    "@codecov/bundler-plugin-core": "npm:^1.0.1"
+    "@codecov/bundler-plugin-core": "npm:^1.2.1"
     unplugin: "npm:^1.10.1"
   peerDependencies:
     vite: 4.x || 5.x
-  checksum: 10c0/e6fb5d924fd17cd4ac429c5c5279cc3ff13c25853826aa0cd70468916475d09a163df2669f3a646d7738a4659203de7ccf397ec9834813eef5e013cf4db9c72a
+  checksum: 10c0/bc443322859b3675456af1de2399dc380751ed1910adff0ad3dc84d625dac41fd6301192342a9fb65f033ce56bccd5ab082bb22443cc73bfd464bcf48ef5de32
   languageName: node
   linkType: hard
 
@@ -12550,7 +12550,7 @@ __metadata:
     "@acemarke/react-prod-sourcemaps": "npm:^0.3.1"
     "@babel/plugin-proposal-private-property-in-object": "npm:^7.21.11"
     "@chromatic-com/storybook": "npm:^1"
-    "@codecov/vite-plugin": "npm:^1.0.1"
+    "@codecov/vite-plugin": "npm:^1.2.1"
     "@hookform/resolvers": "npm:^2.8.5"
     "@radix-ui/react-accordion": "npm:^1.1.2"
     "@radix-ui/react-checkbox": "npm:^1.1.1"


### PR DESCRIPTION
# Description

Couple of Vite config changes here and a plugin version bump. Goal of this is to resolve some issues with caching, browsers not supporting `Promise.allSettled`, and bumping a plugin version so it works properly with the extended hash values.

Will hopefully resolve: https://codecov.sentry.io/issues/5968807574/events/3a931390316b4d78a3de37186f8306d1/

# Notable Changes

- Polyfill `Promise.allSettled`
- Update Codecov Vite plugin
- Adjust output file names