### PR TITLE
fix: TA finishing touches and just in case fixes

### DIFF
--- a/src/pages/RepoPage/FailedTestsTab/CodecovCLI/CodecovCLI.test.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/CodecovCLI/CodecovCLI.test.tsx
@@ -223,7 +223,7 @@ describe('CodecovCLI', () => {
       expect(link).toBeInTheDocument()
       expect(link).toHaveAttribute(
         'href',
-        'https://docs.codecov.com/docs/test-result-ingestion-beta#failed-test-reporting'
+        'https://docs.codecov.com/docs/test-analytics#failed-test-reporting'
       )
     })
   })

--- a/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/FailedTestsTable/FailedTestsTable.test.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/FailedTestsTable/FailedTestsTable.test.tsx
@@ -270,7 +270,7 @@ describe('FailedTestsTable', () => {
       const nameColumn = await screen.findByText('Test name')
       expect(nameColumn).toBeInTheDocument()
 
-      const durationColumn = await screen.findByText('Avg duration')
+      const durationColumn = await screen.findByText('Avg. duration')
       expect(durationColumn).toBeInTheDocument()
 
       const failureRateColumn = await screen.findByText('Failure rate')
@@ -366,7 +366,7 @@ describe('FailedTestsTable', () => {
         wrapper: wrapper(queryClient),
       })
 
-      const durationColumn = await screen.findByText('Avg duration')
+      const durationColumn = await screen.findByText('Avg. duration')
       await user.click(durationColumn)
 
       await waitFor(() => {

--- a/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/FailedTestsTable/FailedTestsTable.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/FailedTestsTable/FailedTestsTable.tsx
@@ -126,7 +126,7 @@ const getColumns = ({
       cell: (info) => info.renderValue(),
     }),
     columnHelper.accessor('avgDuration', {
-      header: () => 'Avg duration',
+      header: () => 'Avg. duration',
       cell: (info) => `${(info.renderValue() ?? 0).toFixed(3)}s`,
     }),
     columnHelper.accessor('failureRate', {
@@ -238,42 +238,40 @@ const FailedTestsTable = () => {
   const tableData = useMemo(() => {
     if (!testData?.testResults) return []
 
-    return (
-      testData.testResults.map((result) => {
-        const value = (result.flakeRate ?? 0) * 100
-        const isFlakeInt = Number.isInteger(value)
+    return testData.testResults.map((result) => {
+      const value = (result.flakeRate ?? 0) * 100
+      const isFlakeInt = Number.isInteger(value)
 
-        const FlakeRateContent = (
-          <Tooltip delayDuration={0} skipDelayDuration={100}>
-            <Tooltip.Root>
-              <Tooltip.Trigger className="underline decoration-dotted decoration-1 underline-offset-4">
-                {isFlakeInt ? `${value}%` : `${value.toFixed(2)}%`}
-              </Tooltip.Trigger>
-              <Tooltip.Portal>
-                <Tooltip.Content
-                  className="bg-ds-gray-primary p-2 text-xs text-ds-gray-octonary"
-                  side="right"
-                >
-                  {result.totalPassCount} Passed, {result.totalFailCount} Failed
-                  ({result.totalFlakyFailCount} Flaky), {result.totalSkipCount}{' '}
-                  Skipped
-                  <Tooltip.Arrow className="size-4 fill-ds-gray-primary" />
-                </Tooltip.Content>
-              </Tooltip.Portal>
-            </Tooltip.Root>
-          </Tooltip>
-        )
+      const FlakeRateContent = (
+        <Tooltip delayDuration={0} skipDelayDuration={100}>
+          <Tooltip.Root>
+            <Tooltip.Trigger className="underline decoration-dotted decoration-1 underline-offset-4">
+              {isFlakeInt ? `${value}%` : `${value.toFixed(2)}%`}
+            </Tooltip.Trigger>
+            <Tooltip.Portal>
+              <Tooltip.Content
+                className="bg-ds-gray-primary p-2 text-xs text-ds-gray-octonary"
+                side="right"
+              >
+                {result.totalPassCount} Passed, {result.totalFailCount} Failed (
+                {result.totalFlakyFailCount} Flaky), {result.totalSkipCount}{' '}
+                Skipped
+                <Tooltip.Arrow className="size-4 fill-ds-gray-primary" />
+              </Tooltip.Content>
+            </Tooltip.Portal>
+          </Tooltip.Root>
+        </Tooltip>
+      )
 
-        return {
-          name: result.name,
-          avgDuration: result.avgDuration,
-          failureRate: result.failureRate,
-          flakeRate: FlakeRateContent,
-          commitsFailed: result.commitsFailed,
-          updatedAt: result.updatedAt,
-        }
-      }) ?? []
-    )
+      return {
+        name: result.name,
+        avgDuration: result.avgDuration,
+        failureRate: result.failureRate,
+        flakeRate: FlakeRateContent,
+        commitsFailed: result.commitsFailed,
+        updatedAt: result.updatedAt,
+      }
+    })
   }, [testData?.testResults])
 
   const columns = useMemo(

--- a/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/SelectorSection/BranchSelector/BranchSelector.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/SelectorSection/BranchSelector/BranchSelector.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 import { useHistory, useParams } from 'react-router-dom'
 
 import { Branch, useBranch, useBranches } from 'services/branches'
@@ -76,15 +76,20 @@ const BranchSelector = () => {
     )
   }
 
-  const sortedBranchList = overview?.defaultBranch
-    ? [
+  const sortedBranchList = useMemo(() => {
+    if (!branchList?.branches) return []
+
+    if (overview?.defaultBranch) {
+      return [
         // Pins the default branch to the top of the list always, filters it from results otherwise
         { name: overview.defaultBranch, head: null },
-        ...(branchList?.branches?.filter(
+        ...branchList.branches.filter(
           (branch) => branch.name !== overview.defaultBranch
-        ) ?? []),
+        ),
       ]
-    : (branchList?.branches ?? [])
+    }
+    return branchList.branches
+  }, [overview?.defaultBranch, branchList.branches])
 
   return (
     <div className="flex w-full flex-col gap-1 px-4 lg:w-64 xl:w-80">

--- a/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/SelectorSection/SelectorSection.test.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/SelectorSection/SelectorSection.test.tsx
@@ -196,7 +196,7 @@ describe('SelectorSection', () => {
 
       expect(link).toHaveAttribute(
         'href',
-        'https://docs.codecov.com/docs/test-result-ingestion-beta#data-retention'
+        'https://docs.codecov.com/docs/test-analytics#data-retention'
       )
     })
   })

--- a/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/hooks/useFlakeAggregates/useFlakeAggregates.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/hooks/useFlakeAggregates/useFlakeAggregates.tsx
@@ -15,12 +15,14 @@ const FlakeAggregatesSchema = z.object({
           __typename: z.literal('Repository'),
           testAnalytics: z
             .object({
-              flakeAggregates: z.object({
-                flakeCount: z.number(),
-                flakeCountPercentChange: z.number().nullable(),
-                flakeRate: z.number(),
-                flakeRatePercentChange: z.number().nullable(),
-              }),
+              flakeAggregates: z
+                .object({
+                  flakeCount: z.number(),
+                  flakeCountPercentChange: z.number().nullable(),
+                  flakeRate: z.number(),
+                  flakeRatePercentChange: z.number().nullable(),
+                })
+                .nullable(),
             })
             .nullable(),
         }),
@@ -100,6 +102,7 @@ export const useFlakeAggregates = ({
             status: 404,
             data: {},
             dev: 'useFlakeAggregates - 404 Failed to parse data',
+            error: parsedData.error,
           } satisfies NetworkErrorObject)
         }
 

--- a/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/hooks/useInfiniteTestResults/useInfiniteTestResults.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/hooks/useInfiniteTestResults/useInfiniteTestResults.tsx
@@ -233,6 +233,7 @@ export const useInfiniteTestResults = ({
             status: 404,
             data: {},
             dev: 'useInfiniteTestResults - 404 Failed to parse data',
+            error: parsedData.error,
           } satisfies NetworkErrorObject)
         }
 

--- a/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/hooks/useTestResultsAggregates/useTestResultsAggregates.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/hooks/useTestResultsAggregates/useTestResultsAggregates.tsx
@@ -22,18 +22,20 @@ const TestResultsAggregatesSchema = z.object({
           defaultBranch: z.string().nullable(),
           testAnalytics: z
             .object({
-              testResultsAggregates: z.object({
-                totalDuration: z.number(),
-                totalDurationPercentChange: z.number().nullable(),
-                slowestTestsDuration: z.number(),
-                slowestTestsDurationPercentChange: z.number().nullable(),
-                totalSlowTests: z.number(),
-                totalSlowTestsPercentChange: z.number().nullable(),
-                totalFails: z.number(),
-                totalFailsPercentChange: z.number().nullable(),
-                totalSkips: z.number(),
-                totalSkipsPercentChange: z.number().nullable(),
-              }),
+              testResultsAggregates: z
+                .object({
+                  totalDuration: z.number(),
+                  totalDurationPercentChange: z.number().nullable(),
+                  slowestTestsDuration: z.number(),
+                  slowestTestsDurationPercentChange: z.number().nullable(),
+                  totalSlowTests: z.number(),
+                  totalSlowTestsPercentChange: z.number().nullable(),
+                  totalFails: z.number(),
+                  totalFailsPercentChange: z.number().nullable(),
+                  totalSkips: z.number(),
+                  totalSkipsPercentChange: z.number().nullable(),
+                })
+                .nullable(),
             })
             .nullable(),
         }),
@@ -115,6 +117,7 @@ export const useTestResultsAggregates = ({
             status: 404,
             data: {},
             dev: 'useTestResultsAggregates - 404 Failed to parse data',
+            error: parsedData.error,
           } satisfies NetworkErrorObject)
         }
 

--- a/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/hooks/useTestResultsFlags/useTestResultsFlags.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/hooks/useTestResultsFlags/useTestResultsFlags.tsx
@@ -76,6 +76,7 @@ export const useTestResultsFlags = ({ term }: { term?: string }) => {
             status: 404,
             data: {},
             dev: 'useTestResultsFlags - 404 Failed to parse data',
+            error: parsedData.error,
           } satisfies NetworkErrorObject)
         }
 

--- a/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/hooks/useTestResultsTestSuites/useTestResultsTestSuites.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/hooks/useTestResultsTestSuites/useTestResultsTestSuites.tsx
@@ -76,6 +76,7 @@ export const useTestResultsTestSuites = ({ term }: { term?: string }) => {
             status: 404,
             data: {},
             dev: 'useTestResultsTestSuites - 404 Failed to parse data',
+            error: parsedData.error,
           } satisfies NetworkErrorObject)
         }
 

