### PR TITLE
feat: Change tab copy from Beta to new

### DIFF
--- a/src/pages/RepoPage/RepoPageTabs.test.tsx
+++ b/src/pages/RepoPage/RepoPageTabs.test.tsx
@@ -405,7 +405,7 @@ describe('RepoPageTabs', () => {
       expect(tab).toHaveAttribute('href', '/gh/codecov/test-repo/tests')
     })
 
-    it('renders beta badge', async () => {
+    it('renders new badge', async () => {
       setup({
         coverageEnabled: false,
       })
@@ -413,8 +413,8 @@ describe('RepoPageTabs', () => {
         wrapper: wrapper('/gh/codecov/test-repo/tests/new'),
       })
 
-      const betaBadge = await screen.findByText('beta')
-      expect(betaBadge).toBeInTheDocument()
+      const newBadge = await screen.findByText('New')
+      expect(newBadge).toBeInTheDocument()
     })
   })
 

--- a/src/pages/RepoPage/RepoPageTabs.tsx
+++ b/src/pages/RepoPage/RepoPageTabs.tsx
@@ -103,7 +103,7 @@ export const useRepoTabs = ({ refetchEnabled }: UseRepoTabsArgs) => {
       pageName: 'failedTests',
       children: (
         <>
-          Tests <Badge>beta</Badge>{' '}
+          Tests <Badge>New</Badge>{' '}
         </>
       ),
     })
@@ -112,7 +112,7 @@ export const useRepoTabs = ({ refetchEnabled }: UseRepoTabsArgs) => {
       pageName: 'failedTestsOnboarding',
       children: (
         <>
-          Tests <Badge>beta</Badge>{' '}
+          Tests <Badge>New</Badge>{' '}
         </>
       ),
     })


### PR DESCRIPTION
# Description

Since we're moving Test Analytics out of beta now, we'd like to update the copy on the tab from "Beta" to "New"

Closes https://github.com/codecov/engineering-team/issues/2862

# Screenshots

![Screenshot 2024-11-07 at 10 52 10 AM](https://github.com/user-attachments/assets/90869661-effb-4fe5-8eba-24dd94d00ecc)


# Link to Sample Entry

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.