### PR TITLE
fix: RepoPage table header having no BG

### DIFF
--- a/src/pages/RepoPage/CoverageTab/OverviewTab/subroute/FileExplorer/FileExplorer.jsx
+++ b/src/pages/RepoPage/CoverageTab/OverviewTab/subroute/FileExplorer/FileExplorer.jsx
@@ -23,7 +23,7 @@ function FileExplorer() {
 
   return (
     <div className="flex flex-col gap-4">
-      <div className="sticky top-0 z-10 flex justify-between gap-2 pt-2">
+      <div className="sticky top-0 z-10 flex justify-between gap-2 bg-ds-background pt-2">
         <div className="flex flex-1 items-center gap-4">
           <DisplayTypeButton
             dataLength={branchData?.length}


### PR DESCRIPTION
# Description

The current header for the repo page code tree/file list has no bg set so it's transparent, which isn't great. This PR is a small fix to resolve it

# Notable Changes

- Add BG to file wrapping sticky header 

# Screenshots

Before:

![Screenshot 2024-12-03 at 10 39 43](https://github.com/user-attachments/assets/bfb8f0a6-3fb3-4473-a899-aa09ecb3ec2c)

After:

![Screenshot 2024-12-03 at 10 45 34](https://github.com/user-attachments/assets/6fffd086-74db-4f57-942d-9d526a799900)