### PR TITLE
chore: Migrate usePullHeadData to TS Query V5

### DIFF
--- a/src/pages/PullRequestPage/Header/HeaderDefault/HeaderDefault.tsx
+++ b/src/pages/PullRequestPage/Header/HeaderDefault/HeaderDefault.tsx
@@ -1,15 +1,16 @@
-import cs from 'classnames'
+import { useSuspenseQuery as useSuspenseQueryV5 } from '@tanstack/react-queryV5'
 import capitalize from 'lodash/capitalize'
 import { useParams } from 'react-router-dom'
 
 import { Provider } from 'shared/api/helpers'
+import { cn } from 'shared/utils/cn'
 import { formatTimeToNow } from 'shared/utils/dates'
 import { getProviderPullURL } from 'shared/utils/provider'
 import A from 'ui/A'
 import CIStatusLabel from 'ui/CIStatus'
 import Icon from 'ui/Icon'
 
-import { usePullHeadData } from './hooks'
+import { PullHeadDataQueryOpts } from './queries/PullHeadDataQueryOpts'
 
 import { pullStateToColor } from '../constants'
 
@@ -22,7 +23,9 @@ interface URLParams {
 
 function HeaderDefault() {
   const { provider, owner, repo, pullId } = useParams<URLParams>()
-  const { data } = usePullHeadData({ provider, owner, repo, pullId })
+  const { data } = useSuspenseQueryV5(
+    PullHeadDataQueryOpts({ provider, owner, repo, pullId })
+  )
 
   const pull = data?.pull
 
@@ -33,8 +36,8 @@ function HeaderDefault() {
           {pull?.title}
           {pull?.state ? (
             <span
-              className={cs(
-                'text-white font-bold px-3 py-0.5 text-xs rounded',
+              className={cn(
+                'rounded px-3 py-0.5 text-xs font-bold text-white',
                 pullStateToColor[pull?.state]
               )}
             >

--- a/src/pages/PullRequestPage/Header/HeaderDefault/hooks/index.ts
+++ b/src/pages/PullRequestPage/Header/HeaderDefault/hooks/index.ts
@@ -1,1 +1,0 @@
-export * from './usePullHeadData'

--- a/src/pages/PullRequestPage/Header/HeaderDefault/queries/PullHeadDataQueryOpts.test.tsx
+++ b/src/pages/PullRequestPage/Header/HeaderDefault/queries/PullHeadDataQueryOpts.test.tsx
@@ -1,9 +1,13 @@
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import {
+  QueryClientProvider as QueryClientProviderV5,
+  QueryClient as QueryClientV5,
+  useQuery as useQueryV5,
+} from '@tanstack/react-queryV5'
 import { renderHook, waitFor } from '@testing-library/react'
 import { graphql, HttpResponse } from 'msw'
 import { setupServer } from 'msw/node'
 
-import { usePullHeadData } from './usePullHeadData'
+import { PullHeadDataQueryOpts } from './PullHeadDataQueryOpts'
 
 const mockPullData = {
   owner: {
@@ -50,13 +54,15 @@ const mockNullOwner = {
 
 const mockUnsuccessfulParseError = {}
 
-const queryClient = new QueryClient({
+const queryClientV5 = new QueryClientV5({
   defaultOptions: { queries: { retry: false } },
 })
 const server = setupServer()
 
 const wrapper: React.FC<React.PropsWithChildren> = ({ children }) => (
-  <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  <QueryClientProviderV5 client={queryClientV5}>
+    {children}
+  </QueryClientProviderV5>
 )
 
 beforeAll(() => {
@@ -64,7 +70,7 @@ beforeAll(() => {
 })
 
 afterEach(() => {
-  queryClient.clear()
+  queryClientV5.clear()
   server.resetHandlers()
 })
 
@@ -110,15 +116,15 @@ describe('usePullHeadData', () => {
           setup({})
           const { result } = renderHook(
             () =>
-              usePullHeadData({
-                provider: 'gh',
-                owner: 'codecov',
-                repo: 'cool-repo',
-                pullId: '1',
-              }),
-            {
-              wrapper,
-            }
+              useQueryV5(
+                PullHeadDataQueryOpts({
+                  provider: 'gh',
+                  owner: 'codecov',
+                  repo: 'cool-repo',
+                  pullId: '1',
+                })
+              ),
+            { wrapper }
           )
 
           await waitFor(() => result.current.isLoading)
@@ -149,15 +155,15 @@ describe('usePullHeadData', () => {
           setup({ isNullOwner: true })
           const { result } = renderHook(
             () =>
-              usePullHeadData({
-                provider: 'gh',
-                owner: 'codecov',
-                repo: 'cool-repo',
-                pullId: '1',
-              }),
-            {
-              wrapper,
-            }
+              useQueryV5(
+                PullHeadDataQueryOpts({
+                  provider: 'gh',
+                  owner: 'codecov',
+                  repo: 'cool-repo',
+                  pullId: '1',
+                })
+              ),
+            { wrapper }
           )
 
           await waitFor(() => result.current.isLoading)
@@ -188,15 +194,15 @@ describe('usePullHeadData', () => {
 
         const { result } = renderHook(
           () =>
-            usePullHeadData({
-              provider: 'gh',
-              owner: 'codecov',
-              repo: 'cool-repo',
-              pullId: '1',
-            }),
-          {
-            wrapper,
-          }
+            useQueryV5(
+              PullHeadDataQueryOpts({
+                provider: 'gh',
+                owner: 'codecov',
+                repo: 'cool-repo',
+                pullId: '1',
+              })
+            ),
+          { wrapper }
         )
 
         await waitFor(() => expect(result.current.isError).toBeTruthy())
@@ -225,15 +231,15 @@ describe('usePullHeadData', () => {
         setup({ isOwnerNotActivatedError: true })
         const { result } = renderHook(
           () =>
-            usePullHeadData({
-              provider: 'gh',
-              owner: 'codecov',
-              repo: 'cool-repo',
-              pullId: '1',
-            }),
-          {
-            wrapper,
-          }
+            useQueryV5(
+              PullHeadDataQueryOpts({
+                provider: 'gh',
+                owner: 'codecov',
+                repo: 'cool-repo',
+                pullId: '1',
+              })
+            ),
+          { wrapper }
         )
 
         await waitFor(() => expect(result.current.isError).toBeTruthy())
@@ -262,15 +268,15 @@ describe('usePullHeadData', () => {
         setup({ isUnsuccessfulParseError: true })
         const { result } = renderHook(
           () =>
-            usePullHeadData({
-              provider: 'gh',
-              owner: 'codecov',
-              repo: 'cool-repo',
-              pullId: '1',
-            }),
-          {
-            wrapper,
-          }
+            useQueryV5(
+              PullHeadDataQueryOpts({
+                provider: 'gh',
+                owner: 'codecov',
+                repo: 'cool-repo',
+                pullId: '1',
+              })
+            ),
+          { wrapper }
         )
 
         await waitFor(() => expect(result.current.isError).toBeTruthy())

--- a/src/pages/PullRequestPage/Header/HeaderDefault/queries/PullHeadDataQueryOpts.tsx
+++ b/src/pages/PullRequestPage/Header/HeaderDefault/queries/PullHeadDataQueryOpts.tsx
@@ -1,4 +1,4 @@
-import { useQuery } from '@tanstack/react-query'
+import { queryOptions as queryOptionsV5 } from '@tanstack/react-queryV5'
 import { z } from 'zod'
 
 import {
@@ -80,20 +80,20 @@ const query = `
   }
 `
 
-interface UsePullHeadDataArgs {
+interface PullHeadDataQueryArgs {
   provider: string
   owner: string
   repo: string
   pullId: string
 }
 
-export const usePullHeadData = ({
+export const PullHeadDataQueryOpts = ({
   provider,
   owner,
   repo,
   pullId,
-}: UsePullHeadDataArgs) =>
-  useQuery({
+}: PullHeadDataQueryArgs) =>
+  queryOptionsV5({
     queryKey: ['PullHeader', provider, owner, repo, pullId, query],
     queryFn: ({ signal }) =>
       Api.graphql({


### PR DESCRIPTION
# Description

This PR updates the `usePullHeadData` hook over to the query options API version: `PullHeadDataQueryOpts`.

Ticket codecov/engineering-team#2965

# Notable Changes

- Refactor `usePullHeadData` to `PullHeadDataQueryOpts`
- Update tests