--- a/src/pages/RepoPage/FailedTestsTab/GitHubActions/GitHubActions.test.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/GitHubActions/GitHubActions.test.tsx
@@ -213,7 +213,7 @@ describe('GitHubActions', () => {
       expect(link).toBeInTheDocument()
       expect(link).toHaveAttribute(
         'href',
-        'https://docs.codecov.com/docs/test-result-ingestion-beta#failed-test-reporting'
+        'https://docs.codecov.com/docs/test-analytics#failed-test-reporting'
       )
     })
   })

--- a/src/services/navigation/useNavLinks/useStaticNavLinks.test.tsx
+++ b/src/services/navigation/useNavLinks/useStaticNavLinks.test.tsx
@@ -89,8 +89,8 @@ describe('useStaticNavLinks', () => {
       ${links.quickStart}                    | ${'https://docs.codecov.com/docs/quick-start'}
       ${links.installSelfHosted}             | ${'https://docs.codecov.com/docs/installing-codecov-self-hosted'}
       ${links.login}                         | ${`/login`}
-      ${links.testsAnalytics}                | ${'https://docs.codecov.com/docs/test-result-ingestion-beta#failed-test-reporting'}
-      ${links.testsAnalyticsDataRetention}   | ${'https://docs.codecov.com/docs/test-result-ingestion-beta#data-retention'}
+      ${links.testsAnalytics}                | ${'https://docs.codecov.com/docs/test-analytics#failed-test-reporting'}
+      ${links.testsAnalyticsDataRetention}   | ${'https://docs.codecov.com/docs/test-analytics#data-retention'}
       ${links.expiredReports}                | ${'https://docs.codecov.com/docs/codecov-yaml#section-expired-reports'}
       ${links.unusableReports}               | ${'https://docs.codecov.com/docs/error-reference#unusable-reports'}
       ${links.demoRepo}                      | ${'/github/codecov/gazebo'}

--- a/src/services/navigation/useNavLinks/useStaticNavLinks.ts
+++ b/src/services/navigation/useNavLinks/useStaticNavLinks.ts
@@ -460,14 +460,13 @@ export function useStaticNavLinks() {
     testsAnalytics: {
       text: 'Tests Analytics',
       path: () =>
-        'https://docs.codecov.com/docs/test-result-ingestion-beta#failed-test-reporting',
+        'https://docs.codecov.com/docs/test-analytics#failed-test-reporting',
       isExternalLink: true,
       openNewTab: true,
     },
     testsAnalyticsDataRetention: {
       text: 'Test Analytics Data Retention',
-      path: () =>
-        'https://docs.codecov.com/docs/test-result-ingestion-beta#data-retention',
+      path: () => 'https://docs.codecov.com/docs/test-analytics#data-retention',
       isExternalLink: true,
       openNewTab: true,
     },


### PR DESCRIPTION
# Description

This PR does a lot of teeny updates and fixes in preparation for the TA launch:

- Nullable on TA and Flake Aggregates objects from zod, in the event those objects don't exist on request
- Adds "error" object to rejectNetworkError call when failing to parse on relevant TA hooks
- Updates the links to say "test-analytics" from "test-result-ingestion-beta" for anyone that hovers them
- Memoizes the branch selection list to prevent some extra overhead on failed tests table re-renders
- Removes unnecessary ?? operator 
- Adds "." to the end of Avg on the failed tests table

# Screenshots

https://github.com/user-attachments/assets/5c922300-63b1-4552-af71-89cca8becbcf


# Link to Sample Entry

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.