### PR TITLE
feat: Add new Hooks for fetching testSuites and flags on Failed Tests Page

### DIFF
--- a/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/hooks/useTestResultsFlags/useTestResultsFlags.test.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/hooks/useTestResultsFlags/useTestResultsFlags.test.tsx
@@ -1,0 +1,153 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { renderHook, waitFor } from '@testing-library/react'
+import { graphql, HttpResponse } from 'msw'
+import { setupServer } from 'msw/node'
+import { MemoryRouter, Route } from 'react-router-dom'
+import { MockInstance } from 'vitest'
+
+import { useTestResultsFlags } from './useTestResultsFlags'
+
+const queryClient = new QueryClient({
+  defaultOptions: { queries: { retry: false } },
+})
+
+const wrapper = ({ children }: { children: React.ReactNode }) => (
+  <MemoryRouter initialEntries={['/gh/codecov/gazebo']}>
+    <Route path="/:provider/:owner/:repo">
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    </Route>
+  </MemoryRouter>
+)
+
+const server = setupServer()
+
+beforeAll(() => {
+  server.listen()
+})
+
+afterEach(() => {
+  queryClient.clear()
+  server.resetHandlers()
+})
+
+afterAll(() => {
+  server.close()
+})
+
+const mockNotFoundError = {
+  owner: {
+    repository: {
+      __typename: 'NotFoundError',
+      message: 'repo not found',
+    },
+  },
+}
+
+const mockIncorrectResponse = {
+  owner: {
+    repository: {
+      invalid: 'invalid',
+    },
+  },
+}
+
+const mockResponse = {
+  owner: {
+    repository: {
+      __typename: 'Repository',
+      testAnalytics: {
+        flags: ['nah', 'ok', 'three'],
+      },
+    },
+  },
+}
+
+describe('useTestResultsFlags', () => {
+  function setup({
+    isNotFoundError = false,
+    isUnsuccessfulParseError = false,
+  }) {
+    server.use(
+      graphql.query('GetTestResultsFlags', (info) => {
+        if (isNotFoundError) {
+          return HttpResponse.json({ data: mockNotFoundError })
+        } else if (isUnsuccessfulParseError) {
+          return HttpResponse.json({ data: mockIncorrectResponse })
+        }
+        return HttpResponse.json({ data: mockResponse })
+      })
+    )
+  }
+
+  describe('when called with successful res', () => {
+    it('returns the data', async () => {
+      setup({})
+      const { result } = renderHook(() => useTestResultsFlags({}), {
+        wrapper,
+      })
+
+      await waitFor(() => result.current.isLoading)
+      await waitFor(() => !result.current.isLoading)
+
+      await waitFor(() =>
+        expect(result.current.data).toEqual({
+          flags: ['nah', 'ok', 'three'],
+        })
+      )
+    })
+  })
+
+  describe('when failed to parse data', () => {
+    let consoleSpy: MockInstance
+    beforeAll(() => {
+      consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    })
+
+    afterAll(() => {
+      consoleSpy.mockRestore()
+    })
+
+    it('returns a failed to parse error', async () => {
+      setup({ isUnsuccessfulParseError: true })
+      const { result } = renderHook(() => useTestResultsFlags({}), {
+        wrapper,
+      })
+
+      await waitFor(() =>
+        expect(result.current.error).toEqual(
+          expect.objectContaining({
+            status: 404,
+            dev: 'useTestResultsFlags - 404 Failed to parse data',
+          })
+        )
+      )
+    })
+  })
+
+  describe('when data not found', () => {
+    let consoleSpy: MockInstance
+    beforeAll(() => {
+      consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    })
+
+    afterAll(() => {
+      consoleSpy.mockRestore()
+    })
+
+    it('returns a not found error', async () => {
+      setup({ isNotFoundError: true })
+      const { result } = renderHook(() => useTestResultsFlags({}), {
+        wrapper,
+      })
+
+      await waitFor(() =>
+        expect(result.current.error).toEqual(
+          expect.objectContaining({
+            status: 404,
+            data: {},
+          })
+        )
+      )
+    })
+  })
+})

