### PR TITLE
chore: Migrate useCommitPageData to TSQ V5

### DIFF
--- a/src/pages/CommitDetailPage/CommitBundleAnalysis/CommitBundleAnalysis.test.tsx
+++ b/src/pages/CommitDetailPage/CommitBundleAnalysis/CommitBundleAnalysis.test.tsx
@@ -1,4 +1,8 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import {
+  QueryClientProvider as QueryClientProviderV5,
+  QueryClient as QueryClientV5,
+} from '@tanstack/react-queryV5'
 import { render, screen } from '@testing-library/react'
 import { graphql, HttpResponse } from 'msw'
 import { setupServer } from 'msw/node'
@@ -127,23 +131,26 @@ const mockRepoOverview = ({
 })
 
 const queryClient = new QueryClient({
-  defaultOptions: {
-    queries: { retry: false, suspense: true },
-  },
+  defaultOptions: { queries: { retry: false, suspense: true } },
+})
+const queryClientV5 = new QueryClientV5({
+  defaultOptions: { queries: { retry: false } },
 })
 
 const wrapper: React.FC<React.PropsWithChildren> = ({ children }) => (
-  <QueryClientProvider client={queryClient}>
-    <MemoryRouter
-      initialEntries={[
-        '/gh/test-org/test-repo/commit/e736f78b3cb5c8abb1d6b2ec5e5102de455f98ed',
-      ]}
-    >
-      <Route path="/:provider/:owner/:repo/commit/:commit">
-        <Suspense fallback={<p>Loading...</p>}>{children}</Suspense>
-      </Route>
-    </MemoryRouter>
-  </QueryClientProvider>
+  <QueryClientProviderV5 client={queryClientV5}>
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter
+        initialEntries={[
+          '/gh/test-org/test-repo/commit/e736f78b3cb5c8abb1d6b2ec5e5102de455f98ed',
+        ]}
+      >
+        <Route path="/:provider/:owner/:repo/commit/:commit">
+          <Suspense fallback={<p>Loading</p>}>{children}</Suspense>
+        </Route>
+      </MemoryRouter>
+    </QueryClientProvider>
+  </QueryClientProviderV5>
 )
 
 const server = setupServer()
