### PR TITLE
feat: Remove Reset button when not on default branch + double click selector to remove param

### DIFF
--- a/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/FailedTestsTable/FailedTestsTable.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/FailedTestsTable/FailedTestsTable.tsx
@@ -228,11 +228,12 @@ const FailedTestsTable = () => {
     },
   })
 
+  const isDefaultBranch = !!branch && testData?.defaultBranch === branch
+  const isTeamOrFreePlan =
+    isTeamPlan(testData?.plan) || isFreePlan(testData?.plan)
   // Only show flake rate column when on default branch for pro / enterprise plans or public repos
   const hideFlakeRate =
-    ((isTeamPlan(testData?.plan) || isFreePlan(testData?.plan)) &&
-      testData?.private) ||
-    (!!branch && testData?.defaultBranch !== branch)
+    (isTeamOrFreePlan && testData?.private) || !isDefaultBranch
 
   const tableData = useMemo(() => {
     if (!testData?.testResults) return []
@@ -304,7 +305,10 @@ const FailedTestsTable = () => {
   if (isEmpty(testData?.testResults) && !isLoading && !!branch) {
     return (
       <div className="flex flex-col gap-2">
-        <TableHeader totalCount={testData?.totalCount} />
+        <TableHeader
+          totalCount={testData?.totalCount}
+          isDefaultBranch={isDefaultBranch}
+        />
         <hr />
         <p className="mt-4 text-center">No test results found</p>
       </div>
@@ -313,7 +317,10 @@ const FailedTestsTable = () => {
 
   return (
     <>
-      <TableHeader totalCount={testData?.totalCount} />
+      <TableHeader
+        totalCount={testData?.totalCount}
+        isDefaultBranch={isDefaultBranch}
+      />
       <div className="tableui">
         <table>
           <colgroup>

--- a/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/FailedTestsTable/FailedTestsTable.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/FailedTestsTable/FailedTestsTable.tsx
@@ -228,12 +228,12 @@ const FailedTestsTable = () => {
     },
   })
 
-  const isDefaultBranch = !!branch && testData?.defaultBranch === branch
+  const isDefaultBranch = testData?.defaultBranch === branch
   const isTeamOrFreePlan =
     isTeamPlan(testData?.plan) || isFreePlan(testData?.plan)
   // Only show flake rate column when on default branch for pro / enterprise plans or public repos
   const hideFlakeRate =
-    (isTeamOrFreePlan && testData?.private) || !isDefaultBranch
+    (isTeamOrFreePlan && testData?.private) || (!!branch && !isDefaultBranch)
 
   const tableData = useMemo(() => {
     if (!testData?.testResults) return []

--- a/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/MetricsSection/MetricsSection.test.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/MetricsSection/MetricsSection.test.tsx
@@ -203,6 +203,26 @@ describe('MetricsSection', () => {
           testSuites: [],
         })
       })
+
+      it('removes the location param on second button click', async () => {
+        const { user } = setup()
+        render(<MetricsSection />, {
+          wrapper: wrapper('/gh/owner/repo/tests/main'),
+        })
+        const select = await screen.findByText('12')
+        expect(select).toBeInTheDocument()
+
+        await user.click(select)
+        await user.click(select)
+
+        expect(testLocation?.state).toStrictEqual({
+          parameter: '',
+          flags: [],
+          historicalTrend: '',
+          term: '',
+          testSuites: [],
+        })
+      })
     })
 
     describe('flaky tests card', () => {
@@ -234,6 +254,26 @@ describe('MetricsSection', () => {
 
         expect(testLocation?.state).toStrictEqual({
           parameter: 'FLAKY_TESTS',
+          flags: [],
+          historicalTrend: '',
+          term: '',
+          testSuites: [],
+        })
+      })
+
+      it('removes the location param on second button click', async () => {
+        const { user } = setup()
+        render(<MetricsSection />, {
+          wrapper: wrapper('/gh/owner/repo/tests/main'),
+        })
+        const select = await screen.findByText(88)
+        expect(select).toBeInTheDocument()
+
+        await user.click(select)
+        await user.click(select)
+
+        expect(testLocation?.state).toStrictEqual({
+          parameter: '',
           flags: [],
           historicalTrend: '',
           term: '',
@@ -294,6 +334,26 @@ describe('MetricsSection', () => {
           testSuites: [],
         })
       })
+
+      it('removes the location param on second button click', async () => {
+        const { user } = setup()
+        render(<MetricsSection />, {
+          wrapper: wrapper('/gh/owner/repo/tests/main'),
+        })
+        const select = await screen.findByText(1)
+        expect(select).toBeInTheDocument()
+
+        await user.click(select)
+        await user.click(select)
+
+        expect(testLocation?.state).toStrictEqual({
+          parameter: '',
+          flags: [],
+          historicalTrend: '',
+          term: '',
+          testSuites: [],
+        })
+      })
     })
 
     describe('total skips card', () => {
@@ -325,6 +385,26 @@ describe('MetricsSection', () => {
 
         expect(testLocation?.state).toStrictEqual({
           parameter: 'SKIPPED_TESTS',
+          flags: [],
+          historicalTrend: '',
+          term: '',
+          testSuites: [],
+        })
+      })
+
+      it('removes the location param on second button click', async () => {
+        const { user } = setup()
+        render(<MetricsSection />, {
+          wrapper: wrapper('/gh/owner/repo/tests/main'),
+        })
+        const select = await screen.findByText(20)
+        expect(select).toBeInTheDocument()
+
+        await user.click(select)
+        await user.click(select)
+
+        expect(testLocation?.state).toStrictEqual({
+          parameter: '',
           flags: [],
           historicalTrend: '',
           term: '',

--- a/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/MetricsSection/MetricsSection.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/MetricsSection/MetricsSection.tsx
@@ -105,7 +105,7 @@ const SlowestTestsCard = ({
   slowestTestsDuration?: number | null
   isSelected: boolean
   updateParams: (newParams: {
-    parameter: TestResultsFilterParameterType
+    parameter: TestResultsFilterParameterType | ''
   }) => void
 }) => {
   return (
@@ -126,7 +126,9 @@ const SlowestTestsCard = ({
             'font-semibold': isSelected,
           })}
           onClick={() => {
-            updateParams({ parameter: 'SLOWEST_TESTS' })
+            updateParams({
+              parameter: isSelected ? '' : 'SLOWEST_TESTS',
+            })
           }}
         >
           {slowestTests}
@@ -153,7 +155,7 @@ const TotalFlakyTestsCard = ({
   flakeCountPercentChange?: number | null
   isSelected: boolean
   updateParams: (newParams: {
-    parameter: TestResultsFilterParameterType
+    parameter: TestResultsFilterParameterType | ''
   }) => void
 }) => {
   return (
@@ -173,7 +175,7 @@ const TotalFlakyTestsCard = ({
             'font-semibold': isSelected,
           })}
           onClick={() => {
-            updateParams({ parameter: 'FLAKY_TESTS' })
+            updateParams({ parameter: isSelected ? '' : 'FLAKY_TESTS' })
           }}
         >
           {flakeCount}
@@ -231,7 +233,7 @@ const TotalFailuresCard = ({
   totalFailsPercentChange?: number | null
   isSelected: boolean
   updateParams: (newParams: {
-    parameter: TestResultsFilterParameterType
+    parameter: TestResultsFilterParameterType | ''
   }) => void
 }) => {
   return (
@@ -251,7 +253,7 @@ const TotalFailuresCard = ({
             'font-semibold': isSelected,
           })}
           onClick={() => {
-            updateParams({ parameter: 'FAILED_TESTS' })
+            updateParams({ parameter: isSelected ? '' : 'FAILED_TESTS' })
           }}
         >
           {totalFails}
@@ -277,7 +279,7 @@ const TotalSkippedTestsCard = ({
   totalSkipsPercentChange?: number | null
   isSelected: boolean
   updateParams: (newParams: {
-    parameter: TestResultsFilterParameterType
+    parameter: TestResultsFilterParameterType | ''
   }) => void
 }) => {
   return (
@@ -297,7 +299,9 @@ const TotalSkippedTestsCard = ({
             'font-semibold': isSelected,
           })}
           onClick={() => {
-            updateParams({ parameter: 'SKIPPED_TESTS' })
+            updateParams({
+              parameter: isSelected ? '' : 'SKIPPED_TESTS',
+            })
           }}
         >
           {totalSkips}

--- a/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/TableHeader/TableHeader.test.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/TableHeader/TableHeader.test.tsx
@@ -42,7 +42,9 @@ describe('TableHeader', () => {
   })
 
   it('renders the TableHeader component', () => {
-    render(<TableHeader totalCount={50000} />, { wrapper: wrapper() })
+    render(<TableHeader totalCount={50000} isDefaultBranch />, {
+      wrapper: wrapper(),
+    })
     const testsText = screen.getByText('Tests (50.0K)')
     const searchInput = screen.getByPlaceholderText('Search by name')
     const resetButton = screen.getByText('Reset to default')
@@ -53,7 +55,9 @@ describe('TableHeader', () => {
   })
 
   it('updates search term on input change', async () => {
-    render(<TableHeader totalCount={50000} />, { wrapper: wrapper() })
+    render(<TableHeader totalCount={50000} isDefaultBranch />, {
+      wrapper: wrapper(),
+    })
     const searchInput = screen.getByPlaceholderText('Search by name')
     await userEvent.type(searchInput, 'test')
     expect(searchInput).toHaveValue('test')
@@ -63,7 +67,7 @@ describe('TableHeader', () => {
   })
 
   it('resets to default parameters on button click', async () => {
-    render(<TableHeader totalCount={50000} />, {
+    render(<TableHeader totalCount={50000} isDefaultBranch />, {
       wrapper: wrapper('/gh/codecov/cool-repo/tests?term=test'),
     })
     const resetButton = screen.getByText('Reset to default')
@@ -74,28 +78,40 @@ describe('TableHeader', () => {
   })
 
   it('disables reset button when parameters are default', () => {
-    render(<TableHeader totalCount={50000} />, { wrapper: wrapper() })
+    render(<TableHeader totalCount={50000} isDefaultBranch />, {
+      wrapper: wrapper(),
+    })
     const resetButton = screen.getByText('Reset to default')
     expect(resetButton).toBeDisabled()
   })
 
   it('enables reset button when parameters are not default', () => {
-    render(<TableHeader totalCount={50000} />, {
+    render(<TableHeader totalCount={50000} isDefaultBranch />, {
       wrapper: wrapper('/gh/codecov/cool-repo/tests?term=test'),
     })
     const resetButton = screen.getByText('Reset to default')
     expect(resetButton).not.toBeDisabled()
   })
 
+  it('hides reset button when not on default branch', () => {
+    render(<TableHeader totalCount={50000} isDefaultBranch={false} />, {
+      wrapper: wrapper(),
+    })
+    const resetButton = screen.queryByText('Reset to default')
+    expect(resetButton).not.toBeInTheDocument()
+  })
+
   describe('header title', () => {
     it('renders the default header title', () => {
-      render(<TableHeader totalCount={50000} />, { wrapper: wrapper() })
+      render(<TableHeader totalCount={50000} isDefaultBranch />, {
+        wrapper: wrapper(),
+      })
       const headerTitle = screen.getByText('Tests (50.0K)')
       expect(headerTitle).toBeInTheDocument()
     })
 
     it('renders the flaky tests header title', () => {
-      render(<TableHeader totalCount={50000} />, {
+      render(<TableHeader totalCount={50000} isDefaultBranch />, {
         wrapper: wrapper('/gh/codecov/cool-repo/tests?parameter=FLAKY_TESTS'),
       })
       const headerTitle = screen.getByText('Flaky tests (50.0K)')
@@ -103,7 +119,7 @@ describe('TableHeader', () => {
     })
 
     it('renders the failed tests header title', () => {
-      render(<TableHeader totalCount={50000} />, {
+      render(<TableHeader totalCount={50000} isDefaultBranch />, {
         wrapper: wrapper('/gh/codecov/cool-repo/tests?parameter=FAILED_TESTS'),
       })
       const headerTitle = screen.getByText('Failed tests (50.0K)')
@@ -111,7 +127,7 @@ describe('TableHeader', () => {
     })
 
     it('renders the tests header title', () => {
-      render(<TableHeader totalCount={50000} />, {
+      render(<TableHeader totalCount={50000} isDefaultBranch />, {
         wrapper: wrapper('/gh/codecov/cool-repo/tests?parameter=TESTS'),
       })
       const headerTitle = screen.getByText('Tests (50.0K)')
@@ -119,7 +135,7 @@ describe('TableHeader', () => {
     })
 
     it('renders the skipped tests header title', () => {
-      render(<TableHeader totalCount={50000} />, {
+      render(<TableHeader totalCount={50000} isDefaultBranch />, {
         wrapper: wrapper('/gh/codecov/cool-repo/tests?parameter=SKIPPED_TESTS'),
       })
       const headerTitle = screen.getByText('Skipped tests (50.0K)')
@@ -127,7 +143,7 @@ describe('TableHeader', () => {
     })
 
     it('renders the slowest tests header title', () => {
-      render(<TableHeader totalCount={50000} />, {
+      render(<TableHeader totalCount={50000} isDefaultBranch />, {
         wrapper: wrapper('/gh/codecov/cool-repo/tests?parameter=SLOWEST_TESTS'),
       })
       const headerTitle = screen.getByText('Slowest tests (50.0K)')

--- a/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/TableHeader/TableHeader.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/TableHeader/TableHeader.tsx
@@ -10,6 +10,7 @@ import { defaultQueryParams } from '../SelectorSection'
 
 interface TableHeaderProps {
   totalCount: number
+  isDefaultBranch: boolean
 }
 
 const getHeaderTitle = (parameter: keyof typeof TestResultsFilterParameter) => {
@@ -18,7 +19,10 @@ const getHeaderTitle = (parameter: keyof typeof TestResultsFilterParameter) => {
     : 'Tests'
 }
 
-const TableHeader: React.FC<TableHeaderProps> = ({ totalCount }) => {
+const TableHeader: React.FC<TableHeaderProps> = ({
+  totalCount,
+  isDefaultBranch,
+}) => {
   const { params, updateParams } = useLocationParams(defaultQueryParams)
   // @ts-expect-error, useLocationParams needs to be updated to have full types
   const [searchTerm, setSearchTerm] = useState(params.term)
@@ -50,19 +54,21 @@ const TableHeader: React.FC<TableHeaderProps> = ({ totalCount }) => {
             setSearchValue={handleSearchChange}
             data-testid="search-input-failed-tests"
           />
-          <Button
-            disabled={isParamsDefault}
-            to={undefined}
-            hook="reset-failed-tests"
-            onClick={() => {
-              if (!isParamsDefault) {
-                updateParams(defaultQueryParams)
-                setSearchTerm('')
-              }
-            }}
-          >
-            Reset to default
-          </Button>
+          {isDefaultBranch ? (
+            <Button
+              disabled={isParamsDefault}
+              to={undefined}
+              hook="reset-failed-tests"
+              onClick={() => {
+                if (!isParamsDefault) {
+                  updateParams(defaultQueryParams)
+                  setSearchTerm('')
+                }
+              }}
+            >
+              Reset to default
+            </Button>
+          ) : null}
         </div>
       </div>
     </>


### PR DESCRIPTION
# Description

This PR aims to add two enhancements to the Failed Tests Page
- When clicking on metric that is already selected in Metric Section, we remove the parameter
  - used the existing isSelected prop to default back to '' if clicked again
- When not on default branch, remove the "reset to default" button
  - created a const and passed the prop down for isDefaultBranch which was being used in another const above

The rest of the PR is just updating/adding tests

Closes https://github.com/codecov/engineering-team/issues/2775
Closes https://github.com/codecov/engineering-team/issues/2801


# Screenshots

https://github.com/user-attachments/assets/6c46e7f6-d40c-405b-8f06-902001538b98

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.