### PR TITLE
fix: Responsiveness tweaks for TA Selector section

### DIFF
--- a/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/SelectorSection/BranchSelector/BranchSelector.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/SelectorSection/BranchSelector/BranchSelector.tsx
@@ -77,14 +77,14 @@ const BranchSelector = () => {
   }
 
   return (
-    <div className="flex flex-col gap-1 pr-4 sm:w-52 lg:w-80">
+    <div className="flex flex-col gap-1 pr-4 sm:w-52 lg:w-64 xl:w-80">
       <h3 className="flex items-center gap-1 text-sm font-semibold text-ds-gray-octonary">
         <span className="text-ds-gray-quinary">
           <Icon name="branch" size="sm" variant="developer" />
         </span>
         Branch Context
       </h3>
-      <span className="min-w-52 text-sm">
+      <span className="text-sm">
         <Select
           // @ts-expect-error - Select has some TS issues because it's still written in JS
           dataMarketing="branch-selector-test-results-tab"

--- a/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/SelectorSection/BranchSelector/BranchSelector.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/SelectorSection/BranchSelector/BranchSelector.tsx
@@ -77,7 +77,7 @@ const BranchSelector = () => {
   }
 
   return (
-    <div className="flex flex-col gap-1 pr-4 sm:w-52 lg:w-64 xl:w-80">
+    <div className="flex w-full flex-col gap-1 px-4 lg:w-64 xl:w-80">
       <h3 className="flex items-center gap-1 text-sm font-semibold text-ds-gray-octonary">
         <span className="text-ds-gray-quinary">
           <Icon name="branch" size="sm" variant="developer" />

--- a/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/SelectorSection/SelectorSection.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/SelectorSection/SelectorSection.tsx
@@ -89,7 +89,7 @@ function SelectorSection() {
   )
 
   return (
-    <div className="flex flex-1 flex-row justify-between">
+    <div className="flex flex-1 flex-col gap-2 md:flex-row md:justify-between md:gap-0">
       <BranchSelector />
       {selectedBranch === overview?.defaultBranch ? (
         <>
@@ -150,7 +150,7 @@ function SelectorSection() {
               />
             </div>
           </div>
-          <div className="flex flex-col gap-1 pl-4">
+          <div className="flex flex-col gap-1 px-4 md:pl-4">
             <h3 className="text-sm font-semibold text-ds-gray-octonary">
               Flags
             </h3>

--- a/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/SelectorSection/SelectorSection.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/SelectorSection/SelectorSection.tsx
@@ -97,7 +97,7 @@ function SelectorSection() {
             <h3 className="text-sm font-semibold text-ds-gray-octonary">
               Historical trend
             </h3>
-            <div className="sm:w-52 lg:w-80">
+            <div className="w-full lg:w-64 xl:w-80">
               <Select
                 // @ts-expect-error Select is not typed
                 dataMarketing="select-historical-trend"
@@ -120,11 +120,11 @@ function SelectorSection() {
               60 day retention
             </A>
           </div>
-          <div className="flex flex-col gap-1 px-4">
+          <div className="flex flex-col gap-1 px-4 md:py-0">
             <h3 className="text-sm font-semibold text-ds-gray-octonary">
               Test suites
             </h3>
-            <div className="sm:w-52 lg:w-80">
+            <div className="w-full lg:w-64 xl:w-80">
               <MultiSelect
                 // @ts-expect-error MultiSelect is not typed
                 dataMarketing="select-test-suites"
@@ -154,7 +154,7 @@ function SelectorSection() {
             <h3 className="text-sm font-semibold text-ds-gray-octonary">
               Flags
             </h3>
-            <div className="sm:w-52 lg:w-80">
+            <div className="w-full lg:w-64 xl:w-80">
               <MultiSelect
                 // @ts-expect-error MultiSelect is not typed
                 dataMarketing="select-flags"

--- a/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/TableHeader/TableHeader.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/TableHeader/TableHeader.tsx
@@ -39,7 +39,7 @@ const TableHeader: React.FC<TableHeaderProps> = ({
     <>
       <hr />
       <div className="flex items-center justify-between py-2">
-        <h2 className="text-lg font-semibold capitalize">
+        <h2 className="pl-4 text-lg font-semibold capitalize">
           {/* @ts-expect-error, params is not typed */}
           {getHeaderTitle(params?.parameter)} (
           {totalCount > 999 ? `${(totalCount / 1000).toFixed(1)}K` : totalCount}


### PR DESCRIPTION
# Description

This PR aims to fix some responsiveness issues that occurred when on some smaller screen sizes on the Test Analytics page.

# Screenshots


https://github.com/user-attachments/assets/caa264d1-be0f-4e4b-83e6-1965ad6503a1

<img width="581" alt="Screenshot 2024-11-08 at 9 33 23 AM" src="https://github.com/user-attachments/assets/64a80143-473b-4695-ae3c-42f0d6762a88">



# Link to Sample Entry

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.