### PR TITLE
feat: Minor Polish for Failed Tests Table

### DIFF
--- a/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/FailedTestsPage.test.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/FailedTestsPage.test.tsx
@@ -1,7 +1,7 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { render, screen } from '@testing-library/react'
-import { graphql, HttpResponse } from 'msw2'
-import { setupServer } from 'msw2/node'
+import { graphql, HttpResponse } from 'msw'
+import { setupServer } from 'msw/node'
 import { PropsWithChildren, Suspense } from 'react'
 import { MemoryRouter, Route } from 'react-router-dom'
 

--- a/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/FailedTestsTable/FailedTestsTable.test.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/FailedTestsTable/FailedTestsTable.test.tsx
@@ -156,6 +156,7 @@ describe('FailedTestsTable', () => {
                 repository: {
                   __typename: 'Repository',
                   private: isPrivate,
+                  defaultBranch: 'main',
                   testAnalytics: {
                     testResults: {
                       edges: [],
@@ -180,6 +181,7 @@ describe('FailedTestsTable', () => {
             repository: {
               __typename: 'Repository',
               private: isPrivate,
+              defaultBranch: 'main',
               testAnalytics: {
                 testResults: {
                   edges: info.variables.after
@@ -231,6 +233,20 @@ describe('FailedTestsTable', () => {
           })
           render(<FailedTestsTable />, {
             wrapper: wrapper(queryClient),
+          })
+
+          await waitFor(() => expect(queryClient.isFetching()).toBeFalsy())
+
+          const flakeRateColumn = screen.queryByText('Flake rate')
+          expect(flakeRateColumn).not.toBeInTheDocument()
+        })
+      })
+
+      describe('when not on default branch', () => {
+        it('does not render flake rate column', async () => {
+          const { queryClient } = setup({})
+          render(<FailedTestsTable />, {
+            wrapper: wrapper(queryClient, ['/gh/codecov/repo/tests/lol']),
           })
 
           await waitFor(() => expect(queryClient.isFetching()).toBeFalsy())

--- a/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/FailedTestsTable/FailedTestsTable.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/FailedTestsTable/FailedTestsTable.tsx
@@ -210,16 +210,18 @@ const FailedTestsTable = () => {
       // eslint-disable-next-line camelcase
       test_suites: testSuites as string[],
       parameter: queryParams?.parameter as TestResultsFilterParameterType,
-      history: queryParams?.historicalTrend as MEASUREMENT_INTERVAL_TYPE,
+      interval: queryParams?.historicalTrend as MEASUREMENT_INTERVAL_TYPE,
     },
     opts: {
       suspense: false,
     },
   })
 
+  // Only show flake rate column when on default branch for pro / enterprise plans or public repos
   const hideFlakeRate =
-    (isTeamPlan(testData?.plan) || isFreePlan(testData?.plan)) &&
-    testData?.private
+    ((isTeamPlan(testData?.plan) || isFreePlan(testData?.plan)) &&
+      testData?.private) ||
+    (!!branch && testData?.defaultBranch !== branch)
 
   const tableData = useMemo(() => {
     if (!testData?.testResults) return []

--- a/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/MetricsSection/MetricsSection.test.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/MetricsSection/MetricsSection.test.tsx
@@ -1,8 +1,8 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { graphql, HttpResponse } from 'msw2'
-import { setupServer } from 'msw2/node'
+import { graphql, HttpResponse } from 'msw'
+import { setupServer } from 'msw/node'
 import { PropsWithChildren, Suspense } from 'react'
 import { MemoryRouter, Route, useLocation } from 'react-router-dom'
 

--- a/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/SelectorSection/SelectorSection.test.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/SelectorSection/SelectorSection.test.tsx
@@ -1,8 +1,8 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { graphql, HttpResponse } from 'msw2'
-import { setupServer } from 'msw2/node'
+import { graphql, HttpResponse } from 'msw'
+import { setupServer } from 'msw/node'
 import { PropsWithChildren, Suspense } from 'react'
 import { MemoryRouter, Route, useLocation } from 'react-router-dom'
 
@@ -159,6 +159,21 @@ describe('SelectorSection', () => {
       expect(historicalTrend).toBeInTheDocument()
       expect(testSuites).toBeInTheDocument()
       expect(flags).toBeInTheDocument()
+    })
+
+    it('has 60 day retention link', async () => {
+      setup()
+      render(<SelectorSection />, {
+        wrapper: wrapper('/gh/owner/repo/tests/main'),
+      })
+
+      const link = await screen.findByRole('link')
+      expect(link).toBeInTheDocument()
+
+      expect(link).toHaveAttribute(
+        'href',
+        'https://docs.codecov.com/docs/test-result-ingestion-beta#data-retention'
+      )
     })
   })
 

--- a/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/SelectorSection/SelectorSection.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/SelectorSection/SelectorSection.tsx
@@ -94,7 +94,11 @@ function SelectorSection() {
                 renderSelected={({ label }: { label: string }) => label}
               />
             </div>
-            <A to="" isExternal hook={'60-day-retention'}>
+            <A
+              to={{ pageName: 'testsAnalyticsDataRetention' }}
+              isExternal
+              hook="60-day-retention"
+            >
               60 day retention
             </A>
           </div>

--- a/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/hooks/useFlakeAggregates/useFlakeAggregates.test.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/hooks/useFlakeAggregates/useFlakeAggregates.test.tsx
@@ -1,7 +1,7 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { renderHook, waitFor } from '@testing-library/react'
-import { graphql, HttpResponse } from 'msw2'
-import { setupServer } from 'msw2/node'
+import { graphql, HttpResponse } from 'msw'
+import { setupServer } from 'msw/node'
 import { MemoryRouter, Route } from 'react-router-dom'
 import { MockInstance } from 'vitest'
 

--- a/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/hooks/useInfiniteTestResults/useInfiniteTestResults.test.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/hooks/useInfiniteTestResults/useInfiniteTestResults.test.tsx
@@ -13,6 +13,7 @@ const mockTestResults = {
     repository: {
       __typename: 'Repository',
       private: false,
+      defaultBranch: 'main',
       testAnalytics: {
         testResults: {
           edges: [

--- a/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/hooks/useInfiniteTestResults/useInfiniteTestResults.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/hooks/useInfiniteTestResults/useInfiniteTestResults.tsx
@@ -70,6 +70,7 @@ const GetTestResultsSchema = z.object({
         z.object({
           __typename: z.literal('Repository'),
           private: z.boolean().nullable(),
+          defaultBranch: z.string().nullable(),
           testAnalytics: z
             .object({
               testResults: z.object({
@@ -113,6 +114,7 @@ query GetTestResults(
       __typename
       ... on Repository {
         private
+        defaultBranch
         testAnalytics {
           testResults(
             filters: $filters
@@ -162,7 +164,7 @@ interface UseTestResultsArgs {
   filters?: {
     branch?: string
     flags?: string[]
-    history?: MEASUREMENT_INTERVAL_TYPE
+    interval?: MEASUREMENT_INTERVAL_TYPE
     parameter?: TestResultsFilterParameterType
     term?: string
     test_suites?: string[]
@@ -177,6 +179,7 @@ interface UseTestResultsArgs {
     pageInfo: { endCursor: string | null; hasNextPage: boolean }
     private: boolean | null
     plan: string | null
+    defaultBranch: string | null
   }>
 }
 
@@ -270,6 +273,7 @@ export const useInfiniteTestResults = ({
           },
           private: data?.owner?.repository?.private ?? null,
           plan: data?.owner?.plan?.value ?? null,
+          defaultBranch: data?.owner?.repository?.defaultBranch ?? null,
         }
       }),
     getNextPageParam: (lastPage) => {
@@ -290,6 +294,7 @@ export const useInfiniteTestResults = ({
       testResults: memoedData,
       private: data?.pages?.[0]?.private ?? null,
       plan: data?.pages?.[0]?.plan ?? null,
+      defaultBranch: data?.pages?.[0]?.defaultBranch ?? null,
     },
     ...rest,
   }

--- a/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/hooks/useTestResultsAggregates/useTestsResultsAggregates.test.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/hooks/useTestResultsAggregates/useTestsResultsAggregates.test.tsx
@@ -1,7 +1,7 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { renderHook, waitFor } from '@testing-library/react'
-import { graphql, HttpResponse } from 'msw2'
-import { setupServer } from 'msw2/node'
+import { graphql, HttpResponse } from 'msw'
+import { setupServer } from 'msw/node'
 import { MemoryRouter, Route } from 'react-router-dom'
 import { MockInstance } from 'vitest'
 

--- a/src/services/navigation/useNavLinks/useStaticNavLinks.js
+++ b/src/services/navigation/useNavLinks/useStaticNavLinks.js
@@ -463,6 +463,13 @@ export function useStaticNavLinks() {
       isExternalLink: true,
       openNewTab: true,
     },
+    testsAnalyticsDataRetention: {
+      text: 'Test Analytics Data Retention',
+      path: () =>
+        'https://docs.codecov.com/docs/test-result-ingestion-beta#data-retention',
+      isExternalLink: true,
+      openNewTab: true,
+    },
     expiredReports: {
       text: 'Expired Reports',
       path: () =>

--- a/src/services/navigation/useNavLinks/useStaticNavLinks.test.jsx
+++ b/src/services/navigation/useNavLinks/useStaticNavLinks.test.jsx
@@ -90,6 +90,7 @@ describe('useStaticNavLinks', () => {
       ${links.installSelfHosted}             | ${'https://docs.codecov.com/docs/installing-codecov-self-hosted'}
       ${links.login}                         | ${`/login`}
       ${links.testsAnalytics}                | ${'https://docs.codecov.com/docs/test-result-ingestion-beta#failed-test-reporting'}
+      ${links.testsAnalyticsDataRetention}   | ${'https://docs.codecov.com/docs/test-result-ingestion-beta#data-retention'}
       ${links.expiredReports}                | ${'https://docs.codecov.com/docs/codecov-yaml#section-expired-reports'}
       ${links.unusableReports}               | ${'https://docs.codecov.com/docs/error-reference#unusable-reports'}
       ${links.demoRepo}                      | ${'/github/codecov/gazebo'}


### PR DESCRIPTION
# Description

This PR adds a couple polish items to the failed tests table:

- Hide flake rate column when not on default branch
- Adds link for 60 day retention and UT
- Updates MSW stuff from msw2 -> msw

# Screenshots

Showing link on bottom of image
<img width="1512" alt="Screenshot 2024-10-18 at 4 34 04 PM" src="https://github.com/user-attachments/assets/ae28dfa4-e39d-469a-b7d7-c4edb483cb9c">


Showing no flake rate on non-default branch:
<img width="1512" alt="Screenshot 2024-10-18 at 4 34 12 PM" src="https://github.com/user-attachments/assets/d742a8ce-43ee-4a5a-8d38-7655fc67eb45">


# Link to Sample Entry

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.