### PR TITLE
chore: Update action to v5 in TA onboarding

### DIFF
--- a/src/pages/RepoPage/FailedTestsTab/GitHubActions/GitHubActions.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/GitHubActions/GitHubActions.tsx
@@ -51,7 +51,7 @@ const JobsScript = `jobs:
           pytest --cov --junitxml=junit.xml
       # Copy and paste the codecov/test-results-action here
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         with:
           token: \${{ secrets.CODECOV_TOKEN }}
       - name: Upload test results to Codecov


### PR DESCRIPTION
Updates codecov-action to v5 in the TA onboarding example.
