### PR TITLE
feat: Link Flags/Test Suites hooks to Failed Tests Table Selectors

### DIFF
--- a/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/SelectorSection/SelectorSection.test.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/SelectorSection/SelectorSection.test.tsx
@@ -24,6 +24,20 @@ const mockRepoOverview = {
   },
 }
 
+const mockFlags = {
+  __typename: 'Repository',
+  testAnalytics: {
+    flags: ['alpha', 'beta', 'charlie', 'delta'],
+  },
+}
+
+const mockTestSuites = {
+  __typename: 'Repository',
+  testAnalytics: {
+    testSuites: ['java', 'script', 'ok', 'blahbloo'],
+  },
+}
+
 const mockBranch = {
   branch: {
     name: 'main',
@@ -120,6 +134,16 @@ describe('SelectorSection', () => {
         return HttpResponse.json({
           data: { owner: { repository: mockBranches } },
         })
+      }),
+      graphql.query('GetTestResultsFlags', (info) => {
+        return HttpResponse.json({
+          data: { owner: { repository: mockFlags } },
+        })
+      }),
+      graphql.query('GetTestResultsTestSuites', (info) => {
+        return HttpResponse.json({
+          data: { owner: { repository: mockTestSuites } },
+        })
       })
     )
 
@@ -188,12 +212,12 @@ describe('SelectorSection', () => {
       expect(select).toBeInTheDocument()
       await user.click(select)
 
-      const flag1 = await screen.findByText('1')
+      const flag1 = await screen.findByText('alpha')
       expect(flag1).toBeInTheDocument()
       await user.click(flag1)
 
       expect(testLocation?.state).toStrictEqual({
-        flags: [1],
+        flags: ['alpha'],
         historicalTrend: '',
         testSuites: [],
         parameter: '',

--- a/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/SelectorSection/SelectorSection.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/SelectorSection/SelectorSection.tsx
@@ -17,6 +17,8 @@ import Select from 'ui/Select'
 import BranchSelector from './BranchSelector'
 
 import { TestResultsFilterParameterType } from '../hooks/useInfiniteTestResults/useInfiniteTestResults'
+import { useTestResultsFlags } from '../hooks/useTestResultsFlags/useTestResultsFlags'
+import { useTestResultsTestSuites } from '../hooks/useTestResultsTestSuites/useTestResultsTestSuites'
 
 interface URLParams {
   provider: string
@@ -61,15 +63,17 @@ function SelectorSection() {
     // @ts-expect-error need to type out useLocationParams
   }, [params?.flags, params?.testSuites])
 
-  // This is just here for now to appease linter til we link it up
-  console.log(testSuiteSearch, flagSearch)
-
   const { provider, owner, repo, branch } = useParams<URLParams>()
 
   const { data: overview } = useRepoOverview({
     provider,
     owner,
     repo,
+  })
+
+  const { data: flagResults } = useTestResultsFlags({ term: flagSearch })
+  const { data: testSuiteResults } = useTestResultsTestSuites({
+    term: testSuiteSearch,
   })
 
   const decodedBranch = getDecodedBranch(branch)
@@ -83,8 +87,6 @@ function SelectorSection() {
   const defaultTimeValue = MeasurementTimeOptions.find(
     (option) => option.value === MEASUREMENT_INTERVAL.INTERVAL_30_DAY
   )
-
-  const mockTestSuites = ['java', 'script', 'javascript', 'blah']
 
   return (
     <div className="flex flex-1 flex-row justify-between">
@@ -133,7 +135,7 @@ function SelectorSection() {
                   updateParams({ testSuites })
                 }}
                 onSearch={(term: string) => setTestSuiteSearch(term)}
-                items={mockTestSuites}
+                items={testSuiteResults?.testSuites ?? []}
                 renderSelected={(selectedItems: string[]) => (
                   <span className="flex items-center gap-2">
                     <Icon variant="solid" name="folder" />
@@ -164,7 +166,7 @@ function SelectorSection() {
                   updateParams({ flags })
                 }}
                 onSearch={(term: string) => setFlagSearch(term)}
-                items={[1, 2, 3, 4]}
+                items={flagResults?.flags ?? []}
                 renderSelected={(selectedItems: string[]) => (
                   <span className="flex items-center gap-2">
                     <Icon variant="solid" name="flag" />


### PR DESCRIPTION
# Description

This PR links the two hooks created in https://github.com/codecov/gazebo/pull/3419 to the failedTestsTable via the SelectorSection component.

Luckily we've already done most of the heavy lifting with linking the filters to the hook so this PR simply calls the hooks and inputs their items to the multiSelect components, and then sets their current values to the states we already have on the component

Closes https://github.com/codecov/engineering-team/issues/2670 and https://github.com/codecov/engineering-team/issues/2671

# Screenshots

https://github.com/user-attachments/assets/ae16d16c-82c9-426b-8018-3b81e4dfd7f5

# Link to Sample Entry

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.