### PR TITLE
fix: HTML Validation issues with GitHub Rate Limit Banner

### DIFF
--- a/src/shared/GlobalBanners/GitHubRateLimitExceeded/GitHubRateLimitExceededBanner.test.tsx
+++ b/src/shared/GlobalBanners/GitHubRateLimitExceeded/GitHubRateLimitExceededBanner.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter, Route } from 'react-router'
+
+import GitHubRateLimitExceededBanner from './GitHubRateLimitExceededBanner'
+
+const wrapper =
+  (initialEntry = '/gh'): React.FC<React.PropsWithChildren> =>
+  ({ children }) => (
+    <MemoryRouter initialEntries={[initialEntry]}>
+      <Route path="/:provider">{children}</Route>
+    </MemoryRouter>
+  )
+
+describe('GitHubRateLimitExceededBanner', () => {
+  describe('provider is GH', () => {
+    it('renders the banner', () => {
+      render(<GitHubRateLimitExceededBanner />, {
+        wrapper: wrapper('/gh'),
+      })
+
+      const title = screen.getByText('Rate limit exceeded')
+      expect(title).toBeInTheDocument()
+
+      const description = screen.getByText(/Unable to calculate/)
+      expect(description).toBeInTheDocument()
+
+      const link = screen.getByRole('link', { name: 'Github documentation.' })
+      expect(link).toBeInTheDocument()
+      expect(link).toHaveAttribute(
+        'href',
+        'https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api'
+      )
+    })
+  })
+
+  describe('provider is not GH', () => {
+    it('does not render', () => {
+      const { container } = render(<GitHubRateLimitExceededBanner />, {
+        wrapper: wrapper('/bb'),
+      })
+
+      expect(container).toBeEmptyDOMElement()
+    })
+  })
+})

--- a/src/shared/GlobalBanners/GitHubRateLimitExceeded/GitHubRateLimitExceededBanner.tsx
+++ b/src/shared/GlobalBanners/GitHubRateLimitExceeded/GitHubRateLimitExceededBanner.tsx
@@ -5,8 +5,12 @@ import { providerToName } from 'shared/utils/provider'
 import A from 'ui/A'
 import { Alert } from 'ui/Alert'
 
+interface URLParams {
+  provider: Provider
+}
+
 const GitHubRateLimitExceededBanner = () => {
-  const { provider } = useParams<{ provider: Provider }>()
+  const { provider } = useParams<URLParams>()
   const isGh = providerToName(provider) === 'Github'
 
   if (!isGh) return null
@@ -14,22 +18,18 @@ const GitHubRateLimitExceededBanner = () => {
   return (
     <div className="mb-2">
       <Alert variant="warning">
-        <Alert.Title>
-          <h2 className="flex gap-2 font-semibold">Rate limit exceeded</h2>
-        </Alert.Title>
+        <Alert.Title>Rate limit exceeded</Alert.Title>
         <Alert.Description>
-          <p className="flex items-center gap-2">
-            Unable to calculate coverage due to GitHub rate limit exceeded.
-            Please retry later. More info on rate limits:
-            <A
-              data-testid="codecovGithubApp-link"
-              to={{ pageName: 'githubRateLimitExceeded' }}
-              hook={undefined}
-              isExternal={true}
-            >
-              Github documentation.
-            </A>
-          </p>
+          Unable to calculate coverage due to GitHub rate limit exceeded. Please
+          retry later. More info on rate limits:{' '}
+          <A
+            data-testid="codecovGithubApp-link"
+            to={{ pageName: 'githubRateLimitExceeded' }}
+            hook={undefined}
+            isExternal={true}
+          >
+            Github documentation.
+          </A>
         </Alert.Description>
       </Alert>
     </div>


### PR DESCRIPTION
# Description

This PR resolves the following issues:

```
Warning: validateDOMNesting(...): <h2> cannot appear as a child of <h5>.
Warning: validateDOMNesting(...): <p> cannot appear as a descendant of <p>.
```

# Notable Changes

- Remove `h2` and `p` elements

# Screenshots

Before:
<img width="1258" alt="Screenshot 2024-11-28 at 15 21 25" src="https://github.com/user-attachments/assets/339e9ee9-ca13-45f2-b0eb-505af2009791">

After:

<img width="1262" alt="Screenshot 2024-11-28 at 15 17 49" src="https://github.com/user-attachments/assets/0a7e6a55-209e-4625-9e4a-177c5b1f3f48">