### PR TITLE
feat: Handle self hosted activation statuses  

### DIFF
--- a/src/pages/RepoPage/ActivationAlert/ActivationAlert.tsx
+++ b/src/pages/RepoPage/ActivationAlert/ActivationAlert.tsx
@@ -1,9 +1,12 @@
 import { useParams } from 'react-router-dom'
 
+import config from 'config'
+
 import { usePlanData } from 'services/account'
 import { isFreePlan } from 'shared/utils/billing'
 
 import ActivationRequiredAlert from './ActivationRequiredAlert'
+import ActivationRequiredSelfHostet from './ActivationRequiredSelfHosted'
 import FreePlanSeatsTakenAlert from './FreePlanSeatsTakenAlert'
 import PaidPlanSeatsTakenAlert from './PaidPlanSeatsTakenAlert'
 import UnauthorizedRepoDisplay from './UnauthorizedRepoDisplay'
@@ -28,6 +31,10 @@ function ActivationAlert() {
 
   const renderActivationRequiredAlert =
     !isFreePlan(planData?.plan?.value) && planData?.plan?.hasSeatsLeft
+
+  if (config.IS_SELF_HOSTED) {
+    return <ActivationRequiredSelfHostet />
+  }
 
   if (renderFreePlanSeatsTakenAlert) {
     return <FreePlanSeatsTakenAlert />

--- a/src/pages/RepoPage/ActivationAlert/ActivationAlert.tsx
+++ b/src/pages/RepoPage/ActivationAlert/ActivationAlert.tsx
@@ -6,7 +6,7 @@ import { usePlanData } from 'services/account'
 import { isFreePlan } from 'shared/utils/billing'
 
 import ActivationRequiredAlert from './ActivationRequiredAlert'
-import ActivationRequiredSelfHostet from './ActivationRequiredSelfHosted'
+import ActivationRequiredSelfHosted from './ActivationRequiredSelfHosted'
 import FreePlanSeatsTakenAlert from './FreePlanSeatsTakenAlert'
 import PaidPlanSeatsTakenAlert from './PaidPlanSeatsTakenAlert'
 import UnauthorizedRepoDisplay from './UnauthorizedRepoDisplay'
@@ -33,7 +33,7 @@ function ActivationAlert() {
     !isFreePlan(planData?.plan?.value) && planData?.plan?.hasSeatsLeft
 
   if (config.IS_SELF_HOSTED) {
-    return <ActivationRequiredSelfHostet />
+    return <ActivationRequiredSelfHosted />
   }
 
   if (renderFreePlanSeatsTakenAlert) {

--- a/src/pages/RepoPage/ActivationAlert/ActivationRequiredSelfHosted/ActivationRequiredSelfHosted.test.tsx
+++ b/src/pages/RepoPage/ActivationAlert/ActivationRequiredSelfHosted/ActivationRequiredSelfHosted.test.tsx
@@ -129,7 +129,7 @@ describe('ActivationRequiredSelfHosted', () => {
           name: /Manage members/,
         })
         expect(link).toBeInTheDocument()
-        expect(link).toHaveAttribute('href', '/admin/gh/access')
+        expect(link).toHaveAttribute('href', '/admin/gh/users')
       })
     })
   })

