### PR TITLE
fix: Broken tests when custom GH_APP set locally

### DIFF
--- a/src/layouts/Header/components/UserDropdown/UserDropdown.test.tsx
+++ b/src/layouts/Header/components/UserDropdown/UserDropdown.test.tsx
@@ -110,6 +110,7 @@ describe('UserDropdown', () => {
       error: null,
     })
     config.IS_SELF_HOSTED = selfHosted
+    config.GH_APP = 'codecov'
     config.API_URL = ''
 
     server.use(

--- a/src/pages/AccountSettings/tabs/Admin/GithubIntegrationSection/GithubIntegrationSection.test.jsx
+++ b/src/pages/AccountSettings/tabs/Admin/GithubIntegrationSection/GithubIntegrationSection.test.jsx
@@ -51,6 +51,7 @@ describe('GithubIntegrationSection', () => {
     }
   ) {
     config.IS_SELF_HOSTED = isSelfHosted
+    config.GH_APP = 'codecov'
 
     server.use(
       http.get(`/internal/gh/codecov/account-details/`, (info) => {

--- a/src/pages/DefaultOrgSelector/DefaultOrgSelector.test.jsx
+++ b/src/pages/DefaultOrgSelector/DefaultOrgSelector.test.jsx
@@ -189,6 +189,7 @@ describe('DefaultOrgSelector', () => {
     window.open = mockWindow
     const fetchNextPage = vi.fn()
     config.SENTRY_DSN = undefined
+    config.GH_APP = 'codecov'
     const user = userEvent.setup()
 
     server.use(

--- a/src/pages/DefaultOrgSelector/GitHubHelpBanner/GitHubHelpBanner.test.tsx
+++ b/src/pages/DefaultOrgSelector/GitHubHelpBanner/GitHubHelpBanner.test.tsx
@@ -5,6 +5,8 @@ import { graphql, HttpResponse } from 'msw'
 import { setupServer } from 'msw/node'
 import { MemoryRouter, Route, Switch } from 'react-router-dom'
 
+import config from 'config'
+
 import GitHubHelpBanner from './GitHubHelpBanner'
 
 const queryClient = new QueryClient({
@@ -86,7 +88,7 @@ describe('GitHubHelpBanner', () => {
       })
       expect(link).toHaveAttribute(
         'href',
-        'https://github.com/apps/codecov/installations/select_target'
+        `https://github.com/apps/${config.GH_APP}/installations/select_target`
       )
     })
   })

--- a/src/services/navigation/useNavLinks/useStaticNavLinks.ts
+++ b/src/services/navigation/useNavLinks/useStaticNavLinks.ts
@@ -194,7 +194,7 @@ export function useStaticNavLinks() {
       openNewTab: true,
     },
     codecovGithubApp: {
-      path: () => 'https://github.com/apps/codecov',
+      path: () => `https://github.com/apps/${config.GH_APP}`,
       isExternalLink: true,
       text: 'Codecov Github App',
       openNewTab: true,

--- a/src/ui/ContextSwitcher/ContextSwitcher.test.jsx
+++ b/src/ui/ContextSwitcher/ContextSwitcher.test.jsx
@@ -250,6 +250,7 @@ describe('ContextSwitcher', () => {
 
     it('renders manage access restrictions', async () => {
       setup()
+      config.GH_APP = 'codecov'
       render(
         <ContextSwitcher
           activeContext={{
@@ -715,6 +716,7 @@ describe('ContextSwitcher', () => {
   describe('when on self-hosted', () => {
     beforeEach(() => {
       config.IS_SELF_HOSTED = true
+      config.GH_APP = 'codecov'
       setup()
     })
 


### PR DESCRIPTION
Was testing our the new changes to `GH_APP` and found some tests breaking when I had the config value set locally. This PR fixes those tests.
