### PR TITLE
fix: Results array for impacted files is nullable

### DIFF
--- a/src/pages/CommitDetailPage/CommitCoverage/routes/FilesChangedTab/FilesChangedTab.test.tsx
+++ b/src/pages/CommitDetailPage/CommitCoverage/routes/FilesChangedTab/FilesChangedTab.test.tsx
@@ -136,20 +136,4 @@ describe('FilesChangedTab', () => {
       })
     })
   })
-
-  describe('when there is an error rendering the Files Changed Table', () => {
-    it('displays error message', async () => {
-      mocks.filesChangedTable.mockImplementation(() => {
-        throw new Error('this is an expected error')
-      })
-
-      setup({ planValue: TierNames.PRO, isPrivate: false })
-      render(<FilesChangedTab />, { wrapper })
-
-      const errorMessage = await screen.findByTestId(
-        'files-changed-table-error'
-      )
-      expect(errorMessage).toBeInTheDocument()
-    })
-  })
 })

--- a/src/pages/CommitDetailPage/CommitCoverage/routes/FilesChangedTab/FilesChangedTab.tsx
+++ b/src/pages/CommitDetailPage/CommitCoverage/routes/FilesChangedTab/FilesChangedTab.tsx
@@ -1,11 +1,9 @@
-import { ErrorBoundary } from '@sentry/react'
 import { lazy, Suspense } from 'react'
 import { useParams } from 'react-router-dom'
 
 import ToggleHeader from 'pages/CommitDetailPage/Header/ToggleHeader/ToggleHeader'
 import { useRepoSettingsTeam } from 'services/repo'
 import { TierNames, useTier } from 'services/tier'
-import A from 'ui/A'
 import Spinner from 'ui/Spinner'
 
 const FilesChangedTable = lazy(() => import('./FilesChangedTable'))
@@ -38,27 +36,10 @@ function FilesChanged() {
   }
 
   return (
-    <ErrorBoundary
-      fallback={
-        <p className="m-4" data-testid="files-changed-table-error">
-          There was an error fetching the changed files. Please try refreshing
-          the page. If the error persists, please{' '}
-          <A
-            to={{ pageName: 'support' }}
-            hook="contact-support-link"
-            isExternal
-          >
-            contact support
-          </A>
-          {'.'}
-        </p>
-      }
-    >
-      <Suspense fallback={<Loader />}>
-        <ToggleHeader />
-        <FilesChangedTable />
-      </Suspense>
-    </ErrorBoundary>
+    <Suspense fallback={<Loader />}>
+      <ToggleHeader />
+      <FilesChangedTable />
+    </Suspense>
   )
 }
 

--- a/src/pages/CommitDetailPage/CommitCoverage/routes/FilesChangedTab/FilesChangedTable/FilesChangedTable.tsx
+++ b/src/pages/CommitDetailPage/CommitCoverage/routes/FilesChangedTab/FilesChangedTable/FilesChangedTable.tsx
@@ -279,7 +279,7 @@ export default function FilesChangedTable() {
       commit?.compareWithParent?.__typename === 'Comparison' &&
       commit?.compareWithParent?.impactedFiles?.__typename === 'ImpactedFiles'
     ) {
-      return commit?.compareWithParent?.impactedFiles?.results
+      return commit?.compareWithParent?.impactedFiles?.results ?? []
     }
 
     return []

--- a/src/pages/CommitDetailPage/CommitCoverage/routes/FilesChangedTab/FilesChangedTableTeam/FilesChangedTableTeam.tsx
+++ b/src/pages/CommitDetailPage/CommitCoverage/routes/FilesChangedTab/FilesChangedTableTeam/FilesChangedTableTeam.tsx
@@ -170,7 +170,7 @@ export default function FilesChangedTableTeam() {
       commitData?.commit?.compareWithParent?.impactedFiles?.__typename ===
         'ImpactedFiles'
     ) {
-      return commitData?.commit?.compareWithParent?.impactedFiles?.results
+      return commitData?.commit?.compareWithParent?.impactedFiles?.results ?? []
     }
 
     return []

