### PR TITLE
fix: Incorrect CSS order in Virtual File Renderers

### DIFF
--- a/src/ui/VirtualRenderers/VirtualDiffRenderer.tsx
+++ b/src/ui/VirtualRenderers/VirtualDiffRenderer.tsx
@@ -256,6 +256,14 @@ const CodeBody = ({
               className="absolute left-0 top-0 pl-[192px]"
             >
               <div className="grid">
+                <div className="z-[-1] col-start-1 row-start-1 ">
+                  <ColorBar
+                    isHighlighted={
+                      location.hash === headHash || location.hash === baseHash
+                    }
+                    coverage={lineData?.[item.index]?.headCoverage}
+                  />
+                </div>
                 <div
                   className="col-start-1 row-start-1 flex flex-1 justify-between"
                   style={{
@@ -275,14 +283,6 @@ const CodeBody = ({
                       hitCount={lineData?.[item.index]?.hitCount}
                     />
                   ) : null}
-                </div>
-                <div className="z-[-1] col-start-1 row-start-1 ">
-                  <ColorBar
-                    isHighlighted={
-                      location.hash === headHash || location.hash === baseHash
-                    }
-                    coverage={lineData?.[item.index]?.headCoverage}
-                  />
                 </div>
               </div>
             </div>

--- a/src/ui/VirtualRenderers/VirtualDiffRenderer.tsx
+++ b/src/ui/VirtualRenderers/VirtualDiffRenderer.tsx
@@ -34,8 +34,9 @@ import { useSyncScrollMargin } from './useSyncScrollMargin'
 import { useSyncTotalWidth } from './useSyncTotalWidth'
 import { useSyncWrapperWidth } from './useSyncWrapperWidth'
 
-import './VirtualFileRenderer.css'
+// prism theme is required to come before so it doesn't override our custom css
 import 'shared/utils/prism/prismTheme.css'
+import './VirtualFileRenderer.css'
 
 export interface LineData {
   headNumber: string | null
@@ -255,14 +256,6 @@ const CodeBody = ({
               className="absolute left-0 top-0 pl-[192px]"
             >
               <div className="grid">
-                <div className="z-[-1] col-start-1 row-start-1 ">
-                  <ColorBar
-                    isHighlighted={
-                      location.hash === headHash || location.hash === baseHash
-                    }
-                    coverage={lineData?.[item.index]?.headCoverage}
-                  />
-                </div>
                 <div
                   className="col-start-1 row-start-1 flex flex-1 justify-between"
                   style={{
@@ -282,6 +275,14 @@ const CodeBody = ({
                       hitCount={lineData?.[item.index]?.hitCount}
                     />
                   ) : null}
+                </div>
+                <div className="z-[-1] col-start-1 row-start-1 ">
+                  <ColorBar
+                    isHighlighted={
+                      location.hash === headHash || location.hash === baseHash
+                    }
+                    coverage={lineData?.[item.index]?.headCoverage}
+                  />
                 </div>
               </div>
             </div>

--- a/src/ui/VirtualRenderers/VirtualFileRenderer.tsx
+++ b/src/ui/VirtualRenderers/VirtualFileRenderer.tsx
@@ -36,8 +36,9 @@ import { useSyncScrollMargin } from './useSyncScrollMargin'
 import { useSyncTotalWidth } from './useSyncTotalWidth'
 import { useSyncWrapperWidth } from './useSyncWrapperWidth'
 
-import './VirtualFileRenderer.css'
+// prism theme is required to come before so it doesn't override our custom css
 import 'shared/utils/prism/prismTheme.css'
+import './VirtualFileRenderer.css'
 
 interface CodeBodyProps {
   tokens: Token[][]
@@ -158,12 +159,6 @@ const CodeBody = ({
               className="absolute left-0 top-0 pl-[94px]"
             >
               <div className="grid">
-                <div className="z-[-1] col-start-1 row-start-1">
-                  <ColorBar
-                    isHighlighted={location.hash === `#L${lineNumber}`}
-                    coverage={coverage?.[lineNumber]}
-                  />
-                </div>
                 <div
                   className="col-start-1 row-start-1"
                   style={{
@@ -175,6 +170,12 @@ const CodeBody = ({
                   {tokens[item.index]?.map((token: Token, key: React.Key) => (
                     <span {...getTokenProps({ token, key })} key={key} />
                   ))}
+                </div>
+                <div className="z-[-1] col-start-1 row-start-1">
+                  <ColorBar
+                    isHighlighted={location.hash === `#L${lineNumber}`}
+                    coverage={coverage?.[lineNumber]}
+                  />
                 </div>
               </div>
             </div>

--- a/src/ui/VirtualRenderers/VirtualFileRenderer.tsx
+++ b/src/ui/VirtualRenderers/VirtualFileRenderer.tsx
@@ -159,6 +159,12 @@ const CodeBody = ({
               className="absolute left-0 top-0 pl-[94px]"
             >
               <div className="grid">
+                <div className="z-[-1] col-start-1 row-start-1">
+                  <ColorBar
+                    isHighlighted={location.hash === `#L${lineNumber}`}
+                    coverage={coverage?.[lineNumber]}
+                  />
+                </div>
                 <div
                   className="col-start-1 row-start-1"
                   style={{
@@ -170,12 +176,6 @@ const CodeBody = ({
                   {tokens[item.index]?.map((token: Token, key: React.Key) => (
                     <span {...getTokenProps({ token, key })} key={key} />
                   ))}
-                </div>
-                <div className="z-[-1] col-start-1 row-start-1">
-                  <ColorBar
-                    isHighlighted={location.hash === `#L${lineNumber}`}
-                    coverage={coverage?.[lineNumber]}
-                  />
                 </div>
               </div>
             </div>


### PR DESCRIPTION
# Description

Quick ordering change of the way we import styles into the virtual file renderers

# Screenshots

Before:

![Screenshot 2024-11-08 at 09 54 58](https://github.com/user-attachments/assets/acfd2509-8ade-4835-87e6-d9fc3cde76a7)

After:

![Screenshot 2024-11-08 at 09 54 28](https://github.com/user-attachments/assets/6d1dc6cc-5662-4d75-ba43-f1e5c1418ce8)