### PR TITLE
fix: Change flags to anchor style

### DIFF
--- a/src/pages/RepoPage/CoverageTab/FlagsTab/subroute/FlagsTable/FlagsTable.tsx
+++ b/src/pages/RepoPage/CoverageTab/FlagsTab/subroute/FlagsTable/FlagsTable.tsx
@@ -75,6 +75,7 @@ function createTableData({
                 pageName: 'coverage',
                 options: { queryParams: { flags: [value.name] } },
               }}
+              variant="link"
               isExternal={false}
               hook={'flag-to-coverage-page'}
             >

--- a/src/pages/RepoPage/CoverageTab/FlagsTab/subroute/FlagsTable/FlagsTable.tsx
+++ b/src/pages/RepoPage/CoverageTab/FlagsTab/subroute/FlagsTable/FlagsTable.tsx
@@ -75,7 +75,6 @@ function createTableData({
                 pageName: 'coverage',
                 options: { queryParams: { flags: [value.name] } },
               }}
-              variant="black"
               isExternal={false}
               hook={'flag-to-coverage-page'}
             >


### PR DESCRIPTION
# Description

Just changing links to `link: "text-ds-blue-darker"` to better represent there are clickable.

Closes https://github.com/codecov/engineering-team/issues/2774

<img width="864" alt="Screenshot 2024-11-20 at 4 24 00 PM" src="https://github.com/user-attachments/assets/278ef946-6f56-43c6-b3ac-0d7aa99a8468">


# Code Example

# Notable Changes

# Screenshots

# Link to Sample Entry

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.