### PR TITLE
feat: Pin default branch to top of branch selector items

### DIFF
--- a/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/SelectorSection/BranchSelector/BranchSelector.test.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/SelectorSection/BranchSelector/BranchSelector.test.tsx
@@ -274,6 +274,21 @@ describe('BranchSelector', () => {
     })
 
     describe('user selects a branch', () => {
+      it('shows default branch as first option in dropdown', async () => {
+        const { queryClient, user } = setup()
+        render(<BranchSelector />, {
+          wrapper: wrapper(queryClient),
+        })
+
+        const select = await screen.findByRole('button', {
+          name: 'test results branch selector',
+        })
+        await user.click(select)
+
+        const options = screen.getAllByRole('option')
+        expect(options[0]).toHaveTextContent('main')
+      })
+
       it('navigates to the selected branch', async () => {
         const { user, queryClient } = setup()
         render(<BranchSelector />, {

--- a/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/SelectorSection/BranchSelector/BranchSelector.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/SelectorSection/BranchSelector/BranchSelector.tsx
@@ -89,7 +89,17 @@ const BranchSelector = () => {
           // @ts-expect-error - Select has some TS issues because it's still written in JS
           dataMarketing="branch-selector-test-results-tab"
           ariaName="test results branch selector"
-          items={branchList?.branches ?? []}
+          items={
+            overview?.defaultBranch
+              ? [
+                  // Pins the default branch to the top of the list always, filters it from results otherwise
+                  { name: overview.defaultBranch, head: null },
+                  ...(branchList?.branches?.filter(
+                    (branch) => branch.name !== overview.defaultBranch
+                  ) ?? []),
+                ]
+              : (branchList?.branches ?? [])
+          }
           value={selection}
           onChange={(item: Branch) => {
             history.push(

--- a/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/SelectorSection/BranchSelector/BranchSelector.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/SelectorSection/BranchSelector/BranchSelector.tsx
@@ -76,6 +76,16 @@ const BranchSelector = () => {
     )
   }
 
+  const sortedBranchList = overview?.defaultBranch
+    ? [
+        // Pins the default branch to the top of the list always, filters it from results otherwise
+        { name: overview.defaultBranch, head: null },
+        ...(branchList?.branches?.filter(
+          (branch) => branch.name !== overview.defaultBranch
+        ) ?? []),
+      ]
+    : (branchList?.branches ?? [])
+
   return (
     <div className="flex w-full flex-col gap-1 px-4 lg:w-64 xl:w-80">
       <h3 className="flex items-center gap-1 text-sm font-semibold text-ds-gray-octonary">
@@ -89,17 +99,7 @@ const BranchSelector = () => {
           // @ts-expect-error - Select has some TS issues because it's still written in JS
           dataMarketing="branch-selector-test-results-tab"
           ariaName="test results branch selector"
-          items={
-            overview?.defaultBranch
-              ? [
-                  // Pins the default branch to the top of the list always, filters it from results otherwise
-                  { name: overview.defaultBranch, head: null },
-                  ...(branchList?.branches?.filter(
-                    (branch) => branch.name !== overview.defaultBranch
-                  ) ?? []),
-                ]
-              : (branchList?.branches ?? [])
-          }
+          items={sortedBranchList}
           value={selection}
           onChange={(item: Branch) => {
             history.push(


### PR DESCRIPTION
# Description

This PR aims to pin the default branch (if it exists) to the top of the list of branches on the Branch Selector for the Failed Tests tab.

This is a quality of life fix to make it easy for folks to go back to the "main" view.

Closes https://github.com/codecov/engineering-team/issues/2855

# Screenshots

<img width="1332" alt="Screenshot 2024-11-08 at 10 23 10 AM" src="https://github.com/user-attachments/assets/7d845c4d-2dd0-4e8d-ac8d-07c1acb0b1d2">
<img width="1311" alt="Screenshot 2024-11-08 at 10 23 16 AM" src="https://github.com/user-attachments/assets/2e0c127d-b00d-4b97-b7f0-f61973c51c04">


# Link to Sample Entry

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.