--- a/src/pages/CommitDetailPage/CommitCoverage/routes/IndirectChangesTab/IndirectChangesTable/IndirectChangesTable.tsx
+++ b/src/pages/CommitDetailPage/CommitCoverage/routes/IndirectChangesTab/IndirectChangesTable/IndirectChangesTable.tsx
@@ -177,7 +177,7 @@ export default function FilesChangedTable() {
       commitData?.commit?.compareWithParent?.impactedFiles?.__typename ===
         'ImpactedFiles'
     ) {
-      return commitData?.commit?.compareWithParent?.impactedFiles?.results
+      return commitData?.commit?.compareWithParent?.impactedFiles?.results ?? []
     }
     return []
   }, [commitData?.commit?.compareWithParent])

--- a/src/pages/PullRequestPage/PullCoverage/routes/FilesChangedTab/FilesChanged/FilesChangedTable/FilesChangedTable.tsx
+++ b/src/pages/PullRequestPage/PullCoverage/routes/FilesChangedTab/FilesChanged/FilesChangedTable/FilesChangedTable.tsx
@@ -273,13 +273,13 @@ export default function FilesChangedTable() {
       pullData?.pull?.compareWithBase?.impactedFiles?.__typename ===
         'ImpactedFiles'
     ) {
-      return pullData?.pull?.compareWithBase?.impactedFiles?.results
+      return pullData?.pull?.compareWithBase?.impactedFiles?.results ?? []
     }
     return []
   }, [pullData?.pull?.compareWithBase])
 
   useEffect(() => {
-    if (data.length > 0 && currentlySelectedFile) {
+    if (data && data.length > 0 && currentlySelectedFile) {
       const fileToExpandIndex = data.findIndex(
         (file) => file && file.headName === currentlySelectedFile
       )

--- a/src/pages/PullRequestPage/PullCoverage/routes/FilesChangedTab/FilesChanged/TableTeam/TableTeam.tsx
+++ b/src/pages/PullRequestPage/PullCoverage/routes/FilesChangedTab/FilesChanged/TableTeam/TableTeam.tsx
@@ -185,13 +185,13 @@ export default function FilesChangedTableTeam() {
       pullData?.pull?.compareWithBase?.impactedFiles?.__typename ===
         'ImpactedFiles'
     ) {
-      return pullData?.pull?.compareWithBase?.impactedFiles?.results
+      return pullData?.pull?.compareWithBase?.impactedFiles?.results ?? []
     }
     return []
   }, [pullData?.pull?.compareWithBase])
 
   useEffect(() => {
-    if (data.length > 0 && currentlySelectedFile) {
+    if (data && data.length > 0 && currentlySelectedFile) {
       const fileToExpandIndex = data.findIndex(
         (file) => file && file.headName === currentlySelectedFile
       )

--- a/src/services/commit/useCommit.test.tsx
+++ b/src/services/commit/useCommit.test.tsx
@@ -550,6 +550,7 @@ describe('useCommit', () => {
         expect(result.current.error).toEqual(
           expect.objectContaining({
             status: 404,
+            dev: 'useCommit - 404 not found',
           })
         )
       )
@@ -587,6 +588,7 @@ describe('useCommit', () => {
         expect(result.current.error).toEqual(
           expect.objectContaining({
             status: 403,
+            dev: 'useCommit - 403 owner not activated',
           })
         )
       )
@@ -624,6 +626,7 @@ describe('useCommit', () => {
         expect(result.current.error).toEqual(
           expect.objectContaining({
             status: 404,
+            dev: 'useCommit - 404 failed to parse',
           })
         )
       )

--- a/src/services/commit/useCommit.tsx
+++ b/src/services/commit/useCommit.tsx
@@ -18,6 +18,7 @@ import {
   RepoOwnerNotActivatedErrorSchema,
 } from 'services/repo/schemas'
 import Api from 'shared/api'
+import { NetworkErrorObject } from 'shared/api/helpers'
 import {
   ErrorCodeEnum,
   UploadStateEnum,
@@ -93,7 +94,7 @@ export type ImpactedFileType = z.infer<typeof ImpactedFileSchema>
 
 const ImpactedFileResultsSchema = z.object({
   __typename: z.literal('ImpactedFiles'),
-  results: z.array(ImpactedFileSchema.nullable()),
+  results: z.array(ImpactedFileSchema.nullable()).nullable(),
 })
 
 const ImpactedFileResultsUnionSchema = z.discriminatedUnion('__typename', [
@@ -369,8 +370,9 @@ export function useCommit({
         if (!parsedRes.success) {
           return Promise.reject({
             status: 404,
-            data: null,
-          })
+            data: {},
+            dev: 'useCommit - 404 failed to parse',
+          } satisfies NetworkErrorObject)
         }
 
         const data = parsedRes.data
@@ -379,7 +381,8 @@ export function useCommit({
           return Promise.reject({
             status: 404,
             data: {},
-          })
+            dev: 'useCommit - 404 not found',
+          } satisfies NetworkErrorObject)
         }
 
         if (data?.owner?.repository?.__typename === 'OwnerNotActivatedError') {
@@ -395,7 +398,8 @@ export function useCommit({
                 </p>
               ),
             },
-          })
+            dev: 'useCommit - 403 owner not activated',
+          } satisfies NetworkErrorObject)
         }
 
         const commit = data?.owner?.repository?.commit

--- a/src/services/commit/useCommit.tsx
+++ b/src/services/commit/useCommit.tsx
@@ -45,13 +45,7 @@ const UploadErrorSchema = z.object({
 })
 
 const ErrorsSchema = z.object({
-  edges: z.array(
-    z
-      .object({
-        node: UploadErrorSchema,
-      })
-      .nullable()
-  ),
+  edges: z.array(z.object({ node: UploadErrorSchema }).nullable()),
 })
 
 const UploadSchema = z.object({
@@ -71,13 +65,7 @@ const UploadSchema = z.object({
 })
 
 const UploadsSchema = z.object({
-  edges: z.array(
-    z
-      .object({
-        node: UploadSchema,
-      })
-      .nullable()
-  ),
+  edges: z.array(z.object({ node: UploadSchema }).nullable()),
 })
 
 const ImpactedFileSchema = z

--- a/src/services/commit/useCommitTeam.test.tsx
+++ b/src/services/commit/useCommitTeam.test.tsx
@@ -353,6 +353,7 @@ describe('useCommitTeam', () => {
         expect(result.current.error).toEqual(
           expect.objectContaining({
             status: 404,
+            dev: 'useCommitTeam - 404 not found',
           })
         )
       )
@@ -390,6 +391,7 @@ describe('useCommitTeam', () => {
         expect(result.current.error).toEqual(
           expect.objectContaining({
             status: 403,
+            dev: 'useCommitTeam - 403 owner not activated',
           })
         )
       )
@@ -427,6 +429,7 @@ describe('useCommitTeam', () => {
         expect(result.current.error).toEqual(
           expect.objectContaining({
             status: 404,
+            dev: 'useCommitTeam - 404 failed to parse',
           })
         )
       )

--- a/src/services/commit/useCommitTeam.tsx
+++ b/src/services/commit/useCommitTeam.tsx
@@ -14,6 +14,7 @@ import {
   RepoOwnerNotActivatedErrorSchema,
 } from 'services/repo/schemas'
 import Api from 'shared/api'
+import { NetworkErrorObject } from 'shared/api/helpers'
 import {
   ErrorCodeEnum,
   UploadStateEnum,
@@ -103,7 +104,7 @@ export type ImpactedFile = z.infer<typeof ImpactedFileSchema>
 const ImpactedFilesSchema = z.discriminatedUnion('__typename', [
   z.object({
     __typename: z.literal('ImpactedFiles'),
-    results: z.array(ImpactedFileSchema),
+    results: z.array(ImpactedFileSchema).nullable(),
   }),
   z.object({
     __typename: z.literal('UnknownFlags'),
@@ -318,8 +319,9 @@ export function useCommitTeam({
         if (!parsedRes.success) {
           return Promise.reject({
             status: 404,
-            data: null,
-          })
+            data: {},
+            dev: 'useCommitTeam - 404 failed to parse',
+          } satisfies NetworkErrorObject)
         }
 
         const data = parsedRes.data
@@ -328,7 +330,8 @@ export function useCommitTeam({
           return Promise.reject({
             status: 404,
             data: {},
-          })
+            dev: 'useCommitTeam - 404 not found',
+          } satisfies NetworkErrorObject)
         }
 
         if (data?.owner?.repository?.__typename === 'OwnerNotActivatedError') {
@@ -344,7 +347,8 @@ export function useCommitTeam({
                 </p>
               ),
             },
-          })
+            dev: 'useCommitTeam - 403 owner not activated',
+          } satisfies NetworkErrorObject)
         }
 
         const commit = data?.owner?.repository?.commit

--- a/src/services/commit/useCompareTotals.test.tsx
+++ b/src/services/commit/useCompareTotals.test.tsx
@@ -3,7 +3,6 @@ import { renderHook, waitFor } from '@testing-library/react'
 import { graphql, HttpResponse } from 'msw'
 import { setupServer } from 'msw/node'
 import { type MockInstance } from 'vitest'
-import { ZodError } from 'zod'
 
 import { useCompareTotals } from './useCompareTotals'
 
@@ -198,6 +197,7 @@ describe('useCompareTotals', () => {
           expect(result.current.error).toEqual(
             expect.objectContaining({
               status: 404,
+              dev: 'useCompareTotals - 404 not found',
             })
           )
         )
@@ -233,6 +233,7 @@ describe('useCompareTotals', () => {
           expect(result.current.error).toEqual(
             expect.objectContaining({
               status: 403,
+              dev: 'useCompareTotals - 403 owner not activated',
             })
           )
         )
@@ -268,46 +269,10 @@ describe('useCompareTotals', () => {
           expect(result.current.error).toEqual(
             expect.objectContaining({
               status: 404,
+              dev: 'useCompareTotals - 404 failed to parse',
             })
           )
         )
-      })
-
-      it('declares the error', async () => {
-        setup({ isUnsuccessfulParseError: true })
-        const { result } = renderHook(
-          () =>
-            useCompareTotals({
-              provider: 'gh',
-              owner: 'codecov',
-              repo: 'cool-repo',
-              commitid: '123',
-            }),
-          { wrapper }
-        )
-
-        await waitFor(() => expect(result.current.isError).toBeTruthy())
-        await waitFor(() =>
-          expect(result.current.error).toEqual(
-            expect.objectContaining({
-              data: expect.any(ZodError),
-            })
-          )
-        )
-
-        interface ErrorWithZodData {
-          status: number
-          data: ZodError
-        }
-
-        const zodError = result?.current?.error as ErrorWithZodData
-        expect(zodError.data.errors).toContainEqual({
-          code: 'invalid_type',
-          expected: 'object',
-          message: 'Required',
-          path: ['owner'],
-          received: 'undefined',
-        })
       })
     })
   })

--- a/src/services/commit/useCompareTotals.tsx
+++ b/src/services/commit/useCompareTotals.tsx
@@ -18,7 +18,7 @@ import { type NetworkErrorObject } from 'shared/api/helpers'
 import A from 'ui/A'
 
 const CoverageObjSchema = z.object({
-  percentCovered: z.number().nullable(),
+  coverage: z.number().nullable(),
 })
 
 const ImpactedFileSchema = z

--- a/src/services/commit/useCompareTotals.tsx
+++ b/src/services/commit/useCompareTotals.tsx
@@ -14,6 +14,7 @@ import {
   RepoOwnerNotActivatedErrorSchema,
 } from 'services/repo/schemas'
 import Api from 'shared/api'
+import { type NetworkErrorObject } from 'shared/api/helpers'
 import A from 'ui/A'
 
 const CoverageObjSchema = z.object({
@@ -32,7 +33,7 @@ const ImpactedFileSchema = z
 const ImpactedFilesSchema = z.discriminatedUnion('__typename', [
   z.object({
     __typename: z.literal('ImpactedFiles'),
-    results: z.array(ImpactedFileSchema),
+    results: z.array(ImpactedFileSchema).nullable(),
   }),
   z.object({
     __typename: z.literal('UnknownFlags'),
@@ -43,10 +44,10 @@ const ImpactedFilesSchema = z.discriminatedUnion('__typename', [
 const ComparisonSchema = z.object({
   __typename: z.literal('Comparison'),
   state: z.string(),
+  indirectChangedFilesCount: z.number(),
+  directChangedFilesCount: z.number(),
   patchTotals: CoverageObjSchema.nullable(),
   impactedFiles: ImpactedFilesSchema,
-  directChangedFilesCount: z.number(),
-  indirectChangedFilesCount: z.number(),
 })
 
 const CompareWithParentSchema = z
@@ -199,8 +200,9 @@ export function useCompareTotals({
         if (!parsedRes.success) {
           return Promise.reject({
             status: 404,
-            data: parsedRes.error,
-          })
+            data: {},
+            dev: 'useCompareTotals - 404 failed to parse',
+          } satisfies NetworkErrorObject)
         }
 
         const data = parsedRes.data
@@ -209,7 +211,8 @@ export function useCompareTotals({
           return Promise.reject({
             status: 404,
             data: {},
-          })
+            dev: 'useCompareTotals - 404 not found',
+          } satisfies NetworkErrorObject)
         }
 
         if (data?.owner?.repository?.__typename === 'OwnerNotActivatedError') {
@@ -225,7 +228,8 @@ export function useCompareTotals({
                 </p>
               ),
             },
-          })
+            dev: 'useCompareTotals - 403 owner not activated',
+          } satisfies NetworkErrorObject)
         }
 
         return data

--- a/src/services/commit/useCompareTotalsTeam.test.tsx
+++ b/src/services/commit/useCompareTotalsTeam.test.tsx
@@ -200,7 +200,10 @@ describe('useCompareTotalsTeam', () => {
       await waitFor(() => expect(result.current.isError).toBeTruthy())
       await waitFor(() =>
         expect(result.current.error).toEqual(
-          expect.objectContaining({ status: 404 })
+          expect.objectContaining({
+            status: 404,
+            dev: 'useCompareTotalsTeam - 404 not found',
+          })
         )
       )
     })
@@ -233,7 +236,10 @@ describe('useCompareTotalsTeam', () => {
       await waitFor(() => expect(result.current.isError).toBeTruthy())
       await waitFor(() =>
         expect(result.current.error).toEqual(
-          expect.objectContaining({ status: 403 })
+          expect.objectContaining({
+            status: 403,
+            dev: 'useCompareTotalsTeam - 403 owner not activated',
+          })
         )
       )
     })
@@ -266,7 +272,10 @@ describe('useCompareTotalsTeam', () => {
       await waitFor(() => expect(result.current.isError).toBeTruthy())
       await waitFor(() =>
         expect(result.current.error).toEqual(
-          expect.objectContaining({ status: 404 })
+          expect.objectContaining({
+            status: 404,
+            dev: 'useCompareTotalsTeam - 404 failed to parse',
+          })
         )
       )
     })

--- a/src/services/commit/useCompareTotalsTeam.tsx
+++ b/src/services/commit/useCompareTotalsTeam.tsx
@@ -14,6 +14,7 @@ import {
   RepoOwnerNotActivatedErrorSchema,
 } from 'services/repo/schemas'
 import Api from 'shared/api'
+import { NetworkErrorObject } from 'shared/api/helpers'
 import A from 'ui/A'
 
 const CoverageObjSchema = z.object({
@@ -30,7 +31,7 @@ const ImpactedFileSchema = z
 const ImpactedFilesSchema = z.discriminatedUnion('__typename', [
   z.object({
     __typename: z.literal('ImpactedFiles'),
-    results: z.array(ImpactedFileSchema),
+    results: z.array(ImpactedFileSchema).nullable(),
   }),
   z.object({
     __typename: z.literal('UnknownFlags'),
@@ -187,8 +188,9 @@ export function useCompareTotalsTeam({
         if (!parsedRes.success) {
           return Promise.reject({
             status: 404,
-            data: null,
-          })
+            data: {},
+            dev: 'useCompareTotalsTeam - 404 failed to parse',
+          } satisfies NetworkErrorObject)
         }
 
         const data = parsedRes.data
@@ -197,7 +199,8 @@ export function useCompareTotalsTeam({
           return Promise.reject({
             status: 404,
             data: {},
-          })
+            dev: 'useCompareTotalsTeam - 404 not found',
+          } satisfies NetworkErrorObject)
         }
 
         if (data?.owner?.repository?.__typename === 'OwnerNotActivatedError') {
@@ -213,7 +216,8 @@ export function useCompareTotalsTeam({
                 </p>
               ),
             },
-          })
+            dev: 'useCompareTotalsTeam - 403 owner not activated',
+          } satisfies NetworkErrorObject)
         }
 
         return data?.owner?.repository?.commit ?? null

--- a/src/services/pull/usePull.test.tsx
+++ b/src/services/pull/usePull.test.tsx
@@ -263,7 +263,10 @@ describe('usePull', () => {
 
         await waitFor(() =>
           expect(result.current.error).toEqual(
-            expect.objectContaining({ status: 403 })
+            expect.objectContaining({
+              status: 403,
+              dev: 'usePull - 403 owner not activated',
+            })
           )
         )
       })
@@ -300,7 +303,10 @@ describe('usePull', () => {
 
         await waitFor(() =>
           expect(result.current.error).toEqual(
-            expect.objectContaining({ status: 404, data: {} })
+            expect.objectContaining({
+              status: 404,
+              dev: 'usePull - 404 not found',
+            })
           )
         )
       })
@@ -389,7 +395,10 @@ describe('usePull', () => {
 
         await waitFor(() =>
           expect(result.current.error).toEqual(
-            expect.objectContaining({ status: 404, data: {} })
+            expect.objectContaining({
+              status: 404,
+              dev: 'usePull - 404 failed to parse',
+            })
           )
         )
       })

--- a/src/services/pull/usePull.tsx
+++ b/src/services/pull/usePull.tsx
@@ -14,6 +14,7 @@ import {
   RepoOwnerNotActivatedErrorSchema,
 } from 'services/repo/schemas'
 import Api from 'shared/api'
+import { type NetworkErrorObject } from 'shared/api/helpers'
 import { UploadTypeEnum } from 'shared/utils/commit'
 import { userHasAccess } from 'shared/utils/user'
 import A from 'ui/A'
@@ -60,7 +61,7 @@ export type ImpactedFile = z.infer<typeof ImpactedFileSchema>
 const ImpactedFilesSchema = z.discriminatedUnion('__typename', [
   z.object({
     __typename: z.literal('ImpactedFiles'),
-    results: z.array(ImpactedFileSchema),
+    results: z.array(ImpactedFileSchema).nullable(),
   }),
   z.object({
     __typename: z.literal('UnknownFlags'),
@@ -329,7 +330,8 @@ export function usePull({
           return Promise.reject({
             status: 404,
             data: {},
-          })
+            dev: 'usePull - 404 failed to parse',
+          } satisfies NetworkErrorObject)
         }
 
         const data = parsedRes.data
@@ -338,7 +340,8 @@ export function usePull({
           return Promise.reject({
             status: 404,
             data: {},
-          })
+            dev: 'usePull - 404 not found',
+          } satisfies NetworkErrorObject)
         }
 
         if (data?.owner?.repository?.__typename === 'OwnerNotActivatedError') {
@@ -354,7 +357,8 @@ export function usePull({
                 </p>
               ),
             },
-          })
+            dev: 'usePull - 403 owner not activated',
+          } satisfies NetworkErrorObject)
         }
 
         const pull = data?.owner?.repository?.pull

--- a/src/services/pull/usePullCompareTotalsTeam.test.tsx
+++ b/src/services/pull/usePullCompareTotalsTeam.test.tsx
@@ -206,7 +206,10 @@ describe('usePullCompareTotalsTeam', () => {
       await waitFor(() => expect(result.current.isError).toBeTruthy())
       await waitFor(() =>
         expect(result.current.error).toEqual(
-          expect.objectContaining({ status: 404 })
+          expect.objectContaining({
+            status: 404,
+            dev: 'usePullCompareTotalsTeam - 404 not found',
+          })
         )
       )
     })
@@ -238,7 +241,10 @@ describe('usePullCompareTotalsTeam', () => {
       await waitFor(() => expect(result.current.isError).toBeTruthy())
       await waitFor(() =>
         expect(result.current.error).toEqual(
-          expect.objectContaining({ status: 403 })
+          expect.objectContaining({
+            status: 403,
+            dev: 'usePullCompareTotalsTeam - 403 owner not activated',
+          })
         )
       )
     })
@@ -270,7 +276,10 @@ describe('usePullCompareTotalsTeam', () => {
       await waitFor(() => expect(result.current.isError).toBeTruthy())
       await waitFor(() =>
         expect(result.current.error).toEqual(
-          expect.objectContaining({ status: 404 })
+          expect.objectContaining({
+            status: 404,
+            dev: 'usePullCompareTotalsTeam - 404 failed to parse',
+          })
         )
       )
     })

--- a/src/services/pull/usePullTeam.test.tsx
+++ b/src/services/pull/usePullTeam.test.tsx
@@ -257,6 +257,7 @@ describe('usePullTeam', () => {
         expect(result.current.error).toEqual(
           expect.objectContaining({
             status: 404,
+            dev: 'usePullTeam - 404 not found',
           })
         )
       )
@@ -293,6 +294,7 @@ describe('usePullTeam', () => {
         expect(result.current.error).toEqual(
           expect.objectContaining({
             status: 403,
+            dev: 'usePullTeam - 403 owner not activated',
           })
         )
       )
@@ -329,6 +331,7 @@ describe('usePullTeam', () => {
         expect(result.current.error).toEqual(
           expect.objectContaining({
             status: 404,
+            dev: 'usePullTeam - 404 failed to parse',
           })
         )
       )

--- a/src/services/pull/usePullTeam.tsx
+++ b/src/services/pull/usePullTeam.tsx
@@ -14,6 +14,7 @@ import {
   RepoOwnerNotActivatedErrorSchema,
 } from 'services/repo/schemas'
 import Api from 'shared/api'
+import { NetworkErrorObject } from 'shared/api/helpers'
 import A from 'ui/A'
 
 import { usePullCompareTotalsTeam } from './usePullCompareTotalsTeam'
@@ -54,7 +55,7 @@ export type ImpactedFile = z.infer<typeof ImpactedFileSchema>
 const ImpactedFilesSchema = z.discriminatedUnion('__typename', [
   z.object({
     __typename: z.literal('ImpactedFiles'),
-    results: z.array(ImpactedFileSchema),
+    results: z.array(ImpactedFileSchema).nullable(),
   }),
   z.object({
     __typename: z.literal('UnknownFlags'),
@@ -211,8 +212,9 @@ export function usePullTeam({
         if (!parsedRes.success) {
           return Promise.reject({
             status: 404,
-            data: null,
-          })
+            data: {},
+            dev: 'usePullTeam - 404 failed to parse',
+          } satisfies NetworkErrorObject)
         }
 
         const data = parsedRes.data
@@ -221,7 +223,8 @@ export function usePullTeam({
           return Promise.reject({
             status: 404,
             data: {},
-          })
+            dev: 'usePullTeam - 404 not found',
+          } satisfies NetworkErrorObject)
         }
 
         if (data?.owner?.repository?.__typename === 'OwnerNotActivatedError') {
@@ -237,7 +240,8 @@ export function usePullTeam({
                 </p>
               ),
             },
-          })
+            dev: 'usePullTeam - 403 owner not activated',
+          } satisfies NetworkErrorObject)
         }
 
         const pull = data?.owner?.repository?.pull


### PR DESCRIPTION
# Description

This PR fixes some zod schema issues where a field was being marked as non-nullable, however it is in fact nullable. This was most likely the root cause for: #3371. I've gone through and updated all instances of this `results` field to be nullable, and all the places where it's used. This should resolve the issue raised in #3371, so i've gone ahead and removed that error boundary so we start collecting these network errors up in the `NetworkErrorBoundary` again.

# Notable Changes

- Update zod schemas in hooks calling `impactedFiles.results` from the API to be nullable
- Update code using this field to handle if it is `null`
- Update `CoverageObjSchema` in `useCompareTotals` to be `coverage` not `percentCovered`
- Remove error boundary from `FilesChangedTab`