### PR TITLE
fix: New charts not getting the correct props on Analytics Page

### DIFF
--- a/src/pages/AnalyticsPage/AnalyticsPage.jsx
+++ b/src/pages/AnalyticsPage/AnalyticsPage.jsx
@@ -42,14 +42,16 @@ function AnalyticsPage() {
     <div className="flex flex-col gap-4">
       {ownerData?.isCurrentUserPartOfOrg ? <Tabs /> : null}
       <ChartSelectors
-        startDate={params?.startDate}
-        endDate={params?.endDate}
-        repositories={params?.repositories}
+        params={params}
         updateParams={updateParams}
         active={true}
         sortItem={sortItem}
       />
-      <Chart params={params} />
+      <Chart
+        startDate={params?.startDate}
+        endDate={params?.endDate}
+        repositories={params?.repositories}
+      />
       <ReposTable
         owner={owner}
         searchValue={params?.search}


### PR DESCRIPTION
# Description

Quick fix to pass the correct props around.