@@ -153,6 +160,7 @@ beforeAll(() => {
 
 afterEach(() => {
   queryClient.clear()
+  queryClientV5.clear()
   server.resetHandlers()
 })
 

--- a/src/pages/CommitDetailPage/CommitBundleAnalysis/CommitBundleAnalysis.tsx
+++ b/src/pages/CommitDetailPage/CommitBundleAnalysis/CommitBundleAnalysis.tsx
@@ -1,3 +1,4 @@
+import { useSuspenseQuery as useSuspenseQueryV5 } from '@tanstack/react-queryV5'
 import { lazy, Suspense } from 'react'
 import { useParams } from 'react-router-dom'
 
@@ -9,7 +10,10 @@ import BundleMessage from './BundleMessage'
 import EmptyTable from './EmptyTable'
 import FirstPullBanner from './FirstPullBanner'
 
-import { TBundleAnalysisComparisonResult, useCommitPageData } from '../hooks'
+import {
+  CommitPageDataQueryOpts,
+  TBundleAnalysisComparisonResult,
+} from '../queries/CommitPageDataQueryOpts'
 
 const CommitBundleAnalysisTable = lazy(
   () => import('./CommitBundleAnalysisTable')
@@ -63,12 +67,14 @@ const BundleContent: React.FC<BundleContentProps> = ({ bundleCompareType }) => {
 
 const CommitBundleAnalysis: React.FC = () => {
   const { provider, owner, repo, commit: commitSha } = useParams<URLParams>()
-  const { data: commitPageData } = useCommitPageData({
-    provider,
-    owner,
-    repo,
-    commitId: commitSha,
-  })
+  const { data: commitPageData } = useSuspenseQueryV5(
+    CommitPageDataQueryOpts({
+      provider,
+      owner,
+      repo,
+      commitId: commitSha,
+    })
+  )
 
   const bundleCompareType =
     commitPageData?.commit?.bundleAnalysis?.bundleAnalysisCompareWithParent

--- a/src/pages/CommitDetailPage/CommitCoverage/CommitCoverage.jsx
+++ b/src/pages/CommitDetailPage/CommitCoverage/CommitCoverage.jsx
@@ -1,3 +1,4 @@
+import { useSuspenseQuery as useSuspenseQueryV5 } from '@tanstack/react-queryV5'
 import isEmpty from 'lodash/isEmpty'
 import { lazy, Suspense } from 'react'
 import { Redirect, Switch, useParams } from 'react-router-dom'
@@ -22,7 +23,7 @@ import ErroredUploads from './ErroredUploads'
 import FirstPullBanner from './FirstPullBanner'
 import YamlErrorBanner from './YamlErrorBanner'
 
-import { useCommitPageData } from '../hooks'
+import { CommitPageDataQueryOpts } from '../queries/CommitPageDataQueryOpts'
 
 const CommitDetailFileExplorer = lazy(
   () => import('./routes/CommitDetailFileExplorer')
@@ -45,12 +46,14 @@ function CommitRoutes() {
   const { provider, owner, repo, commit: commitSha } = useParams()
   const { data: tierName } = useTier({ owner, provider })
   const { data: overview } = useRepoOverview({ provider, owner, repo })
-  const { data: commitPageData } = useCommitPageData({
-    provider,
-    owner,
-    repo,
-    commitId: commitSha,
-  })
+  const { data: commitPageData } = useSuspenseQueryV5(
+    CommitPageDataQueryOpts({
+      provider,
+      owner,
+      repo,
+      commitId: commitSha,
+    })
+  )
 
   const compareTypeName = commitPageData?.commit?.compareWithParent?.__typename
   const ErrorBannerComponent = (
@@ -174,12 +177,14 @@ function CommitCoverage() {
   const { data: tierName } = useTier({ owner, provider })
   const { data: overview } = useRepoOverview({ provider, owner, repo })
   const { data: rateLimit } = useRepoRateLimitStatus({ provider, owner, repo })
-  const { data: commitPageData } = useCommitPageData({
-    provider,
-    owner,
-    repo,
-    commitId: commitSha,
-  })
+  const { data: commitPageData } = useSuspenseQueryV5(
+    CommitPageDataQueryOpts({
+      provider,
+      owner,
+      repo,
+      commitId: commitSha,
+    })
+  )
 
   const showCommitSummary = !(overview.private && tierName === TierNames.TEAM)
   const showFirstPullBanner =

--- a/src/pages/CommitDetailPage/CommitCoverage/CommitCoverage.test.jsx
+++ b/src/pages/CommitDetailPage/CommitCoverage/CommitCoverage.test.jsx
@@ -416,7 +416,7 @@ describe('CommitCoverage', () => {
       defaultOptions: { queries: { retry: false, suspense: true } },
     })
     const queryClientV5 = new QueryClientV5({
-      defaultOptions: { queries: { retry: false, suspense: true } },
+      defaultOptions: { queries: { retry: false } },
     })
 
     server.use(

--- a/src/pages/CommitDetailPage/CommitCoverage/CommitCoverage.test.jsx
+++ b/src/pages/CommitDetailPage/CommitCoverage/CommitCoverage.test.jsx
@@ -1,5 +1,9 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import {
+  QueryClientProvider as QueryClientProviderV5,
+  QueryClient as QueryClientV5,
+} from '@tanstack/react-queryV5'
+import {
   render,
   screen,
   waitForElementToBeRemoved,
@@ -356,17 +360,20 @@ const server = setupServer()
 const wrapper =
   ({
     queryClient,
+    queryClientV5,
     initialEntries = '/gh/test-org/test-repo/commit/1234567890abcdef',
     path = '/:provider/:owner/:repo/commit/:commit',
   }) =>
   ({ children }) => (
-    <QueryClientProvider client={queryClient}>
-      <MemoryRouter initialEntries={[initialEntries]}>
-        <Route path={path}>
-          <Suspense fallback={<p>Loading</p>}>{children}</Suspense>
-        </Route>
-      </MemoryRouter>
-    </QueryClientProvider>
+    <QueryClientProviderV5 client={queryClientV5}>
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter initialEntries={[initialEntries]}>
+          <Route path={path}>
+            <Suspense fallback={<p>Loading</p>}>{children}</Suspense>
+          </Route>
+        </MemoryRouter>
+      </QueryClientProvider>
+    </QueryClientProviderV5>
   )
 
 beforeAll(() => {
@@ -406,12 +413,10 @@ describe('CommitCoverage', () => {
     }
   ) {
     const queryClient = new QueryClient({
-      defaultOptions: {
-        queries: {
-          retry: false,
-          suspense: true,
-        },
-      },
+      defaultOptions: { queries: { retry: false, suspense: true } },
+    })
+    const queryClientV5 = new QueryClientV5({
+      defaultOptions: { queries: { retry: false, suspense: true } },
     })
 
     server.use(
@@ -468,14 +473,16 @@ describe('CommitCoverage', () => {
       })
     )
 
-    return { queryClient }
+    return { queryClient, queryClientV5 }
   }
 
   describe('testing different routes', () => {
     describe('/:provider/:owner/:repo/commit/:commit', () => {
       it('renders files changed tab', async () => {
-        const { queryClient } = setup()
-        render(<CommitCoverage />, { wrapper: wrapper({ queryClient }) })
+        const { queryClient, queryClientV5 } = setup()
+        render(<CommitCoverage />, {
+          wrapper: wrapper({ queryClient, queryClientV5 }),
+        })
 
         const filesChangedTab = await screen.findByText('FilesChangedTab')
         expect(filesChangedTab).toBeInTheDocument()
@@ -484,10 +491,11 @@ describe('CommitCoverage', () => {
 
     describe('/:provider/:owner/:repo/commit/:commit/indirect-changes', () => {
       it('renders indirect changes tab', async () => {
-        const { queryClient } = setup()
+        const { queryClient, queryClientV5 } = setup()
         render(<CommitCoverage />, {
           wrapper: wrapper({
             queryClient,
+            queryClientV5,
             path: '/:provider/:owner/:repo/commit/:commit/indirect-changes',
             initialEntries:
               '/gh/test-org/test-repo/commit/1234567890abcdef/indirect-changes',
@@ -501,10 +509,11 @@ describe('CommitCoverage', () => {
 
     describe('/:provider/:owner/:repo/commit/:commit/tree/', () => {
       it('renders commit detail file explorer', async () => {
-        const { queryClient } = setup()
+        const { queryClient, queryClientV5 } = setup()
         render(<CommitCoverage />, {
           wrapper: wrapper({
             queryClient,
+            queryClientV5,
             path: '/:provider/:owner/:repo/commit/:commit/tree/',
             initialEntries:
               '/gh/test-org/test-repo/commit/1234567890abcdef/tree',
@@ -518,10 +527,11 @@ describe('CommitCoverage', () => {
 
     describe('/:provider/:owner/:repo/commit/:commit/tree/:path+', () => {
       it('renders commit detail file explorer', async () => {
-        const { queryClient } = setup()
+        const { queryClient, queryClientV5 } = setup()
         render(<CommitCoverage />, {
           wrapper: wrapper({
             queryClient,
+            queryClientV5,
             path: '/:provider/:owner/:repo/commit/:commit/tree/:path+',
             initialEntries:
               '/gh/test-org/test-repo/commit/1234567890abcdef/tree/src/',
@@ -535,10 +545,11 @@ describe('CommitCoverage', () => {
 
     describe('/:provider/:owner/:repo/commit/:commit/blob/:path+', () => {
       it('renders commit detail file viewer', async () => {
-        const { queryClient } = setup()
+        const { queryClient, queryClientV5 } = setup()
         render(<CommitCoverage />, {
           wrapper: wrapper({
             queryClient,
+            queryClientV5,
             path: '/:provider/:owner/:repo/commit/:commit/blob/:path+',
             initialEntries:
               '/gh/test-org/test-repo/commit/1234567890abcdef/blob/src/index.js',
@@ -554,8 +565,10 @@ describe('CommitCoverage', () => {
   describe('there are no errored uploads', () => {
     describe('rendering uploads card', () => {
       it('renders uploads card', async () => {
-        const { queryClient } = setup()
-        render(<CommitCoverage />, { wrapper: wrapper({ queryClient }) })
+        const { queryClient, queryClientV5 } = setup()
+        render(<CommitCoverage />, {
+          wrapper: wrapper({ queryClient, queryClientV5 }),
+        })
 
         const uploadsCard = await screen.findByText('UploadsCard')
         expect(uploadsCard).toBeInTheDocument()
@@ -564,11 +577,13 @@ describe('CommitCoverage', () => {
 
     describe('user is on a team plan', () => {
       it('does not render commit coverage summary', async () => {
-        const { queryClient } = setup({
+        const { queryClient, queryClientV5 } = setup({
           tierName: TierNames.TEAM,
           isPrivate: true,
         })
-        render(<CommitCoverage />, { wrapper: wrapper({ queryClient }) })
+        render(<CommitCoverage />, {
+          wrapper: wrapper({ queryClient, queryClientV5 }),
+        })
 
         const loader = await screen.findByText('Loading')
         await waitForElementToBeRemoved(loader)
@@ -578,11 +593,13 @@ describe('CommitCoverage', () => {
       })
 
       it('does not render indirect changes tab', async () => {
-        const { queryClient } = setup({
+        const { queryClient, queryClientV5 } = setup({
           tierName: TierNames.TEAM,
           isPrivate: true,
         })
-        render(<CommitCoverage />, { wrapper: wrapper({ queryClient }) })
+        render(<CommitCoverage />, {
+          wrapper: wrapper({ queryClient, queryClientV5 }),
+        })
 
         const loader = await screen.findByText('Loading')
         await waitForElementToBeRemoved(loader)
@@ -595,8 +612,10 @@ describe('CommitCoverage', () => {
 
   describe('there are bot errors', () => {
     it('renders commit summary', async () => {
-      const { queryClient } = setup({ hasErroredUploads: true })
-      render(<CommitCoverage />, { wrapper: wrapper({ queryClient }) })
+      const { queryClient, queryClientV5 } = setup({ hasErroredUploads: true })
+      render(<CommitCoverage />, {
+        wrapper: wrapper({ queryClient, queryClientV5 }),
+      })
 
       const commitCoverageSummary = await screen.findByText(
         'CommitCoverageSummary'
@@ -605,16 +624,20 @@ describe('CommitCoverage', () => {
     })
 
     it('renders uploads card', async () => {
-      const { queryClient } = setup({ hasErroredUploads: true })
-      render(<CommitCoverage />, { wrapper: wrapper({ queryClient }) })
+      const { queryClient, queryClientV5 } = setup({ hasErroredUploads: true })
+      render(<CommitCoverage />, {
+        wrapper: wrapper({ queryClient, queryClientV5 }),
+      })
 
       const uploadsCard = await screen.findByText('UploadsCard')
       expect(uploadsCard).toBeInTheDocument()
     })
 
     it('renders bot error banner', async () => {
-      const { queryClient } = setup({ hasCommitErrors: true })
-      render(<CommitCoverage />, { wrapper: wrapper({ queryClient }) })
+      const { queryClient, queryClientV5 } = setup({ hasCommitErrors: true })
+      render(<CommitCoverage />, {
+        wrapper: wrapper({ queryClient, queryClientV5 }),
+      })
 
       const botErrorBanner = await screen.findByText('BotErrorBanner')
       expect(botErrorBanner).toBeInTheDocument()
@@ -623,8 +646,10 @@ describe('CommitCoverage', () => {
 
   describe('there are yaml errors', () => {
     it('renders commit summary', async () => {
-      const { queryClient } = setup({ hasErroredUploads: true })
-      render(<CommitCoverage />, { wrapper: wrapper({ queryClient }) })
+      const { queryClient, queryClientV5 } = setup({ hasErroredUploads: true })
+      render(<CommitCoverage />, {
+        wrapper: wrapper({ queryClient, queryClientV5 }),
+      })
 
       const commitCoverageSummary = await screen.findByText(
         'CommitCoverageSummary'
@@ -633,16 +658,20 @@ describe('CommitCoverage', () => {
     })
 
     it('renders uploads card', async () => {
-      const { queryClient } = setup({ hasErroredUploads: true })
-      render(<CommitCoverage />, { wrapper: wrapper({ queryClient }) })
+      const { queryClient, queryClientV5 } = setup({ hasErroredUploads: true })
+      render(<CommitCoverage />, {
+        wrapper: wrapper({ queryClient, queryClientV5 }),
+      })
 
       const uploadsCard = await screen.findByText('UploadsCard')
       expect(uploadsCard).toBeInTheDocument()
     })
 
     it('renders yaml error banner', async () => {
-      const { queryClient } = setup({ hasCommitErrors: true })
-      render(<CommitCoverage />, { wrapper: wrapper({ queryClient }) })
+      const { queryClient, queryClientV5 } = setup({ hasCommitErrors: true })
+      render(<CommitCoverage />, {
+        wrapper: wrapper({ queryClient, queryClientV5 }),
+      })
 
       const yamlErrorBanner = await screen.findByText('YamlErrorBanner')
       expect(yamlErrorBanner).toBeInTheDocument()
@@ -651,8 +680,10 @@ describe('CommitCoverage', () => {
 
   describe('there are errored uploads', () => {
     it('renders commit summary', async () => {
-      const { queryClient } = setup({ hasErroredUploads: true })
-      render(<CommitCoverage />, { wrapper: wrapper({ queryClient }) })
+      const { queryClient, queryClientV5 } = setup({ hasErroredUploads: true })
+      render(<CommitCoverage />, {
+        wrapper: wrapper({ queryClient, queryClientV5 }),
+      })
 
       const commitCoverageSummary = await screen.findByText(
         'CommitCoverageSummary'
@@ -661,16 +692,20 @@ describe('CommitCoverage', () => {
     })
 
     it('renders uploads card', async () => {
-      const { queryClient } = setup({ hasErroredUploads: true })
-      render(<CommitCoverage />, { wrapper: wrapper({ queryClient }) })
+      const { queryClient, queryClientV5 } = setup({ hasErroredUploads: true })
+      render(<CommitCoverage />, {
+        wrapper: wrapper({ queryClient, queryClientV5 }),
+      })
 
       const uploadsCard = await screen.findByText('UploadsCard')
       expect(uploadsCard).toBeInTheDocument()
     })
 
     it('renders error uploads component', async () => {
-      const { queryClient } = setup({ hasErroredUploads: true })
-      render(<CommitCoverage />, { wrapper: wrapper({ queryClient }) })
+      const { queryClient, queryClientV5 } = setup({ hasErroredUploads: true })
+      render(<CommitCoverage />, {
+        wrapper: wrapper({ queryClient, queryClientV5 }),
+      })
 
       const erroredUploads = await screen.findByText(
         /No coverage data is available due to incomplete uploads on the first attempt./
@@ -681,8 +716,10 @@ describe('CommitCoverage', () => {
 
   describe('comparison returns first pull request', () => {
     it('renders first pull banner', async () => {
-      const { queryClient } = setup({ hasFirstPR: true })
-      render(<CommitCoverage />, { wrapper: wrapper({ queryClient }) })
+      const { queryClient, queryClientV5 } = setup({ hasFirstPR: true })
+      render(<CommitCoverage />, {
+        wrapper: wrapper({ queryClient, queryClientV5 }),
+      })
 
       const firstPullRequest = await screen.findByText(/Welcome to Codecov/)
       expect(firstPullRequest).toBeInTheDocument()
@@ -691,17 +728,23 @@ describe('CommitCoverage', () => {
 
   describe('commit has errors', () => {
     it('renders error banner for missing base commit', async () => {
-      const { queryClient } = setup({
+      const { queryClient, queryClientV5 } = setup({
         hasCommitPageMissingCommitDataError: true,
       })
-      render(<CommitCoverage />, { wrapper: wrapper({ queryClient }) })
+      render(<CommitCoverage />, {
+        wrapper: wrapper({ queryClient, queryClientV5 }),
+      })
 
       const missingBaseCommit = await screen.findByText(/Missing Base Commit/)
       expect(missingBaseCommit).toBeInTheDocument()
     })
     it('renders error banner', async () => {
-      const { queryClient } = setup({ hasCommitPageOtherDataError: true })
-      render(<CommitCoverage />, { wrapper: wrapper({ queryClient }) })
+      const { queryClient, queryClientV5 } = setup({
+        hasCommitPageOtherDataError: true,
+      })
+      render(<CommitCoverage />, {
+        wrapper: wrapper({ queryClient, queryClientV5 }),
+      })
 
       const missingBaseCommit = await screen.findByText(/Missing Base Report/)
       expect(missingBaseCommit).toBeInTheDocument()
@@ -710,12 +753,14 @@ describe('CommitCoverage', () => {
 
   describe('github rate limit messaging', () => {
     it('renders banner when github is rate limited', async () => {
-      const { queryClient } = setup({
+      const { queryClient, queryClientV5 } = setup({
         coverageEnabled: true,
         bundleAnalysisEnabled: true,
         isGithubRateLimited: true,
       })
-      render(<CommitCoverage />, { wrapper: wrapper({ queryClient }) })
+      render(<CommitCoverage />, {
+        wrapper: wrapper({ queryClient, queryClientV5 }),
+      })
 
       const rateLimitText = await screen.findByText(
         /Unable to calculate coverage/
@@ -724,11 +769,13 @@ describe('CommitCoverage', () => {
     })
 
     it('does not render banner when github is not rate limited', async () => {
-      const { queryClient } = setup({
+      const { queryClient, queryClientV5 } = setup({
         coverageEnabled: true,
         bundleAnalysisEnabled: true,
       })
-      render(<CommitCoverage />, { wrapper: wrapper({ queryClient }) })
+      render(<CommitCoverage />, {
+        wrapper: wrapper({ queryClient, queryClientV5 }),
+      })
 
       const rateLimitText = screen.queryByText(/Unable to calculate coverage/)
       expect(rateLimitText).not.toBeInTheDocument()

--- a/src/pages/CommitDetailPage/CommitDetailPage.test.tsx
+++ b/src/pages/CommitDetailPage/CommitDetailPage.test.tsx
@@ -1,4 +1,8 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import {
+  QueryClientProvider as QueryClientProviderV5,
+  QueryClient as QueryClientV5,
+} from '@tanstack/react-queryV5'
 import { render, screen } from '@testing-library/react'
 import { graphql, HttpResponse } from 'msw'
 import { setupServer } from 'msw/node'
@@ -100,7 +104,10 @@ const mockBundleDropdownSummary = {
 
 const server = setupServer()
 const queryClient = new QueryClient({
-  defaultOptions: { queries: { suspense: true } },
+  defaultOptions: { queries: { retry: false, suspense: true } },
+})
+const queryClientV5 = new QueryClientV5({
+  defaultOptions: { queries: { retry: false } },
 })
 
 const wrapper =
@@ -108,15 +115,17 @@ const wrapper =
     initialEntries = '/gh/test-org/test-repo/commit/e736f78b3cb5c8abb1d6b2ec5e5102de455f98ed'
   ): React.FC<React.PropsWithChildren> =>
   ({ children }) => (
-    <QueryClientProvider client={queryClient}>
-      <MemoryRouter initialEntries={[initialEntries]}>
-        <Route path="/:provider/:owner/:repo/commit/:commit">
-          <RepoBreadcrumbProvider>
-            <Suspense fallback={null}>{children}</Suspense>
-          </RepoBreadcrumbProvider>
-        </Route>
-      </MemoryRouter>
-    </QueryClientProvider>
+    <QueryClientProviderV5 client={queryClientV5}>
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter initialEntries={[initialEntries]}>
+          <Route path="/:provider/:owner/:repo/commit/:commit">
+            <RepoBreadcrumbProvider>
+              <Suspense fallback={null}>{children}</Suspense>
+            </RepoBreadcrumbProvider>
+          </Route>
+        </MemoryRouter>
+      </QueryClientProvider>
+    </QueryClientProviderV5>
   )
 
 beforeAll(() => {
@@ -125,6 +134,7 @@ beforeAll(() => {
 
 afterEach(() => {
   queryClient.clear()
+  queryClientV5.clear()
   server.resetHandlers()
 })
 

--- a/src/pages/CommitDetailPage/CommitDetailPage.tsx
+++ b/src/pages/CommitDetailPage/CommitDetailPage.tsx
@@ -1,4 +1,7 @@
-import { useQueryClient } from '@tanstack/react-query'
+import {
+  useQueryClient as useQueryClientV5,
+  useSuspenseQuery as useSuspenseQueryV5,
+} from '@tanstack/react-queryV5'
 import qs from 'qs'
 import { lazy, Suspense, useLayoutEffect } from 'react'
 import { useLocation, useParams } from 'react-router-dom'
@@ -12,7 +15,7 @@ import SummaryDropdown from 'ui/SummaryDropdown'
 import CommitBundleDropdown from './Dropdowns/CommitBundleDropdown'
 import CommitCoverageDropdown from './Dropdowns/CommitCoverageDropdown'
 import Header from './Header'
-import { useCommitPageData } from './hooks'
+import { CommitPageDataQueryOpts } from './queries/CommitPageDataQueryOpts'
 
 const CommitCoverage = lazy(() => import('./CommitCoverage'))
 const CommitBundleAnalysis = lazy(() => import('./CommitBundleAnalysis'))
@@ -44,15 +47,17 @@ const CommitDetailPage: React.FC = () => {
   const shortSHA = commitSha?.slice(0, 7)
 
   // reset cache when user navigates to the commit detail page
-  const queryClient = useQueryClient()
-  queryClient.setQueryData(['IgnoredUploadIds'], [])
+  const queryClientV5 = useQueryClientV5()
+  queryClientV5.setQueryData(['IgnoredUploadIds'], [])
 
-  const { data: commitPageData, isLoading } = useCommitPageData({
-    provider,
-    owner,
-    repo,
-    commitId: commitSha,
-  })
+  const { data: commitPageData, isLoading } = useSuspenseQueryV5(
+    CommitPageDataQueryOpts({
+      provider,
+      owner,
+      repo,
+      commitId: commitSha,
+    })
+  )
 
   const { setBreadcrumbs, setBaseCrumbs } = useCrumbs()
   useLayoutEffect(() => {

--- a/src/pages/CommitDetailPage/hooks/index.js
+++ b/src/pages/CommitDetailPage/hooks/index.js
@@ -1,1 +1,0 @@
-export * from './useCommitPageData'

--- a/src/pages/CommitDetailPage/queries/CommitPageDataQueryOpts.test.tsx
+++ b/src/pages/CommitDetailPage/queries/CommitPageDataQueryOpts.test.tsx
@@ -1,9 +1,13 @@
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import {
+  QueryClientProvider as QueryClientProviderV5,
+  QueryClient as QueryClientV5,
+  useQuery as useQueryV5,
+} from '@tanstack/react-queryV5'
 import { renderHook, waitFor } from '@testing-library/react'
 import { graphql, HttpResponse } from 'msw'
 import { setupServer } from 'msw/node'
 
-import { useCommitPageData } from './useCommitPageData'
+import { CommitPageDataQueryOpts } from './CommitPageDataQueryOpts'
 
 const mockCommitData = {
   owner: {
@@ -54,13 +58,15 @@ const mockNullOwner = {
 
 const mockUnsuccessfulParseError = {}
 
-const queryClient = new QueryClient({
+const queryClientV5 = new QueryClientV5({
   defaultOptions: { queries: { retry: false } },
 })
 const server = setupServer()
 
 const wrapper: React.FC<React.PropsWithChildren> = ({ children }) => (
-  <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  <QueryClientProviderV5 client={queryClientV5}>
+    {children}
+  </QueryClientProviderV5>
 )
 
 beforeAll(() => {
@@ -68,7 +74,7 @@ beforeAll(() => {
 })
 
 afterEach(() => {
-  queryClient.clear()
+  queryClientV5.clear()
   server.resetHandlers()
 })
 
@@ -115,12 +121,14 @@ describe('useCommitPageData', () => {
 
           const { result } = renderHook(
             () =>
-              useCommitPageData({
-                provider: 'gh',
-                owner: 'codecov',
-                repo: 'cool-repo',
-                commitId: 'id-1',
-              }),
+              useQueryV5(
+                CommitPageDataQueryOpts({
+                  provider: 'gh',
+                  owner: 'codecov',
+                  repo: 'cool-repo',
+                  commitId: 'id-1',
+                })
+              ),
             { wrapper }
           )
 
@@ -156,12 +164,14 @@ describe('useCommitPageData', () => {
 
           const { result } = renderHook(
             () =>
-              useCommitPageData({
-                provider: 'gh',
-                owner: 'codecov',
-                repo: 'cool-repo',
-                commitId: 'id-1',
-              }),
+              useQueryV5(
+                CommitPageDataQueryOpts({
+                  provider: 'gh',
+                  owner: 'codecov',
+                  repo: 'cool-repo',
+                  commitId: 'id-1',
+                })
+              ),
             { wrapper }
           )
 
@@ -199,12 +209,14 @@ describe('useCommitPageData', () => {
 
         const { result } = renderHook(
           () =>
-            useCommitPageData({
-              provider: 'gh',
-              owner: 'codecov',
-              repo: 'cool-repo',
-              commitId: 'id-1',
-            }),
+            useQueryV5(
+              CommitPageDataQueryOpts({
+                provider: 'gh',
+                owner: 'codecov',
+                repo: 'cool-repo',
+                commitId: 'id-1',
+              })
+            ),
           { wrapper }
         )
 
@@ -235,12 +247,14 @@ describe('useCommitPageData', () => {
 
         const { result } = renderHook(
           () =>
-            useCommitPageData({
-              provider: 'gh',
-              owner: 'codecov',
-              repo: 'cool-repo',
-              commitId: 'id-1',
-            }),
+            useQueryV5(
+              CommitPageDataQueryOpts({
+                provider: 'gh',
+                owner: 'codecov',
+                repo: 'cool-repo',
+                commitId: 'id-1',
+              })
+            ),
           { wrapper }
         )
 
@@ -271,12 +285,14 @@ describe('useCommitPageData', () => {
 
         const { result } = renderHook(
           () =>
-            useCommitPageData({
-              provider: 'gh',
-              owner: 'codecov',
-              repo: 'cool-repo',
-              commitId: 'id-1',
-            }),
+            useQueryV5(
+              CommitPageDataQueryOpts({
+                provider: 'gh',
+                owner: 'codecov',
+                repo: 'cool-repo',
+                commitId: 'id-1',
+              })
+            ),
           { wrapper }
         )
 


### PR DESCRIPTION
# Description

This PR updates the `useCommitPageData` hook to `CommitPageDataQueryOpts` following along with the new style of writing data fetching utils.

Ticket: codecov/engineering-team#2966

# Notable Changes

- Update `useCommitPageData` to `CommitPageDataQueryOpts`
- Update tests