### PR TITLE
feat: Grab the plugin name for the given bundle

### DIFF
--- a/src/pages/RepoPage/BundlesTab/BundleContent/AssetsTable/AssetsTable.test.tsx
+++ b/src/pages/RepoPage/BundlesTab/BundleContent/AssetsTable/AssetsTable.test.tsx
@@ -69,6 +69,7 @@ const mockAssets = (hasNextPage = true) => {
               bundleAnalysisReport: {
                 __typename: 'BundleAnalysisReport',
                 bundle: {
+                  info: { pluginName: '@codecov/vite-plugin' },
                   bundleData: { size: { uncompress: 6000 } },
                   assetsPaginated: {
                     edges: [

--- a/src/pages/RepoPage/BundlesTab/BundleContent/AssetsTable/AssetsTable.tsx
+++ b/src/pages/RepoPage/BundlesTab/BundleContent/AssetsTable/AssetsTable.tsx
@@ -227,21 +227,16 @@ export const AssetsTable: React.FC = () => {
     orderingDirection = 'ASC'
   }
 
-  const {
-    data,
-    fetchNextPage,
-    isInitialLoading,
-    isFetchingNextPage,
-    hasNextPage,
-  } = useBundleAssetsTable({
-    provider,
-    owner,
-    repo,
-    branch,
-    bundle,
-    ordering,
-    orderingDirection,
-  })
+  const { data, fetchNextPage, isLoading, isFetchingNextPage, hasNextPage } =
+    useBundleAssetsTable({
+      provider,
+      owner,
+      repo,
+      branch,
+      bundle,
+      ordering,
+      orderingDirection,
+    })
 
   useEffect(() => {
     if (inView && hasNextPage) {
@@ -249,22 +244,28 @@ export const AssetsTable: React.FC = () => {
     }
   }, [fetchNextPage, hasNextPage, inView])
 
-  const tableData: Array<Column> = useMemo(() => {
+  const tableData = useMemo(() => {
     if (data) {
-      return data?.pages
-        .map((page) => page.assets)
-        .flat()
-        .filter(Boolean)
-        .map((asset) => ({
-          name: asset!.name,
-          extension: asset!.extension,
-          size: asset!.bundleData.size.uncompress,
-          loadTime: asset!.bundleData.loadTime.threeG,
-          changeOverTime: asset!.measurements ?? undefined,
-        }))
+      return {
+        bundleInfo: data?.pages[0]?.bundleInfo,
+        assets: data?.pages
+          .map((page) => page.assets)
+          .flat()
+          .filter(Boolean)
+          .map((asset) => ({
+            name: asset!.name,
+            extension: asset!.extension,
+            size: asset!.bundleData.size.uncompress,
+            loadTime: asset!.bundleData.loadTime.threeG,
+            changeOverTime: asset!.measurements ?? undefined,
+          })),
+      }
     }
 
-    return []
+    return {
+      assets: [],
+      bundleInfo: null,
+    }
   }, [data])
 
   const bundleSize = useMemo(
@@ -276,7 +277,7 @@ export const AssetsTable: React.FC = () => {
 
   const table = useReactTable({
     columns,
-    data: tableData,
+    data: tableData.assets,
     state: {
       sorting,
       expanded,
@@ -288,7 +289,7 @@ export const AssetsTable: React.FC = () => {
     getExpandedRowModel: getExpandedRowModel(),
   })
 
-  if (tableData.length === 0 && !isInitialLoading) {
+  if (tableData.assets.length === 0 && !isLoading) {
     return <EmptyTable />
   }
 
@@ -343,7 +344,7 @@ export const AssetsTable: React.FC = () => {
               })}
             </div>
           ))}
-          {isInitialLoading ? (
+          {isLoading ? (
             <Loader />
           ) : (
             <div>

--- a/src/pages/RepoPage/BundlesTab/BundleContent/AssetsTable/useBundleAssetsTable.test.tsx
+++ b/src/pages/RepoPage/BundlesTab/BundleContent/AssetsTable/useBundleAssetsTable.test.tsx
@@ -40,11 +40,8 @@ const mockedBundleAssets = {
             bundleAnalysisReport: {
               __typename: 'BundleAnalysisReport',
               bundle: {
-                bundleData: {
-                  size: {
-                    uncompress: 12,
-                  },
-                },
+                info: { pluginName: '@codecov/vite-plugin' },
+                bundleData: { size: { uncompress: 12 } },
                 assetsPaginated: {
                   edges: [
                     {
@@ -167,7 +164,11 @@ describe('useBundleAssetsTable', () => {
             },
           ],
           bundleData: { size: { uncompress: 12 } },
-          pageInfo: { endCursor: null, hasNextPage: false },
+          bundleInfo: { pluginName: '@codecov/vite-plugin' },
+          pageInfo: {
+            endCursor: null,
+            hasNextPage: false,
+          },
         },
       ],
     }

--- a/src/pages/RepoPage/BundlesTab/BundleContent/AssetsTable/useBundleAssetsTable.ts
+++ b/src/pages/RepoPage/BundlesTab/BundleContent/AssetsTable/useBundleAssetsTable.ts
@@ -1,8 +1,9 @@
+import { useInfiniteQuery as useInfiniteQueryV5 } from '@tanstack/react-queryV5'
 import { useMemo } from 'react'
 
 import { OrderingDirection } from 'types'
 
-import { useBundleAssets } from 'services/bundleAnalysis/useBundleAssets'
+import { BundleAssetsQueryOpts } from 'services/bundleAnalysis/BundleAssetsQueryOpts'
 import { useLocationParams } from 'services/navigation'
 import { useRepoOverview } from 'services/repo'
 import { createTimeSeriesQueryVars, Trend } from 'shared/utils/timeseriesCharts'
@@ -54,21 +55,23 @@ export function useBundleAssetsTable({
     }
   }, [overview?.oldestCommitAt, today, trend])
 
-  return useBundleAssets({
-    provider,
-    owner,
-    repo,
-    branch,
-    bundle,
-    dateAfter: queryVars.after,
-    dateBefore: queryVars.before,
-    interval: queryVars.interval,
-    ordering,
-    orderingDirection,
-    filters: {
-      reportGroups: typeFilters,
-      loadTypes: loadTypes,
-    },
-    opts: { enabled: branch !== '' && bundle !== '' },
+  return useInfiniteQueryV5({
+    ...BundleAssetsQueryOpts({
+      provider,
+      owner,
+      repo,
+      branch,
+      bundle,
+      dateAfter: queryVars.after,
+      dateBefore: queryVars.before,
+      interval: queryVars.interval,
+      ordering,
+      orderingDirection,
+      filters: {
+        reportGroups: typeFilters,
+        loadTypes: loadTypes,
+      },
+    }),
+    enabled: branch !== '' && bundle !== '',
   })
 }

--- a/src/pages/RepoPage/BundlesTab/BundleContent/BundleContent.test.tsx
+++ b/src/pages/RepoPage/BundlesTab/BundleContent/BundleContent.test.tsx
@@ -103,6 +103,7 @@ const mockAssets = {
             bundleAnalysisReport: {
               __typename: 'BundleAnalysisReport',
               bundle: {
+                info: { pluginName: '@codecov/vite-plugin' },
                 bundleData: { size: { uncompress: 12 } },
                 assetsPaginated: {
                   edges: [

--- a/src/services/bundleAnalysis/BundleAssetsQueryOpts.test.tsx
+++ b/src/services/bundleAnalysis/BundleAssetsQueryOpts.test.tsx
@@ -1,6 +1,7 @@
 import {
   QueryClientProvider as QueryClientProviderV5,
   QueryClient as QueryClientV5,
+  useInfiniteQuery as useInfiniteQueryV5,
 } from '@tanstack/react-queryV5'
 import { renderHook, waitFor } from '@testing-library/react'
 import { graphql, HttpResponse } from 'msw'
@@ -8,7 +9,7 @@ import { setupServer } from 'msw/node'
 import { Suspense } from 'react'
 import { type MockInstance } from 'vitest'
 
-import { useBundleAssets } from './useBundleAssets'
+import { BundleAssetsQueryOpts } from './BundleAssetsQueryOpts'
 
 const node1 = {
   name: 'asset-1',
@@ -166,11 +167,8 @@ describe('useBundleAssets', () => {
                       bundleAnalysisReport: {
                         __typename: 'BundleAnalysisReport',
                         bundle: {
-                          bundleData: {
-                            size: {
-                              uncompress: 12,
-                            },
-                          },
+                          info: { pluginName: '@codecov/vite-plugin' },
+                          bundleData: { size: { uncompress: 12 } },
                           assetsPaginated: {
                             edges: info.variables.assetsAfter
                               ? [{ node: node3 }]
@@ -204,12 +202,14 @@ describe('useBundleAssets', () => {
       setup({})
       const { result } = renderHook(
         () =>
-          useBundleAssets({
-            provider: 'gh',
-            owner: 'codecov',
-            repo: 'codecov',
-            branch: 'main',
-            bundle: 'test-bundle',
+          useInfiniteQueryV5({
+            ...BundleAssetsQueryOpts({
+              provider: 'gh',
+              owner: 'codecov',
+              repo: 'codecov',
+              branch: 'main',
+              bundle: 'test-bundle',
+            }),
           }),
         {
           wrapper,
@@ -223,6 +223,7 @@ describe('useBundleAssets', () => {
             {
               assets: [node1, node2],
               bundleData: { size: { uncompress: 12 } },
+              bundleInfo: { pluginName: '@codecov/vite-plugin' },
               pageInfo: {
                 hasNextPage: true,
                 endCursor: 'cursor-2',
@@ -238,12 +239,14 @@ describe('useBundleAssets', () => {
         setup({})
         const { result } = renderHook(
           () =>
-            useBundleAssets({
-              provider: 'gh',
-              owner: 'codecov',
-              repo: 'codecov',
-              branch: 'main',
-              bundle: 'test-bundle',
+            useInfiniteQueryV5({
+              ...BundleAssetsQueryOpts({
+                provider: 'gh',
+                owner: 'codecov',
+                repo: 'codecov',
+                branch: 'main',
+                bundle: 'test-bundle',
+              }),
             }),
           {
             wrapper,
@@ -256,6 +259,7 @@ describe('useBundleAssets', () => {
             pages: [
               {
                 assets: [node1, node2],
+                bundleInfo: { pluginName: '@codecov/vite-plugin' },
                 bundleData: { size: { uncompress: 12 } },
                 pageInfo: {
                   hasNextPage: true,
@@ -277,6 +281,7 @@ describe('useBundleAssets', () => {
             pages: [
               {
                 assets: [node1, node2],
+                bundleInfo: { pluginName: '@codecov/vite-plugin' },
                 bundleData: { size: { uncompress: 12 } },
                 pageInfo: {
                   endCursor: 'cursor-2',
@@ -286,6 +291,7 @@ describe('useBundleAssets', () => {
               {
                 assets: [node3],
                 bundleData: { size: { uncompress: 12 } },
+                bundleInfo: { pluginName: '@codecov/vite-plugin' },
                 pageInfo: {
                   endCursor: 'cursor-1',
                   hasNextPage: false,
@@ -302,12 +308,14 @@ describe('useBundleAssets', () => {
         setup({ missingHeadReport: true })
         const { result } = renderHook(
           () =>
-            useBundleAssets({
-              provider: 'gh',
-              owner: 'codecov',
-              repo: 'codecov',
-              branch: 'main',
-              bundle: 'test-bundle',
+            useInfiniteQueryV5({
+              ...BundleAssetsQueryOpts({
+                provider: 'gh',
+                owner: 'codecov',
+                repo: 'codecov',
+                branch: 'main',
+                bundle: 'test-bundle',
+              }),
             }),
           {
             wrapper,
@@ -324,6 +332,7 @@ describe('useBundleAssets', () => {
               {
                 assets: [],
                 bundleData: null,
+                bundleInfo: null,
                 pageInfo: null,
               },
             ],
@@ -338,12 +347,14 @@ describe('useBundleAssets', () => {
       setup({ isNullOwner: true })
       const { result } = renderHook(
         () =>
-          useBundleAssets({
-            provider: 'gh',
-            owner: 'codecov',
-            repo: 'codecov',
-            branch: 'main',
-            bundle: 'test-bundle',
+          useInfiniteQueryV5({
+            ...BundleAssetsQueryOpts({
+              provider: 'gh',
+              owner: 'codecov',
+              repo: 'codecov',
+              branch: 'main',
+              bundle: 'test-bundle',
+            }),
           }),
         {
           wrapper,
@@ -356,7 +367,9 @@ describe('useBundleAssets', () => {
       await waitFor(() => {
         expect(result.current.data).toEqual({
           pageParams: [''],
-          pages: [{ assets: [], bundleData: null, pageInfo: null }],
+          pages: [
+            { assets: [], bundleData: null, bundleInfo: null, pageInfo: null },
+          ],
         })
       })
     })
@@ -377,12 +390,14 @@ describe('useBundleAssets', () => {
       setup({ isNotFoundError: true })
       const { result } = renderHook(
         () =>
-          useBundleAssets({
-            provider: 'gh',
-            owner: 'codecov',
-            repo: 'codecov',
-            branch: 'main',
-            bundle: 'test-bundle',
+          useInfiniteQueryV5({
+            ...BundleAssetsQueryOpts({
+              provider: 'gh',
+              owner: 'codecov',
+              repo: 'codecov',
+              branch: 'main',
+              bundle: 'test-bundle',
+            }),
           }),
         {
           wrapper,
@@ -415,12 +430,14 @@ describe('useBundleAssets', () => {
       setup({ isOwnerNotActivatedError: true })
       const { result } = renderHook(
         () =>
-          useBundleAssets({
-            provider: 'gh',
-            owner: 'codecov',
-            repo: 'codecov',
-            branch: 'main',
-            bundle: 'test-bundle',
+          useInfiniteQueryV5({
+            ...BundleAssetsQueryOpts({
+              provider: 'gh',
+              owner: 'codecov',
+              repo: 'codecov',
+              branch: 'main',
+              bundle: 'test-bundle',
+            }),
           }),
         {
           wrapper,
@@ -453,12 +470,14 @@ describe('useBundleAssets', () => {
       setup({ isUnsuccessfulParseError: true })
       const { result } = renderHook(
         () =>
-          useBundleAssets({
-            provider: 'gh',
-            owner: 'codecov',
-            repo: 'codecov',
-            branch: 'main',
-            bundle: 'test-bundle',
+          useInfiniteQueryV5({
+            ...BundleAssetsQueryOpts({
+              provider: 'gh',
+              owner: 'codecov',
+              repo: 'codecov',
+              branch: 'main',
+              bundle: 'test-bundle',
+            }),
           }),
         {
           wrapper,

--- a/src/services/bundleAnalysis/BundleAssetsQueryOpts.tsx
+++ b/src/services/bundleAnalysis/BundleAssetsQueryOpts.tsx
@@ -141,7 +141,7 @@ query BundleAssets(
                 ... on BundleAnalysisReport {
                   bundle(name: $bundle, filters: $filters) {
                     info {
-                      plugin_name
+                      pluginName
                     }
                     bundleData {
                       size {


### PR DESCRIPTION
# Description

This PR updates the query options for grabbing a list of assets used to display the asset table, so that we can determine if we want to render the new path column in the asset table

Closes codecov/engineering-team#2957

# Notable Changes

- Grab plugin name in assets table query options
  - also updated to be the TSQ V5 style we're moving to
- Update `useBundleAssetsTable`
- Update tests