### PR TITLE
feat: Add CI status tooltip

### DIFF
--- a/src/services/navigation/useNavLinks/useStaticNavLinks.js
+++ b/src/services/navigation/useNavLinks/useStaticNavLinks.js
@@ -506,5 +506,12 @@ export function useStaticNavLinks() {
       isExternalLink: true,
       openNewTab: true,
     },
+    requireCIPassDocs: {
+      text: 'Codecov YAML require CI to pass',
+      path: () =>
+        'https://docs.codecov.com/docs/codecovyml-reference#codecovrequire_ci_to_pass',
+      isExternalLink: true,
+      openNewTab: true,
+    },
   }
 }

--- a/src/services/navigation/useNavLinks/useStaticNavLinks.test.jsx
+++ b/src/services/navigation/useNavLinks/useStaticNavLinks.test.jsx
@@ -97,6 +97,7 @@ describe('useStaticNavLinks', () => {
       ${links.proPlanFeedbackSurvey}         | ${'https://forms.gle/nf37sRAtyQeXVTdr8'}
       ${links.bundleFeedbackSurvey}          | ${'https://forms.gle/8fzZrwWEaBRz4ufD9'}
       ${links.tokenlessDocs}                 | ${'https://docs.codecov.com/docs/codecov-tokens#uploading-without-a-token'}
+      ${links.requireCIPassDocs}             | ${'https://docs.codecov.com/docs/codecovyml-reference#codecovrequire_ci_to_pass'}
     `('static links return path', ({ link, outcome }) => {
       it(`${link.text}: Returns the correct link`, () => {
         expect(link.path()).toBe(outcome)

--- a/src/ui/CIStatus/CIStatus.test.jsx
+++ b/src/ui/CIStatus/CIStatus.test.jsx
@@ -1,43 +1,65 @@
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import { MemoryRouter, Route } from 'react-router-dom'
+import ResizeObserver from 'resize-observer-polyfill'
 
 import CIStatus from '.'
+
+global.ResizeObserver = ResizeObserver
+
+const wrapper = ({ children }) => (
+  <MemoryRouter
+    initialEntries={[
+      '/gh/codecov/test-repo/commit/803897e6ceeb6828778070208c06c5a978a48a68',
+    ]}
+  >
+    <Route path="/:provider/:owner/:repo/commit/:commit">{children}</Route>
+  </MemoryRouter>
+)
 
 describe('CIStatus', () => {
   describe('when rendered', () => {
     it('shows ci passed', () => {
-      render(<CIStatus ciPassed={true} />)
+      render(<CIStatus ciPassed={true} />, { wrapper })
 
       const passed = screen.getByText(/Passed/)
       expect(passed).toBeInTheDocument()
     })
 
     it('shows ci failed', () => {
-      render(<CIStatus ciPassed={false} />)
+      render(<CIStatus ciPassed={false} />, { wrapper })
 
       const failed = screen.getByText(/Failed/)
       expect(failed).toBeInTheDocument()
     })
 
     it('shows no status if no status is given', () => {
-      render(<CIStatus ciPassed={undefined} />)
+      render(<CIStatus ciPassed={undefined} />, { wrapper })
 
       const noStatus = screen.getByText(/No Status/)
       expect(noStatus).toBeInTheDocument()
     })
 
     it('shows tooltip on hover', async () => {
-      render(<CIStatus ciPassed={true} />)
+      render(<CIStatus ciPassed={true} />, { wrapper })
 
       const tooltipTrigger = screen.getByTestId('ci-tooltip-trigger')
       await userEvent.hover(tooltipTrigger)
 
-      const link = await screen.findByTestId('docs-link')
-      expect(link).toBeInTheDocument()
-      expect(link).toHaveAttribute(
+      const link = await screen.findAllByTestId('yml-require-ci-pass-link')
+      expect(link).toHaveLength(2)
+      expect(link[0]).toHaveAttribute(
         'href',
         'https://docs.codecov.com/docs/codecovyml-reference#codecovrequire_ci_to_pass'
       )
+    })
+
+    it('does not show tooltip when not hovered', async () => {
+      render(<CIStatus ciPassed={true} />, { wrapper })
+
+      expect(
+        screen.queryByTestId('yml-require-ci-pass-link')
+      ).not.toBeInTheDocument()
     })
   })
 })

--- a/src/ui/CIStatus/CIStatus.test.jsx
+++ b/src/ui/CIStatus/CIStatus.test.jsx
@@ -1,4 +1,5 @@
 import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 
 import CIStatus from '.'
 
@@ -23,6 +24,20 @@ describe('CIStatus', () => {
 
       const noStatus = screen.getByText(/No Status/)
       expect(noStatus).toBeInTheDocument()
+    })
+
+    it('shows tooltip on hover', async () => {
+      render(<CIStatus ciPassed={true} />)
+
+      const tooltipTrigger = screen.getByTestId('ci-tooltip-trigger')
+      await userEvent.hover(tooltipTrigger)
+
+      const link = await screen.findByTestId('docs-link')
+      expect(link).toBeInTheDocument()
+      expect(link).toHaveAttribute(
+        'href',
+        'https://docs.codecov.com/docs/codecovyml-reference#codecovrequire_ci_to_pass'
+      )
     })
   })
 })

--- a/src/ui/CIStatus/CIStatus.tsx
+++ b/src/ui/CIStatus/CIStatus.tsx
@@ -23,8 +23,8 @@ export default function CIStatusLabel({ ciPassed }: CIStatusLabelProps) {
   const iconName = ciPassed ? 'check' : 'x'
 
   return (
-    <Tooltip>
-      <Tooltip.Root delayDuration={500}>
+    <Tooltip delayDuration={0} skipDelayDuration={100}>
+      <Tooltip.Root>
         <Tooltip.Trigger>
           <span
             className="flex flex-none items-center gap-1 text-xs"
@@ -42,23 +42,22 @@ export default function CIStatusLabel({ ciPassed }: CIStatusLabelProps) {
         </Tooltip.Trigger>
         <Tooltip.Portal>
           <Tooltip.Content
-            className="inline rounded border border-ds-gray-secondary bg-ds-gray-primary px-3 py-2 text-xs"
+            className="rounded-md border border-ds-gray-secondary bg-ds-gray-primary px-3 py-2 text-xs"
             side="right"
           >
-            <div className="absolute left-[-7px] size-0 border-y-[10px] border-r-[10px] border-y-transparent border-r-ds-gray-secondary" />
-            <TooltipArrow className="fill-ds-gray-primary" />
-            <span className="text-ds-gray-octonary">
-              This CI status is based on all of your{' '}
+            <p className="text-ds-gray-octonary">
+              This CI status is based on all of your <br />
               <A
                 to={{ pageName: 'requireCIPassDocs' }}
                 hook="yml-require-ci-pass-link"
-                data-testid="docs-link"
+                data-testid="yml-require-ci-pass-link"
                 isExternal
               >
                 non-Codecov related checks
               </A>
               .
-            </span>
+            </p>
+            <TooltipArrow className="fill-ds-gray-primary" />
           </Tooltip.Content>
         </Tooltip.Portal>
       </Tooltip.Root>

--- a/src/ui/CIStatus/CIStatus.tsx
+++ b/src/ui/CIStatus/CIStatus.tsx
@@ -1,4 +1,8 @@
+import { TooltipArrow } from '@radix-ui/react-tooltip'
+
+import A from 'ui/A'
 import Icon from 'ui/Icon'
+import { Tooltip } from 'ui/Tooltip'
 
 interface CIStatusLabelProps {
   ciPassed?: boolean | null
@@ -19,13 +23,45 @@ export default function CIStatusLabel({ ciPassed }: CIStatusLabelProps) {
   const iconName = ciPassed ? 'check' : 'x'
 
   return (
-    <span className="flex flex-none items-center gap-1 text-xs">
-      <span
-        className={ciPassed ? 'text-ds-primary-green' : 'text-ds-primary-red'}
-      >
-        <Icon size="sm" name={iconName} label={iconName} />
-      </span>
-      CI {ciPassed ? 'Passed' : 'Failed'}
-    </span>
+    <Tooltip>
+      <Tooltip.Root open delayDuration={500}>
+        <Tooltip.Trigger>
+          <span
+            className="flex flex-none items-center gap-1 text-xs"
+            data-testid="ci-tooltip-trigger"
+          >
+            <span
+              className={
+                ciPassed ? 'text-ds-primary-green' : 'text-ds-primary-red'
+              }
+            >
+              <Icon size="sm" name={iconName} label={iconName} />
+            </span>
+            CI {ciPassed ? 'Passed' : 'Failed'}
+          </span>
+        </Tooltip.Trigger>
+        <Tooltip.Portal>
+          <Tooltip.Content
+            className="inline rounded border border-ds-gray-secondary bg-ds-gray-primary px-3 py-2 text-xs"
+            side="right"
+          >
+            <div className="absolute left-[-7px] size-0 border-y-[10px] border-r-[10px] border-y-transparent border-r-ds-gray-secondary" />
+            <TooltipArrow className="fill-ds-gray-primary" />
+            <span className="text-ds-gray-octonary">
+              This CI status is based on all of your{' '}
+              <A
+                to={{ pageName: 'requireCIPassDocs' }}
+                hook="yml-require-ci-pass-link"
+                data-testid="docs-link"
+                isExternal
+              >
+                non-Codecov related checks
+              </A>
+              .
+            </span>
+          </Tooltip.Content>
+        </Tooltip.Portal>
+      </Tooltip.Root>
+    </Tooltip>
   )
 }

--- a/src/ui/CIStatus/CIStatus.tsx
+++ b/src/ui/CIStatus/CIStatus.tsx
@@ -42,10 +42,10 @@ export default function CIStatusLabel({ ciPassed }: CIStatusLabelProps) {
         </Tooltip.Trigger>
         <Tooltip.Portal>
           <Tooltip.Content
-            className="rounded-md border border-ds-gray-secondary bg-ds-gray-primary px-3 py-2 text-xs"
+            className="rounded-md bg-ds-gray-primary px-3 py-2 text-xs"
             side="right"
           >
-            <p className="text-ds-gray-octonary">
+            <p>
               This CI status is based on all of your <br />
               <A
                 to={{ pageName: 'requireCIPassDocs' }}

--- a/src/ui/CIStatus/CIStatus.tsx
+++ b/src/ui/CIStatus/CIStatus.tsx
@@ -24,7 +24,7 @@ export default function CIStatusLabel({ ciPassed }: CIStatusLabelProps) {
 
   return (
     <Tooltip>
-      <Tooltip.Root open delayDuration={500}>
+      <Tooltip.Root delayDuration={500}>
         <Tooltip.Trigger>
           <span
             className="flex flex-none items-center gap-1 text-xs"

--- a/src/ui/SummaryDropdown/SummaryDropdown.tsx
+++ b/src/ui/SummaryDropdown/SummaryDropdown.tsx
@@ -54,7 +54,7 @@ const SummaryTrigger = forwardRef<
   React.ElementRef<typeof AccordionPrimitive.Trigger>,
   TriggerProps
 >(({ children, className, ...props }, forwardedRef) => (
-  <AccordionPrimitive.Header className="sticky top-0 z-30">
+  <AccordionPrimitive.Header className="sticky top-0">
     <AccordionPrimitive.Trigger
       className={cn(trigger({ className }))}
       {...props}


### PR DESCRIPTION
# Description

Closes https://github.com/codecov/engineering-team/issues/2523

Discussed with Adalene and we decided to do away with the border style to match with the tooltips on their way for TA.

# Code Example

# Notable Changes

# Screenshots
<img width="432" alt="Screenshot 2024-10-22 at 1 42 31 PM" src="https://github.com/user-attachments/assets/d6274077-3d92-451d-ac92-ab8b22ccb744">

Looked into the reason why we had z-30 in SummaryDropdown and it looks like we don't currently need it.
<img width="1728" alt="Screenshot 2024-10-23 at 9 28 28 AM" src="https://github.com/user-attachments/assets/1145ce50-3fa1-4e1d-8e85-68f388b883d9">
<img width="1728" alt="Screenshot 2024-10-23 at 9 28 12 AM" src="https://github.com/user-attachments/assets/962744e5-e448-4156-b98a-52a26294cf68">



# Link to Sample Entry

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.