### PR TITLE
chore: Remove old single file renderer

### DIFF
--- a/src/shared/RawFileViewer/RawFileViewer.test.tsx
+++ b/src/shared/RawFileViewer/RawFileViewer.test.tsx
@@ -7,7 +7,6 @@ import { MemoryRouter, Route } from 'react-router-dom'
 import RawFileViewer from './RawFileViewer'
 
 const mocks = vi.hoisted(() => ({
-  useFlags: vi.fn(),
   useScrollToLine: vi.fn(),
   captureMessage: vi.fn(),
 }))
@@ -18,14 +17,6 @@ vi.mock('@sentry/react', async () => {
     ...originalModule,
     withProfiler: (component: any) => component,
     captureMessage: mocks.captureMessage,
-  }
-})
-
-vi.mock('shared/featureFlags', async () => {
-  const originalModule = await vi.importActual('shared/featureFlags')
-  return {
-    ...originalModule,
-    useFlags: mocks.useFlags,
   }
 })
 
@@ -134,8 +125,6 @@ interface SetupArgs {
 
 describe('RawFileViewer', () => {
   function setup({ content, owner, coverage, isCriticalFile }: SetupArgs) {
-    mocks.useFlags.mockReturnValue({ virtualFileRenderer: true })
-
     mocks.useScrollToLine.mockImplementation(() => ({
       lineRef: () => {},
       handleClick: vi.fn(),

--- a/src/shared/RawFileViewer/RawFileViewer.tsx
+++ b/src/shared/RawFileViewer/RawFileViewer.tsx
@@ -7,15 +7,11 @@ import { useLocation, useParams } from 'react-router-dom'
 import NotFound from 'pages/NotFound'
 import { useCommitBasedCoverageForFileViewer } from 'services/file'
 import { useOwner } from 'services/user'
-import { useFlags } from 'shared/featureFlags'
-import { CODE_RENDERER_TYPE } from 'shared/utils/fileviewer'
 import { unsupportedExtensionsMapper } from 'shared/utils/unsupportedExtensionsMapper'
 import { getFilenameFromFilePath } from 'shared/utils/url'
 import A from 'ui/A'
-import CodeRenderer from 'ui/CodeRenderer'
 import CodeRendererProgressHeader from 'ui/CodeRenderer/CodeRendererProgressHeader'
 import CriticalFileLabel from 'ui/CodeRenderer/CriticalFileLabel'
-import SingleLine from 'ui/CodeRenderer/SingleLine'
 import ToggleHeader from 'ui/FileViewer/ToggleHeader'
 import Title from 'ui/FileViewer/ToggleHeader/Title'
 import { VirtualFileRenderer } from 'ui/VirtualRenderers'
@@ -86,10 +82,6 @@ function CodeRendererContent({
   coverageData,
   stickyPadding,
 }: CodeRendererContentProps) {
-  const { virtualFileRenderer } = useFlags({
-    virtualFileRenderer: false,
-  })
-
   if (isUnsupportedFileType) {
     return (
       <div className="border border-solid border-ds-gray-tertiary p-2">
@@ -99,32 +91,11 @@ function CodeRendererContent({
   }
 
   if (content) {
-    if (virtualFileRenderer) {
-      return (
-        <VirtualFileRenderer
-          code={content}
-          coverage={coverageData}
-          fileName={getFilenameFromFilePath(path)}
-        />
-      )
-    }
-
     return (
-      <CodeRenderer
+      <VirtualFileRenderer
         code={content}
+        coverage={coverageData}
         fileName={getFilenameFromFilePath(path)}
-        rendererType={CODE_RENDERER_TYPE.SINGLE_LINE}
-        LineComponent={({ i, line, getLineProps, getTokenProps }) => (
-          <SingleLine
-            key={i}
-            line={line}
-            number={i + 1}
-            getLineProps={getLineProps}
-            getTokenProps={getTokenProps}
-            coverage={coverageData && coverageData[i + 1]}
-            stickyPadding={stickyPadding}
-          />
-        )}
       />
     )
   }


### PR DESCRIPTION
# Description

This PR removes the old code renderer, in favour of the new virtual file renderer. This PR also includes some feature flag cleanup, and adding mocks to tests.