### PR TITLE
feat: Update useBundleAssets to fetch routes field

### DIFF
--- a/src/pages/RepoPage/BundlesTab/BundleContent/AssetsTable/AssetsTable.test.tsx
+++ b/src/pages/RepoPage/BundlesTab/BundleContent/AssetsTable/AssetsTable.test.tsx
@@ -16,6 +16,7 @@ import { AssetsTable, ChangeOverTime } from './AssetsTable'
 const mockAssets = (hasNextPage = true) => {
   const asset1 = {
     name: 'asset-1',
+    routes: ['/'],
     extension: 'js',
     bundleData: {
       loadTime: { threeG: 2000, highSpeed: 2000 },
@@ -32,6 +33,7 @@ const mockAssets = (hasNextPage = true) => {
 
   const asset2 = {
     name: 'asset-2',
+    routes: ['/about'],
     extension: 'js',
     bundleData: {
       loadTime: { threeG: 2000, highSpeed: 2000 },
@@ -48,6 +50,7 @@ const mockAssets = (hasNextPage = true) => {
 
   const asset3 = {
     name: 'asset-3',
+    routes: ['/login'],
     extension: 'js',
     bundleData: {
       loadTime: { threeG: 2000, highSpeed: 2000 },

--- a/src/pages/RepoPage/BundlesTab/BundleContent/AssetsTable/useBundleAssetsTable.test.tsx
+++ b/src/pages/RepoPage/BundlesTab/BundleContent/AssetsTable/useBundleAssetsTable.test.tsx
@@ -50,23 +50,14 @@ const mockedBundleAssets = {
                     {
                       node: {
                         name: 'asset-1',
+                        routes: ['/'],
                         extension: 'js',
                         bundleData: {
-                          loadTime: {
-                            threeG: 1,
-                            highSpeed: 2,
-                          },
-                          size: {
-                            uncompress: 3,
-                            gzip: 4,
-                          },
+                          loadTime: { threeG: 1, highSpeed: 2 },
+                          size: { uncompress: 3, gzip: 4 },
                         },
                         measurements: {
-                          change: {
-                            size: {
-                              uncompress: 5,
-                            },
-                          },
+                          change: { size: { uncompress: 5 } },
                           measurements: [
                             { timestamp: '2022-10-10T11:59:59', avg: 6 },
                           ],
@@ -74,10 +65,7 @@ const mockedBundleAssets = {
                       },
                     },
                   ],
-                  pageInfo: {
-                    hasNextPage: false,
-                    endCursor: null,
-                  },
+                  pageInfo: { hasNextPage: false, endCursor: null },
                 },
               },
             },
@@ -165,42 +153,21 @@ describe('useBundleAssetsTable', () => {
         {
           assets: [
             {
-              bundleData: {
-                loadTime: {
-                  highSpeed: 2,
-                  threeG: 1,
-                },
-                size: {
-                  gzip: 4,
-                  uncompress: 3,
-                },
-              },
-              extension: 'js',
-              measurements: {
-                change: {
-                  size: {
-                    uncompress: 5,
-                  },
-                },
-                measurements: [
-                  {
-                    avg: 6,
-                    timestamp: '2022-10-10T11:59:59',
-                  },
-                ],
-              },
               name: 'asset-1',
+              routes: ['/'],
+              extension: 'js',
+              bundleData: {
+                loadTime: { highSpeed: 2, threeG: 1 },
+                size: { gzip: 4, uncompress: 3 },
+              },
+              measurements: {
+                change: { size: { uncompress: 5 } },
+                measurements: [{ avg: 6, timestamp: '2022-10-10T11:59:59' }],
+              },
             },
           ],
-          bundleData: {
-            size: {
-              uncompress: 12,
-            },
-          },
-          pageInfo: {
-            endCursor: null,
-            hasNextPage: false,
-          },
+          bundleData: { size: { uncompress: 12 } },
+          pageInfo: { endCursor: null, hasNextPage: false },
         },
       ],
     }

--- a/src/pages/RepoPage/BundlesTab/BundleContent/BundleContent.test.tsx
+++ b/src/pages/RepoPage/BundlesTab/BundleContent/BundleContent.test.tsx
@@ -109,6 +109,7 @@ const mockAssets = {
                     {
                       node: {
                         name: 'asset-1',
+                        routes: ['/'],
                         extension: 'js',
                         bundleData: {
                           loadTime: {

--- a/src/services/bundleAnalysis/useBundleAssets.test.tsx
+++ b/src/services/bundleAnalysis/useBundleAssets.test.tsx
@@ -12,6 +12,7 @@ import { useBundleAssets } from './useBundleAssets'
 
 const node1 = {
   name: 'asset-1',
+  routes: ['/'],
   extension: 'js',
   bundleData: {
     loadTime: { threeG: 1, highSpeed: 2 },
@@ -25,6 +26,7 @@ const node1 = {
 
 const node2 = {
   name: 'asset-2',
+  routes: ['/login'],
   extension: 'js',
   bundleData: {
     loadTime: { threeG: 1, highSpeed: 2 },
@@ -38,6 +40,7 @@ const node2 = {
 
 const node3 = {
   name: 'asset-3',
+  routes: ['/about'],
   extension: 'js',
   bundleData: {
     loadTime: { threeG: 1, highSpeed: 2 },

--- a/src/services/bundleAnalysis/useBundleAssets.tsx
+++ b/src/services/bundleAnalysis/useBundleAssets.tsx
@@ -52,6 +52,7 @@ const AssetMeasurementsSchema = z.object({
 
 const BundleAssetSchema = z.object({
   name: z.string(),
+  routes: z.array(z.string()).nullable(),
   extension: z.string(),
   bundleData: BundleDataSchema,
   measurements: AssetMeasurementsSchema.nullable(),
@@ -151,6 +152,7 @@ query BundleAssets(
                       edges {
                         node {
                           name
+                          routes
                           extension
                           bundleData {
                             loadTime {


### PR DESCRIPTION
# Description

This PR updates the `useBundleAssets` hook to also fetch the newly introduced `routes` field on the `BundleAsset` type. This will be used to populate later on in the new column we're going to be adding to the assets table on the bundles tab.

Closes codecov/engineering-team#2956

# Notable Changes

- Update query and schema with new `routes` field in `useBundleAssets`
- Update tests