### PR TITLE
feat: Rework how we capture service errors to sentry

### DIFF
--- a/src/layouts/shared/NetworkErrorBoundary/NetworkErrorBoundary.jsx
+++ b/src/layouts/shared/NetworkErrorBoundary/NetworkErrorBoundary.jsx
@@ -1,4 +1,3 @@
-import * as Sentry from '@sentry/react'
 import { useQueryClient } from '@tanstack/react-query'
 import cs from 'classnames'
 import PropTypes from 'prop-types'
@@ -171,21 +170,6 @@ class NetworkErrorBoundary extends Component {
     // if the error is not a network error, we don't do anything and
     // another error boundary will take it from there
     if (Object.keys(errorToUI).includes(String(error.status))) {
-      // only capture network errors if they are not a rate limit error
-      // this will typically only be schema parsing errors
-      if (error.status !== 429 && error.dev && error.error) {
-        Sentry.captureMessage('Network Error', {
-          // group all network errors together based off of their dev message
-          fingerprint: error.dev,
-          // add a breadcrumb for with the message and error
-          addBreadcrumb: {
-            category: 'network-error',
-            message: error.dev,
-            level: 'error',
-            data: error.error,
-          },
-        })
-      }
       return { hasNetworkError: true, error }
     }
 

--- a/src/layouts/shared/NetworkErrorBoundary/NetworkErrorBoundary.test.jsx
+++ b/src/layouts/shared/NetworkErrorBoundary/NetworkErrorBoundary.test.jsx
@@ -13,18 +13,6 @@ import NetworkErrorBoundary from './NetworkErrorBoundary'
 vi.spyOn(console, 'error').mockImplementation(() => undefined)
 vi.mock('config')
 
-const mocks = vi.hoisted(() => ({
-  captureMessage: vi.fn(),
-}))
-
-vi.mock('@sentry/react', async () => {
-  const actual = await vi.importActual('@sentry/react')
-  return {
-    ...actual,
-    captureMessage: mocks.captureMessage,
-  }
-})
-
 const queryClient = new QueryClient({
   defaultOptions: { queries: { retry: false } },
 })
@@ -194,34 +182,6 @@ describe('NetworkErrorBoundary', () => {
       const returnButton = await screen.findByText('Return to previous page')
       expect(returnButton).toBeInTheDocument()
     })
-
-    it('calls captureMessage with the error when dev and error are provided', async () => {
-      const { user } = setup()
-      render(
-        <App
-          status={401}
-          detail="not authenticated"
-          error="cool error"
-          dev="401 - cool error"
-        />,
-        { wrapper: wrapper() }
-      )
-
-      const textBox = await screen.findByRole('textbox')
-      await user.type(textBox, 'fail')
-
-      await waitFor(() =>
-        expect(mocks.captureMessage).toHaveBeenCalledWith('Network Error', {
-          fingerprint: '401 - cool error',
-          addBreadcrumb: {
-            category: 'network-error',
-            data: 'cool error',
-            level: 'error',
-            message: '401 - cool error',
-          },
-        })
-      )
-    })
   })
 
   describe('when the children component has a 403 error', () => {
@@ -263,34 +223,6 @@ describe('NetworkErrorBoundary', () => {
       const button = await screen.findByText('Return to previous page')
       expect(button).toBeInTheDocument()
     })
-
-    it('calls captureMessage with the error when dev and error are provided', async () => {
-      const { user } = setup()
-      render(
-        <App
-          status={403}
-          detail="you not admin"
-          error="cool error"
-          dev="403 - cool error"
-        />,
-        { wrapper: wrapper() }
-      )
-
-      const textBox = await screen.findByRole('textbox')
-      await user.type(textBox, 'fail')
-
-      await waitFor(() =>
-        expect(mocks.captureMessage).toHaveBeenCalledWith('Network Error', {
-          fingerprint: '403 - cool error',
-          addBreadcrumb: {
-            category: 'network-error',
-            data: 'cool error',
-            level: 'error',
-            message: '403 - cool error',
-          },
-        })
-      )
-    })
   })
 
   describe('when the children component has a 404 error', () => {
@@ -320,34 +252,6 @@ describe('NetworkErrorBoundary', () => {
         const button = await screen.findByText('Return to previous page')
         expect(button).toBeInTheDocument()
       })
-
-      it('calls captureMessage with the error when dev and error are provided', async () => {
-        const { user } = setup()
-        render(
-          <App
-            status={404}
-            detail="not found"
-            error="cool error"
-            dev="404 - cool error"
-          />,
-          { wrapper: wrapper() }
-        )
-
-        const textBox = await screen.findByRole('textbox')
-        await user.type(textBox, 'fail')
-
-        await waitFor(() =>
-          expect(mocks.captureMessage).toHaveBeenCalledWith('Network Error', {
-            fingerprint: '404 - cool error',
-            addBreadcrumb: {
-              category: 'network-error',
-              data: 'cool error',
-              level: 'error',
-              message: '404 - cool error',
-            },
-          })
-        )
-      })
     })
 
     describe('when running in self hosted mode', () => {
@@ -375,34 +279,6 @@ describe('NetworkErrorBoundary', () => {
 
         const button = await screen.findByText('Return to previous page')
         expect(button).toBeInTheDocument()
-      })
-
-      it('calls captureMessage with the error when dev and error are provided', async () => {
-        const { user } = setup({ isSelfHosted: true })
-        render(
-          <App
-            status={404}
-            detail="not found"
-            error="cool error"
-            dev="404 - cool error"
-          />,
-          { wrapper: wrapper() }
-        )
-
-        const textBox = await screen.findByRole('textbox')
-        await user.type(textBox, 'fail')
-
-        await waitFor(() =>
-          expect(mocks.captureMessage).toHaveBeenCalledWith('Network Error', {
-            fingerprint: '404 - cool error',
-            addBreadcrumb: {
-              category: 'network-error',
-              data: 'cool error',
-              level: 'error',
-              message: '404 - cool error',
-            },
-          })
-        )
       })
     })
   })
