### PR TITLE
fix: Add org/ to upload command for other ci onboarding

### DIFF
--- a/src/pages/RepoPage/CoverageOnboarding/OtherCI/OtherCI.test.tsx
+++ b/src/pages/RepoPage/CoverageOnboarding/OtherCI/OtherCI.test.tsx
@@ -207,7 +207,7 @@ describe('OtherCI', () => {
         setup({ hasOrgUploadToken: true })
         render(<OtherCI />, { wrapper })
 
-        const box = await screen.findByText(/-r cool-repo/)
+        const box = await screen.findByText(/-r codecov\/cool-repo/)
         expect(box).toBeInTheDocument()
       })
     })
@@ -217,7 +217,7 @@ describe('OtherCI', () => {
         setup({})
         render(<OtherCI />, { wrapper })
 
-        const box = screen.queryByText(/-r cool-repo/)
+        const box = screen.queryByText(/-r codecov\/cool-repo/)
         expect(box).not.toBeInTheDocument()
       })
     })

--- a/src/pages/RepoPage/CoverageOnboarding/OtherCI/OtherCI.tsx
+++ b/src/pages/RepoPage/CoverageOnboarding/OtherCI/OtherCI.tsx
@@ -37,7 +37,7 @@ function OtherCI() {
 
   const apiUrlCopy = config.IS_SELF_HOSTED ? ` -u ${config.API_URL}` : ''
   const uploadCommand = `./codecov${apiUrlCopy} upload-process${
-    orgUploadToken ? ` -r ${repo}` : ''
+    orgUploadToken ? ` -r ${owner}/${repo}` : ''
   }`
 
   return (


### PR DESCRIPTION
Noticed this was wrong during an investigation this morning - the CLI throws an error if you do not include the org/ part of the repo slug.
