### PR TITLE
fix: Tooltip copy for failed tests

### DIFF
--- a/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/MetricsSection/MetricsSection.test.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/MetricsSection/MetricsSection.test.tsx
@@ -308,7 +308,7 @@ describe('MetricsSection', () => {
           wrapper: wrapper('/gh/owner/repo/tests/main'),
         })
 
-        const title = await screen.findByText('Failures')
+        const title = await screen.findByText('Cumulative Failures')
         const context = await screen.findByText(1)
         const description = await screen.findByText(
           'The number of test failures across all branches.'

--- a/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/MetricsSection/MetricsSection.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/MetricsSection/MetricsSection.tsx
@@ -249,10 +249,10 @@ const TotalFailuresCard = ({
     <MetricCard>
       <MetricCard.Header>
         <MetricCard.Title className="flex items-center gap-2">
-          Failures
+          Cumulative Failures
           <TooltipWithIcon>
-            The number of failures indicate the number of errors that caused the
-            tests to fail.
+            The sum of all test failures, incremented each time any test has
+            failed.
           </TooltipWithIcon>
         </MetricCard.Title>
       </MetricCard.Header>


### PR DESCRIPTION
# Description

This PR updates the copy on the failed tests tooltip, as well as the failed tests metric section header. No other changes, purely copy updates.

Closes https://github.com/codecov/engineering-team/issues/2887

# Screenshots

<img width="462" alt="Screenshot 2024-11-13 at 4 32 42 PM" src="https://github.com/user-attachments/assets/ce445f30-8c16-41b1-9e80-78fa10d0a3c5">


# Link to Sample Entry

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.