### PR TITLE
feat: Update Jest TA onboarding copy to include filepath setting

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -223,6 +223,9 @@ describe('App', () => {
       }),
       graphql.query('GetRepoOverview', (info) => {
         return HttpResponse.json({ data: mockRepoOverview })
+      }),
+      graphql.query('GetUploadTokenRequired', (info) => {
+        return HttpResponse.json({ data: {} })
       })
     )
   }

--- a/src/pages/RepoPage/FailedTestsTab/FrameworkTabsCard/FrameworkTabs/FrameworkTabs.test.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/FrameworkTabsCard/FrameworkTabs/FrameworkTabs.test.tsx
@@ -44,7 +44,7 @@ describe('FrameworkTabs', () => {
 
     expect(jestButton).toHaveClass('border-b-2 border-ds-gray-octonary')
 
-    const codeSnippet = screen.getByText(/npm i --save-dev jest-junit/)
+    const codeSnippet = await screen.findByTestId('jest-framework-copy')
     expect(codeSnippet).toBeInTheDocument()
   })
 

--- a/src/pages/RepoPage/FailedTestsTab/FrameworkTabsCard/FrameworkTabs/FrameworkTabs.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/FrameworkTabsCard/FrameworkTabs/FrameworkTabs.tsx
@@ -16,8 +16,24 @@ const FrameworkCopy = {
   [Frameworks.PYTEST]:
     'pytest --cov --junitxml=junit.xml -o junit_family=legacy',
   [Frameworks.VITEST]: 'vitest --reporter=junit',
+  [Frameworks.JEST]: (
+    <p data-testid="jest-framework-copy">
+      npm i --save-dev jest-junit <br />
+      JEST_JUNIT_CLASSNAME=
+      <span className="text-codecov-code">{'"{filepath}"'}</span> jest
+      --reporters=jest-junit
+    </p>
+  ),
+  [Frameworks.PHP_UNIT]: './vendor/bin/phpunit --log-junit junit.xml',
+} as const
+
+const FrameworkClipboard = {
+  [Frameworks.PYTEST]:
+    'pytest --cov --junitxml=junit.xml -o junit_family=legacy',
+  [Frameworks.VITEST]: 'vitest --reporter=junit',
   [Frameworks.JEST]:
-    'npm i --save-dev jest-junit \njest --reporters=jest-junit',
+    'npm i --save-dev jest-junit \n JEST_JUNIT_CLASSNAME="{filepath}" jest --reporters=jest-junit',
+
   [Frameworks.PHP_UNIT]: './vendor/bin/phpunit --log-junit junit.xml',
 } as const
 
@@ -42,7 +58,7 @@ export function FrameworkTabs() {
           </button>
         ))}
       </div>
-      <CodeSnippet clipboard={FrameworkCopy[selectedFramework]}>
+      <CodeSnippet clipboard={FrameworkClipboard[selectedFramework]}>
         {FrameworkCopy[selectedFramework]}
       </CodeSnippet>
     </div>

--- a/src/pages/RepoPage/FailedTestsTab/FrameworkTabsCard/FrameworkTabs/FrameworkTabs.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/FrameworkTabsCard/FrameworkTabs/FrameworkTabs.tsx
@@ -28,13 +28,9 @@ const FrameworkCopy = {
 } as const
 
 const FrameworkClipboard = {
-  [Frameworks.PYTEST]:
-    'pytest --cov --junitxml=junit.xml -o junit_family=legacy',
-  [Frameworks.VITEST]: 'vitest --reporter=junit',
+  ...FrameworkCopy,
   [Frameworks.JEST]:
     'npm i --save-dev jest-junit \n JEST_JUNIT_CLASSNAME="{filepath}" jest --reporters=jest-junit',
-
-  [Frameworks.PHP_UNIT]: './vendor/bin/phpunit --log-junit junit.xml',
 } as const
 
 export function FrameworkTabs() {


### PR DESCRIPTION
# Description

This PR ships a copy update to the TA onboarding page around adding a new setting specific for Jest TA setups. We now need to include this new env variable when running jest so we can capture the file path and output it correctly

Needed to basically "copy paste" all the clipboard values into a separate value since the copy may be a JSX element now, and when copying a JSX element you get [Object object] which is not what we want. Thanks @spalmurray-codecov for pointing that out!

Closes https://github.com/codecov/engineering-team/issues/2605

# Screenshots

<img width="763" alt="Screenshot 2024-10-23 at 12 44 46 PM" src="https://github.com/user-attachments/assets/c9191d3b-56fe-40cc-a3e6-2c01eeac971f">

# Link to Sample Entry

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.