### PR TITLE
fix: Incorrect default colors on Tooltip

### DIFF
--- a/src/ui/Tooltip/Tooltip.tsx
+++ b/src/ui/Tooltip/Tooltip.tsx
@@ -43,7 +43,7 @@ const TooltipContent = forwardRef<
     sideOffset={sideOffset}
     {...props}
     className={cn(
-      'bg-gray-800 px-3 py-2 text-sm text-white shadow-md',
+      'bg-ds-gray-primary px-3 py-2 text-sm text-ds-gray-octonary shadow-md',
       className
     )}
   >
@@ -57,7 +57,11 @@ const TooltipArrow = forwardRef<
   React.ElementRef<typeof RadixTooltip.Arrow>,
   React.ComponentPropsWithoutRef<typeof RadixTooltip.Arrow>
 >(({ className, ...props }, ref) => (
-  <RadixTooltip.Arrow ref={ref} {...props} className={className} />
+  <RadixTooltip.Arrow
+    ref={ref}
+    {...props}
+    className={cn('fill-ds-gray-primary', className)}
+  />
 ))
 
 TooltipArrow.displayName = 'TooltipArrow'


### PR DESCRIPTION
Sets default colors on the Tooltip component as expected.

Closes https://github.com/codecov/engineering-team/issues/2701

![Screenshot 2024-10-21 at 14 34 47](https://github.com/user-attachments/assets/1ac7bb6c-0e8b-4d26-9872-7bf6d97be9cc)

![Screenshot 2024-10-21 at 14 35 07](https://github.com/user-attachments/assets/a12606e0-ca2e-441e-b119-8c03dd36aab6)
