### PR TITLE
chore: Migrate useSelfHostedSeatsAndLicense to TS Query V5

### DIFF
--- a/src/services/selfHosted/SelfHostedSeatsAndLicenseQueryOpts.test.tsx
+++ b/src/services/selfHosted/SelfHostedSeatsAndLicenseQueryOpts.test.tsx
@@ -1,10 +1,14 @@
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import {
+  QueryClientProvider as QueryClientProviderV5,
+  QueryClient as QueryClientV5,
+  useQuery as useQueryV5,
+} from '@tanstack/react-queryV5'
 import { renderHook, waitFor } from '@testing-library/react'
 import { graphql, HttpResponse } from 'msw'
 import { setupServer } from 'msw/node'
 import { type MockInstance } from 'vitest'
 
-import { useSelfHostedSeatsAndLicense } from './useSelfHostedSeatsAndLicense'
+import { SelfHostedSeatsAndLicenseQueryOpts } from './SelfHostedSeatsAndLicenseQueryOpts'
 
 const mockSelfHostedLicense = {
   config: {
@@ -16,12 +20,14 @@ const mockSelfHostedLicense = {
 
 const mockUnsuccessfulParseError = {}
 
-const queryClient = new QueryClient({
+const queryClientV5 = new QueryClientV5({
   defaultOptions: { queries: { retry: false } },
 })
 
 const wrapper: React.FC<React.PropsWithChildren> = ({ children }) => (
-  <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  <QueryClientProviderV5 client={queryClientV5}>
+    {children}
+  </QueryClientProviderV5>
 )
 
 const server = setupServer()
@@ -30,7 +36,7 @@ beforeAll(() => {
 })
 
 afterEach(() => {
-  queryClient.clear()
+  queryClientV5.clear()
   server.resetHandlers()
 })
 
@@ -61,7 +67,10 @@ describe('useSelfHostedSeatsAndLicense', () => {
         it('returns the license details', async () => {
           setup({})
           const { result } = renderHook(
-            () => useSelfHostedSeatsAndLicense({ provider: 'gh' }),
+            () =>
+              useQueryV5(
+                SelfHostedSeatsAndLicenseQueryOpts({ provider: 'gh' })
+              ),
             { wrapper }
           )
 
@@ -91,7 +100,8 @@ describe('useSelfHostedSeatsAndLicense', () => {
       it('throws a 404', async () => {
         setup({ isUnsuccessfulParseError: true })
         const { result } = renderHook(
-          () => useSelfHostedSeatsAndLicense({ provider: 'gh' }),
+          () =>
+            useQueryV5(SelfHostedSeatsAndLicenseQueryOpts({ provider: 'gh' })),
           { wrapper }
         )
 

--- a/src/services/selfHosted/index.ts
+++ b/src/services/selfHosted/index.ts
@@ -1,2 +1,1 @@
 export * from './useSelfHostedCurrentUser'
-export * from './useSelfHostedSeatsAndLicense'

--- a/src/shared/GlobalBanners/SelfHostedLicenseExpiration/SelfHostedLicenseExpiration.tsx
+++ b/src/shared/GlobalBanners/SelfHostedLicenseExpiration/SelfHostedLicenseExpiration.tsx
@@ -1,10 +1,11 @@
+import { useSuspenseQuery as useSuspenseQueryV5 } from '@tanstack/react-queryV5'
 import { differenceInCalendarDays } from 'date-fns'
 import { useState } from 'react'
 import { useParams } from 'react-router-dom'
 
 import config from 'config'
 
-import { useSelfHostedSeatsAndLicense } from 'services/selfHosted/useSelfHostedSeatsAndLicense'
+import { SelfHostedSeatsAndLicenseQueryOpts } from 'services/selfHosted/SelfHostedSeatsAndLicenseQueryOpts'
 import { Provider } from 'shared/api/helpers'
 import Banner from 'ui/Banner'
 import Button from 'ui/Button'
@@ -56,24 +57,17 @@ interface URLParams {
 const SelfHostedLicenseExpiration = () => {
   const { provider } = useParams<URLParams>()
   const [isModalOpen, setIsModalOpen] = useState(false)
-  const isSelfHosted = !!config.IS_SELF_HOSTED
-  const isDedicatedNamespace = !!config.IS_DEDICATED_NAMESPACE
-  const { data } = useSelfHostedSeatsAndLicense({
-    provider,
-    opts: { enabled: !!provider && isSelfHosted && isDedicatedNamespace },
-  })
+  const { data } = useSuspenseQueryV5(
+    SelfHostedSeatsAndLicenseQueryOpts({
+      provider,
+    })
+  )
 
   const licenseExpirationDate = data?.selfHostedLicense?.expirationDate
   const seatsUsed = data?.seatsUsed
   const seatsLimit = data?.seatsLimit
 
-  if (
-    !isSelfHosted ||
-    !isDedicatedNamespace ||
-    !licenseExpirationDate ||
-    !seatsUsed ||
-    !seatsLimit
-  ) {
+  if (!licenseExpirationDate || !seatsUsed || !seatsLimit) {
     return null
   }
 
@@ -81,6 +75,7 @@ const SelfHostedLicenseExpiration = () => {
     new Date(licenseExpirationDate),
     new Date()
   )
+
   const isSeatsLimitReached = seatsUsed === seatsLimit
   const isLicenseExpired = dateDiff < 0
   const isLicenseExpiringWithin30Days = dateDiff < 31 && dateDiff >= 0
@@ -122,4 +117,15 @@ const SelfHostedLicenseExpiration = () => {
   )
 }
 
-export default SelfHostedLicenseExpiration
+function SelfHostedLicenseExpirationWrapper() {
+  const isSelfHosted = !!config.IS_SELF_HOSTED
+  const isDedicatedNamespace = !!config.IS_DEDICATED_NAMESPACE
+
+  if (!isSelfHosted || !isDedicatedNamespace) {
+    return null
+  }
+
+  return <SelfHostedLicenseExpiration />
+}
+
+export default SelfHostedLicenseExpirationWrapper

--- a/src/shared/GlobalBanners/SelfHostedLicenseExpiration/SelfHostedLicenseExpiration.tsx
+++ b/src/shared/GlobalBanners/SelfHostedLicenseExpiration/SelfHostedLicenseExpiration.tsx
@@ -117,6 +117,9 @@ const SelfHostedLicenseExpiration = () => {
   )
 }
 
+// This wrapper is just so we don't make a request to the API if we're not on a
+// self-hosted instance, this is because we're useSuspenseQuery is not
+// toggal'ble through a `enabled` field like useQuery
 function SelfHostedLicenseExpirationWrapper() {
   const isSelfHosted = !!config.IS_SELF_HOSTED
   const isDedicatedNamespace = !!config.IS_DEDICATED_NAMESPACE

--- a/src/shared/GlobalBanners/SelfHostedLicenseExpiration/SelfHostedLicenseExpiration.tsx
+++ b/src/shared/GlobalBanners/SelfHostedLicenseExpiration/SelfHostedLicenseExpiration.tsx
@@ -119,7 +119,7 @@ const SelfHostedLicenseExpiration = () => {
 
 // This wrapper is just so we don't make a request to the API if we're not on a
 // self-hosted instance, this is because we're useSuspenseQuery is not
-// toggal'ble through a `enabled` field like useQuery
+// toggle'ble through a `enabled` field like useQuery
 function SelfHostedLicenseExpirationWrapper() {
   const isSelfHosted = !!config.IS_SELF_HOSTED
   const isDedicatedNamespace = !!config.IS_DEDICATED_NAMESPACE


### PR DESCRIPTION
# Description

This PR migrates the `useSelfHostedSeatsAndLicense` to the TSQ V5 query options version `SelfHostedSeatsAndLicenseQueryOpts`, as well as a TS migration

Ticket: codecov/engineering-team#2961

# Notable Changes

- Migrate `useSelfHostedSeatsAndLicense` to `SelfHostedSeatsAndLicenseQueryOpts`
- Update `SelfHostedLicenseExpiration`
  - Refactor to TS
  - Add in tiny wrapper component so that we can short circuit rendering the actual banner and triggering the data fetching, as suspense queries cannot be controlled via an `enabled` property