### PR TITLE
feat: Migrate isEnterprisePlan to GQL Field

### DIFF
--- a/src/pages/AccountSettings/AccountSettings.jsx
+++ b/src/pages/AccountSettings/AccountSettings.jsx
@@ -8,7 +8,6 @@ import { SentryRoute } from 'sentry'
 import SidebarLayout from 'layouts/SidebarLayout'
 import { usePlanData } from 'services/account'
 import { useIsCurrentUserAnAdmin, useUser } from 'services/user'
-import { isEnterprisePlan } from 'shared/utils/billing'
 import LoadingLogo from 'ui/LoadingLogo'
 
 import AccountSettingsSideMenu from './AccountSettingsSideMenu'
@@ -34,7 +33,7 @@ function AccountSettings() {
   const { data: currentUser } = useUser()
 
   const { data } = usePlanData({ provider, owner })
-  const viewOktaAccess = isEnterprisePlan(data?.plan?.value)
+  const viewOktaAccess = data?.plan?.isEnterprisePlan
 
   const isViewingPersonalSettings =
     currentUser?.user?.username?.toLowerCase() === owner?.toLowerCase()

--- a/src/pages/AccountSettings/AccountSettings.test.jsx
+++ b/src/pages/AccountSettings/AccountSettings.test.jsx
@@ -39,7 +39,6 @@ const mockPlanData = {
   pretrialUsersCount: 0,
   planUserCount: 1,
   hasSeatsLeft: true,
-  isEnterprisePlan: false,
 }
 
 const mockCurrentUser = (username) => ({
@@ -162,6 +161,8 @@ describe('AccountSettings', () => {
               plan: {
                 ...mockPlanData,
                 value: planValue,
+                isEnterprisePlan:
+                  planValue === Plans.USERS_ENTERPRISEM ? true : false,
               },
             },
           },

--- a/src/pages/AccountSettings/AccountSettings.test.jsx
+++ b/src/pages/AccountSettings/AccountSettings.test.jsx
@@ -39,6 +39,7 @@ const mockPlanData = {
   pretrialUsersCount: 0,
   planUserCount: 1,
   hasSeatsLeft: true,
+  isEnterprisePlan: false,
 }
 
 const mockCurrentUser = (username) => ({

--- a/src/pages/AccountSettings/AccountSettings.test.jsx
+++ b/src/pages/AccountSettings/AccountSettings.test.jsx
@@ -161,8 +161,7 @@ describe('AccountSettings', () => {
               plan: {
                 ...mockPlanData,
                 value: planValue,
-                isEnterprisePlan:
-                  planValue === Plans.USERS_ENTERPRISEM ? true : false,
+                isEnterprisePlan: planValue === Plans.USERS_ENTERPRISEM,
               },
             },
           },

--- a/src/pages/AccountSettings/AccountSettingsSideMenu.jsx
+++ b/src/pages/AccountSettings/AccountSettingsSideMenu.jsx
@@ -4,7 +4,6 @@ import config from 'config'
 
 import { usePlanData } from 'services/account'
 import { useIsCurrentUserAnAdmin, useUser } from 'services/user'
-import { isEnterprisePlan } from 'shared/utils/billing'
 import Sidemenu from 'ui/Sidemenu'
 
 function defaultLinks({ internalAccessTab, viewOktaAccess }) {
@@ -66,7 +65,7 @@ function AccountSettingsSideMenu() {
     currentUser?.user?.username?.toLowerCase() === owner?.toLowerCase()
 
   const { data } = usePlanData({ provider, owner })
-  const viewOktaAccess = isEnterprisePlan(data?.plan?.value)
+  const viewOktaAccess = data?.plan?.isEnterprisePlan
 
   const links = generateLinks({
     isAdmin,

--- a/src/pages/AccountSettings/AccountSettingsSideMenu.test.jsx
+++ b/src/pages/AccountSettings/AccountSettingsSideMenu.test.jsx
@@ -149,8 +149,7 @@ describe('AccountSettingsSideMenu', () => {
               plan: {
                 ...mockPlanData,
                 value: planValue,
-                isEnterprisePlan:
-                  planValue === Plans.USERS_ENTERPRISEM ? true : false,
+                isEnterprisePlan: planValue === Plans.USERS_ENTERPRISEM,
               },
             },
           },

--- a/src/pages/AccountSettings/AccountSettingsSideMenu.test.jsx
+++ b/src/pages/AccountSettings/AccountSettingsSideMenu.test.jsx
@@ -27,7 +27,6 @@ const mockPlanData = {
   pretrialUsersCount: 0,
   planUserCount: 1,
   hasSeatsLeft: true,
-  isEnterprisePlan: false,
 }
 
 const mockCurrentUser = (username) => ({
@@ -150,6 +149,8 @@ describe('AccountSettingsSideMenu', () => {
               plan: {
                 ...mockPlanData,
                 value: planValue,
+                isEnterprisePlan:
+                  planValue === Plans.USERS_ENTERPRISEM ? true : false,
               },
             },
           },

--- a/src/pages/AccountSettings/AccountSettingsSideMenu.test.jsx
+++ b/src/pages/AccountSettings/AccountSettingsSideMenu.test.jsx
@@ -27,6 +27,7 @@ const mockPlanData = {
   pretrialUsersCount: 0,
   planUserCount: 1,
   hasSeatsLeft: true,
+  isEnterprisePlan: false,
 }
 
 const mockCurrentUser = (username) => ({

--- a/src/pages/DefaultOrgSelector/DefaultOrgSelector.test.jsx
+++ b/src/pages/DefaultOrgSelector/DefaultOrgSelector.test.jsx
@@ -212,6 +212,7 @@ describe('DefaultOrgSelector', () => {
               hasPrivateRepos: privateRepos,
               plan: {
                 ...mockTrialData,
+                isEnterprisePlan: false,
                 trialStatus,
                 value,
               },

--- a/src/pages/MembersPage/MembersActivation/Activation/Activation.jsx
+++ b/src/pages/MembersPage/MembersActivation/Activation/Activation.jsx
@@ -74,7 +74,12 @@ function Activation() {
         activated members of{' '}
         <span className="text-lg font-semibold">{planQuantity}</span> available
         seats{' '}
-        {accountDetails && <ChangePlanLink accountDetails={accountDetails} />}
+        {accountDetails && (
+          <ChangePlanLink
+            accountDetails={accountDetails}
+            plan={planData?.plan}
+          />
+        )}
       </p>
       {/* TODO: new feature https://www.figma.com/file/iNTJAiBYGem3A4LmI4gvKX/Plan-and-members?node-id=103%3A1696 */}
     </div>

--- a/src/pages/MembersPage/MembersActivation/Activation/Activation.test.jsx
+++ b/src/pages/MembersPage/MembersActivation/Activation/Activation.test.jsx
@@ -26,6 +26,7 @@ const mockedAccountDetails = {
 }
 
 const mockPlanData = {
+  isEnterprisePlan: false,
   baseUnitPrice: 10,
   benefits: [],
   billingRate: 'monthly',

--- a/src/pages/MembersPage/MembersActivation/Activation/ChangePlanLink/ChangePlanLink.jsx
+++ b/src/pages/MembersPage/MembersActivation/Activation/ChangePlanLink/ChangePlanLink.jsx
@@ -27,7 +27,7 @@ ChangePlanLink.propTypes = {
   accountDetails: PropType.shape({
     subscriptionDetail: PropType.shape({ collectionMethod: PropType.string }),
   }).isRequired,
-  plan: PropType.object(),
+  plan: PropType.object,
 }
 
 export default ChangePlanLink

--- a/src/pages/MembersPage/MembersActivation/Activation/ChangePlanLink/ChangePlanLink.jsx
+++ b/src/pages/MembersPage/MembersActivation/Activation/ChangePlanLink/ChangePlanLink.jsx
@@ -2,16 +2,15 @@ import PropType from 'prop-types'
 
 import config from 'config'
 
-import { CollectionMethods, isEnterprisePlan } from 'shared/utils/billing'
+import { CollectionMethods } from 'shared/utils/billing'
 import A from 'ui/A'
 
-function ChangePlanLink({ accountDetails }) {
+function ChangePlanLink({ accountDetails, plan }) {
   const isInvoicedCustomer =
     accountDetails?.subscriptionDetail?.collectionMethod ===
     CollectionMethods.INVOICED_CUSTOMER_METHOD
-  const plan = accountDetails?.plan?.value
 
-  if (config.IS_SELF_HOSTED || isInvoicedCustomer || isEnterprisePlan(plan)) {
+  if (config.IS_SELF_HOSTED || isInvoicedCustomer || plan?.isEnterprisePlan) {
     return null
   }
 
@@ -27,8 +26,8 @@ function ChangePlanLink({ accountDetails }) {
 ChangePlanLink.propTypes = {
   accountDetails: PropType.shape({
     subscriptionDetail: PropType.shape({ collectionMethod: PropType.string }),
-    plan: PropType.shape({ value: PropType.string }),
   }).isRequired,
+  plan: PropType.object(),
 }
 
 export default ChangePlanLink

--- a/src/pages/MembersPage/MembersActivation/MembersActivation.test.jsx
+++ b/src/pages/MembersPage/MembersActivation/MembersActivation.test.jsx
@@ -40,6 +40,7 @@ const mockPlanData = {
   pretrialUsersCount: 0,
   planUserCount: 1,
   hasSeatsLeft: true,
+  isEnterprisePlan: false,
 }
 
 const server = setupServer()

--- a/src/pages/OwnerPage/HeaderBanners/ExceededUploadsAlert/ExceededUploadsAlert.test.jsx
+++ b/src/pages/OwnerPage/HeaderBanners/ExceededUploadsAlert/ExceededUploadsAlert.test.jsx
@@ -37,6 +37,7 @@ const mockPlanDataResponse = {
   pretrialUsersCount: 0,
   planUserCount: 1,
   hasSeatsLeft: true,
+  isEnterprisePlan: false,
 }
 
 beforeAll(() => {

--- a/src/pages/OwnerPage/HeaderBanners/HeaderBanners.test.jsx
+++ b/src/pages/OwnerPage/HeaderBanners/HeaderBanners.test.jsx
@@ -40,6 +40,7 @@ const mockPlanDataResponse = {
   pretrialUsersCount: 0,
   planUserCount: 1,
   hasSeatsLeft: true,
+  isEnterprisePlan: false,
 }
 
 const mockPlanDataResponseNoUploadLimit = {

--- a/src/pages/OwnerPage/HeaderBanners/ReachingUploadLimitAlert/ReachingUploadLimitAlert.test.jsx
+++ b/src/pages/OwnerPage/HeaderBanners/ReachingUploadLimitAlert/ReachingUploadLimitAlert.test.jsx
@@ -30,6 +30,7 @@ const mockPlanDataResponse = {
   marketingName: 'Pro Team',
   monthlyUploadLimit: 341,
   value: Plans.USERS_PR_INAPPM,
+  isEnterprisePlan: false,
   trialStatus: TrialStatuses.NOT_STARTED,
   trialStartDate: '',
   trialEndDate: '',

--- a/src/pages/OwnerPage/Tabs/TrialReminder/TrialReminder.test.tsx
+++ b/src/pages/OwnerPage/Tabs/TrialReminder/TrialReminder.test.tsx
@@ -39,6 +39,7 @@ const mockResponse = {
   pretrialUsersCount: 0,
   planUserCount: 1,
   hasSeatsLeft: true,
+  isEnterprisePlan: false,
 }
 
 const wrapper: React.FC<React.PropsWithChildren> = ({ children }) => {

--- a/src/pages/PlanPage/subRoutes/CancelPlanPage/CancelPlanPage.test.tsx
+++ b/src/pages/PlanPage/subRoutes/CancelPlanPage/CancelPlanPage.test.tsx
@@ -152,8 +152,7 @@ describe('CancelPlanPage', () => {
                 ...mockPlanData,
                 trialStatus,
                 value: planValue,
-                isEnterprisePlan:
-                  planValue === Plans.USERS_ENTERPRISEM ? true : false,
+                isEnterprisePlan: planValue === Plans.USERS_ENTERPRISEM,
               },
             },
           },

--- a/src/pages/PlanPage/subRoutes/CancelPlanPage/CancelPlanPage.test.tsx
+++ b/src/pages/PlanPage/subRoutes/CancelPlanPage/CancelPlanPage.test.tsx
@@ -152,6 +152,8 @@ describe('CancelPlanPage', () => {
                 ...mockPlanData,
                 trialStatus,
                 value: planValue,
+                isEnterprisePlan:
+                  planValue === Plans.USERS_ENTERPRISEM ? true : false,
               },
             },
           },

--- a/src/pages/PlanPage/subRoutes/CancelPlanPage/CancelPlanPage.test.tsx
+++ b/src/pages/PlanPage/subRoutes/CancelPlanPage/CancelPlanPage.test.tsx
@@ -78,6 +78,7 @@ const mockPlanData = {
   pretrialUsersCount: 0,
   planUserCount: 1,
   hasSeatsLeft: true,
+  isEnterprisePlan: false,
 }
 
 const queryClient = new QueryClient({

--- a/src/pages/PlanPage/subRoutes/CancelPlanPage/CancelPlanPage.tsx
+++ b/src/pages/PlanPage/subRoutes/CancelPlanPage/CancelPlanPage.tsx
@@ -10,7 +10,6 @@ import {
   usePlanData,
 } from 'services/account'
 import {
-  isEnterprisePlan,
   isMonthlyPlan,
   isProPlan,
   isTrialPlan,
@@ -46,7 +45,7 @@ function CancelPlanPage() {
     planData?.plan?.trialStatus === TrialStatuses.ONGOING
 
   // redirect right away if the user is on an enterprise plan
-  if (isEnterprisePlan(accountDetailsData?.plan?.value) || isOnTrial) {
+  if (planData?.plan?.isEnterprisePlan || isOnTrial) {
     return <Redirect to={`/plan/${provider}/${owner}`} />
   }
 

--- a/src/pages/PlanPage/subRoutes/CurrentOrgPlan/CurrentPlanCard/CurrentPlanCard.test.tsx
+++ b/src/pages/PlanPage/subRoutes/CurrentOrgPlan/CurrentPlanCard/CurrentPlanCard.test.tsx
@@ -1,10 +1,11 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { render, screen } from '@testing-library/react'
-import { http, HttpResponse } from 'msw'
+import { graphql, http, HttpResponse } from 'msw'
 import { setupServer } from 'msw/node'
 import React from 'react'
 import { MemoryRouter, Route } from 'react-router-dom'
 
+import { TrialStatuses } from 'services/account'
 import { PlanName, Plans } from 'shared/utils/billing'
 
 import CurrentPlanCard from './CurrentPlanCard'
@@ -23,6 +24,7 @@ const proPlanDetails = {
     quantity: 5,
     value: Plans.USERS_PR_INAPPM,
     billingRate: null,
+    isEnterprisePlan: false,
   },
 }
 
@@ -37,6 +39,7 @@ const freePlanDetails = {
       'Unlimited public repositories',
       'Unlimited private repositories',
     ],
+    isEnterprisePlan: false,
   },
 }
 
@@ -51,6 +54,7 @@ const enterprisePlan = {
       'Unlimited public repositories',
       'Unlimited private repositories',
     ],
+    isEnterprisePlan: true,
   },
 }
 
@@ -65,6 +69,7 @@ const usesInvoiceTeamPlan = {
       'Unlimited public repositories',
       'Unlimited private repositories',
     ],
+    isEnterprisePlan: false,
   },
   usesInvoice: true,
 }
@@ -77,6 +82,7 @@ const trialPlanDetails = {
     benefits: ['Configurable # of users', 'Unlimited repos'],
     quantity: 5,
     value: Plans.USERS_TRIAL,
+    isEnterprisePlan: false,
   },
 }
 
@@ -116,6 +122,27 @@ describe('CurrentPlanCard', () => {
     server.use(
       http.get('/internal/bb/critical-role/account-details/', () => {
         return HttpResponse.json(planDetails)
+      }),
+      graphql.query('GetPlanData', () => {
+        const planChunk = {
+          trialStatus: TrialStatuses.NOT_STARTED,
+          trialStartDate: '',
+          trialEndDate: '',
+          trialTotalDays: 0,
+          pretrialUsersCount: 0,
+          planUserCount: 1,
+          hasSeatsLeft: true,
+          monthlyUploadLimit: 100,
+        }
+
+        return HttpResponse.json({
+          data: {
+            owner: {
+              hasPrivateRepos: true,
+              plan: { ...planDetails.plan, ...planChunk },
+            },
+          },
+        })
       })
     )
   }

--- a/src/pages/PlanPage/subRoutes/CurrentOrgPlan/CurrentPlanCard/CurrentPlanCard.tsx
+++ b/src/pages/PlanPage/subRoutes/CurrentOrgPlan/CurrentPlanCard/CurrentPlanCard.tsx
@@ -1,9 +1,8 @@
 import { useParams } from 'react-router-dom'
 
-import { useAccountDetails } from 'services/account'
+import { useAccountDetails, usePlanData } from 'services/account'
 import {
   CollectionMethods,
-  isEnterprisePlan,
   isFreePlan,
   isTrialPlan,
 } from 'shared/utils/billing'
@@ -20,20 +19,22 @@ interface URLParams {
 function CurrentPlanCard() {
   const { provider, owner } = useParams<URLParams>()
   const { data: accountDetails } = useAccountDetails({ provider, owner })
-  const plan = accountDetails?.rootOrganization?.plan ?? accountDetails?.plan
+  const { data: planData } = usePlanData({ provider, owner })
   const scheduledPhase = accountDetails?.scheduleDetail?.scheduledPhase
   const collectionMethod = accountDetails?.subscriptionDetail?.collectionMethod
 
-  if (isFreePlan(plan?.value) || isTrialPlan(plan?.value)) {
-    return <FreePlanCard plan={plan} scheduledPhase={scheduledPhase} />
+  if (isFreePlan(planData?.plan?.value) || isTrialPlan(planData?.plan?.value)) {
+    return (
+      <FreePlanCard plan={planData?.plan} scheduledPhase={scheduledPhase} />
+    )
   }
 
   if (
-    isEnterprisePlan(plan?.value) ||
+    planData?.plan?.isEnterprisePlan ||
     collectionMethod === CollectionMethods.INVOICED_CUSTOMER_METHOD ||
     accountDetails?.usesInvoice
   ) {
-    return <EnterprisePlanCard plan={plan} />
+    return <EnterprisePlanCard plan={planData?.plan} />
   }
 
   return <PaidPlanCard />

--- a/src/pages/PlanPage/subRoutes/CurrentOrgPlan/CurrentPlanCard/FreePlanCard/FreePlanCard.jsx
+++ b/src/pages/PlanPage/subRoutes/CurrentOrgPlan/CurrentPlanCard/FreePlanCard/FreePlanCard.jsx
@@ -93,7 +93,10 @@ function FreePlanCard({ plan, scheduledPhase }) {
       </div>
       {shouldDisplayTeamCard({ plans }) && <PlanUpgradeTeam />}
       <PlanUpgradePro
-        isSentryUpgrade={canApplySentryUpgrade({ plan, plans })}
+        isSentryUpgrade={canApplySentryUpgrade({
+          isEnterprisePlan: planData?.plan?.isEnterprisePlan,
+          plans,
+        })}
         plans={plans}
       />
       <div className="text-xs">

--- a/src/pages/PlanPage/subRoutes/CurrentOrgPlan/CurrentPlanCard/FreePlanCard/FreePlanCard.test.jsx
+++ b/src/pages/PlanPage/subRoutes/CurrentOrgPlan/CurrentPlanCard/FreePlanCard/FreePlanCard.test.jsx
@@ -147,6 +147,7 @@ const mockPlanData = {
   pretrialUsersCount: 0,
   planUserCount: 1,
   hasSeatsLeft: true,
+  isEnterprisePlan: false,
 }
 
 const mockPreTrialPlanInfo = {

--- a/src/pages/PlanPage/subRoutes/CurrentOrgPlan/CurrentPlanCard/FreePlanCard/PlanUpgradeTeam/PlanUpgradeTeam.test.jsx
+++ b/src/pages/PlanPage/subRoutes/CurrentOrgPlan/CurrentPlanCard/FreePlanCard/PlanUpgradeTeam/PlanUpgradeTeam.test.jsx
@@ -13,6 +13,7 @@ import PlanUpgradeTeam from './PlanUpgradeTeam'
 vi.mock('shared/plan/BenefitList', () => ({ default: () => 'BenefitsList' }))
 
 const mockPlanBasic = {
+  isEnterprisePlan: false,
   baseUnitPrice: 0,
   benefits: ['Up to # user', 'Unlimited public repositories'],
   billingRate: 'monthly',
@@ -29,6 +30,7 @@ const mockPlanBasic = {
 }
 
 const mockPlanPro = {
+  isEnterprisePlan: false,
   baseUnitPrice: 10,
   benefits: ['Up to # user', 'Unlimited public repositories'],
   billingRate: 'monthly',
@@ -45,6 +47,7 @@ const mockPlanPro = {
 }
 
 const mockPlanTrialing = {
+  isEnterprisePlan: false,
   baseUnitPrice: 10,
   benefits: ['Up to # user', 'Unlimited public repositories'],
   billingRate: 'monthly',

--- a/src/pages/PlanPage/subRoutes/CurrentOrgPlan/CurrentPlanCard/FreePlanCard/ProPlanSubheading/ProPlanSubheading.test.tsx
+++ b/src/pages/PlanPage/subRoutes/CurrentOrgPlan/CurrentPlanCard/FreePlanCard/ProPlanSubheading/ProPlanSubheading.test.tsx
@@ -23,6 +23,7 @@ const mockResponse = {
   pretrialUsersCount: 0,
   planUserCount: 1,
   hasSeatsLeft: true,
+  isEnterprisePlan: false,
 }
 
 const server = setupServer()

--- a/src/pages/PlanPage/subRoutes/CurrentOrgPlan/CurrentPlanCard/PaidPlanCard/PaidPlanCard.test.tsx
+++ b/src/pages/PlanPage/subRoutes/CurrentOrgPlan/CurrentPlanCard/PaidPlanCard/PaidPlanCard.test.tsx
@@ -28,6 +28,7 @@ vi.mock('shared/plan/ScheduledPlanDetails', () => ({
 }))
 
 const mockProPlan = {
+  isEnterprisePlan: false,
   marketingName: 'Pro',
   value: Plans.USERS_PR_INAPPM,
   billingRate: 'monthly',
@@ -44,6 +45,7 @@ const mockProPlan = {
 }
 
 const mockTeamPlan = {
+  isEnterprisePlan: false,
   marketingName: 'Team',
   value: Plans.USERS_TEAMM,
   billingRate: 'monthly',

--- a/src/pages/PlanPage/subRoutes/CurrentOrgPlan/CurrentPlanCard/PaidPlanCard/PaidPlanCard.tsx
+++ b/src/pages/PlanPage/subRoutes/CurrentOrgPlan/CurrentPlanCard/PaidPlanCard/PaidPlanCard.tsx
@@ -59,7 +59,11 @@ function PaidPlanCard() {
           <p className="mb-2 text-xs font-semibold">Pricing</p>
           <div className="mb-4">
             {value && baseUnitPrice ? (
-              <PlanPricing value={value} baseUnitPrice={baseUnitPrice} />
+              <PlanPricing
+                plan={plan}
+                value={value}
+                baseUnitPrice={baseUnitPrice}
+              />
             ) : null}
             {seats ? (
               <p className="text-xs text-ds-gray-senary">

--- a/src/pages/PlanPage/subRoutes/CurrentOrgPlan/CurrentPlanCard/shared/ActionsBilling/ActionsBilling.jsx
+++ b/src/pages/PlanPage/subRoutes/CurrentOrgPlan/CurrentPlanCard/shared/ActionsBilling/ActionsBilling.jsx
@@ -53,7 +53,12 @@ function PlansActionsBilling({ plan }) {
     )
   }
 
-  if (canApplySentryUpgrade({ plan, plans })) {
+  if (
+    canApplySentryUpgrade({
+      isEnterprisePlan: planData?.plan?.isEnterprisePlan,
+      plans,
+    })
+  ) {
     return (
       <div className="flex self-start">
         <Button to={{ pageName: 'upgradeOrgPlan' }} variant="primary">

--- a/src/pages/PlanPage/subRoutes/CurrentOrgPlan/CurrentPlanCard/shared/ActionsBilling/ActionsBilling.test.jsx
+++ b/src/pages/PlanPage/subRoutes/CurrentOrgPlan/CurrentPlanCard/shared/ActionsBilling/ActionsBilling.test.jsx
@@ -163,6 +163,7 @@ const mockTrialData = {
     pretrialUsersCount: 0,
     planUserCount: 1,
     hasSeatsLeft: true,
+    isEnterprisePlan: false,
   },
 }
 

--- a/src/pages/PlanPage/subRoutes/CurrentOrgPlan/CurrentPlanCard/shared/PlanPricing/PlanPricing.jsx
+++ b/src/pages/PlanPage/subRoutes/CurrentOrgPlan/CurrentPlanCard/shared/PlanPricing/PlanPricing.jsx
@@ -26,7 +26,7 @@ function PlanPricing({ plan, value, baseUnitPrice }) {
 }
 
 PlanPricing.propTypes = {
-  plan: PropTypes.object().isRequired,
+  plan: PropTypes.object.isRequired,
   value: PropTypes.string.isRequired,
   baseUnitPrice: PropTypes.number.isRequired,
 }

--- a/src/pages/PlanPage/subRoutes/CurrentOrgPlan/CurrentPlanCard/shared/PlanPricing/PlanPricing.jsx
+++ b/src/pages/PlanPage/subRoutes/CurrentOrgPlan/CurrentPlanCard/shared/PlanPricing/PlanPricing.jsx
@@ -1,19 +1,15 @@
 import PropTypes from 'prop-types'
 
-import {
-  isEnterprisePlan,
-  isFreePlan,
-  isSentryPlan,
-} from 'shared/utils/billing'
+import { isFreePlan, isSentryPlan } from 'shared/utils/billing'
 
 const SENTRY_PRICE = 29
 
-function PlanPricing({ value, baseUnitPrice }) {
+function PlanPricing({ plan, value, baseUnitPrice }) {
   if (isFreePlan(value)) {
     return <h2 className="text-2xl font-semibold">Free</h2>
   }
 
-  if (isEnterprisePlan(value)) {
+  if (plan?.isEnterprisePlan) {
     return <h2 className="text-2xl font-semibold">Custom pricing</h2>
   }
 
@@ -30,6 +26,7 @@ function PlanPricing({ value, baseUnitPrice }) {
 }
 
 PlanPricing.propTypes = {
+  plan: PropTypes.object().isRequired,
   value: PropTypes.string.isRequired,
   baseUnitPrice: PropTypes.number.isRequired,
 }

--- a/src/pages/PlanPage/subRoutes/CurrentOrgPlan/CurrentPlanCard/shared/PlanPricing/PlanPricing.test.jsx
+++ b/src/pages/PlanPage/subRoutes/CurrentOrgPlan/CurrentPlanCard/shared/PlanPricing/PlanPricing.test.jsx
@@ -73,7 +73,11 @@ describe('PlanPricing', () => {
     describe('enterprise plan is monthly', () => {
       it('renders custom pricing', () => {
         render(
-          <PlanPricing value={Plans.USERS_ENTERPRISEM} baseUnitPrice={10} />
+          <PlanPricing
+            plan={{ isEnterprisePlan: true }}
+            value={Plans.USERS_ENTERPRISEM}
+            baseUnitPrice={10}
+          />
         )
 
         const price = screen.getByText('Custom pricing')
@@ -84,7 +88,11 @@ describe('PlanPricing', () => {
     describe('enterprise plan is yearly', () => {
       it('renders custom pricing', () => {
         render(
-          <PlanPricing value={Plans.USERS_ENTERPRISEY} baseUnitPrice={10} />
+          <PlanPricing
+            plan={{ isEnterprisePlan: true }}
+            value={Plans.USERS_ENTERPRISEY}
+            baseUnitPrice={10}
+          />
         )
 
         const price = screen.getByText('Custom pricing')

--- a/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeDetails/ProPlanDetails/ProPlanDetails.test.jsx
+++ b/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeDetails/ProPlanDetails/ProPlanDetails.test.jsx
@@ -129,6 +129,7 @@ const mockPlanData = {
   pretrialUsersCount: 0,
   planUserCount: 1,
   hasSeatsLeft: true,
+  isEnterprisePlan: false,
 }
 
 const server = setupServer()

--- a/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeDetails/SentryPlanDetails/SentryPlanDetails.test.jsx
+++ b/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeDetails/SentryPlanDetails/SentryPlanDetails.test.jsx
@@ -126,6 +126,7 @@ const mockPlanData = {
   pretrialUsersCount: 0,
   planUserCount: 1,
   hasSeatsLeft: true,
+  isEnterprisePlan: false,
 }
 
 const server = setupServer()

--- a/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeDetails/TeamPlanDetails/TeamPlanDetails.test.jsx
+++ b/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeDetails/TeamPlanDetails/TeamPlanDetails.test.jsx
@@ -91,6 +91,7 @@ const mockPlanData = {
   pretrialUsersCount: 0,
   planUserCount: 1,
   hasSeatsLeft: true,
+  isEnterprisePlan: false,
 }
 
 const server = setupServer()

--- a/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/Controllers/ProPlanController/BillingOptions/BillingOptions.test.tsx
+++ b/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/Controllers/ProPlanController/BillingOptions/BillingOptions.test.tsx
@@ -66,6 +66,7 @@ const mockPlanDataResponse = {
   pretrialUsersCount: 0,
   planUserCount: 1,
   hasSeatsLeft: true,
+  isEnterprisePlan: false,
 }
 
 const server = setupServer()

--- a/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/Controllers/ProPlanController/ProPlanController.test.tsx
+++ b/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/Controllers/ProPlanController/ProPlanController.test.tsx
@@ -128,6 +128,7 @@ const mockPlanDataResponseMonthly = {
   pretrialUsersCount: 0,
   planUserCount: 1,
   hasSeatsLeft: true,
+  isEnterprisePlan: false,
 }
 
 const mockPlanDataResponseYearly = {
@@ -144,6 +145,7 @@ const mockPlanDataResponseYearly = {
   pretrialUsersCount: 0,
   planUserCount: 1,
   hasSeatsLeft: true,
+  isEnterprisePlan: false,
 }
 
 const queryClient = new QueryClient({

--- a/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/Controllers/SentryPlanController/BillingOptions/BillingOptions.test.tsx
+++ b/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/Controllers/SentryPlanController/BillingOptions/BillingOptions.test.tsx
@@ -72,6 +72,7 @@ const mockPlanDataResponse = {
   pretrialUsersCount: 0,
   planUserCount: 1,
   hasSeatsLeft: true,
+  isEnterprisePlan: false,
 }
 
 const server = setupServer()

--- a/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/Controllers/SentryPlanController/SentryPlanController.test.tsx
+++ b/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/Controllers/SentryPlanController/SentryPlanController.test.tsx
@@ -114,6 +114,7 @@ const mockPlanDataResponseMonthly = {
   pretrialUsersCount: 0,
   planUserCount: 1,
   hasSeatsLeft: true,
+  isEnterprisePlan: false,
 }
 
 const mockPlanDataResponseYearly = {
@@ -130,6 +131,7 @@ const mockPlanDataResponseYearly = {
   pretrialUsersCount: 0,
   planUserCount: 1,
   hasSeatsLeft: true,
+  isEnterprisePlan: false,
 }
 
 const queryClient = new QueryClient({

--- a/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/Controllers/TeamPlanController/BillingOptions/BillingOptions.test.tsx
+++ b/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/Controllers/TeamPlanController/BillingOptions/BillingOptions.test.tsx
@@ -49,6 +49,7 @@ const mockPlanDataResponse = {
   marketingName: 'Team',
   monthlyUploadLimit: 250,
   value: Plans.USERS_TEAMM,
+  isEnterprisePlan: false,
   trialStatus: TrialStatuses.NOT_STARTED,
   trialStartDate: '',
   trialEndDate: '',

--- a/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/Controllers/TeamPlanController/ErrorBanner/ErrorBanner.test.tsx
+++ b/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/Controllers/TeamPlanController/ErrorBanner/ErrorBanner.test.tsx
@@ -23,6 +23,7 @@ const basicPlan = {
     'Unlimited private repositories',
   ],
   monthlyUploadLimit: 250,
+  hasSeatsLeft: true,
 }
 
 const teamPlanMonth = {
@@ -32,7 +33,7 @@ const teamPlanMonth = {
   marketingName: 'Users Team',
   monthlyUploadLimit: 2500,
   value: Plans.USERS_TEAMM,
-  quantity: 10,
+  hasSeatsLeft: true,
 }
 
 const teamPlanYear = {
@@ -42,7 +43,7 @@ const teamPlanYear = {
   marketingName: 'Users Team',
   monthlyUploadLimit: 2500,
   value: Plans.USERS_TEAMY,
-  quantity: 5,
+  hasSeatsLeft: true,
 }
 
 const proPlanYear = {
@@ -52,69 +53,6 @@ const proPlanYear = {
   billingRate: 'annually',
   marketingName: 'Users Pro',
   monthlyUploadLimit: null,
-  quantity: 5,
-}
-
-const mockAccountDetailsBasic = {
-  plan: basicPlan,
-  activatedUserCount: 1,
-  inactiveUserCount: 0,
-}
-
-const mockAccountDetailsTeamMonthly = {
-  plan: teamPlanMonth,
-  activatedUserCount: 7,
-  inactiveUserCount: 0,
-  subscriptionDetail: {
-    latestInvoice: {
-      periodStart: 1595270468,
-      periodEnd: 1597948868,
-      dueDate: '1600544863',
-      amountPaid: 9600.0,
-      amountDue: 9600.0,
-      amountRemaining: 0.0,
-      total: 9600.0,
-      subtotal: 9600.0,
-      invoicePdf:
-        'https://pay.stripe.com/invoice/acct_14SJTOGlVGuVgOrk/invst_Hs2qfFwArnp6AMjWPlwtyqqszoBzO3q/pdf',
-    },
-  },
-}
-
-const mockAccountDetailsTeamYearly = {
-  plan: teamPlanYear,
-  activatedUserCount: 11,
-  inactiveUserCount: 0,
-}
-
-const mockPlanDataResponseMonthly = {
-  baseUnitPrice: 10,
-  benefits: [],
-  billingRate: 'monthly',
-  marketingName: 'Pro Team',
-  monthlyUploadLimit: 2500,
-  value: Plans.USERS_TEAMM,
-  trialStatus: TrialStatuses.NOT_STARTED,
-  trialStartDate: '',
-  trialEndDate: '',
-  trialTotalDays: 0,
-  pretrialUsersCount: 0,
-  planUserCount: 1,
-}
-
-const mockPlanDataResponseYearly = {
-  baseUnitPrice: 10,
-  benefits: [],
-  billingRate: 'yearly',
-  marketingName: 'Pro Team',
-  monthlyUploadLimit: 2500,
-  value: Plans.USERS_TEAMM,
-  trialStatus: TrialStatuses.NOT_STARTED,
-  trialStartDate: '',
-  trialEndDate: '',
-  trialTotalDays: 0,
-  pretrialUsersCount: 0,
-  planUserCount: 1,
   hasSeatsLeft: true,
 }
 
@@ -162,23 +100,13 @@ interface SetupArgs {
 
 describe('ErrorBanner', () => {
   function setup(
-    { planValue = Plans.USERS_BASIC, monthlyPlan = true }: SetupArgs = {
+    { planValue = Plans.USERS_BASIC }: SetupArgs = {
       planValue: Plans.USERS_BASIC,
-      monthlyPlan: true,
     }
   ) {
     const user = userEvent.setup()
 
     server.use(
-      http.get(`/internal/gh/codecov/account-details/`, () => {
-        if (planValue === Plans.USERS_BASIC) {
-          return HttpResponse.json(mockAccountDetailsBasic)
-        } else if (planValue === Plans.USERS_TEAMM) {
-          return HttpResponse.json(mockAccountDetailsTeamMonthly)
-        } else if (planValue === Plans.USERS_TEAMY) {
-          return HttpResponse.json(mockAccountDetailsTeamYearly)
-        }
-      }),
       http.patch('/internal/gh/codecov/account-details/', async () => {
         return HttpResponse.json({ success: false })
       }),
@@ -197,18 +125,43 @@ describe('ErrorBanner', () => {
         })
       }),
       graphql.query('GetPlanData', () => {
-        const planResponse = monthlyPlan
-          ? mockPlanDataResponseMonthly
-          : mockPlanDataResponseYearly
-
-        return HttpResponse.json({
-          data: {
-            owner: {
-              hasPrivateRepos: true,
-              plan: planResponse,
+        const planChunk = {
+          trialStatus: TrialStatuses.NOT_STARTED,
+          trialStartDate: '',
+          trialEndDate: '',
+          trialTotalDays: 0,
+          pretrialUsersCount: 0,
+          planUserCount: 1,
+          isEnterprisePlan: false,
+        }
+        if (planValue === Plans.USERS_BASIC) {
+          return HttpResponse.json({
+            data: {
+              owner: {
+                hasPrivateRepos: true,
+                plan: { ...basicPlan, ...planChunk },
+              },
             },
-          },
-        })
+          })
+        } else if (planValue === Plans.USERS_TEAMM) {
+          return HttpResponse.json({
+            data: {
+              owner: {
+                hasPrivateRepos: true,
+                plan: { ...teamPlanMonth, ...planChunk },
+              },
+            },
+          })
+        } else if (planValue === Plans.USERS_TEAMY) {
+          return HttpResponse.json({
+            data: {
+              owner: {
+                hasPrivateRepos: true,
+                plan: { ...teamPlanYear, ...planChunk },
+              },
+            },
+          })
+        }
       })
     )
 

--- a/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/Controllers/TeamPlanController/ErrorBanner/ErrorBanner.tsx
+++ b/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/Controllers/TeamPlanController/ErrorBanner/ErrorBanner.tsx
@@ -1,7 +1,7 @@
 import { UseFormSetValue } from 'react-hook-form'
 import { useParams } from 'react-router-dom'
 
-import { useAccountDetails, useAvailablePlans } from 'services/account'
+import { useAvailablePlans, usePlanData } from 'services/account'
 import {
   canApplySentryUpgrade,
   findProPlans,
@@ -31,12 +31,13 @@ export default function ErrorBanner({
 }: ErrorBannerProps) {
   const { provider, owner } = useParams<{ provider: string; owner: string }>()
   const { data: plans } = useAvailablePlans({ provider, owner })
-  const { data: accountDetails } = useAccountDetails({ provider, owner })
+  const { data: planData } = usePlanData({ provider, owner })
   const { proPlanYear } = findProPlans({ plans })
   const { sentryPlanYear } = findSentryPlans({ plans })
-  const plan =
-    accountDetails?.rootOrganization?.plan?.value ?? accountDetails?.plan?.value
-  const isSentryUpgrade = canApplySentryUpgrade({ plan, plans })
+  const isSentryUpgrade = canApplySentryUpgrade({
+    isEnterprisePlan: planData?.plan?.isEnterprisePlan,
+    plans,
+  })
   const yearlyProPlan = isSentryUpgrade ? sentryPlanYear : proPlanYear
 
   if (errors?.seats?.message === UPGRADE_FORM_TOO_MANY_SEATS_MESSAGE) {

--- a/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/Controllers/TeamPlanController/TeamPlanController.test.tsx
+++ b/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/Controllers/TeamPlanController/TeamPlanController.test.tsx
@@ -115,6 +115,7 @@ const mockPlanDataResponseMonthly = {
   pretrialUsersCount: 0,
   planUserCount: 1,
   hasSeatsLeft: true,
+  isEnterprisePlan: false,
 }
 
 const mockPlanDataResponseYearly = {
@@ -131,6 +132,7 @@ const mockPlanDataResponseYearly = {
   pretrialUsersCount: 0,
   planUserCount: 1,
   hasSeatsLeft: true,
+  isEnterprisePlan: false,
 }
 
 const queryClient = new QueryClient({

--- a/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/PlanTypeOptions/PlanTypeOptions.tsx
+++ b/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/PlanTypeOptions/PlanTypeOptions.tsx
@@ -1,7 +1,7 @@
 import { UseFormSetValue } from 'react-hook-form'
 import { useParams } from 'react-router-dom'
 
-import { useAccountDetails, useAvailablePlans } from 'services/account'
+import { useAvailablePlans, usePlanData } from 'services/account'
 import { useLocationParams } from 'services/navigation'
 import { TierNames } from 'services/tier'
 import {
@@ -35,7 +35,7 @@ const PlanTypeOptions: React.FC<PlanTypeOptionsProps> = ({
 }) => {
   const { provider, owner } = useParams<{ provider: string; owner: string }>()
   const { data: plans } = useAvailablePlans({ provider, owner })
-  const { data: accountDetails } = useAccountDetails({ provider, owner })
+  const { data: planData } = usePlanData({ provider, owner })
   const { proPlanYear, proPlanMonth } = findProPlans({ plans })
   const planParam = usePlanParams()
 
@@ -45,9 +45,10 @@ const PlanTypeOptions: React.FC<PlanTypeOptionsProps> = ({
   })
 
   const hasTeamPlans = shouldDisplayTeamCard({ plans })
-  const plan =
-    accountDetails?.rootOrganization?.plan?.value ?? accountDetails?.plan?.value
-  const isSentryUpgrade = canApplySentryUpgrade({ plan, plans })
+  const isSentryUpgrade = canApplySentryUpgrade({
+    isEnterprisePlan: planData?.plan?.isEnterprisePlan,
+    plans,
+  })
 
   const yearlyProPlan = isSentryUpgrade ? sentryPlanYear : proPlanYear
   const monthlyProPlan = isSentryUpgrade ? sentryPlanMonth : proPlanMonth

--- a/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/UpgradeForm.test.tsx
+++ b/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/UpgradeForm.test.tsx
@@ -206,6 +206,7 @@ const mockPlanDataResponseMonthly = {
   pretrialUsersCount: 0,
   planUserCount: 1,
   hasSeatsLeft: true,
+  isEnterprisePlan: false,
 }
 
 const mockPlanDataResponseYearly = {
@@ -222,6 +223,7 @@ const mockPlanDataResponseYearly = {
   pretrialUsersCount: 0,
   planUserCount: 1,
   hasSeatsLeft: true,
+  isEnterprisePlan: false,
 }
 
 const queryClient = new QueryClient({

--- a/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/UpgradeForm.tsx
+++ b/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/UpgradeForm.tsx
@@ -51,7 +51,7 @@ function UpgradeForm({ selectedPlan, setSelectedPlan }: UpgradeFormProps) {
   const { data: planData } = usePlanData({ owner, provider })
   const { upgradePlan } = useUpgradeControls()
   const isSentryUpgrade = canApplySentryUpgrade({
-    plan: currentPlan?.value,
+    isEnterprisePlan: planData?.plan?.isEnterprisePlan,
     plans,
   })
   const minSeats =
@@ -73,6 +73,7 @@ function UpgradeForm({ selectedPlan, setSelectedPlan }: UpgradeFormProps) {
       plans,
       trialStatus,
       selectedPlan,
+      isEnterprisePlan: planData?.plan?.isEnterprisePlan,
     }),
     resolver: zodResolver(
       getSchema({

--- a/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradePlanPage.jsx
+++ b/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradePlanPage.jsx
@@ -1,14 +1,17 @@
 import { useLayoutEffect, useState } from 'react'
 import { Redirect, useParams } from 'react-router-dom'
 
-import { useAccountDetails, useAvailablePlans } from 'services/account'
+import {
+  useAccountDetails,
+  useAvailablePlans,
+  usePlanData,
+} from 'services/account'
 import { TierNames } from 'services/tier'
 import {
   canApplySentryUpgrade,
   findProPlans,
   findSentryPlans,
   findTeamPlans,
-  isEnterprisePlan,
   isFreePlan,
   isTeamPlan,
   shouldDisplayTeamCard,
@@ -25,6 +28,7 @@ function UpgradePlanPage() {
   const setCrumbs = useSetCrumbs()
   const { data: accountDetails } = useAccountDetails({ provider, owner })
   const { data: plans } = useAvailablePlans({ provider, owner })
+  const { data: planData } = usePlanData({ provider, owner })
   const planParam = usePlanParams()
 
   const { proPlanYear } = findProPlans({ plans })
@@ -34,7 +38,10 @@ function UpgradePlanPage() {
 
   const plan = accountDetails?.rootOrganization?.plan ?? accountDetails?.plan
 
-  const isSentryUpgrade = canApplySentryUpgrade({ plan, plans })
+  const isSentryUpgrade = canApplySentryUpgrade({
+    isEnterprisePlan: planData?.plan?.isEnterprisePlan,
+    plans,
+  })
 
   let defaultPaidYearlyPlan = null
   if (
@@ -60,7 +67,7 @@ function UpgradePlanPage() {
   }, [setCrumbs, plan?.value])
 
   // redirect right away if the user is on an enterprise plan
-  if (isEnterprisePlan(plan?.value)) {
+  if (planData?.plan?.isEnterprisePlan) {
     return <Redirect to={`/plan/${provider}/${owner}`} />
   }
 

--- a/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradePlanPage.test.jsx
+++ b/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradePlanPage.test.jsx
@@ -133,7 +133,6 @@ const teamPlanYear = {
 }
 
 const mockPlanData = {
-  isEnterprisePlan: false,
   baseUnitPrice: 10,
   benefits: [],
   billingRate: 'monthly',
@@ -210,6 +209,8 @@ describe('UpgradePlanPage', () => {
               hasPrivateRepos: true,
               plan: {
                 ...mockPlanData,
+                isEnterprisePlan:
+                  planValue === Plans.USERS_ENTERPRISEM ? true : false,
               },
             },
           },

--- a/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradePlanPage.test.jsx
+++ b/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradePlanPage.test.jsx
@@ -133,6 +133,7 @@ const teamPlanYear = {
 }
 
 const mockPlanData = {
+  isEnterprisePlan: false,
   baseUnitPrice: 10,
   benefits: [],
   billingRate: 'monthly',

--- a/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradePlanPage.test.jsx
+++ b/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradePlanPage.test.jsx
@@ -209,8 +209,7 @@ describe('UpgradePlanPage', () => {
               hasPrivateRepos: true,
               plan: {
                 ...mockPlanData,
-                isEnterprisePlan:
-                  planValue === Plans.USERS_ENTERPRISEM ? true : false,
+                isEnterprisePlan: planValue === Plans.USERS_ENTERPRISEM,
               },
             },
           },

--- a/src/pages/RepoPage/ActivationAlert/ActivationAlert.test.tsx
+++ b/src/pages/RepoPage/ActivationAlert/ActivationAlert.test.tsx
@@ -63,6 +63,7 @@ const mockTrialData = {
   pretrialUsersCount: 0,
   planUserCount: 1,
   hasSeatsLeft: true,
+  isEnterprisePlan: false,
 }
 
 describe('ActivationAlert', () => {

--- a/src/pages/RepoPage/CoverageOnboarding/ActivationBanner/ActivationBanner.test.tsx
+++ b/src/pages/RepoPage/CoverageOnboarding/ActivationBanner/ActivationBanner.test.tsx
@@ -63,6 +63,7 @@ const mockTrialData = {
   pretrialUsersCount: 0,
   planUserCount: 1,
   hasSeatsLeft: true,
+  isEnterprisePlan: false,
 }
 
 describe('ActivationBanner', () => {

--- a/src/services/account/usePlanData.test.tsx
+++ b/src/services/account/usePlanData.test.tsx
@@ -23,6 +23,7 @@ const mockTrialData = {
     pretrialUsersCount: 0,
     planUserCount: 1,
     hasSeatsLeft: true,
+    isEnterprisePlan: false,
   },
   pretrialPlan: {
     baseUnitPrice: 10,

--- a/src/services/account/usePlanData.test.tsx
+++ b/src/services/account/usePlanData.test.tsx
@@ -84,6 +84,7 @@ describe('usePlanData', () => {
           expect(result.current.data).toStrictEqual({
             hasPrivateRepos: true,
             plan: {
+              isEnterprisePlan: false,
               baseUnitPrice: 10,
               benefits: [],
               billingRate: 'monthly',

--- a/src/services/account/usePlanData.ts
+++ b/src/services/account/usePlanData.ts
@@ -109,8 +109,6 @@ export const usePlanData = ({ provider, owner, opts }: UsePlanDataArgs) =>
       }).then((res) => {
         const parsedRes = PlanDataSchema.safeParse(res?.data)
 
-        console.log('parsedRes', parsedRes.error)
-
         if (!parsedRes.success) {
           return Promise.reject({
             status: 404,

--- a/src/services/account/usePlanData.ts
+++ b/src/services/account/usePlanData.ts
@@ -27,6 +27,7 @@ const PlanSchema = z.object({
   trialTotalDays: z.number().nullable(),
   planUserCount: z.number().nullable(),
   hasSeatsLeft: z.boolean(),
+  isEnterprisePlan: z.boolean(),
 })
 
 export type Plan = z.infer<typeof PlanSchema>
@@ -80,6 +81,7 @@ export const query = `
         trialTotalDays
         planUserCount
         hasSeatsLeft
+        isEnterprisePlan
       }
       pretrialPlan {
         baseUnitPrice
@@ -106,6 +108,8 @@ export const usePlanData = ({ provider, owner, opts }: UsePlanDataArgs) =>
         },
       }).then((res) => {
         const parsedRes = PlanDataSchema.safeParse(res?.data)
+
+        console.log('parsedRes', parsedRes.error)
 
         if (!parsedRes.success) {
           return Promise.reject({

--- a/src/shared/GlobalTopBanners/ProPlanFeedbackBanner/ProPlanFeedbackBanner.test.tsx
+++ b/src/shared/GlobalTopBanners/ProPlanFeedbackBanner/ProPlanFeedbackBanner.test.tsx
@@ -23,6 +23,7 @@ const mockProTier = {
 const mockTrialData = {
   hasPrivateRepos: true,
   plan: {
+    isEnterprisePlan: false,
     baseUnitPrice: 10,
     benefits: [],
     billingRate: 'monthly',

--- a/src/shared/GlobalTopBanners/TrialBanner/TrialBanner.test.tsx
+++ b/src/shared/GlobalTopBanners/TrialBanner/TrialBanner.test.tsx
@@ -30,6 +30,7 @@ const proPlanMonth = {
   trialTotalDays: 0,
   pretrialUsersCount: 0,
   planUserCount: 1,
+  isEnterprisePlan: false,
 }
 
 const trialPlan = {
@@ -47,9 +48,11 @@ const trialPlan = {
   trialTotalDays: 0,
   pretrialUsersCount: 0,
   planUserCount: 1,
+  isEnterprisePlan: false,
 }
 
 const basicPlan = {
+  isEnterprisePlan: false,
   marketingName: 'Basic',
   value: Plans.USERS_BASIC,
   billingRate: null,
@@ -149,6 +152,7 @@ describe('TrialBanner', () => {
                 pretrialUsersCount: plan.pretrialUsersCount,
                 planUserCount: plan.planUserCount,
                 hasSeatsLeft: true,
+                isEnterprisePlan: plan.isEnterprisePlan,
               },
             },
           },

--- a/src/shared/utils/billing.test.ts
+++ b/src/shared/utils/billing.test.ts
@@ -2,7 +2,6 @@ import { renderHook } from '@testing-library/react'
 
 import {
   canApplySentryUpgrade,
-  EnterprisePlans,
   findProPlans,
   findSentryPlans,
   findTeamPlans,
@@ -12,7 +11,6 @@ import {
   isAnnualPlan,
   isBasicPlan,
   isCodecovProPlan,
-  isEnterprisePlan,
   isFreePlan,
   isMonthlyPlan,
   isPaidPlan,
@@ -220,23 +218,6 @@ describe('shouldDisplayTeamCard', () => {
   })
 })
 
-describe('isEnterprisePlans', () => {
-  it('supports enterprise monthly plan', () => {
-    expect(isEnterprisePlan('users-enterprisem')).toBe(true)
-    expect(isEnterprisePlan(EnterprisePlans.USERS_ENTERPRISEM)).toBe(true)
-  })
-
-  it('supports enterprise yearly plan', () => {
-    expect(isEnterprisePlan('users-enterprisey')).toBe(true)
-    expect(isEnterprisePlan(EnterprisePlans.USERS_ENTERPRISEY)).toBe(true)
-  })
-
-  it('defaults to false otherwise', () => {
-    expect(isEnterprisePlan('users-inappy')).toBe(false)
-    expect(isEnterprisePlan(undefined)).toBe(false)
-  })
-})
-
 describe('useProPlans', () => {
   function setup(flagValue: boolean) {
     mocks.useFlags.mockReturnValue({
@@ -345,7 +326,7 @@ describe('getNextBillingDate', () => {
 describe('isAnnualPlan', () => {
   it('supports enterprise annual plan', () => {
     expect(isAnnualPlan('users-enterprisey')).toBe(true)
-    expect(isAnnualPlan(EnterprisePlans.USERS_ENTERPRISEY)).toBe(true)
+    expect(isAnnualPlan(Plans.USERS_ENTERPRISEY)).toBe(true)
   })
 
   it('supports basic annual plan', () => {
@@ -372,7 +353,7 @@ describe('isAnnualPlan', () => {
 describe('isMonthlyPlan', () => {
   it('supports enterprise monthly plan', () => {
     expect(isMonthlyPlan('users-enterprisem')).toBe(true)
-    expect(isMonthlyPlan(EnterprisePlans.USERS_ENTERPRISEM)).toBe(true)
+    expect(isMonthlyPlan(Plans.USERS_ENTERPRISEM)).toBe(true)
   })
 
   it('supports basic monthly plan', () => {
@@ -573,7 +554,7 @@ describe('findTeamPlans', () => {
 describe('canApplySentryUpgrade', () => {
   it('returns true when list contains monthly plan', () => {
     const result = canApplySentryUpgrade({
-      plan: Plans.USERS_PR_INAPPM,
+      isEnterprisePlan: false,
       plans: [{ value: Plans.USERS_SENTRYM }] as Plan[],
     })
 
@@ -582,7 +563,7 @@ describe('canApplySentryUpgrade', () => {
 
   it('returns true when list contains annual plan', () => {
     const result = canApplySentryUpgrade({
-      plan: Plans.USERS_PR_INAPPM,
+      isEnterprisePlan: false,
       plans: [{ value: Plans.USERS_SENTRYY }] as Plan[],
     })
 
@@ -591,7 +572,6 @@ describe('canApplySentryUpgrade', () => {
 
   it('returns false when plans are not in list', () => {
     const result = canApplySentryUpgrade({
-      plan: Plans.USERS_PR_INAPPM,
       plans: [{ value: Plans.USERS_FREE }] as Plan[],
     })
 
@@ -600,7 +580,7 @@ describe('canApplySentryUpgrade', () => {
 
   it('returns false when user has enterprise plan', () => {
     const result = canApplySentryUpgrade({
-      plan: Plans.USERS_ENTERPRISEM,
+      isEnterprisePlan: true,
       plans: [{ value: Plans.USERS_SENTRYY }] as Plan[],
     })
 

--- a/src/shared/utils/billing.ts
+++ b/src/shared/utils/billing.ts
@@ -35,19 +35,6 @@ export interface Plan {
   quantity?: number
 }
 
-export const EnterprisePlans = Object.freeze({
-  USERS_ENTERPRISEM: 'users-enterprisem',
-  USERS_ENTERPRISEY: 'users-enterprisey',
-})
-
-export function isEnterprisePlan(plan?: PlanName | null) {
-  if (isString(plan)) {
-    return (Object.values(EnterprisePlans) as string[]).includes(plan)
-  }
-
-  return false
-}
-
 export function isFreePlan(plan?: PlanName | null) {
   if (isString(plan)) {
     if (plan === Plans.USERS_BASIC || plan === Plans.USERS_FREE) return true
@@ -189,13 +176,13 @@ export const findTeamPlans = ({ plans }: { plans?: Plan[] | null }) => {
 }
 
 export const canApplySentryUpgrade = ({
-  plan,
+  isEnterprisePlan,
   plans,
 }: {
-  plan?: PlanName
+  isEnterprisePlan?: boolean
   plans?: Plan[] | null
 }) => {
-  if (isEnterprisePlan(plan) || !isArray(plans)) {
+  if (isEnterprisePlan || !isArray(plans)) {
     return false
   }
 

--- a/src/shared/utils/upgradeForm.ts
+++ b/src/shared/utils/upgradeForm.ts
@@ -213,11 +213,13 @@ export const getDefaultValuesUpgradeForm = ({
   plans,
   trialStatus,
   selectedPlan,
+  isEnterprisePlan,
 }: {
   accountDetails?: z.infer<typeof AccountDetailsSchema> | null
   plans?: Plan[] | null
   trialStatus?: TrialStatus
   selectedPlan?: Plan | null
+  isEnterprisePlan?: boolean
 }) => {
   const currentPlan = accountDetails?.plan
   const currentPlanValue = currentPlan?.value
@@ -230,7 +232,7 @@ export const getDefaultValuesUpgradeForm = ({
   const { teamPlanYear, teamPlanMonth } = findTeamPlans({ plans })
 
   const isSentryUpgrade = canApplySentryUpgrade({
-    plan: currentPlanValue,
+    isEnterprisePlan,
     plans,
   })
 


### PR DESCRIPTION
# Description

This PR aims to remove the isEnterprisePlan helper function in Gazebo in favor of the new GraphQL field for the same.

As part of this PR there are also some changes removing the accountDetails hook has the SOT for retrieving a user's plan in favor of the usePlanData hook, which seems to be the "go-to" pattern for more recently created components anyway.

Outside of that, all the tests that touch plan details had to be updated to include this new field, and in the cases where we deprecated the useAccountDetails hook in favor of usePlanData we also had to add or update the mocks to reflect the differences in the plan mocks as well.

Closes https://github.com/codecov/engineering-team/issues/3061


This PR will probably be the "biggest" of these migration PRs because it's the first one. I don't expect others to be as meaty, though they may have just as many files touched

# Link to Sample Entry

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.