--- a/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/hooks/useTestResultsFlags/useTestResultsFlags.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/hooks/useTestResultsFlags/useTestResultsFlags.tsx
@@ -1,0 +1,97 @@
+import { useQuery } from '@tanstack/react-query'
+import { useParams } from 'react-router-dom'
+import { z } from 'zod'
+
+import { RepoNotFoundErrorSchema } from 'services/repo'
+import Api from 'shared/api'
+import { NetworkErrorObject } from 'shared/api/helpers'
+
+const TestResultsFlagsSchema = z.object({
+  owner: z
+    .object({
+      repository: z.discriminatedUnion('__typename', [
+        z.object({
+          __typename: z.literal('Repository'),
+          testAnalytics: z
+            .object({
+              flags: z.array(z.string()),
+            })
+            .nullable(),
+        }),
+        RepoNotFoundErrorSchema,
+      ]),
+    })
+    .nullable(),
+})
+
+const query = `
+  query GetTestResultsFlags(
+    $owner: String!
+    $repo: String!
+    $term: String
+  ) {
+    owner(username: $owner) {
+      repository: repository(name: $repo) {
+        __typename
+        ... on Repository {
+            testAnalytics {
+             flags(term: $term)
+          }
+        }
+        ... on NotFoundError {
+          message
+        }
+      }
+    }
+  }
+  `
+
+interface URLParams {
+  provider: string
+  owner: string
+  repo: string
+}
+
+export const useTestResultsFlags = ({ term }: { term?: string }) => {
+  const { provider, owner, repo } = useParams<URLParams>()
+
+  return useQuery({
+    queryKey: ['GetTestResultsFlags', provider, owner, repo, term],
+    queryFn: ({ signal }) =>
+      Api.graphql({
+        provider,
+        query,
+        signal,
+        variables: {
+          provider,
+          owner,
+          repo,
+          term,
+        },
+      }).then((res) => {
+        const parsedData = TestResultsFlagsSchema.safeParse(res?.data)
+
+        if (!parsedData.success) {
+          return Promise.reject({
+            status: 404,
+            data: {},
+            dev: 'useTestResultsFlags - 404 Failed to parse data',
+          } satisfies NetworkErrorObject)
+        }
+
+        const data = parsedData.data
+
+        if (data?.owner?.repository?.__typename === 'NotFoundError') {
+          return Promise.reject({
+            status: 404,
+            data: {},
+            dev: 'useTestResultsFlags - 404 Not found error',
+          } satisfies NetworkErrorObject)
+        }
+
+        return {
+          flags: data?.owner?.repository?.testAnalytics?.flags,
+        }
+      }),
+  })
+}

--- a/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/hooks/useTestResultsTestSuites/useTestResultsTestSuites.test.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/hooks/useTestResultsTestSuites/useTestResultsTestSuites.test.tsx
@@ -1,0 +1,153 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { renderHook, waitFor } from '@testing-library/react'
+import { graphql, HttpResponse } from 'msw'
+import { setupServer } from 'msw/node'
+import { MemoryRouter, Route } from 'react-router-dom'
+import { MockInstance } from 'vitest'
+
+import { useTestResultsTestSuites } from './useTestResultsTestSuites'
+
+const queryClient = new QueryClient({
+  defaultOptions: { queries: { retry: false } },
+})
+
+const wrapper = ({ children }: { children: React.ReactNode }) => (
+  <MemoryRouter initialEntries={['/gh/codecov/gazebo']}>
+    <Route path="/:provider/:owner/:repo">
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    </Route>
+  </MemoryRouter>
+)
+
+const server = setupServer()
+
+beforeAll(() => {
+  server.listen()
+})
+
+afterEach(() => {
+  queryClient.clear()
+  server.resetHandlers()
+})
+
+afterAll(() => {
+  server.close()
+})
+
+const mockNotFoundError = {
+  owner: {
+    repository: {
+      __typename: 'NotFoundError',
+      message: 'repo not found',
+    },
+  },
+}
+
+const mockIncorrectResponse = {
+  owner: {
+    repository: {
+      invalid: 'invalid',
+    },
+  },
+}
+
+const mockResponse = {
+  owner: {
+    repository: {
+      __typename: 'Repository',
+      testAnalytics: {
+        testSuites: ['java', 'script', 'javascript'],
+      },
+    },
+  },
+}
+
+describe('useTestResultsTestSuites', () => {
+  function setup({
+    isNotFoundError = false,
+    isUnsuccessfulParseError = false,
+  }) {
+    server.use(
+      graphql.query('GetTestResultsTestSuites', (info) => {
+        if (isNotFoundError) {
+          return HttpResponse.json({ data: mockNotFoundError })
+        } else if (isUnsuccessfulParseError) {
+          return HttpResponse.json({ data: mockIncorrectResponse })
+        }
+        return HttpResponse.json({ data: mockResponse })
+      })
+    )
+  }
+
+  describe('when called with successful res', () => {
+    it('returns the data', async () => {
+      setup({})
+      const { result } = renderHook(() => useTestResultsTestSuites({}), {
+        wrapper,
+      })
+
+      await waitFor(() => result.current.isLoading)
+      await waitFor(() => !result.current.isLoading)
+
+      await waitFor(() =>
+        expect(result.current.data).toEqual({
+          testSuites: ['java', 'script', 'javascript'],
+        })
+      )
+    })
+  })
+
+  describe('when failed to parse data', () => {
+    let consoleSpy: MockInstance
+    beforeAll(() => {
+      consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    })
+
+    afterAll(() => {
+      consoleSpy.mockRestore()
+    })
+
+    it('returns a failed to parse error', async () => {
+      setup({ isUnsuccessfulParseError: true })
+      const { result } = renderHook(() => useTestResultsTestSuites({}), {
+        wrapper,
+      })
+
+      await waitFor(() =>
+        expect(result.current.error).toEqual(
+          expect.objectContaining({
+            status: 404,
+            dev: 'useTestResultsTestSuites - 404 Failed to parse data',
+          })
+        )
+      )
+    })
+  })
+
+  describe('when data not found', () => {
+    let consoleSpy: MockInstance
+    beforeAll(() => {
+      consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    })
+
+    afterAll(() => {
+      consoleSpy.mockRestore()
+    })
+
+    it('returns a not found error', async () => {
+      setup({ isNotFoundError: true })
+      const { result } = renderHook(() => useTestResultsTestSuites({}), {
+        wrapper,
+      })
+
+      await waitFor(() =>
+        expect(result.current.error).toEqual(
+          expect.objectContaining({
+            status: 404,
+            data: {},
+          })
+        )
+      )
+    })
+  })
+})

