### PR TITLE
fix: PR comments for rejectNetworkError and using Const values

### DIFF
--- a/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/MetricsSection/MetricsSection.test.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/MetricsSection/MetricsSection.test.tsx
@@ -8,6 +8,8 @@ import { MemoryRouter, Route, useLocation } from 'react-router-dom'
 
 import MetricsSection, { historicalTrendToCopy } from './MetricsSection'
 
+import { TestResultsFilterParameter } from '../hooks/useInfiniteTestResults/useInfiniteTestResults'
+
 const mockAggResponse = (
   planValue = 'users-enterprisem',
   isPrivate = false
@@ -196,7 +198,7 @@ describe('MetricsSection', () => {
         await user.click(select)
 
         expect(testLocation?.state).toStrictEqual({
-          parameter: 'SLOWEST_TESTS',
+          parameter: TestResultsFilterParameter.SLOWEST_TESTS,
           flags: [],
           historicalTrend: '',
           term: '',
@@ -253,7 +255,7 @@ describe('MetricsSection', () => {
         await user.click(select)
 
         expect(testLocation?.state).toStrictEqual({
-          parameter: 'FLAKY_TESTS',
+          parameter: TestResultsFilterParameter.FLAKY_TESTS,
           flags: [],
           historicalTrend: '',
           term: '',
@@ -327,7 +329,7 @@ describe('MetricsSection', () => {
         await user.click(select)
 
         expect(testLocation?.state).toStrictEqual({
-          parameter: 'FAILED_TESTS',
+          parameter: TestResultsFilterParameter.FAILED_TESTS,
           flags: [],
           historicalTrend: '',
           term: '',
@@ -384,7 +386,7 @@ describe('MetricsSection', () => {
         await user.click(select)
 
         expect(testLocation?.state).toStrictEqual({
-          parameter: 'SKIPPED_TESTS',
+          parameter: TestResultsFilterParameter.SKIPPED_TESTS,
           flags: [],
           historicalTrend: '',
           term: '',

--- a/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/MetricsSection/MetricsSection.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/MetricsSection/MetricsSection.tsx
@@ -12,7 +12,10 @@ import { MetricCard } from 'ui/MetricCard'
 import { Tooltip } from 'ui/Tooltip'
 
 import { useFlakeAggregates } from '../hooks/useFlakeAggregates'
-import { TestResultsFilterParameterType } from '../hooks/useInfiniteTestResults/useInfiniteTestResults'
+import {
+  TestResultsFilterParameter,
+  TestResultsFilterParameterType,
+} from '../hooks/useInfiniteTestResults/useInfiniteTestResults'
 import { useTestResultsAggregates } from '../hooks/useTestResultsAggregates'
 import { defaultQueryParams } from '../SelectorSection'
 
@@ -127,7 +130,9 @@ const SlowestTestsCard = ({
           })}
           onClick={() => {
             updateParams({
-              parameter: isSelected ? '' : 'SLOWEST_TESTS',
+              parameter: isSelected
+                ? ''
+                : TestResultsFilterParameter.SLOWEST_TESTS,
             })
           }}
         >
@@ -175,7 +180,11 @@ const TotalFlakyTestsCard = ({
             'font-semibold': isSelected,
           })}
           onClick={() => {
-            updateParams({ parameter: isSelected ? '' : 'FLAKY_TESTS' })
+            updateParams({
+              parameter: isSelected
+                ? ''
+                : TestResultsFilterParameter.FLAKY_TESTS,
+            })
           }}
         >
           {flakeCount}
@@ -253,7 +262,11 @@ const TotalFailuresCard = ({
             'font-semibold': isSelected,
           })}
           onClick={() => {
-            updateParams({ parameter: isSelected ? '' : 'FAILED_TESTS' })
+            updateParams({
+              parameter: isSelected
+                ? ''
+                : TestResultsFilterParameter.FAILED_TESTS,
+            })
           }}
         >
           {totalFails}
@@ -300,7 +313,9 @@ const TotalSkippedTestsCard = ({
           })}
           onClick={() => {
             updateParams({
-              parameter: isSelected ? '' : 'SKIPPED_TESTS',
+              parameter: isSelected
+                ? ''
+                : TestResultsFilterParameter.SKIPPED_TESTS,
             })
           }}
         >
@@ -397,7 +412,10 @@ function MetricsSection() {
               }
               slowestTestsDuration={aggregates?.slowestTestsDuration}
               updateParams={updateParams}
-              isSelected={queryParams?.parameter === 'SLOWEST_TESTS'}
+              isSelected={
+                queryParams?.parameter ===
+                TestResultsFilterParameter.SLOWEST_TESTS
+              }
             />
           </div>
         </div>
@@ -419,7 +437,10 @@ function MetricsSection() {
                     flakeAggregates?.flakeCountPercentChange
                   }
                   updateParams={updateParams}
-                  isSelected={queryParams?.parameter === 'FLAKY_TESTS'}
+                  isSelected={
+                    queryParams?.parameter ===
+                    TestResultsFilterParameter.FLAKY_TESTS
+                  }
                 />
                 <AverageFlakeRateCard
                   flakeRate={flakeAggregates?.flakeRate}
@@ -433,13 +454,19 @@ function MetricsSection() {
               totalFails={aggregates?.totalFails}
               totalFailsPercentChange={aggregates?.totalFailsPercentChange}
               updateParams={updateParams}
-              isSelected={queryParams?.parameter === 'FAILED_TESTS'}
+              isSelected={
+                queryParams?.parameter ===
+                TestResultsFilterParameter.FAILED_TESTS
+              }
             />
             <TotalSkippedTestsCard
               totalSkips={aggregates?.totalSkips}
               totalSkipsPercentChange={aggregates?.totalSkipsPercentChange}
               updateParams={updateParams}
-              isSelected={queryParams?.parameter === 'SKIPPED_TESTS'}
+              isSelected={
+                queryParams?.parameter ===
+                TestResultsFilterParameter.SKIPPED_TESTS
+              }
             />
           </div>
         </div>

--- a/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/hooks/useFlakeAggregates/useFlakeAggregates.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/hooks/useFlakeAggregates/useFlakeAggregates.tsx
@@ -5,7 +5,7 @@ import { z } from 'zod'
 import { MeasurementInterval } from 'pages/RepoPage/shared/constants'
 import { RepoNotFoundErrorSchema } from 'services/repo'
 import Api from 'shared/api'
-import { NetworkErrorObject } from 'shared/api/helpers'
+import { NetworkErrorObject, rejectNetworkError } from 'shared/api/helpers'
 
 const FlakeAggregatesSchema = z.object({
   owner: z
@@ -96,7 +96,7 @@ export const useFlakeAggregates = ({
         const parsedData = FlakeAggregatesSchema.safeParse(res?.data)
 
         if (!parsedData.success) {
-          return Promise.reject({
+          return rejectNetworkError({
             status: 404,
             data: {},
             dev: 'useFlakeAggregates - 404 Failed to parse data',
@@ -106,7 +106,7 @@ export const useFlakeAggregates = ({
         const data = parsedData.data
 
         if (data?.owner?.repository?.__typename === 'NotFoundError') {
-          return Promise.reject({
+          return rejectNetworkError({
             status: 404,
             data: {},
             dev: 'useFlakeAggregates - 404 Not found error',

--- a/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/hooks/useInfiniteTestResults/useInfiniteTestResults.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/hooks/useInfiniteTestResults/useInfiniteTestResults.tsx
@@ -11,7 +11,7 @@ import {
   RepoOwnerNotActivatedErrorSchema,
 } from 'services/repo'
 import Api from 'shared/api'
-import { type NetworkErrorObject } from 'shared/api/helpers'
+import { type NetworkErrorObject, rejectNetworkError } from 'shared/api/helpers'
 import { mapEdges } from 'shared/utils/graphql'
 import A from 'ui/A'
 
@@ -229,7 +229,7 @@ export const useInfiniteTestResults = ({
         const parsedData = GetTestResultsSchema.safeParse(res?.data)
 
         if (!parsedData.success) {
-          return Promise.reject({
+          return rejectNetworkError({
             status: 404,
             data: {},
             dev: 'useInfiniteTestResults - 404 Failed to parse data',
@@ -239,7 +239,7 @@ export const useInfiniteTestResults = ({
         const data = parsedData.data
 
         if (data?.owner?.repository?.__typename === 'NotFoundError') {
-          return Promise.reject({
+          return rejectNetworkError({
             status: 404,
             data: {},
             dev: 'useInfiniteTestResults - 404 Not found error',
@@ -247,7 +247,7 @@ export const useInfiniteTestResults = ({
         }
 
         if (data?.owner?.repository?.__typename === 'OwnerNotActivatedError') {
-          return Promise.reject({
+          return rejectNetworkError({
             status: 403,
             data: {
               detail: (

--- a/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/hooks/useTestResultsAggregates/useTestResultsAggregates.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/hooks/useTestResultsAggregates/useTestResultsAggregates.tsx
@@ -5,7 +5,7 @@ import { z } from 'zod'
 import { MeasurementInterval } from 'pages/RepoPage/shared/constants'
 import { RepoNotFoundErrorSchema } from 'services/repo'
 import Api from 'shared/api'
-import { NetworkErrorObject } from 'shared/api/helpers'
+import { NetworkErrorObject, rejectNetworkError } from 'shared/api/helpers'
 
 const TestResultsAggregatesSchema = z.object({
   owner: z
@@ -111,7 +111,7 @@ export const useTestResultsAggregates = ({
         const parsedData = TestResultsAggregatesSchema.safeParse(res?.data)
 
         if (!parsedData.success) {
-          return Promise.reject({
+          return rejectNetworkError({
             status: 404,
             data: {},
             dev: 'useTestResultsAggregates - 404 Failed to parse data',
@@ -121,7 +121,7 @@ export const useTestResultsAggregates = ({
         const data = parsedData.data
 
         if (data?.owner?.repository?.__typename === 'NotFoundError') {
-          return Promise.reject({
+          return rejectNetworkError({
             status: 404,
             data: {},
             dev: 'useTestResultsAggregates - 404 Not found error',

--- a/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/hooks/useTestResultsFlags/useTestResultsFlags.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/hooks/useTestResultsFlags/useTestResultsFlags.tsx
@@ -4,7 +4,7 @@ import { z } from 'zod'
 
 import { RepoNotFoundErrorSchema } from 'services/repo'
 import Api from 'shared/api'
-import { NetworkErrorObject } from 'shared/api/helpers'
+import { NetworkErrorObject, rejectNetworkError } from 'shared/api/helpers'
 
 const TestResultsFlagsSchema = z.object({
   owner: z
@@ -72,7 +72,7 @@ export const useTestResultsFlags = ({ term }: { term?: string }) => {
         const parsedData = TestResultsFlagsSchema.safeParse(res?.data)
 
         if (!parsedData.success) {
-          return Promise.reject({
+          return rejectNetworkError({
             status: 404,
             data: {},
             dev: 'useTestResultsFlags - 404 Failed to parse data',
@@ -82,7 +82,7 @@ export const useTestResultsFlags = ({ term }: { term?: string }) => {
         const data = parsedData.data
 
         if (data?.owner?.repository?.__typename === 'NotFoundError') {
-          return Promise.reject({
+          return rejectNetworkError({
             status: 404,
             data: {},
             dev: 'useTestResultsFlags - 404 Not found error',

--- a/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/hooks/useTestResultsTestSuites/useTestResultsTestSuites.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/hooks/useTestResultsTestSuites/useTestResultsTestSuites.tsx
@@ -4,7 +4,7 @@ import { z } from 'zod'
 
 import { RepoNotFoundErrorSchema } from 'services/repo'
 import Api from 'shared/api'
-import { NetworkErrorObject } from 'shared/api/helpers'
+import { NetworkErrorObject, rejectNetworkError } from 'shared/api/helpers'
 
 const TestResultsTestSuitesSchema = z.object({
   owner: z
@@ -72,7 +72,7 @@ export const useTestResultsTestSuites = ({ term }: { term?: string }) => {
         const parsedData = TestResultsTestSuitesSchema.safeParse(res?.data)
 
         if (!parsedData.success) {
-          return Promise.reject({
+          return rejectNetworkError({
             status: 404,
             data: {},
             dev: 'useTestResultsTestSuites - 404 Failed to parse data',
@@ -82,7 +82,7 @@ export const useTestResultsTestSuites = ({ term }: { term?: string }) => {
         const data = parsedData.data
 
         if (data?.owner?.repository?.__typename === 'NotFoundError') {
-          return Promise.reject({
+          return rejectNetworkError({
             status: 404,
             data: {},
             dev: 'useTestResultsTestSuites - 404 Not found error',


### PR DESCRIPTION
# Description

This PR follows up on a few comments on the tests-analytics-v2 branch to do the following:

- Use const values instead of strings for TestResultsFilterParameter
- Update the hooks reject errors from Promise.reject to rejectNetworkError

# Screenshots

# Link to Sample Entry

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.