### PR TITLE
chore: Migrate useLoginProviders to TS Query V5

### DIFF
--- a/src/pages/EnterpriseLandingPage/EnterpriseLandingPage.test.tsx
+++ b/src/pages/EnterpriseLandingPage/EnterpriseLandingPage.test.tsx
@@ -1,4 +1,8 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import {
+  QueryClientProvider as QueryClientProviderV5,
+  QueryClient as QueryClientV5,
+} from '@tanstack/react-queryV5'
 import { render, screen } from '@testing-library/react'
 import { graphql, HttpResponse } from 'msw'
 import { setupServer } from 'msw/node'
@@ -11,16 +15,23 @@ import EnterpriseLandingPage from './EnterpriseLandingPage'
 vi.mock('config')
 
 const server = setupServer()
-const queryClient = new QueryClient()
+const queryClient = new QueryClient({
+  defaultOptions: { queries: { retry: false } },
+})
+const queryClientV5 = new QueryClientV5({
+  defaultOptions: { queries: { retry: false } },
+})
 
 const wrapper: React.FC<React.PropsWithChildren> = ({ children }) => (
-  <QueryClientProvider client={queryClient}>
-    <ThemeContextProvider>
-      <MemoryRouter initialEntries={['/']}>
-        <Route path="/">{children}</Route>
-      </MemoryRouter>
-    </ThemeContextProvider>
-  </QueryClientProvider>
+  <QueryClientProviderV5 client={queryClientV5}>
+    <QueryClientProvider client={queryClient}>
+      <ThemeContextProvider>
+        <MemoryRouter initialEntries={['/']}>
+          <Route path="/">{children}</Route>
+        </MemoryRouter>
+      </ThemeContextProvider>
+    </QueryClientProvider>
+  </QueryClientProviderV5>
 )
 
 const mockServiceProviders = {
@@ -43,6 +54,7 @@ beforeAll(() => {
 
 afterEach(() => {
   queryClient.clear()
+  queryClientV5.clear()
   server.resetHandlers()
 })
 

--- a/src/pages/EnterpriseLandingPage/EnterpriseLandingPage.tsx
+++ b/src/pages/EnterpriseLandingPage/EnterpriseLandingPage.tsx
@@ -1,5 +1,7 @@
+import { useSuspenseQuery as useSuspenseQueryV5 } from '@tanstack/react-queryV5'
+
 import rocketImg from 'assets/enterprise-rocket.png'
-import { useLoginProviders } from 'services/config/useLoginProviders'
+import { LoginProvidersQueryOpts } from 'services/config/LoginProvidersQueryOpts'
 import { LoginProvidersEnum } from 'shared/utils/loginProviders'
 
 import ProviderCard from './ProviderCard/ProviderCard'
@@ -8,7 +10,7 @@ import { useEnterpriseRedirect } from './useEnterpriseRedirect'
 function EnterpriseLandingPage() {
   useEnterpriseRedirect()
 
-  const { data } = useLoginProviders()
+  const { data } = useSuspenseQueryV5(LoginProvidersQueryOpts())
 
   return (
     <div className="flex flex-col gap-5">

--- a/src/pages/EnterpriseLandingPage/ProviderCard/ProviderCard.tsx
+++ b/src/pages/EnterpriseLandingPage/ProviderCard/ProviderCard.tsx
@@ -1,4 +1,4 @@
-import { EnterpriseLoginProviders } from 'services/config/useLoginProviders'
+import { EnterpriseLoginProviders } from 'services/config/LoginProvidersQueryOpts'
 import { Theme, useThemeContext } from 'shared/ThemeContext'
 import {
   loginProviderImage,

--- a/src/services/config/LoginProvidersQueryOpts.test.tsx
+++ b/src/services/config/LoginProvidersQueryOpts.test.tsx
@@ -1,4 +1,8 @@
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import {
+  QueryClientProvider as QueryClientProviderV5,
+  QueryClient as QueryClientV5,
+  useQuery as useQueryV5,
+} from '@tanstack/react-queryV5'
 import { renderHook, waitFor } from '@testing-library/react'
 import { graphql, HttpResponse } from 'msw'
 import { setupServer } from 'msw/node'
@@ -6,29 +10,29 @@ import { MemoryRouter, Route } from 'react-router-dom'
 
 import {
   EnterpriseLoginProviders,
-  useLoginProviders,
-} from './useLoginProviders'
+  LoginProvidersQueryOpts,
+} from './LoginProvidersQueryOpts'
 
 const server = setupServer()
-const queryClient = new QueryClient({
+const queryClientV5 = new QueryClientV5({
   defaultOptions: { queries: { retry: false } },
 })
 
 const wrapper: React.FC<React.PropsWithChildren> = ({ children }) => (
-  <QueryClientProvider client={queryClient}>
+  <QueryClientProviderV5 client={queryClientV5}>
     <MemoryRouter initialEntries={['/']}>
       <Route path="/">{children}</Route>
     </MemoryRouter>
-  </QueryClientProvider>
+  </QueryClientProviderV5>
 )
 
 beforeAll(() => {
   server.listen()
 })
 
-beforeEach(() => {
+afterEach(() => {
   server.resetHandlers()
-  queryClient.clear()
+  queryClientV5.clear()
 })
 
 afterAll(() => {
@@ -60,7 +64,10 @@ describe('useLoginProviders', () => {
       setup({
         loginProviders: ['GITHUB', 'GITLAB', 'BITBUCKET', 'OKTA'],
       })
-      const { result } = renderHook(() => useLoginProviders(), { wrapper })
+      const { result } = renderHook(
+        () => useQueryV5(LoginProvidersQueryOpts()),
+        { wrapper }
+      )
 
       await waitFor(() => result.current.isSuccess)
 
@@ -85,7 +92,10 @@ describe('useLoginProviders', () => {
           'BITBUCKET_SERVER',
         ],
       })
-      const { result } = renderHook(() => useLoginProviders(), { wrapper })
+      const { result } = renderHook(
+        () => useQueryV5(LoginProvidersQueryOpts()),
+        { wrapper }
+      )
 
       await waitFor(() => result.current.isSuccess)
 
@@ -119,7 +129,10 @@ describe('useLoginProviders', () => {
         hasParsingError: true,
       })
 
-      const { result } = renderHook(() => useLoginProviders(), { wrapper })
+      const { result } = renderHook(
+        () => useQueryV5(LoginProvidersQueryOpts()),
+        { wrapper }
+      )
 
       await waitFor(() => expect(result.current.isError).toBeTruthy())
 

--- a/src/services/config/LoginProvidersQueryOpts.ts
+++ b/src/services/config/LoginProvidersQueryOpts.ts
@@ -1,4 +1,4 @@
-import { useQuery } from '@tanstack/react-query'
+import { queryOptions as queryOptionsV5 } from '@tanstack/react-queryV5'
 import { z } from 'zod'
 
 import Api from 'shared/api'
@@ -30,8 +30,8 @@ query GetLoginProviders {
   }
 }`
 
-export const useLoginProviders = () => {
-  return useQuery({
+export const LoginProvidersQueryOpts = () => {
+  return queryOptionsV5({
     queryKey: ['GetLoginProviders'],
     queryFn: ({ signal }) =>
       Api.graphql({

--- a/src/services/config/index.ts
+++ b/src/services/config/index.ts
@@ -1,2 +1,1 @@
-export * from './useLoginProviders'
 export * from './useSyncProviders'


### PR DESCRIPTION
# Description

This PR migrates the `useLoginProviders` to the queryOptions API version `LoginProvidersQueryOpts`

Ticket: codecov/engineering-team#2962

# Notable Changes

- Migrate `useLoginProviders` to  `LoginProvidersQueryOpts`
- Update usage in `EnterpriseLandingPage`
- Update import in `ProviderCard`