### PR TITLE
feat: center selectors on bundles page

### DIFF
--- a/src/pages/RepoPage/BundlesTab/BundleContent/BundleSelection/BundleSelection.tsx
+++ b/src/pages/RepoPage/BundlesTab/BundleContent/BundleSelection/BundleSelection.tsx
@@ -21,8 +21,8 @@ const BundleSelection: React.FC = () => {
   }, [resetFilterSelects])
 
   return (
-    <div className="flex flex-col gap-8 border-b border-ds-gray-tertiary pb-6 pt-4 md:flex-row md:justify-between">
-      <div className="flex flex-col gap-4 md:flex-row">
+    <div className="flex flex-col gap-8 border-b border-ds-gray-tertiary pb-6 pt-4">
+      <div className="flex flex-col gap-4 md:w-full md:flex-row md:justify-between">
         <BranchSelector resetBundleSelect={resetBundleSelect} />
         <BundleSelector
           ref={bundleSelectRef}


### PR DESCRIPTION
# Description

This PR centers the selectors on the bundles tab to match the new TA format.

# Screenshots

**AFTER**


https://github.com/user-attachments/assets/3fe3c56d-9f0f-4ee0-b340-21c65ca01ea7


**BEFORE**

https://github.com/user-attachments/assets/24d9c979-b4d4-4b7b-8384-7e6031e5da67



# Link to Sample Entry

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.