@@ -454,24 +330,6 @@ describe('NetworkErrorBoundary', () => {
       // Clean up the mock
       global.fetch.mockRestore()
     })
-
-    it('does not call captureMessage ', async () => {
-      const { user } = setup()
-      render(
-        <App
-          status={429}
-          detail="rate limit exceeded"
-          error="cool error"
-          dev="429 - cool error"
-        />,
-        { wrapper: wrapper() }
-      )
-
-      const textBox = await screen.findByRole('textbox')
-      await user.type(textBox, 'fail')
-
-      await waitFor(() => expect(mocks.captureMessage).not.toHaveBeenCalled())
-    })
   })
 
   describe('when the children component has a 500 error', () => {
@@ -501,34 +359,6 @@ describe('NetworkErrorBoundary', () => {
         const button = await screen.findByText('Return to previous page')
         expect(button).toBeInTheDocument()
       })
-
-      it('calls captureMessage with the error when dev and error are provided', async () => {
-        const { user } = setup()
-        render(
-          <App
-            status={500}
-            detail="server error"
-            error="cool error"
-            dev="500 - cool error"
-          />,
-          { wrapper: wrapper() }
-        )
-
-        const textBox = await screen.findByRole('textbox')
-        await user.type(textBox, 'fail')
-
-        await waitFor(() =>
-          expect(mocks.captureMessage).toHaveBeenCalledWith('Network Error', {
-            fingerprint: '500 - cool error',
-            addBreadcrumb: {
-              category: 'network-error',
-              data: 'cool error',
-              level: 'error',
-              message: '500 - cool error',
-            },
-          })
-        )
-      })
     })
 
     describe('when running in self-hosted mode', () => {
@@ -556,34 +386,6 @@ describe('NetworkErrorBoundary', () => {
 
         const button = await screen.findByText('Return to previous page')
         expect(button).toBeInTheDocument()
-      })
-
-      it('calls captureMessage with the error when dev and error are provided', async () => {
-        const { user } = setup({ isSelfHosted: true })
-        render(
-          <App
-            status={500}
-            detail="server error"
-            error="cool error"
-            dev="500 - cool error"
-          />,
-          { wrapper: wrapper() }
-        )
-
-        const textBox = await screen.findByRole('textbox')
-        await user.type(textBox, 'fail')
-
-        await waitFor(() =>
-          expect(mocks.captureMessage).toHaveBeenCalledWith('Network Error', {
-            fingerprint: '500 - cool error',
-            addBreadcrumb: {
-              category: 'network-error',
-              data: 'cool error',
-              level: 'error',
-              message: '500 - cool error',
-            },
-          })
-        )
       })
     })
   })

--- a/src/services/bundleAnalysis/useBundleSummary.tsx
+++ b/src/services/bundleAnalysis/useBundleSummary.tsx
@@ -8,7 +8,10 @@ import {
   useRepoOverview,
 } from 'services/repo'
 import Api from 'shared/api/api'
