### PR TITLE
chore: Upgrade http-proxy-middleware to ^2.0.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -176,8 +176,7 @@
     "micromatch": "^4.0.8",
     "express": "^4.21.0",
     "path-to-regexp@^1.7.0": "^1.9.0",
-    "path-to-regexp@^6.2.0": "^6.3.0",
-    "http-proxy-middleware": "^2.0.7"
+    "path-to-regexp@^6.2.0": "^6.3.0"
   },
   "packageManager": "yarn@4.5.0",
   "engineStrict": false

--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "eslint-plugin-storybook": "^0.8.0",
     "eslint-plugin-tailwindcss": "^3.17.4",
     "eslint-plugin-testing-library": "^6.3.0",
-    "http-proxy-middleware": "^2.0.6",
+    "http-proxy-middleware": "^2.0.7",
     "husky": "^9.1.4",
     "jsdom": "^25.0.0",
     "lint-staged": "^15.2.8",
@@ -176,7 +176,8 @@
     "micromatch": "^4.0.8",
     "express": "^4.21.0",
     "path-to-regexp@^1.7.0": "^1.9.0",
-    "path-to-regexp@^6.2.0": "^6.3.0"
+    "path-to-regexp@^6.2.0": "^6.3.0",
+    "http-proxy-middleware": "^2.0.7"
   },
   "packageManager": "yarn@4.5.0",
   "engineStrict": false

--- a/yarn.lock
+++ b/yarn.lock
@@ -13453,7 +13453,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"http-proxy-middleware@npm:^2.0.7":
+"http-proxy-middleware@npm:^2.0.3, http-proxy-middleware@npm:^2.0.7":
   version: 2.0.7
   resolution: "http-proxy-middleware@npm:2.0.7"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -12761,7 +12761,7 @@ __metadata:
     eslint-plugin-storybook: "npm:^0.8.0"
     eslint-plugin-tailwindcss: "npm:^3.17.4"
     eslint-plugin-testing-library: "npm:^6.3.0"
-    http-proxy-middleware: "npm:^2.0.6"
+    http-proxy-middleware: "npm:^2.0.7"
     husky: "npm:^9.1.4"
     js-cookie: "npm:^3.0.5"
     jsdom: "npm:^25.0.0"
@@ -13453,9 +13453,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"http-proxy-middleware@npm:^2.0.3, http-proxy-middleware@npm:^2.0.6":
-  version: 2.0.6
-  resolution: "http-proxy-middleware@npm:2.0.6"
+"http-proxy-middleware@npm:^2.0.7":
+  version: 2.0.7
+  resolution: "http-proxy-middleware@npm:2.0.7"
   dependencies:
     "@types/http-proxy": "npm:^1.17.8"
     http-proxy: "npm:^1.18.1"
@@ -13467,7 +13467,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/express":
       optional: true
-  checksum: 10c0/25a0e550dd1900ee5048a692e0e9b2b6339d06d487a705d90c47e359e9c6561d648cd7862d001d090e651c9efffa1b6e5160fcf1f299b5fa4935f76e9754eb11
+  checksum: 10c0/8d00a61eb215b83826460b07489d8bb095368ec16e02a9d63e228dcf7524e7c20d61561e5476de1391aecd4ec32ea093279cdc972115b311f8e0a95a24c9e47e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Description

Closes https://github.com/codecov/internal-issues/issues/971

Upgraded our own use of the package for
├─ gazebo@workspace:.
│  └─ http-proxy-middleware@npm:2.0.6 [6563e] (via npm:^2.0.6 [6563e])

but adding a resolution as it is also referenced here
gazebo@workspace:.
   └─ react-scripts@npm:5.0.1 [6563e] (via npm:^5.0.1 [6563e])
      └─ webpack-dev-server@npm:4.15.2 [37b33] (via npm:^4.6.0 [37b33])
         └─ http-proxy-middleware@npm:2.0.6 [edb85] (via npm:^2.0.3 [edb85])

We can remove this resolution when we pull out react-scripts as part of Gazebo V2 work tickets.