### PR TITLE
Adjust api_url to be ingest.codecov.io

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -288,7 +288,7 @@ jobs:
         run: |
           yarn build
         env:
-          CODECOV_API_URL: ${{ secrets.CODECOV_API_URL }}
+          CODECOV_API_URL: https://ingest.codecov.io
           CODECOV_ORG_TOKEN: ${{ secrets.CODECOV_ORG_TOKEN }}
           CODECOV_BUNDLE_NAME: 'gazebo-production'
           UPLOAD_CODECOV_BUNDLE_STATS: true


### PR DESCRIPTION
# Description
We're testing bundle analysis traffic through shelter. We can do so by changing the traffic to go directly to ingest.codecov.io, which is where shelter is hosted.

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.