### PR TITLE
dev: Fix app.tsx flake I think

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -157,9 +157,12 @@ beforeAll(() => {
 
 beforeEach(() => {
   config.IS_SELF_HOSTED = false
+  mockedUseLocationParams.mockReturnValue({ params: {} })
+})
+
+afterEach(() => {
   queryClient.clear()
   server.resetHandlers()
-  mockedUseLocationParams.mockReturnValue({ params: {} })
 })
 
 afterAll(() => {

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -163,6 +163,7 @@ beforeEach(() => {
 afterEach(() => {
   queryClient.clear()
   server.resetHandlers()
+  vi.clearAllMocks()
 })
 
 afterAll(() => {


### PR DESCRIPTION
# Description

I think this is flaking because the mocks aren't being reset properly.

We want to set the var before each, but then clear the query client after each (intuitively that makes sense at least)

# Screenshots

# Link to Sample Entry

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.