### PR TITLE
fix: Copy update on Cumulative Failure tile

### DIFF
--- a/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/MetricsSection/MetricsSection.test.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/MetricsSection/MetricsSection.test.tsx
@@ -316,7 +316,7 @@ describe('MetricsSection', () => {
         const title = await screen.findByText('Cumulative Failures')
         const context = await screen.findByText(1)
         const description = await screen.findByText(
-          'The number of test failures across all branches.'
+          'The number of test failures on your default branch.'
         )
 
         expect(title).toBeInTheDocument()

--- a/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/MetricsSection/MetricsSection.test.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/MetricsSection/MetricsSection.test.tsx
@@ -298,7 +298,7 @@ describe('MetricsSection', () => {
       const title = await screen.findByText('Avg. flake rate')
       const context = await screen.findByText('8.41%')
       const description = await screen.findByText(
-        'The average flake rate across all branches.'
+        'The average flake rate on your default branch.'
       )
 
       expect(title).toBeInTheDocument()

--- a/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/MetricsSection/MetricsSection.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/MetricsSection/MetricsSection.tsx
@@ -276,7 +276,7 @@ const TotalFailuresCard = ({
         ) : null}
       </MetricCard.Content>
       <MetricCard.Description>
-        The number of test failures across all branches.
+        The number of test failures on your default branch.
       </MetricCard.Description>
     </MetricCard>
   )

--- a/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/MetricsSection/MetricsSection.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/MetricsSection/MetricsSection.tsx
@@ -226,7 +226,7 @@ const AverageFlakeRateCard = ({
         ) : null}
       </MetricCard.Content>
       <MetricCard.Description>
-        The average flake rate across all branches.
+        The average flake rate on your default branch.
       </MetricCard.Description>
     </MetricCard>
   )


### PR DESCRIPTION
# Description

This PR just updates some copy on the cumulative failures tile on the failed tests table. Previously we mentioned that the failures shown were for all branches, but its actually just the default branch

Closes https://github.com/codecov/engineering-team/issues/2942

# Screenshots

<img width="219" alt="Screenshot 2024-11-18 at 3 55 31 PM" src="https://github.com/user-attachments/assets/f9aefb73-3d08-46b0-8f7e-82ca281dca92">


# Link to Sample Entry

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.