### PR TITLE
fix: Truncate sunburst chart's breadcrumbs

### DIFF
--- a/src/pages/RepoPage/CoverageTab/OverviewTab/subroute/Sunburst/Sunburst.jsx
+++ b/src/pages/RepoPage/CoverageTab/OverviewTab/subroute/Sunburst/Sunburst.jsx
@@ -56,4 +56,12 @@ function Sunburst() {
   )
 }
 
+export function getPathsToDisplay(breadcrumbPaths) {
+  if (breadcrumbPaths.length <= 1) {
+    return breadcrumbPaths
+  } else {
+    return [breadcrumbPaths[0], { text: '...' }]
+  }
+}
+
 export default Sunburst

--- a/src/pages/RepoPage/CoverageTab/OverviewTab/subroute/Sunburst/Sunburst.jsx
+++ b/src/pages/RepoPage/CoverageTab/OverviewTab/subroute/Sunburst/Sunburst.jsx
@@ -23,6 +23,13 @@ function Sunburst() {
 
   const breadcrumbPaths = useConvertD3ToBreadcrumbs(currentPath)
 
+  let pathsToDisplay
+  if (breadcrumbPaths.length <= 1) {
+    pathsToDisplay = breadcrumbPaths
+  } else {
+    pathsToDisplay = [breadcrumbPaths[0], { text: '...' }]
+  }
+
   if (isFetching || isLoading) {
     return <Placeholder />
   }
@@ -43,7 +50,7 @@ function Sunburst() {
         colorDomainMax={config?.indicationRange?.upperRange}
       />
       <span dir="rtl" className="truncate text-left">
-        <Breadcrumb paths={breadcrumbPaths} />
+        <Breadcrumb paths={pathsToDisplay} />
       </span>
     </>
   )

--- a/src/pages/RepoPage/CoverageTab/OverviewTab/subroute/Sunburst/Sunburst.jsx
+++ b/src/pages/RepoPage/CoverageTab/OverviewTab/subroute/Sunburst/Sunburst.jsx
@@ -23,12 +23,7 @@ function Sunburst() {
 
   const breadcrumbPaths = useConvertD3ToBreadcrumbs(currentPath)
 
-  let pathsToDisplay
-  if (breadcrumbPaths.length <= 1) {
-    pathsToDisplay = breadcrumbPaths
-  } else {
-    pathsToDisplay = [breadcrumbPaths[0], { text: '...' }]
-  }
+  const pathsToDisplay = getPathsToDisplay(breadcrumbPaths)
 
   if (isFetching || isLoading) {
     return <Placeholder />

--- a/src/pages/RepoPage/CoverageTab/OverviewTab/subroute/Sunburst/Sunburst.test.jsx
+++ b/src/pages/RepoPage/CoverageTab/OverviewTab/subroute/Sunburst/Sunburst.test.jsx
@@ -4,7 +4,7 @@ import { graphql, http, HttpResponse } from 'msw'
 import { setupServer } from 'msw/node'
 import { MemoryRouter, Route } from 'react-router-dom'
 
-import Sunburst from './Sunburst'
+import Sunburst, { getPathsToDisplay } from './Sunburst'
 
 vi.mock('ui/SunburstChart', () => ({ default: () => 'Chart Mocked' }))
 
@@ -122,6 +122,25 @@ describe('Sunburst', () => {
       )
 
       expect(chart).toBeInTheDocument()
+    })
+  })
+
+  describe('getPathsToDisplay', () => {
+    it('handles one segment', () => {
+      const breadcrumbPaths = [{ text: 'root' }]
+
+      const pathsToDisplay = getPathsToDisplay(breadcrumbPaths)
+      expect(pathsToDisplay).toEqual([{ text: 'root' }])
+    })
+    it('handles multiple segments', () => {
+      const breadcrumbPaths = [
+        { text: 'file' },
+        { text: 'folder' },
+        { text: 'root' },
+      ]
+
+      const pathsToDisplay = getPathsToDisplay(breadcrumbPaths)
+      expect(pathsToDisplay).toEqual([{ text: 'file' }, { text: '...' }])
     })
   })
 })


### PR DESCRIPTION
Fix bug with sunburst's breadcrumbs show a "..." if too long. It always display just the last element with "..." if it goes more than 1 deep as it seemed like in most cases only 1 fits on the page. This is a quick and dirty solution. For real we should probably give more real estate for this rich information or make a truncatable Breadcrumbs reusable component that has a resize observer.

Closes https://github.com/codecov/engineering-team/issues/2337

Example screenshots:
<img width="348" alt="Screenshot 2024-10-21 at 5 32 02 PM" src="https://github.com/user-attachments/assets/d7982261-f706-4a65-9e37-eb3fb8c4c12a">
<img width="409" alt="Screenshot 2024-10-21 at 5 31 51 PM" src="https://github.com/user-attachments/assets/5e8ad1ba-e55d-45bb-ae2f-a4e7a7da2668">
<img width="428" alt="Screenshot 2024-10-21 at 5 31 45 PM" src="https://github.com/user-attachments/assets/4f870738-7bb8-4bdd-9a4a-0aa532eb999f">


here are the befores which just need a bandaid:
<img width="332" alt="Screenshot 2024-10-21 at 5 34 19 PM" src="https://github.com/user-attachments/assets/19ecf72e-d225-4d34-932c-d4e8b4c7204c">
<img width="327" alt="Screenshot 2024-10-21 at 5 33 38 PM" src="https://github.com/user-attachments/assets/db6a9872-44b2-42e9-a503-d7ba6dc08d2f">

