### PR TITLE
fix: Add debounce to branch search

### DIFF
--- a/src/pages/RepoPage/BundlesTab/BundleContent/BundleSelection/BranchSelector.tsx
+++ b/src/pages/RepoPage/BundlesTab/BundleContent/BundleSelection/BranchSelector.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import { useHistory, useParams } from 'react-router-dom'
+import { useDebounce } from 'react-use'
 
 import { Branch, useBranch, useBranches } from 'services/branches'
 import { useNavLinks } from 'services/navigation'
@@ -29,12 +30,22 @@ const BranchSelector: React.FC<BranchSelectorProps> = ({
   const { bundles: bundlesLink } = useNavLinks()
   const { provider, owner, repo, branch } = useParams<URLParams>()
   const [branchSearchTerm, setBranchSearchTerm] = useState<string>()
+  const [debouncedBranchSearchTerm, setDebouncedBranchSearchTerm] =
+    useState<string>()
 
   const { data: overview } = useRepoOverview({
     provider,
     owner,
     repo,
   })
+
+  useDebounce(
+    () => {
+      setDebouncedBranchSearchTerm(branchSearchTerm)
+    },
+    500,
+    [branchSearchTerm]
+  )
 
   const {
     data: branchList,
@@ -45,7 +56,7 @@ const BranchSelector: React.FC<BranchSelectorProps> = ({
     repo,
     owner,
     provider,
-    filters: { searchValue: branchSearchTerm },
+    filters: { searchValue: debouncedBranchSearchTerm },
     opts: {
       suspense: false,
     },


### PR DESCRIPTION
Add debounce to the branch search element to improve the current slow timing that takes ~10seconds+ to load.

The branch search bar runs below query in postgres sql which takes ~3 seconds to run (20+seconds in the worst case) - see Sentry [board](https://codecov.sentry.io/issues/5001374062/events/?project=5215654&selected_replay_index=4&sort=-transaction.duration). 

Without a debounce, we are sending these 3+second queries over and over as the user types into the search bar and waiting until the last of those queries return a value until displaying it. So separate from trying to optimize the query, this debounce should cut down the time significantly on the frontend.

Closes https://github.com/codecov/engineering-team/issues/2537

Underlying query:
```
SELECT branches.branch, branches.repoid, branches.authors, branches.head, branches.base,
  branches.updatestamp
FROM branches
WHERE (
  branches.repoid = 111 AND UPPER(branches.branch::text) LIKE UPPER('%codecov%')
)
ORDER BY branches.updatestamp DESC
LIMIT 21;
```

RE: optimizing the query on the backend - There is an index on branches.repoid and one on branches.repoid,branches.branch but the latter index doesn't get picked up with `LIKE` operator. The `LIKE` operator does a full scan on all rows returned by the `repoid` filter, according to the `EXPLAIN ANALYZE`. There are options as an alternative to `LIKE` like going for prefix search only instead but that is a worse user experience. I think this frontend fix gets us pretty far for now until we need to go change our db solution for search