--- a/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/hooks/useTestResultsTestSuites/useTestResultsTestSuites.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/hooks/useTestResultsTestSuites/useTestResultsTestSuites.tsx
@@ -1,0 +1,97 @@
+import { useQuery } from '@tanstack/react-query'
+import { useParams } from 'react-router-dom'
+import { z } from 'zod'
+
+import { RepoNotFoundErrorSchema } from 'services/repo'
+import Api from 'shared/api'
+import { NetworkErrorObject } from 'shared/api/helpers'
+
+const TestResultsTestSuitesSchema = z.object({
+  owner: z
+    .object({
+      repository: z.discriminatedUnion('__typename', [
+        z.object({
+          __typename: z.literal('Repository'),
+          testAnalytics: z
+            .object({
+              testSuites: z.array(z.string()),
+            })
+            .nullable(),
+        }),
+        RepoNotFoundErrorSchema,
+      ]),
+    })
+    .nullable(),
+})
+
+const query = `
+  query GetTestResultsTestSuites(
+    $owner: String!
+    $repo: String!
+    $term: String
+  ) {
+    owner(username: $owner) {
+      repository: repository(name: $repo) {
+        __typename
+        ... on Repository {
+            testAnalytics {
+             testSuites(term: $term)
+          }
+        }
+        ... on NotFoundError {
+          message
+        }
+      }
+    }
+  }
+  `
+
+interface URLParams {
+  provider: string
+  owner: string
+  repo: string
+}
+
+export const useTestResultsTestSuites = ({ term }: { term?: string }) => {
+  const { provider, owner, repo } = useParams<URLParams>()
+
+  return useQuery({
+    queryKey: ['GetTestResultsTestSuites', provider, owner, repo, term],
+    queryFn: ({ signal }) =>
+      Api.graphql({
+        provider,
+        query,
+        signal,
+        variables: {
+          provider,
+          owner,
+          repo,
+          term,
+        },
+      }).then((res) => {
+        const parsedData = TestResultsTestSuitesSchema.safeParse(res?.data)
+
+        if (!parsedData.success) {
+          return Promise.reject({
+            status: 404,
+            data: {},
+            dev: 'useTestResultsTestSuites - 404 Failed to parse data',
+          } satisfies NetworkErrorObject)
+        }
+
+        const data = parsedData.data
+
+        if (data?.owner?.repository?.__typename === 'NotFoundError') {
+          return Promise.reject({
+            status: 404,
+            data: {},
+            dev: 'useTestResultsTestSuites - 404 Not found error',
+          } satisfies NetworkErrorObject)
+        }
+
+        return {
+          testSuites: data?.owner?.repository?.testAnalytics?.testSuites,
+        }
+      }),
+  })
+}


### PR DESCRIPTION
# Description

This PR adds two new hooks:

- useTestResultsFlags
- useTestResultsTestSuites


These hooks are meant to drive two of the selectors on the Failed Tests Table Page. They haven't been linked up yet, this PR simply queries the values from API from here: https://github.com/codecov/codecov-api/blob/e14d14dc04de9027b345b0c4b9c1a4dde73044c2/graphql_api/types/test_analytics/test_analytics.graphql#L20-L24

The files are nearly identical, the only difference is one hook is fetching testSuites and the other is fetching Flags. They both have the ability to filter on "term" which is an attribute being passed into the hook

# Screenshots

# Link to Sample Entry

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.