--- a/src/pages/RepoPage/ActivationAlert/ActivationRequiredSelfHosted/ActivationRequiredSelfHosted.test.tsx
+++ b/src/pages/RepoPage/ActivationAlert/ActivationRequiredSelfHosted/ActivationRequiredSelfHosted.test.tsx
@@ -1,0 +1,125 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { render, screen, waitFor } from '@testing-library/react'
+import { http, HttpResponse } from 'msw'
+import { setupServer } from 'msw/node'
+import { MemoryRouter, Route } from 'react-router-dom'
+import { vi } from 'vitest'
+
+import ActivationRequiredSelfHosted from './ActivationRequiredSelfHosted'
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      retry: false,
+      suspense: false,
+    },
+  },
+})
+
+const wrapper: React.FC<React.PropsWithChildren> = ({ children }) => (
+  <QueryClientProvider client={queryClient}>
+    <MemoryRouter initialEntries={['/gh/codecov/gazebo/new']}>
+      <Route path="/:provider/:owner/:repo/new">{children}</Route>
+    </MemoryRouter>
+  </QueryClientProvider>
+)
+
+const server = setupServer()
+
+beforeAll(() => {
+  server.listen({ onUnhandledRequest: 'warn' })
+  console.error = () => {}
+})
+
+afterEach(() => {
+  queryClient.clear()
+  server.resetHandlers()
+  vi.clearAllMocks()
+})
+
+afterAll(() => {
+  server.close()
+})
+
+describe('ActivationRequiredSelfHosted', () => {
+  function setup(isAdmin: boolean) {
+    server.use(
+      http.get('/internal/users/current', (info) =>
+        HttpResponse.json({
+          isAdmin,
+          email: 'user@example.com',
+          name: 'Test User',
+          ownerid: 1,
+          username: 'testuser',
+          activated: true,
+        })
+      )
+    )
+  }
+
+  it('renders the banner with correct heading', async () => {
+    setup(false)
+    render(<ActivationRequiredSelfHosted />, { wrapper })
+
+    const bannerHeading = await screen.findByRole('heading', {
+      name: /Activation Required/,
+    })
+    expect(bannerHeading).toBeInTheDocument()
+  })
+
+  it('renders the banner with correct description', async () => {
+    setup(false)
+    render(<ActivationRequiredSelfHosted />, { wrapper })
+
+    const description = await screen.findByText(
+      /You have available seats, but activation is needed./
+    )
+    expect(description).toBeInTheDocument()
+  })
+
+  it('renders copy for the user', async () => {
+    setup(false)
+    render(<ActivationRequiredSelfHosted />, { wrapper })
+
+    const copy = await screen.findByText(/Contact your admin for activation./)
+    expect(copy).toBeInTheDocument()
+  })
+
+  it('does not render the link if the user is not an admin', async () => {
+    setup(false)
+    render(<ActivationRequiredSelfHosted />, { wrapper })
+
+    await waitFor(() => queryClient.isFetching)
+    await waitFor(() => !queryClient.isFetching)
+
+    const link = screen.queryByRole('link', {
+      name: /Manage members/,
+    })
+    expect(link).not.toBeInTheDocument()
+  })
+
+  it('renders the correct img', async () => {
+    setup(false)
+    render(<ActivationRequiredSelfHosted />, { wrapper })
+
+    const img = await screen.findByAltText('Forbidden')
+    expect(img).toBeInTheDocument()
+    expect(img).toHaveAttribute(
+      'src',
+      '/src/layouts/shared/NetworkErrorBoundary/assets/error-upsidedown-umbrella.svg'
+    )
+  })
+
+  describe('when the user is an admin', () => {
+    it('renders the correct link', async () => {
+      setup(true)
+      render(<ActivationRequiredSelfHosted />, { wrapper })
+
+      const link = await screen.findByRole('link', {
+        name: /Manage members/,
+      })
+      expect(link).toBeInTheDocument()
+      expect(link).toHaveAttribute('href', '/admin/gh/access')
+    })
+  })
+})

--- a/src/pages/RepoPage/ActivationAlert/ActivationRequiredSelfHosted/ActivationRequiredSelfHosted.test.tsx
+++ b/src/pages/RepoPage/ActivationAlert/ActivationRequiredSelfHosted/ActivationRequiredSelfHosted.test.tsx
@@ -1,6 +1,6 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { render, screen, waitFor } from '@testing-library/react'
-import { http, HttpResponse } from 'msw'
+import { graphql, http, HttpResponse } from 'msw'
 import { setupServer } from 'msw/node'
 import { MemoryRouter, Route } from 'react-router-dom'
 import { vi } from 'vitest'
