### PR TITLE
chore: Migrate useCommitHeaderDataTeam to TS Query V5

### DIFF
--- a/src/pages/CommitDetailPage/Header/HeaderTeam/HeaderTeam.jsx
+++ b/src/pages/CommitDetailPage/Header/HeaderTeam/HeaderTeam.jsx
@@ -1,3 +1,4 @@
+import { useSuspenseQuery as useSuspenseQueryV5 } from '@tanstack/react-queryV5'
 import { useParams } from 'react-router-dom'
 
 import { formatTimeToNow } from 'shared/utils/dates'
@@ -8,7 +9,7 @@ import Icon from 'ui/Icon'
 import TotalsNumber from 'ui/TotalsNumber'
 import TruncatedMessage from 'ui/TruncatedMessage/TruncatedMessage'
 
-import { useCommitHeaderDataTeam } from './hooks'
+import { CommitHeaderDataTeamQueryOpts } from './queries/CommitHeaderDataTeamQueryOpts'
 
 import PullLabel from '../PullLabel'
 
@@ -16,12 +17,14 @@ function HeaderTeam() {
   const { provider, owner, repo, commit: commitSha } = useParams()
   const shortSHA = commitSha?.slice(0, 7)
 
-  const { data: headerData } = useCommitHeaderDataTeam({
-    provider,
-    owner,
-    repo,
-    commitId: commitSha,
-  })
+  const { data: headerData } = useSuspenseQueryV5(
+    CommitHeaderDataTeamQueryOpts({
+      provider,
+      owner,
+      repo,
+      commitId: commitSha,
+    })
+  )
   const commit = headerData?.commit
 
   const providerPullUrl = getProviderPullURL({

--- a/src/pages/CommitDetailPage/Header/HeaderTeam/hooks/index.ts
+++ b/src/pages/CommitDetailPage/Header/HeaderTeam/hooks/index.ts
@@ -1,1 +1,0 @@
-export * from './useCommitHeaderDataTeam'

--- a/src/pages/CommitDetailPage/Header/HeaderTeam/queries/CommitHeaderDataTeamQueryOpts.test.tsx
+++ b/src/pages/CommitDetailPage/Header/HeaderTeam/queries/CommitHeaderDataTeamQueryOpts.test.tsx
@@ -1,9 +1,13 @@
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import {
+  QueryClientProvider as QueryClientProviderV5,
+  QueryClient as QueryClientV5,
+  useQuery as useQueryV5,
+} from '@tanstack/react-queryV5'
 import { renderHook, waitFor } from '@testing-library/react'
 import { graphql, HttpResponse } from 'msw'
 import { setupServer } from 'msw/node'
 
-import { useCommitHeaderDataTeam } from './useCommitHeaderDataTeam'
+import { CommitHeaderDataTeamQueryOpts } from './CommitHeaderDataTeamQueryOpts'
 
 const mockRepository = {
   owner: {
@@ -54,13 +58,15 @@ const mockNullOwner = {
 
 const mockUnsuccessfulParseError = {}
 
-const queryClient = new QueryClient({
-  defaultOptions: { queries: { retry: false, useErrorBoundary: false } },
-})
 const server = setupServer()
+const queryClientV5 = new QueryClientV5({
+  defaultOptions: { queries: { retry: false } },
+})
 
 const wrapper: React.FC<React.PropsWithChildren> = ({ children }) => (
-  <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  <QueryClientProviderV5 client={queryClientV5}>
+    {children}
+  </QueryClientProviderV5>
 )
 
 beforeAll(() => {
@@ -68,7 +74,7 @@ beforeAll(() => {
 })
 
 afterEach(() => {
-  queryClient.clear()
+  queryClientV5.clear()
   server.resetHandlers()
 })
 
@@ -83,7 +89,7 @@ interface SetupArgs {
   isNullOwner?: boolean
 }
 
-describe('useCommitHeaderDataTeam', () => {
+describe('CommitHeaderDataTeamQueryOpts', () => {
   function setup({
     isNotFoundError = false,
     isOwnerNotActivatedError = false,
@@ -115,12 +121,14 @@ describe('useCommitHeaderDataTeam', () => {
 
           const { result } = renderHook(
             () =>
-              useCommitHeaderDataTeam({
-                provider: 'gh',
-                owner: 'codecov',
-                repo: 'test-repo',
-                commitId: 'id-1',
-              }),
+              useQueryV5(
+                CommitHeaderDataTeamQueryOpts({
+                  provider: 'gh',
+                  owner: 'codecov',
+                  repo: 'test-repo',
+                  commitId: 'id-1',
+                })
+              ),
             { wrapper }
           )
 
@@ -158,12 +166,14 @@ describe('useCommitHeaderDataTeam', () => {
 
           const { result } = renderHook(
             () =>
-              useCommitHeaderDataTeam({
-                provider: 'gh',
-                owner: 'codecov',
-                repo: 'test-repo',
-                commitId: 'id-1',
-              }),
+              useQueryV5(
+                CommitHeaderDataTeamQueryOpts({
+                  provider: 'gh',
+                  owner: 'codecov',
+                  repo: 'test-repo',
+                  commitId: 'id-1',
+                })
+              ),
             { wrapper }
           )
 
@@ -197,12 +207,14 @@ describe('useCommitHeaderDataTeam', () => {
 
         const { result } = renderHook(
           () =>
-            useCommitHeaderDataTeam({
-              provider: 'gh',
-              owner: 'codecov',
-              repo: 'test-repo',
-              commitId: 'id-1',
-            }),
+            useQueryV5(
+              CommitHeaderDataTeamQueryOpts({
+                provider: 'gh',
+                owner: 'codecov',
+                repo: 'test-repo',
+                commitId: 'id-1',
+              })
+            ),
           { wrapper }
         )
 
@@ -233,12 +245,14 @@ describe('useCommitHeaderDataTeam', () => {
 
         const { result } = renderHook(
           () =>
-            useCommitHeaderDataTeam({
-              provider: 'gh',
-              owner: 'codecov',
-              repo: 'test-repo',
-              commitId: 'id-1',
-            }),
+            useQueryV5(
+              CommitHeaderDataTeamQueryOpts({
+                provider: 'gh',
+                owner: 'codecov',
+                repo: 'test-repo',
+                commitId: 'id-1',
+              })
+            ),
           { wrapper }
         )
 
@@ -269,12 +283,14 @@ describe('useCommitHeaderDataTeam', () => {
 
         const { result } = renderHook(
           () =>
-            useCommitHeaderDataTeam({
-              provider: 'gh',
-              owner: 'codecov',
-              repo: 'test-repo',
-              commitId: 'id-1',
-            }),
+            useQueryV5(
+              CommitHeaderDataTeamQueryOpts({
+                provider: 'gh',
+                owner: 'codecov',
+                repo: 'test-repo',
+                commitId: 'id-1',
+              })
+            ),
           { wrapper }
         )
 


### PR DESCRIPTION
# Description

This PR migrates the `useCommitHeaderDataTeam` to the query options API version `CommitHeaderDataTeamQueryOpts`

Ticket: codecov/engineering-team#2966

# Notable Changes

- Migrate `useCommitHeaderDataTeam` to `CommitHeaderDataTeamQueryOpts`
- Update tests