### PR TITLE
feat: Change errored uploads and uploads list text

### DIFF
--- a/src/pages/CommitDetailPage/CommitCoverage/CommitCoverage.test.jsx
+++ b/src/pages/CommitDetailPage/CommitCoverage/CommitCoverage.test.jsx
@@ -675,7 +675,7 @@ describe('CommitCoverage', () => {
       render(<CommitCoverage />, { wrapper: wrapper({ queryClient }) })
 
       const erroredUploads = await screen.findByText(
-        /The following uploads failed to process:/
+        /No coverage data is available due to incomplete uploads on the first attempt./
       )
       expect(erroredUploads).toBeInTheDocument()
     })

--- a/src/pages/CommitDetailPage/CommitCoverage/ErroredUploads/ErroredUploads.jsx
+++ b/src/pages/CommitDetailPage/CommitCoverage/ErroredUploads/ErroredUploads.jsx
@@ -1,37 +1,23 @@
 import isEmpty from 'lodash/isEmpty'
 import PropTypes from 'prop-types'
 
-import A from 'ui/A'
-
 function ErroredUploads({ erroredUploads }) {
   return (
     !isEmpty(erroredUploads) && (
-      <>
-        <p>The following uploads failed to process:</p>
-        {Object.entries(erroredUploads)?.map(([provider, uploads]) => {
-          return (
-            <div key={provider}>
-              <p className="font-semibold capitalize">{provider}</p>
-              {uploads?.map(({ buildCode, ciUrl, createdAt }) => {
-                return (
-                  <div key={`${buildCode}-${createdAt}`} className="flex gap-1">
-                    <p>{buildCode}</p>
-                    {ciUrl && (
-                      <A href={ciUrl} hook="ci job" isExternal={true}>
-                        view CI build
-                      </A>
-                    )}
-                  </div>
-                )
-              })}
-            </div>
-          )
-        })}
-        <p>
-          We recommend checking the Codecov step of this commit&apos;s CI Run to
-          make sure it uploaded properly and, if needed, run your CI again.
+      <div className="mt-4">
+        <p className="font-semibold">
+          No coverage data is available due to incomplete uploads on the first
+          attempt.
         </p>
-      </>
+        <p className="mb-5">
+          To receive coverage data, ensure your coverage data is accurate and
+          then open a new commit.
+        </p>
+        <p>
+          Note: this page will not reflect the latest results, if you re-run all
+          jobs successfully or merge this commit.
+        </p>
+      </div>
     )
   )
 }

--- a/src/pages/CommitDetailPage/CommitCoverage/ErroredUploads/ErroredUploads.jsx
+++ b/src/pages/CommitDetailPage/CommitCoverage/ErroredUploads/ErroredUploads.jsx
@@ -14,8 +14,8 @@ function ErroredUploads({ erroredUploads }) {
           then open a new commit.
         </p>
         <p>
-          Note: this page will not reflect the latest results, if you re-run all
-          jobs successfully or merge this commit.
+          Note: this page will not reflect the latest results, even if you have
+          re-run all jobs successfully or have merged this commit.
         </p>
       </div>
     )

--- a/src/pages/CommitDetailPage/CommitCoverage/ErroredUploads/ErroredUploads.test.jsx
+++ b/src/pages/CommitDetailPage/CommitCoverage/ErroredUploads/ErroredUploads.test.jsx
@@ -37,35 +37,17 @@ describe('ErroredUploads', () => {
       render(<ErroredUploads erroredUploads={mockErroredUploads} />)
 
       const message = screen.getByText(
-        /The following uploads failed to process:/
+        /No coverage data is available due to incomplete uploads on the first attempt./
       )
       expect(message).toBeInTheDocument()
-    })
-
-    it('all providers involved', () => {
-      render(<ErroredUploads erroredUploads={mockErroredUploads} />)
-
-      const circle = screen.getByText(/circleCI/)
-      expect(circle).toBeInTheDocument()
-
-      const ghActions = screen.getByText(/github actions/)
-      expect(ghActions).toBeInTheDocument()
-    })
-
-    it('build code', () => {
-      render(<ErroredUploads erroredUploads={mockErroredUploads} />)
-
-      const buildCode1 = screen.getByText(82364)
-      expect(buildCode1).toBeInTheDocument()
-
-      const buildCode2 = screen.getByText(20374)
-      expect(buildCode2).toBeInTheDocument()
     })
 
     it('recommendation text', () => {
       render(<ErroredUploads erroredUploads={mockErroredUploads} />)
 
-      const recommendationText = screen.getByText(/We recommend checking/)
+      const recommendationText = screen.getByText(
+        /To receive coverage data, ensure your coverage data is accurate and then open a new commit./
+      )
       expect(recommendationText).toBeInTheDocument()
     })
   })
