### PR TITLE
rev: Revert ignoring failing to import module in Sentry

### DIFF
--- a/src/sentry.ts
+++ b/src/sentry.ts
@@ -19,7 +19,8 @@ const customIgnoredErrors = [
    * well when this error is triggered we automatically refresh the users
    * window to load in the new data (which is triggered by this error).
    */
-  'Failed to fetch dynamically imported module',
+  // Removing this for the time being, to see if we can resolve it fully
+  // 'Failed to fetch dynamically imported module',
 ]
 
 // common ignore errors / URLs to de-clutter Sentry


### PR DESCRIPTION
# Description

I had originally ignored this error to silence some issues in Sentry, however myself and my mentor want to take a bit of a deeper dive into this, and see if there is something else afoot causing this.