### PR TITLE
fix: Correct the deactivated repo message

### DIFF
--- a/src/pages/RepoPage/DeactivatedRepo/DeactivatedRepo.test.tsx
+++ b/src/pages/RepoPage/DeactivatedRepo/DeactivatedRepo.test.tsx
@@ -68,7 +68,7 @@ describe('DeactivatedRepo', () => {
     it('renders corresponding message', async () => {
       render(<DeactivatedRepo />, { wrapper })
 
-      const message = await screen.findByText(/To reactivate the repo go to/)
+      const message = await screen.findByText(/To resume uploading to it/)
       expect(message).toBeInTheDocument()
     })
   })

--- a/src/pages/RepoPage/DeactivatedRepo/DeactivatedRepo.tsx
+++ b/src/pages/RepoPage/DeactivatedRepo/DeactivatedRepo.tsx
@@ -29,20 +29,19 @@ function DeactivatedRepo() {
           className="mx-auto mb-8"
           src={deactivatedRepo}
         />
-        <span className="text-3xl"> This repo has been deactivated </span>
+        <span className="text-3xl"> This repository has been deactivated </span>
         <span className="text-base">
           {isCurrentUserPartOfOrg ? (
             <>
-              To reactivate the repo go to{' '}
+              To resume uploading to it, please activate the repository in{' '}
               <A
-                to={{ pageName: 'settings' }}
+                to={{ pageName: 'configGeneral' }}
                 isExternal={false}
-                hook="link-to-settings"
+                hook="link-to-config-general"
               >
-                Settings{' '}
-              </A>{' '}
-              or upload a coverage report and it will be automatically
-              re-activated.
+                Configuration
+              </A>
+              {'.'}
             </>
           ) : (
             'Contact an administrator of your git organization to grant write-permissions in your git-provider for this repository.'

--- a/src/pages/RepoPage/RepoPage.test.tsx
+++ b/src/pages/RepoPage/RepoPage.test.tsx
@@ -870,7 +870,9 @@ describe('RepoPage', () => {
         })
         render(<RepoPage />, { wrapper: wrapper({ queryClient }) })
 
-        const msg = await screen.findByText('This repo has been deactivated')
+        const msg = await screen.findByText(
+          'This repository has been deactivated'
+        )
         expect(msg).toBeInTheDocument()
       })
     })


### PR DESCRIPTION
Fix the deactivated repo message to match the correct one [here](https://github.com/codecov/codecov-api/blob/15f9614dd6ded618c40e7b74a91700980018b2a7/upload/helpers.py#L762).

Closes https://github.com/codecov/engineering-team/issues/2688

NEW
<img width="1183" alt="Screenshot 2024-11-08 at 4 45 52 PM" src="https://github.com/user-attachments/assets/10026ff6-612d-4d81-88d5-72edb65343ec">

OLD
<img width="969" alt="Screenshot 2024-11-08 at 4 46 47 PM" src="https://github.com/user-attachments/assets/2462b50a-8cf9-4a2f-9271-9907122e0720">

