### PR TITLE
feat: Handle isFirstPullRequest in TA page

### DIFF
--- a/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/FailedTestsTable/FailedTestsTable.test.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/FailedTestsTable/FailedTestsTable.test.tsx
@@ -129,6 +129,7 @@ interface SetupArgs {
   bundleAnalysisEnabled?: boolean
   planValue?: string
   isPrivate?: boolean
+  isFirstPullRequest?: boolean
 }
 
 describe('FailedTestsTable', () => {
@@ -136,6 +137,7 @@ describe('FailedTestsTable', () => {
     noEntries = false,
     planValue = Plans.USERS_ENTERPRISEM,
     isPrivate = false,
+    isFirstPullRequest = false,
   }: SetupArgs) {
     const queryClient = new QueryClient({
       defaultOptions: {
@@ -162,6 +164,7 @@ describe('FailedTestsTable', () => {
                 repository: {
                   __typename: 'Repository',
                   private: isPrivate,
+                  isFirstPullRequest,
                   defaultBranch: 'main',
                   testAnalytics: {
                     testResults: {
@@ -187,6 +190,7 @@ describe('FailedTestsTable', () => {
             repository: {
               __typename: 'Repository',
               private: isPrivate,
+              isFirstPullRequest,
               defaultBranch: 'main',
               testAnalytics: {
                 testResults: {
@@ -345,6 +349,23 @@ describe('FailedTestsTable', () => {
       const hoverObj = await screen.findAllByText(/6 Passed, 5 Failed /)
 
       expect(hoverObj.length).toBeGreaterThan(0)
+    })
+  })
+
+  describe('when first pull request', () => {
+    it('renders no data message', async () => {
+      const { queryClient } = setup({ isFirstPullRequest: true })
+      render(<FailedTestsTable />, {
+        wrapper: wrapper(queryClient),
+      })
+
+      const noDataMessage = await screen.findByText('No data yet')
+      expect(noDataMessage).toBeInTheDocument()
+
+      const mergeIntoMainMessage = await screen.findByText(
+        'To see data for the main branch, merge your PR into the main branch.'
+      )
+      expect(mergeIntoMainMessage).toBeInTheDocument()
     })
   })
 

--- a/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/FailedTestsTable/FailedTestsTable.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/FailedTestsTable/FailedTestsTable.tsx
@@ -300,6 +300,24 @@ const FailedTestsTable = () => {
     }
   }, [fetchNextPage, inView, hasNextPage])
 
+  if (testData?.isFirstPullRequest) {
+    return (
+      <div className="flex flex-col gap-2">
+        <TableHeader
+          totalCount={testData?.totalCount}
+          isDefaultBranch={isDefaultBranch}
+        />
+        <hr />
+        <div className="mt-4 text-center text-ds-gray-quinary">
+          <p>No data yet</p>
+          <p>
+            To see data for the main branch, merge your PR into the main branch.
+          </p>
+        </div>
+      </div>
+    )
+  }
+
   if (isEmpty(testData?.testResults) && !isLoading && !!branch) {
     return (
       <div className="flex flex-col gap-2">

--- a/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/hooks/useInfiniteTestResults/useInfiniteTestResults.test.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/hooks/useInfiniteTestResults/useInfiniteTestResults.test.tsx
@@ -15,6 +15,7 @@ const mockTestResults = {
     repository: {
       __typename: 'Repository',
       private: false,
+      isFirstPullRequest: false,
       defaultBranch: 'main',
       testAnalytics: {
         testResults: {

--- a/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/hooks/useInfiniteTestResults/useInfiniteTestResults.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/hooks/useInfiniteTestResults/useInfiniteTestResults.tsx
@@ -72,6 +72,7 @@ const GetTestResultsSchema = z.object({
           __typename: z.literal('Repository'),
           private: z.boolean().nullable(),
           defaultBranch: z.string().nullable(),
+          isFirstPullRequest: z.boolean(),
           testAnalytics: z
             .object({
               testResults: z.object({
@@ -114,6 +115,7 @@ query GetTestResults(
     repository: repository(name: $repo) {
       __typename
       ... on Repository {
+        isFirstPullRequest
         private
         defaultBranch
         testAnalytics {
@@ -182,6 +184,7 @@ interface UseTestResultsArgs {
     plan: PlanName | null
     defaultBranch: string | null
     totalCount: number | null
+    isFirstPullRequest: boolean | null
   }>
 }
 
@@ -280,6 +283,8 @@ export const useInfiniteTestResults = ({
           private: data?.owner?.repository?.private ?? null,
           plan: data?.owner?.plan?.value ?? null,
           defaultBranch: data?.owner?.repository?.defaultBranch ?? null,
+          isFirstPullRequest:
+            data?.owner?.repository?.isFirstPullRequest ?? null,
         }
       }),
     getNextPageParam: (lastPage) => {
@@ -302,6 +307,7 @@ export const useInfiniteTestResults = ({
       private: data?.pages?.[0]?.private ?? null,
       plan: data?.pages?.[0]?.plan ?? null,
       defaultBranch: data?.pages?.[0]?.defaultBranch ?? null,
+      isFirstPullRequest: data?.pages?.[0]?.isFirstPullRequest ?? null,
     },
     ...rest,
   }


### PR DESCRIPTION
# Description
We want to display an empty state message on the main dashboard to explain why no data is visible yet for the first PR.

# Screenshots
<img width="1307" alt="Screenshot 2024-11-27 at 12 24 31 PM" src="https://github.com/user-attachments/assets/af5a5aad-fcde-4495-8200-e4c502128f3f">


https://github.com/codecov/engineering-team/issues/2780


<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.