### PR TITLE
fix: useCommit doesn't always expect flags

### DIFF
--- a/src/pages/CommitDetailPage/CommitCoverage/UploadsCard/RenderError.tsx
+++ b/src/pages/CommitDetailPage/CommitCoverage/UploadsCard/RenderError.tsx
@@ -123,7 +123,7 @@ const FlagError = () => (
 interface RenderErrorProps {
   errors: (UploadErrorObject | null)[]
   state: (typeof UploadStateEnum)[keyof typeof UploadStateEnum]
-  flags: string[] | null
+  flags: string[] | null | undefined
 }
 
 const RenderError = ({ errors, state, flags }: RenderErrorProps) => {

--- a/src/services/commit/useCommit.tsx
+++ b/src/services/commit/useCommit.tsx
@@ -54,7 +54,7 @@ const UploadSchema = z.object({
   provider: z.string().nullable(),
   createdAt: z.string(),
   updatedAt: z.string(),
-  flags: z.array(z.string()).nullable(),
+  flags: z.array(z.string()).nullish(),
   jobCode: z.string().nullable(),
   downloadUrl: z.string(),
   ciUrl: z.string().nullable(),

--- a/src/shared/utils/extractUploads.ts
+++ b/src/shared/utils/extractUploads.ts
@@ -22,7 +22,7 @@ export interface Upload {
   provider: string | null
   createdAt: string
   updatedAt: string
-  flags: string[] | null | undefined
+  flags?: string[] | null
   jobCode: string | null
   downloadUrl: string
   ciUrl: string | null

--- a/src/shared/utils/extractUploads.ts
+++ b/src/shared/utils/extractUploads.ts
@@ -22,7 +22,7 @@ export interface Upload {
   provider: string | null
   createdAt: string
   updatedAt: string
-  flags: string[] | null
+  flags: string[] | null | undefined
   jobCode: string | null
   downloadUrl: string
   ciUrl: string | null


### PR DESCRIPTION
Before we expect flags to always be in the commit object, but that shouldn't be the case as team plan doesn't support flags.

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.