### PR TITLE
fix: Flake rate to fixed decimals

### DIFF
--- a/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/MetricsSection/MetricsSection.test.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/MetricsSection/MetricsSection.test.tsx
@@ -48,7 +48,7 @@ const mockFlakeAggResponse = {
         flakeAggregates: {
           flakeCount: 88,
           flakeCountPercentChange: 10.0,
-          flakeRate: 8,
+          flakeRate: 8.412412312,
           flakeRatePercentChange: 5.0,
         },
       },
@@ -291,7 +291,7 @@ describe('MetricsSection', () => {
       })
 
       const title = await screen.findByText('Avg. flake rate')
-      const context = await screen.findByText('8%')
+      const context = await screen.findByText('8.41%')
       const description = await screen.findByText(
         'The average flake rate across all branches.'
       )

--- a/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/MetricsSection/MetricsSection.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/MetricsSection/MetricsSection.tsx
@@ -220,7 +220,7 @@ const AverageFlakeRateCard = ({
         </MetricCard.Title>
       </MetricCard.Header>
       <MetricCard.Content>
-        {flakeRate}%
+        {flakeRate?.toFixed(2)}%
         {flakeRatePercentChange ? (
           <PercentBadge value={flakeRatePercentChange} />
         ) : null}


### PR DESCRIPTION
# Description

This PR fixes an issue where flake rate was unbounded coming from API, and bounds it to 2 decimals.


# Screenshots

**BEFORE**

<img width="2136" alt="Screenshot 2024-11-12 at 1 11 45 PM" src="https://github.com/user-attachments/assets/4b21feba-d760-4a81-a975-c4faab72537f">


**AFTER**

<img width="1413" alt="Screenshot 2024-11-12 at 1 10 58 PM" src="https://github.com/user-attachments/assets/12fd8335-15ea-42a5-a260-b2d652506925">


# Link to Sample Entry

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.