@@ -42,7 +42,7 @@ afterAll(() => {
 })
 
 describe('ActivationRequiredSelfHosted', () => {
-  function setup(isAdmin: boolean) {
+  function setup(isAdmin: boolean, seatsUsed: number, seatsLimit: number) {
     server.use(
       http.get('/internal/users/current', (info) =>
         HttpResponse.json({
@@ -53,73 +53,127 @@ describe('ActivationRequiredSelfHosted', () => {
           username: 'testuser',
           activated: true,
         })
-      )
+      ),
+      graphql.query('Seats', (info) => {
+        return HttpResponse.json({
+          data: {
+            config: {
+              seatsUsed,
+              seatsLimit,
+            },
+          },
+        })
+      })
     )
   }
-
-  it('renders the banner with correct heading', async () => {
-    setup(false)
-    render(<ActivationRequiredSelfHosted />, { wrapper })
-
-    const bannerHeading = await screen.findByRole('heading', {
-      name: /Activation Required/,
-    })
-    expect(bannerHeading).toBeInTheDocument()
-  })
-
-  it('renders the banner with correct description', async () => {
-    setup(false)
-    render(<ActivationRequiredSelfHosted />, { wrapper })
-
-    const description = await screen.findByText(
-      /You have available seats, but activation is needed./
-    )
-    expect(description).toBeInTheDocument()
-  })
-
-  it('renders copy for the user', async () => {
-    setup(false)
-    render(<ActivationRequiredSelfHosted />, { wrapper })
-
-    const copy = await screen.findByText(/Contact your admin for activation./)
-    expect(copy).toBeInTheDocument()
-  })
-
-  it('does not render the link if the user is not an admin', async () => {
-    setup(false)
-    render(<ActivationRequiredSelfHosted />, { wrapper })
-
-    await waitFor(() => queryClient.isFetching)
-    await waitFor(() => !queryClient.isFetching)
-
-    const link = screen.queryByRole('link', {
-      name: /Manage members/,
-    })
-    expect(link).not.toBeInTheDocument()
-  })
-
-  it('renders the correct img', async () => {
-    setup(false)
-    render(<ActivationRequiredSelfHosted />, { wrapper })
-
-    const img = await screen.findByAltText('Forbidden')
-    expect(img).toBeInTheDocument()
-    expect(img).toHaveAttribute(
-      'src',
-      '/src/layouts/shared/NetworkErrorBoundary/assets/error-upsidedown-umbrella.svg'
-    )
-  })
-
-  describe('when the user is an admin', () => {
-    it('renders the correct link', async () => {
-      setup(true)
+  describe('when user has seats left', () => {
+    it('renders the banner with correct heading', async () => {
+      setup(false, 0, 10)
       render(<ActivationRequiredSelfHosted />, { wrapper })
 
-      const link = await screen.findByRole('link', {
+      const bannerHeading = await screen.findByRole('heading', {
+        name: /Activation Required/,
+      })
+      expect(bannerHeading).toBeInTheDocument()
+    })
+
+    it('renders the banner with correct description', async () => {
+      setup(false, 1, 10)
+      render(<ActivationRequiredSelfHosted />, { wrapper })
+
+      const description = await screen.findByText(
+        /You have available seats, but activation is needed./
+      )
+      expect(description).toBeInTheDocument()
+    })
+
+    it('renders copy for the user', async () => {
+      setup(false, 1, 10)
+      render(<ActivationRequiredSelfHosted />, { wrapper })
+
+      const copy = await screen.findByText(/Contact your admin for activation./)
+      expect(copy).toBeInTheDocument()
+    })
+
+    it('does not render the link if the user is not an admin', async () => {
+      setup(false, 1, 10)
+      render(<ActivationRequiredSelfHosted />, { wrapper })
+
+      await waitFor(() => queryClient.isFetching)
+      await waitFor(() => !queryClient.isFetching)
+
+      const link = screen.queryByRole('link', {
         name: /Manage members/,
       })
-      expect(link).toBeInTheDocument()
-      expect(link).toHaveAttribute('href', '/admin/gh/access')
+      expect(link).not.toBeInTheDocument()
+    })
+
+    it('renders the correct img', async () => {
+      setup(false, 1, 10)
+      render(<ActivationRequiredSelfHosted />, { wrapper })
+
+      const img = await screen.findByAltText('Forbidden')
+      expect(img).toBeInTheDocument()
+      expect(img).toHaveAttribute(
+        'src',
+        '/src/layouts/shared/NetworkErrorBoundary/assets/error-upsidedown-umbrella.svg'
+      )
+    })
+
+    describe('when the user is an admin', () => {
+      it('renders the correct link', async () => {
+        setup(true, 1, 10)
+        render(<ActivationRequiredSelfHosted />, { wrapper })
+
+        const link = await screen.findByRole('link', {
+          name: /Manage members/,
+        })
+        expect(link).toBeInTheDocument()
+        expect(link).toHaveAttribute('href', '/admin/gh/access')
+      })
+    })
+  })
+
+  describe('when user has no seats left', () => {
+    it('renders the banner with correct heading', async () => {
+      setup(false, 10, 10)
+      render(<ActivationRequiredSelfHosted />, { wrapper })
+
+      const bannerHeading = await screen.findByRole('heading', {
+        name: /Activation Required/,
+      })
+      expect(bannerHeading).toBeInTheDocument()
+    })
+
+    it('renders the banner with correct description', async () => {
+      setup(false, 10, 10)
+      render(<ActivationRequiredSelfHosted />, { wrapper })
+
+      const description = await screen.findByText(
+        /Your organization has utilized all available seats./
+      )
+      expect(description).toBeInTheDocument()
+    })
+
+    it('renders the correct img', async () => {
+      setup(false, 10, 10)
+      render(<ActivationRequiredSelfHosted />, { wrapper })
+
+      const img = await screen.findByAltText('Forbidden')
+      expect(img).toBeInTheDocument()
+    })
+
+    describe('renders contact sales link', () => {
+      it('when the user is an admin', async () => {
+        setup(true, 10, 10)
+        render(<ActivationRequiredSelfHosted />, { wrapper })
+
+        const link = await screen.findByRole('link', {
+          name: /Contact Sales/,
+        })
+        expect(link).toBeInTheDocument()
+        expect(link).toHaveAttribute('href', 'https://about.codecov.io/sales')
+      })
     })
   })
 })

--- a/src/pages/RepoPage/ActivationAlert/ActivationRequiredSelfHosted/ActivationRequiredSelfHosted.tsx
+++ b/src/pages/RepoPage/ActivationAlert/ActivationRequiredSelfHosted/ActivationRequiredSelfHosted.tsx
@@ -6,9 +6,12 @@ import {
 import A from 'ui/A'
 import Button from 'ui/Button'
 
+const alertWrapperClassName =
+  'flex flex-col items-center justify-center gap-8 bg-ds-gray-primary pb-28 pt-12 text-center'
+
 function SeatsLimitReached() {
   return (
-    <div className="flex flex-col items-center justify-center gap-8 bg-ds-gray-primary pb-28 pt-12 text-center">
+    <div className={alertWrapperClassName}>
       <img src={upsideDownUmbrella} alt="Forbidden" className="w-36" />
       <div className="flex w-2/5 flex-col gap-1">
         <h1 className="text-2xl">Activation Required</h1>
@@ -30,7 +33,7 @@ function SeatsLimitReached() {
 
 function SeatsAvailable({ isAdmin }: { isAdmin: boolean }) {
   return (
-    <div className="flex flex-col items-center justify-center gap-8 bg-ds-gray-primary pb-28 pt-12 text-center">
+    <div className={alertWrapperClassName}>
       <img src={upsideDownUmbrella} alt="Forbidden" className="w-36" />
       <div className="flex w-2/5 flex-col gap-1">
         <h1 className="text-2xl">Activation Required</h1>

--- a/src/pages/RepoPage/ActivationAlert/ActivationRequiredSelfHosted/ActivationRequiredSelfHosted.tsx
+++ b/src/pages/RepoPage/ActivationAlert/ActivationRequiredSelfHosted/ActivationRequiredSelfHosted.tsx
@@ -1,10 +1,34 @@
 import upsideDownUmbrella from 'layouts/shared/NetworkErrorBoundary/assets/error-upsidedown-umbrella.svg'
-import { useSelfHostedCurrentUser } from 'services/selfHosted'
+import {
+  useSelfHostedCurrentUser,
+  useSelfHostedSeatsConfig,
+} from 'services/selfHosted'
+import A from 'ui/A'
 import Button from 'ui/Button'
 
-const ActivationRequiredSelfHosted = () => {
-  const { data } = useSelfHostedCurrentUser()
+function SeatsLimitReached() {
+  return (
+    <div className="flex flex-col items-center justify-center gap-8 bg-ds-gray-primary pb-28 pt-12 text-center">
+      <img src={upsideDownUmbrella} alt="Forbidden" className="w-36" />
+      <div className="flex w-2/5 flex-col gap-1">
+        <h1 className="text-2xl">Activation Required</h1>
+        <p>Your organization has utilized all available seats.</p>
+        <div className="mt-5">
+          <A
+            to={{ pageName: 'sales' }}
+            isExternal
+            hook="contact-sales-self-hosted"
+          >
+            Contact Sales
+          </A>{' '}
+          to increase your seat count.
+        </div>
+      </div>
+    </div>
+  )
+}
 
+function SeatsAvailable({ isAdmin }: { isAdmin: boolean }) {
   return (
     <div className="flex flex-col items-center justify-center gap-8 bg-ds-gray-primary pb-28 pt-12 text-center">
       <img src={upsideDownUmbrella} alt="Forbidden" className="w-36" />
@@ -12,7 +36,7 @@ const ActivationRequiredSelfHosted = () => {
         <h1 className="text-2xl">Activation Required</h1>
         <p>You have available seats, but activation is needed.</p>
       </div>
-      {data?.isAdmin ? (
+      {isAdmin ? (
         <Button
           to={{ pageName: 'access' }}
           disabled={undefined}
@@ -25,6 +49,22 @@ const ActivationRequiredSelfHosted = () => {
         <p>Contact your admin for activation.</p>
       )}
     </div>
+  )
+}
+
+function ActivationRequiredSelfHosted() {
+  const { data } = useSelfHostedCurrentUser()
+  const { data: selfHostedSeats } = useSelfHostedSeatsConfig()
+
+  const hasSelfHostedSeats =
+    selfHostedSeats?.seatsUsed &&
+    selfHostedSeats?.seatsLimit &&
+    selfHostedSeats?.seatsUsed < selfHostedSeats?.seatsLimit
+
+  return hasSelfHostedSeats ? (
+    <SeatsAvailable isAdmin={data?.isAdmin ?? false} />
+  ) : (
+    <SeatsLimitReached />
   )
 }
 

--- a/src/pages/RepoPage/ActivationAlert/ActivationRequiredSelfHosted/ActivationRequiredSelfHosted.tsx
+++ b/src/pages/RepoPage/ActivationAlert/ActivationRequiredSelfHosted/ActivationRequiredSelfHosted.tsx
@@ -1,0 +1,31 @@
+import upsideDownUmbrella from 'layouts/shared/NetworkErrorBoundary/assets/error-upsidedown-umbrella.svg'
+import { useSelfHostedCurrentUser } from 'services/selfHosted'
+import Button from 'ui/Button'
+
+const ActivationRequiredSelfHosted = () => {
+  const { data } = useSelfHostedCurrentUser()
+
+  return (
+    <div className="flex flex-col items-center justify-center gap-8 bg-ds-gray-primary pb-28 pt-12 text-center">
+      <img src={upsideDownUmbrella} alt="Forbidden" className="w-36" />
+      <div className="flex w-2/5 flex-col gap-1">
+        <h1 className="text-2xl">Activation Required</h1>
+        <p>You have available seats, but activation is needed.</p>
+      </div>
+      {data?.isAdmin ? (
+        <Button
+          to={{ pageName: 'access' }}
+          disabled={undefined}
+          hook={undefined}
+          variant="primary"
+        >
+          Manage members
+        </Button>
+      ) : (
+        <p>Contact your admin for activation.</p>
+      )}
+    </div>
+  )
+}
+
+export default ActivationRequiredSelfHosted

--- a/src/pages/RepoPage/ActivationAlert/ActivationRequiredSelfHosted/ActivationRequiredSelfHosted.tsx
+++ b/src/pages/RepoPage/ActivationAlert/ActivationRequiredSelfHosted/ActivationRequiredSelfHosted.tsx
@@ -38,7 +38,7 @@ function SeatsAvailable({ isAdmin }: { isAdmin: boolean }) {
       </div>
       {isAdmin ? (
         <Button
-          to={{ pageName: 'access' }}
+          to={{ pageName: 'users' }}
           disabled={undefined}
           hook={undefined}
           variant="primary"

--- a/src/pages/RepoPage/ActivationAlert/ActivationRequiredSelfHosted/index.ts
+++ b/src/pages/RepoPage/ActivationAlert/ActivationRequiredSelfHosted/index.ts
@@ -1,0 +1,1 @@
+export { default } from './ActivationRequiredSelfHosted'

--- a/src/pages/RepoPage/CoverageOnboarding/ActivationBanner/ActivationBanner.tsx
+++ b/src/pages/RepoPage/CoverageOnboarding/ActivationBanner/ActivationBanner.tsx
@@ -1,9 +1,12 @@
 import { useParams } from 'react-router-dom'
 
+import config from 'config'
+
 import { TrialStatuses, usePlanData } from 'services/account'
 import { isBasicPlan, isFreePlan } from 'shared/utils/billing'
 
 import ActivationRequiredBanner from './ActivationRequiredBanner'
+import ActivationRequiredSelfHosted from './ActivationRequiredSelfHosted'
 import FreePlanSeatsLimitBanner from './FreePlanSeatsLimitBanner'
 import PaidPlanSeatsLimitBanner from './PaidPlanSeatsLimitBanner'
 import TrialEligibleBanner from './TrialEligibleBanner'
@@ -26,6 +29,10 @@ function ActivationBanner() {
     isNewTrial
   const seatsLimitReached = !planData?.plan?.hasSeatsLeft
   const isFreePlanValue = isFreePlan(planData?.plan?.value)
+
+  if (config.IS_SELF_HOSTED) {
+    return <ActivationRequiredSelfHosted />
+  }
 
   if (isTrialEligible) {
     return <TrialEligibleBanner />

--- a/src/pages/RepoPage/CoverageOnboarding/ActivationBanner/ActivationRequiredSelfHosted/ActivationRequiredSelfHosted.test.tsx
+++ b/src/pages/RepoPage/CoverageOnboarding/ActivationBanner/ActivationRequiredSelfHosted/ActivationRequiredSelfHosted.test.tsx
@@ -116,7 +116,7 @@ describe('ActivationRequiredSelfHosted', () => {
           name: /Manage members/,
         })
         expect(manageMembersLink).toBeInTheDocument()
-        expect(manageMembersLink).toHaveAttribute('href', '/admin/gh/access')
+        expect(manageMembersLink).toHaveAttribute('href', '/admin/gh/users')
       })
     })
   })

--- a/src/pages/RepoPage/CoverageOnboarding/ActivationBanner/ActivationRequiredSelfHosted/ActivationRequiredSelfHosted.test.tsx
+++ b/src/pages/RepoPage/CoverageOnboarding/ActivationBanner/ActivationRequiredSelfHosted/ActivationRequiredSelfHosted.test.tsx
@@ -1,0 +1,110 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { render, screen, waitFor } from '@testing-library/react'
+import { http, HttpResponse } from 'msw'
+import { setupServer } from 'msw/node'
+import { MemoryRouter, Route } from 'react-router-dom'
+
+import ActivationRequiredSelfHosted from './ActivationRequiredSelfHosted'
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      retry: false,
+    },
+  },
+})
+
+const server = setupServer()
+
+beforeAll(() => {
+  server.listen({ onUnhandledRequest: 'warn' })
+  console.error = () => {}
+})
+
+afterEach(() => {
+  queryClient.clear()
+  server.resetHandlers()
+  vi.clearAllMocks()
+})
+
+afterAll(() => {
+  server.close()
+})
+
+const wrapper: React.FC<React.PropsWithChildren> = ({ children }) => (
+  <QueryClientProvider client={queryClient}>
+    <MemoryRouter initialEntries={['/gh/codecov/gazebo/new']}>
+      <Route path="/:provider/:owner/:repo/new">{children}</Route>
+    </MemoryRouter>
+  </QueryClientProvider>
+)
+
+describe('ActivationRequiredSelfHosted', () => {
+  function setup(isAdmin: boolean) {
+    server.use(
+      http.get('/internal/users/current', (info) =>
+        HttpResponse.json({
+          isAdmin,
+          email: 'user@example.com',
+          name: 'Test User',
+          ownerid: 1,
+          username: 'testuser',
+          activated: true,
+        })
+      )
+    )
+  }
+  it('renders the banner with correct content', async () => {
+    setup(false)
+    render(<ActivationRequiredSelfHosted />, { wrapper })
+
+    const bannerHeading = await screen.findByRole('heading', {
+      name: /Activation Required/,
+    })
+    expect(bannerHeading).toBeInTheDocument()
+
+    const description = await screen.findByText(
+      /You have available seats, but activation is needed./
+    )
+    expect(description).toBeInTheDocument()
+  })
+
+  it('renders contact admin copy if not admin', async () => {
+    setup(false)
+    render(<ActivationRequiredSelfHosted />, { wrapper })
+
+    const contactAdminCopy = await screen.findByText(
+      /Contact your admin for activation./
+    )
+    expect(contactAdminCopy).toBeInTheDocument()
+  })
+
+  it('does not render manage members link if not admin', async () => {
+    setup(false)
+    render(<ActivationRequiredSelfHosted />, { wrapper })
+
+    await waitFor(() => queryClient.isFetching)
+    await waitFor(() => !queryClient.isFetching)
+
+    const manageMembersLink = screen.queryByRole('link', {
+      name: /Manage members/,
+    })
+    expect(manageMembersLink).not.toBeInTheDocument()
+  })
+
+  describe('when admin', () => {
+    it('renders manage members link', async () => {
+      setup(true)
+      render(<ActivationRequiredSelfHosted />, { wrapper })
+
+      await waitFor(() => queryClient.isFetching)
+      await waitFor(() => !queryClient.isFetching)
+
+      const manageMembersLink = await screen.findByRole('link', {
+        name: /Manage members/,
+      })
+      expect(manageMembersLink).toBeInTheDocument()
+      expect(manageMembersLink).toHaveAttribute('href', '/admin/gh/access')
+    })
+  })
+})

--- a/src/pages/RepoPage/CoverageOnboarding/ActivationBanner/ActivationRequiredSelfHosted/ActivationRequiredSelfHosted.tsx
+++ b/src/pages/RepoPage/CoverageOnboarding/ActivationBanner/ActivationRequiredSelfHosted/ActivationRequiredSelfHosted.tsx
@@ -40,9 +40,9 @@ function SeatsAvailable({ isAdmin }: { isAdmin: boolean }) {
           <div className="left-[100px] md:relative">
             {isAdmin ? (
               <Button
-                hook="trial-eligible-banner-access"
+                hook="activation-required-self-hosted-banner-users"
                 to={{
-                  pageName: 'access',
+                  pageName: 'users',
                 }}
                 disabled={false}
                 variant="primary"

--- a/src/pages/RepoPage/CoverageOnboarding/ActivationBanner/ActivationRequiredSelfHosted/ActivationRequiredSelfHosted.tsx
+++ b/src/pages/RepoPage/CoverageOnboarding/ActivationBanner/ActivationRequiredSelfHosted/ActivationRequiredSelfHosted.tsx
@@ -1,0 +1,38 @@
+import { useSelfHostedCurrentUser } from 'services/selfHosted'
+import Banner from 'ui/Banner'
+import BannerContent from 'ui/Banner/BannerContent'
+import BannerHeading from 'ui/Banner/BannerHeading'
+import Button from 'ui/Button'
+
+function ActivationRequiredSelfHosted() {
+  const { data } = useSelfHostedCurrentUser()
+
+  return (
+    <Banner variant="plain">
+      <BannerContent>
+        <BannerHeading>
+          <h2 className="font-semibold">&#8505; Activation Required</h2>
+          <div className="left-[100px] md:relative">
+            {data?.isAdmin ? (
+              <Button
+                hook="trial-eligible-banner-access"
+                to={{
+                  pageName: 'access',
+                }}
+                disabled={false}
+                variant="primary"
+              >
+                Manage members
+              </Button>
+            ) : (
+              <p>Contact your admin for activation.</p>
+            )}
+          </div>
+        </BannerHeading>
+        <p>You have available seats, but activation is needed.</p>
+      </BannerContent>
+    </Banner>
+  )
+}
+
+export default ActivationRequiredSelfHosted

--- a/src/pages/RepoPage/CoverageOnboarding/ActivationBanner/ActivationRequiredSelfHosted/ActivationRequiredSelfHosted.tsx
+++ b/src/pages/RepoPage/CoverageOnboarding/ActivationBanner/ActivationRequiredSelfHosted/ActivationRequiredSelfHosted.tsx
@@ -1,19 +1,44 @@
-import { useSelfHostedCurrentUser } from 'services/selfHosted'
+import {
+  useSelfHostedCurrentUser,
+  useSelfHostedSeatsConfig,
+} from 'services/selfHosted'
+import A from 'ui/A'
 import Banner from 'ui/Banner'
 import BannerContent from 'ui/Banner/BannerContent'
 import BannerHeading from 'ui/Banner/BannerHeading'
 import Button from 'ui/Button'
 
-function ActivationRequiredSelfHosted() {
-  const { data } = useSelfHostedCurrentUser()
+function SeatsLimitReached() {
+  return (
+    <Banner variant="plain">
+      <BannerContent>
+        <BannerHeading>
+          <h2 className="font-semibold">&#8505; Seats Limit Reached</h2>
+        </BannerHeading>
+        <div>
+          Your organization has utilized all available seats.{' '}
+          <A
+            to={{ pageName: 'sales' }}
+            isExternal
+            hook="contact-sales-self-hosted"
+          >
+            Contact Sales
+          </A>{' '}
+          to increase your seat count.
+        </div>
+      </BannerContent>
+    </Banner>
+  )
+}
 
+function SeatsAvailable({ isAdmin }: { isAdmin: boolean }) {
   return (
     <Banner variant="plain">
       <BannerContent>
         <BannerHeading>
           <h2 className="font-semibold">&#8505; Activation Required</h2>
           <div className="left-[100px] md:relative">
-            {data?.isAdmin ? (
+            {isAdmin ? (
               <Button
                 hook="trial-eligible-banner-access"
                 to={{
@@ -32,6 +57,22 @@ function ActivationRequiredSelfHosted() {
         <p>You have available seats, but activation is needed.</p>
       </BannerContent>
     </Banner>
+  )
+}
+
+function ActivationRequiredSelfHosted() {
+  const { data } = useSelfHostedCurrentUser()
+  const { data: selfHostedSeats } = useSelfHostedSeatsConfig()
+
+  const hasSelfHostedSeats =
+    selfHostedSeats?.seatsUsed &&
+    selfHostedSeats?.seatsLimit &&
+    selfHostedSeats?.seatsUsed < selfHostedSeats?.seatsLimit
+
+  return hasSelfHostedSeats ? (
+    <SeatsAvailable isAdmin={data?.isAdmin ?? false} />
+  ) : (
+    <SeatsLimitReached />
   )
 }
 

--- a/src/pages/RepoPage/CoverageOnboarding/ActivationBanner/ActivationRequiredSelfHosted/index.ts
+++ b/src/pages/RepoPage/CoverageOnboarding/ActivationBanner/ActivationRequiredSelfHosted/index.ts
@@ -1,0 +1,1 @@
+export { default } from './ActivationRequiredSelfHosted'


### PR DESCRIPTION
# Description
In onboarding page: (Current user is not activated) => Banner
- User has seats left:
  -  User is admin, link to members page (access)
<img width="1435" alt="Screenshot 2024-11-20 at 11 48 58 AM" src="https://github.com/user-attachments/assets/5fdc9272-69dd-40dc-ae1a-11712f18688f">

  
  -  User is not an admin, contact admin 
<img width="1435" alt="Screenshot 2024-11-20 at 11 48 34 AM" src="https://github.com/user-attachments/assets/8a0abe8d-5b6d-4b4d-b45c-01eabdd80859">

  - User has reached seats limit, contact sales 
<img width="1435" alt="Screenshot 2024-11-21 at 1 04 55 PM" src="https://github.com/user-attachments/assets/dc15d8f8-2725-4a52-9237-f1b35d1011e2">

In the coverage page: (Current user is not activated) => Alert 
- User has seats left:
  - User is admin, link to members page (access)
<img width="1435" alt="Screenshot 2024-11-20 at 11 43 35 AM" src="https://github.com/user-attachments/assets/8bb4fbcc-bf66-4fde-88d4-bd1177c86988">


 - User is not an admin, contact admin 
<img width="1435" alt="Screenshot 2024-11-20 at 11 43 26 AM" src="https://github.com/user-attachments/assets/1f445a0d-ec26-4919-955a-5a9eb04590c5">

  - User has reached seats limit, contact sales 
<img width="1435" alt="Screenshot 2024-11-21 at 1 24 31 PM" src="https://github.com/user-attachments/assets/791aa496-7c56-405b-b667-c4df9bd9bb17">

# Link to Sample Entry
Issue: [#554](https://github.com/codecov/feedback/issues/554) 

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.