### PR TITLE
chore: Collect addtl info on useCommit error

### DIFF
--- a/src/services/commit/useCommit.tsx
+++ b/src/services/commit/useCommit.tsx
@@ -360,6 +360,7 @@ export function useCommit({
             status: 404,
             data: {},
             dev: 'useCommit - 404 failed to parse',
+            error: parsedRes.error,
           } satisfies NetworkErrorObject)
         }
 


### PR DESCRIPTION
Following the pattern here - https://github.com/codecov/gazebo/pull/3423 -  to send errors to Sentry for this query