@@ -75,7 +57,7 @@ describe('ErroredUploads', () => {
       render(<ErroredUploads erroredUploads={{}} />)
 
       const message = screen.queryByText(
-        /The following uploads failed to process:/
+        /No coverage data is available due to incomplete uploads on the first attempt./
       )
       expect(message).not.toBeInTheDocument()
     })

--- a/src/pages/CommitDetailPage/CommitCoverage/UploadsCard/UploadsCard.test.tsx
+++ b/src/pages/CommitDetailPage/CommitCoverage/UploadsCard/UploadsCard.test.tsx
@@ -182,8 +182,8 @@ describe('UploadsCard', () => {
     it('renders the title', () => {
       render(<UploadsCard />, { wrapper })
 
-      const uploads = screen.getByText(/Uploads/)
-      expect(uploads).toBeInTheDocument()
+      const covReportHistory = screen.getByText(/Coverage reports history/)
+      expect(covReportHistory).toBeInTheDocument()
     })
     it('renders different cis', () => {
       render(<UploadsCard />, { wrapper })
@@ -237,7 +237,7 @@ describe('UploadsCard', () => {
     it('renders the title', () => {
       render(<UploadsCard />, { wrapper })
 
-      const uploads = screen.getByText(/Uploads/)
+      const uploads = screen.getByText(/Coverage reports history/)
       expect(uploads).toBeInTheDocument()
     })
     it('renders different cis', () => {
@@ -264,7 +264,7 @@ describe('UploadsCard', () => {
     it('renders the title', () => {
       render(<UploadsCard />, { wrapper })
 
-      const uploads = screen.getByText(/Uploads/)
+      const uploads = screen.getByText(/Coverage reports history/)
       expect(uploads).toBeInTheDocument()
     })
   })

--- a/src/pages/CommitDetailPage/CommitCoverage/UploadsCard/UploadsCard.tsx
+++ b/src/pages/CommitDetailPage/CommitCoverage/UploadsCard/UploadsCard.tsx
@@ -44,7 +44,7 @@ function UploadsCard() {
       <Card className="overflow-x-hidden">
         <Card.Header className="p-4">
           <div className="flex justify-between">
-            <Card.Title size="base">Uploads</Card.Title>
+            <Card.Title size="base">Coverage reports history</Card.Title>
             {/* @ts-expect-error */}
             <A onClick={() => setShowYAMLModal(true)} hook="open yaml modal">
               <span className="text-xs">view YAML file</span>

--- a/src/pages/CommitDetailPage/Dropdowns/CommitCoverageDropdown.tsx
+++ b/src/pages/CommitDetailPage/Dropdowns/CommitCoverageDropdown.tsx
@@ -21,7 +21,7 @@ const CoverageMessage: React.FC = () => {
   const comparison = data?.commit?.compareWithParent
   const uploadErrorCount = data?.uploadErrorCount
 
-  if (uploadErrorCount && uploadErrorCount > 0) {
+  if (!!uploadErrorCount) {
     if (uploadErrorCount === 1) {
       return (
         <>{uploadErrorCount} upload has failed to process &#x26A0;&#xFE0F;</>


### PR DESCRIPTION
# Description

Closes https://github.com/codecov/engineering-team/issues/2521

Figma: https://www.figma.com/design/4Z7yb2dkIIATkfzpWoMYQq/GH-2220?node-id=1-2

We're addressing point 4 and 5 of the Figma file

# Code Example

# Notable Changes
Removing old, unhelpful messaging and replacing with this new one. Anytime a commit has an upload error currently, the UI will be forever stuck show our existing messaging
<img width="1621" alt="Screenshot 2024-10-22 at 1 11 47 AM" src="https://github.com/user-attachments/assets/bdea5887-85b2-4631-8c8c-e3aa9de41067">


# Screenshots
<img width="1721" alt="Screenshot 2024-10-23 at 10 59 02 AM" src="https://github.com/user-attachments/assets/722edba5-64d9-4c56-88ed-94e9eb9bd1dd">