-import type { NetworkErrorObject } from 'shared/api/helpers'
+import {
+  NetworkErrorObject,
+  rejectNetworkErrorToSentry,
+} from 'shared/api/helpers'
 import A from 'ui/A'
 
 const BundleDataSchema = z.object({
@@ -167,12 +170,12 @@ export const useBundleSummary = ({
         const parsedData = RequestSchema.safeParse(res?.data)
 
         if (!parsedData.success) {
-          return Promise.reject({
+          return rejectNetworkErrorToSentry({
             status: 404,
             data: {},
             dev: 'useBundleSummary - 404 Failed to parse data',
             error: parsedData.error,
-          } satisfies NetworkErrorObject)
+          })
         }
 
         const data = parsedData.data

--- a/src/services/bundleAnalysis/useBundleSummary.tsx
+++ b/src/services/bundleAnalysis/useBundleSummary.tsx
@@ -8,10 +8,7 @@ import {
   useRepoOverview,
 } from 'services/repo'
 import Api from 'shared/api/api'
-import {
-  NetworkErrorObject,
-  rejectNetworkErrorToSentry,
-} from 'shared/api/helpers'
+import { NetworkErrorObject, rejectNetworkError } from 'shared/api/helpers'
 import A from 'ui/A'
 
 const BundleDataSchema = z.object({
@@ -170,7 +167,7 @@ export const useBundleSummary = ({
         const parsedData = RequestSchema.safeParse(res?.data)
 
         if (!parsedData.success) {
-          return rejectNetworkErrorToSentry({
+          return rejectNetworkError({
             status: 404,
             data: {},
             dev: 'useBundleSummary - 404 Failed to parse data',

--- a/src/services/commit/useCommit.test.tsx
+++ b/src/services/commit/useCommit.test.tsx
@@ -306,7 +306,7 @@ describe('useCommit', () => {
       }),
       graphql.query(`CompareTotals`, (info) => {
         if (skipPolling) {
-          return HttpResponse.json({ data: {} })
+          return HttpResponse.json({ data: { owner: null } })
         }
         return HttpResponse.json({ data: compareDoneData })
       })

--- a/src/services/commit/useCommit.tsx
+++ b/src/services/commit/useCommit.tsx
@@ -18,10 +18,7 @@ import {
   RepoOwnerNotActivatedErrorSchema,
 } from 'services/repo/schemas'
 import Api from 'shared/api'
-import {
-  NetworkErrorObject,
-  rejectNetworkErrorToSentry,
-} from 'shared/api/helpers'
+import { rejectNetworkError } from 'shared/api/helpers'
 import {
   ErrorCodeEnum,
   UploadStateEnum,
@@ -359,7 +356,7 @@ export function useCommit({
         const parsedRes = RequestSchema.safeParse(res?.data)
 
         if (!parsedRes.success) {
-          return rejectNetworkErrorToSentry({
+          return rejectNetworkError({
             status: 404,
             data: {},
             dev: 'useCommit - 404 failed to parse',
@@ -370,15 +367,15 @@ export function useCommit({
         const data = parsedRes.data
 
         if (data?.owner?.repository?.__typename === 'NotFoundError') {
-          return Promise.reject({
+          return rejectNetworkError({
             status: 404,
             data: {},
             dev: 'useCommit - 404 not found',
-          } satisfies NetworkErrorObject)
+          })
         }
 
         if (data?.owner?.repository?.__typename === 'OwnerNotActivatedError') {
-          return Promise.reject({
+          return rejectNetworkError({
             status: 403,
             data: {
               detail: (
@@ -391,7 +388,7 @@ export function useCommit({
               ),
             },
             dev: 'useCommit - 403 owner not activated',
-          } satisfies NetworkErrorObject)
+          })
         }
 
         const commit = data?.owner?.repository?.commit

--- a/src/services/commit/useCommit.tsx
+++ b/src/services/commit/useCommit.tsx
@@ -18,7 +18,10 @@ import {
   RepoOwnerNotActivatedErrorSchema,
 } from 'services/repo/schemas'
 import Api from 'shared/api'
-import { NetworkErrorObject } from 'shared/api/helpers'
+import {
+  NetworkErrorObject,
+  rejectNetworkErrorToSentry,
+} from 'shared/api/helpers'
 import {
   ErrorCodeEnum,
   UploadStateEnum,
@@ -356,11 +359,12 @@ export function useCommit({
         const parsedRes = RequestSchema.safeParse(res?.data)
 
         if (!parsedRes.success) {
-          return Promise.reject({
+          return rejectNetworkErrorToSentry({
             status: 404,
             data: {},
             dev: 'useCommit - 404 failed to parse',
-          } satisfies NetworkErrorObject)
+            error: parsedRes.error,
+          })
         }
 
         const data = parsedRes.data

--- a/src/shared/api/helpers.test.ts
+++ b/src/shared/api/helpers.test.ts
@@ -116,6 +116,7 @@ describe('rejectNetworkError', () => {
       expect(mocks.addBreadcrumb).toHaveBeenCalledWith({
         category: 'network.error',
         level: 'error',
+        message: 'useCoolHook - 404 not found',
         data: Error('not found'),
       })
     })

--- a/src/shared/api/helpers.test.ts
+++ b/src/shared/api/helpers.test.ts
@@ -2,7 +2,32 @@ import Cookie from 'js-cookie'
 
 import config from 'config'
 
-import { generatePath, getHeaders } from './helpers'
+import { generatePath, getHeaders, rejectNetworkErrorToSentry } from './helpers'
+
+const mocks = vi.hoisted(() => ({
+  withScope: vi.fn(),
+  addBreadcrumb: vi.fn(),
+  captureMessage: vi.fn(),
+  setFingerprint: vi.fn(),
+}))
+
+vi.mock('@sentry/react', async () => {
+  const actual = await vi.importActual('@sentry/react')
+  return {
+    ...actual,
+    withScope: mocks.withScope.mockImplementation((fn) =>
+      fn({
+        addBreadcrumb: mocks.addBreadcrumb,
+        setFingerprint: mocks.setFingerprint,
+        captureMessage: mocks.captureMessage,
+      })
+    ),
+  }
+})
+
+afterEach(() => {
+  vi.clearAllMocks()
+})
 
 describe('generatePath', () => {
   it('generates a path without a query', () => {
@@ -74,6 +99,63 @@ describe('getHeaders', () => {
     expect(getHeaders(undefined)).toStrictEqual({
       Accept: 'application/json',
       'Content-Type': 'application/json; charset=utf-8',
+    })
+  })
+})
+
+describe('rejectNetworkErrorToSentry', () => {
+  describe('when the error has a dev message and error', () => {
+    it('adds a breadcrumb', () => {
+      rejectNetworkErrorToSentry({
+        status: 404,
+        data: {},
+        dev: 'useCoolHook - 404 not found',
+        error: Error('not found'),
+      }).catch((e) => {})
+
+      expect(mocks.addBreadcrumb).toHaveBeenCalledWith({
+        category: 'network.error',
+        level: 'error',
+        data: Error('not found'),
+      })
+    })
+
+    it('sets the fingerprint', () => {
+      rejectNetworkErrorToSentry({
+        status: 404,
+        data: {},
+        dev: 'useCoolHook - 404 not found',
+        error: Error('not found'),
+      }).catch((e) => {})
+
+      expect(mocks.setFingerprint).toHaveBeenCalledWith([
+        'useCoolHook - 404 not found',
+      ])
+    })
+
+    it('captures the error with Sentry', () => {
+      rejectNetworkErrorToSentry({
+        status: 404,
+        data: {},
+        dev: 'useCoolHook - 404 not found',
+        error: Error('not found'),
+      }).catch((e) => {})
+
+      expect(mocks.captureMessage).toHaveBeenCalledWith('Network Error')
+    })
+  })
+
+  describe('when the error does not have an error', () => {
+    it('does not call any Sentry methods', () => {
+      rejectNetworkErrorToSentry({
+        status: 404,
+        data: {},
+        dev: 'useCoolHook - 404 not found',
+      }).catch((e) => {})
+
+      expect(mocks.addBreadcrumb).not.toHaveBeenCalled()
+      expect(mocks.setFingerprint).not.toHaveBeenCalled()
+      expect(mocks.captureMessage).not.toHaveBeenCalled()
     })
   })
 })

--- a/src/shared/api/helpers.test.ts
+++ b/src/shared/api/helpers.test.ts
@@ -2,7 +2,7 @@ import Cookie from 'js-cookie'
 
 import config from 'config'
 
-import { generatePath, getHeaders, rejectNetworkErrorToSentry } from './helpers'
+import { generatePath, getHeaders, rejectNetworkError } from './helpers'
 
 const mocks = vi.hoisted(() => ({
   withScope: vi.fn(),
@@ -103,10 +103,10 @@ describe('getHeaders', () => {
   })
 })
 
-describe('rejectNetworkErrorToSentry', () => {
+describe('rejectNetworkError', () => {
   describe('when the error has a dev message and error', () => {
     it('adds a breadcrumb', () => {
-      rejectNetworkErrorToSentry({
+      rejectNetworkError({
         status: 404,
         data: {},
         dev: 'useCoolHook - 404 not found',
@@ -121,7 +121,7 @@ describe('rejectNetworkErrorToSentry', () => {
     })
 
     it('sets the fingerprint', () => {
-      rejectNetworkErrorToSentry({
+      rejectNetworkError({
         status: 404,
         data: {},
         dev: 'useCoolHook - 404 not found',
@@ -134,7 +134,7 @@ describe('rejectNetworkErrorToSentry', () => {
     })
 
     it('captures the error with Sentry', () => {
-      rejectNetworkErrorToSentry({
+      rejectNetworkError({
         status: 404,
         data: {},
         dev: 'useCoolHook - 404 not found',
@@ -147,7 +147,7 @@ describe('rejectNetworkErrorToSentry', () => {
 
   describe('when the error does not have an error', () => {
     it('does not call any Sentry methods', () => {
-      rejectNetworkErrorToSentry({
+      rejectNetworkError({
         status: 404,
         data: {},
         dev: 'useCoolHook - 404 not found',

--- a/src/shared/api/helpers.ts
+++ b/src/shared/api/helpers.ts
@@ -23,6 +23,7 @@ export function rejectNetworkError(error: NetworkErrorObject) {
       scope.addBreadcrumb({
         category: 'network.error',
         level: 'error',
+        message: error.dev,
         data: error.error,
       })
       scope.setFingerprint([error.dev])

--- a/src/shared/api/helpers.ts
+++ b/src/shared/api/helpers.ts
@@ -15,7 +15,7 @@ export interface NetworkErrorObject {
   error?: Error
 }
 
-export function rejectNetworkErrorToSentry(error: NetworkErrorObject) {
+export function rejectNetworkError(error: NetworkErrorObject) {
   // only capture network errors if they are not a rate limit error
   // this will typically only be schema parsing errors
   if (error.status !== 429 && error.dev && error.error) {

--- a/src/shared/api/helpers.ts
+++ b/src/shared/api/helpers.ts
@@ -1,4 +1,5 @@
 /* eslint-disable camelcase */
+import * as Sentry from '@sentry/react'
 import qs from 'qs'
 
 import config from 'config'
@@ -12,6 +13,28 @@ export interface NetworkErrorObject {
   }
   dev: `${string} - ${number} ${string}`
   error?: Error
+}
+
+export function rejectNetworkErrorToSentry(error: NetworkErrorObject) {
+  // only capture network errors if they are not a rate limit error
+  // this will typically only be schema parsing errors
+  if (error.status !== 429 && error.dev && error.error) {
+    Sentry.withScope((scope) => {
+      scope.addBreadcrumb({
+        category: 'network.error',
+        level: 'error',
+        data: error.error,
+      })
+      scope.setFingerprint([error.dev])
+      scope.captureMessage('Network Error')
+    })
+  }
+
+  return Promise.reject({
+    status: error.status,
+    dev: error.dev,
+    data: error.data,
+  })
 }
 
 export const AllProvidersArray = [

--- a/src/vitest.setup.ts
+++ b/src/vitest.setup.ts
@@ -17,6 +17,7 @@ vi.mock('@sentry/react', async () => {
   return {
     ...originalModule,
     setUser: vi.fn(),
+    withScope: vi.fn(),
     metrics: {
       ...originalModule.metrics!,
       distribution: vi.fn(),


### PR DESCRIPTION
# Description

This PR changes the way that was recently introduced as to how we capture data fetching service errors, and send them to Sentry to tidy things up a little bit, and reduce what is logged out to the console. 

# Code Example

Use with a data fetching hook:

```tsx
if (!parsedRes.success) {
  return rejectNetworkErrorToSentry({
    status: 404,
    data: {},
    dev: 'useCommit - 404 failed to parse',
    error: parsedRes.error,
  })
}
```

# Notable Changes

- Create a function that handles, rejects, and sends info to Sentry for service parsing errors
- Update two examples hooks using this new function
- Create/Update tests 