### PR TITLE
chore: Migrate useSelfHostedSeatsConfig to TS Query V5

### DIFF
--- a/src/layouts/Header/components/SeatDetails/SeatDetails.tsx
+++ b/src/layouts/Header/components/SeatDetails/SeatDetails.tsx
@@ -1,7 +1,17 @@
-import { useSelfHostedSeatsConfig } from 'services/selfHosted'
+import { useSuspenseQuery as useSuspenseQueryV5 } from '@tanstack/react-queryV5'
+import { useParams } from 'react-router'
+
+import { SelfHostedSeatsConfigQueryOpts } from 'services/selfHosted/SelfHostedSeatsConfigQueryOpts'
+
+interface URLParams {
+  provider: string
+}
 
 function SeatDetails() {
-  const { data: selfHostedSeats } = useSelfHostedSeatsConfig()
+  const { provider } = useParams<URLParams>()
+  const { data: selfHostedSeats } = useSuspenseQueryV5(
+    SelfHostedSeatsConfigQueryOpts({ provider })
+  )
 
   if (!selfHostedSeats?.seatsUsed || !selfHostedSeats?.seatsLimit) {
     return <p>Unable to get seat usage information</p>

--- a/src/pages/AccountSettings/tabs/Profile/ActivationBanner/ActivationBanner.jsx
+++ b/src/pages/AccountSettings/tabs/Profile/ActivationBanner/ActivationBanner.jsx
@@ -1,9 +1,9 @@
 import { useQueryClient } from '@tanstack/react-query'
+import { useSuspenseQuery as useSuspenseQueryV5 } from '@tanstack/react-queryV5'
+import { useParams } from 'react-router'
 
-import {
-  useSelfHostedCurrentUser,
-  useSelfHostedSeatsConfig,
-} from 'services/selfHosted'
+import { useSelfHostedCurrentUser } from 'services/selfHosted'
+import { SelfHostedSeatsConfigQueryOpts } from 'services/selfHosted/SelfHostedSeatsConfigQueryOpts'
 import A from 'ui/A'
 import Banner from 'ui/Banner'
 import BannerContent from 'ui/Banner/BannerContent'
@@ -39,9 +39,12 @@ function canChangeActivation({ seatConfig, currentUser }) {
 }
 
 function ActivationBanner() {
+  const { provider } = useParams()
   const queryClient = useQueryClient()
   const { data: currentUser } = useSelfHostedCurrentUser()
-  const { data: seatConfig } = useSelfHostedSeatsConfig()
+  const { data: seatConfig } = useSuspenseQueryV5(
+    SelfHostedSeatsConfigQueryOpts({ provider })
+  )
 
   const { canChange, displaySeatMsg } = canChangeActivation({
     seatConfig,

--- a/src/pages/AccountSettings/tabs/Profile/ActivationBanner/ActivationBanner.test.jsx
+++ b/src/pages/AccountSettings/tabs/Profile/ActivationBanner/ActivationBanner.test.jsx
@@ -1,10 +1,14 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import {
+  QueryClientProvider as QueryClientProviderV5,
+  QueryClient as QueryClientV5,
+} from '@tanstack/react-queryV5'
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { graphql, http, HttpResponse } from 'msw'
 import { setupServer } from 'msw/node'
-import { Route } from 'react-router-dom'
-import { MemoryRouter } from 'react-router-dom/cjs/react-router-dom.min'
+import { Suspense } from 'react'
+import { MemoryRouter, Route } from 'react-router-dom'
 
 import ActivationBanner from './ActivationBanner'
 
@@ -27,26 +31,37 @@ const mockUserData = {
 const queryClient = new QueryClient({
   defaultOptions: { queries: { retry: false } },
 })
-const server = setupServer()
 
-beforeAll(() => {
-  server.listen()
-})
-beforeEach(() => {
-  queryClient.clear()
-  server.resetHandlers()
-})
-afterAll(() => {
-  server.close()
+const queryClientV5 = new QueryClientV5({
+  defaultOptions: { queries: { retry: false } },
 })
 
 const wrapper = ({ children }) => (
-  <QueryClientProvider client={queryClient}>
-    <MemoryRouter initialEntries={['/gh']}>
-      <Route path="/:provider">{children}</Route>
-    </MemoryRouter>
-  </QueryClientProvider>
+  <QueryClientProviderV5 client={queryClientV5}>
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={['/gh']}>
+        <Route path="/:provider">
+          <Suspense fallback={<div>Loading</div>}>{children}</Suspense>
+        </Route>
+      </MemoryRouter>
+    </QueryClientProvider>
+  </QueryClientProviderV5>
 )
+
+const server = setupServer()
+beforeAll(() => {
+  server.listen()
+})
+
+afterEach(() => {
+  queryClient.clear()
+  queryClientV5.clear()
+  server.resetHandlers()
+})
+
+afterAll(() => {
+  server.close()
+})
 
 describe('ActivationBanner', () => {
   function setup(
@@ -58,14 +73,14 @@ describe('ActivationBanner', () => {
     const user = userEvent.setup()
 
     let restUsersCurrent = { ...mockUserData, ...overrideUserData }
-    const querySeats = { ...mockSeatData, ...overrideSeatData }
+    const querySeats = { ...mockSeatData.config, ...overrideSeatData }
 
     server.use(
       http.get('/internal/users/current', () => {
         return HttpResponse.json(restUsersCurrent)
       }),
       graphql.query('Seats', () => {
-        return HttpResponse.json({ data: querySeats })
+        return HttpResponse.json({ data: { config: querySeats } })
       }),
       http.patch('/internal/users/current', async (info) => {
         const { activated } = await info.request.json()
@@ -83,9 +98,8 @@ describe('ActivationBanner', () => {
   }
 
   describe('rendering banner header', () => {
-    beforeEach(() => setup())
-
     it('renders header content', async () => {
+      setup()
       render(<ActivationBanner />, { wrapper })
 
       const heading = await screen.findByText('Activation Status')
@@ -95,9 +109,8 @@ describe('ActivationBanner', () => {
 
   describe('rendering banner content', () => {
     describe('user is activated', () => {
-      beforeEach(() => setup({ overrideUserData: { activated: true } }))
-
       it('displays user is activated', async () => {
+        setup({ overrideUserData: { activated: true } })
         render(<ActivationBanner />, { wrapper })
 
         const activated = await screen.findByText('You are currently activated')
@@ -107,9 +120,8 @@ describe('ActivationBanner', () => {
 
     describe('user is not activated', () => {
       describe('org has free seats', () => {
-        beforeEach(() => setup({ overrideSeatData: { activated: false } }))
-
         it('displays user is not activated', async () => {
+          setup({ overrideSeatData: { activated: false } })
           render(<ActivationBanner />, { wrapper })
 
           const activated = await screen.findByText(
@@ -120,14 +132,11 @@ describe('ActivationBanner', () => {
       })
 
       describe('org does not have free seats', () => {
-        beforeEach(() =>
+        it('displays org out of seat message', async () => {
           setup({
             overrideSeatData: { seatsUsed: 10, seatsLimit: 10 },
             overrideUserData: { activated: false },
           })
-        )
-
-        it('displays org out of seat message', async () => {
           render(<ActivationBanner />, { wrapper })
 
           const noSeatMsg = await screen.findByText(
@@ -137,6 +146,10 @@ describe('ActivationBanner', () => {
         })
 
         it('sets toggle to disabled', async () => {
+          setup({
+            overrideSeatData: { seatsUsed: 10, seatsLimit: 10 },
+            overrideUserData: { activated: false },
+          })
           render(<ActivationBanner />, { wrapper })
 
           const button = await screen.findByRole('button')

--- a/src/pages/AccountSettings/tabs/Profile/Profile.test.jsx
+++ b/src/pages/AccountSettings/tabs/Profile/Profile.test.jsx
@@ -1,7 +1,12 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import {
+  QueryClientProvider as QueryClientProviderV5,
+  QueryClient as QueryClientV5,
+} from '@tanstack/react-queryV5'
 import { render, screen, waitFor } from '@testing-library/react'
 import { graphql, http, HttpResponse } from 'msw'
 import { setupServer } from 'msw/node'
+import { Suspense } from 'react'
 import { MemoryRouter, Route } from 'react-router-dom'
 
 import Profile from './Profile'
@@ -9,13 +14,20 @@ import Profile from './Profile'
 const queryClient = new QueryClient({
   defaultOptions: { queries: { retry: false } },
 })
+const queryClientV5 = new QueryClientV5({
+  defaultOptions: { queries: { retry: false } },
+})
 
 const wrapper = ({ children }) => (
-  <QueryClientProvider client={queryClient}>
-    <MemoryRouter initialEntries={['/account/gh/codecov-user']}>
-      <Route path="/account/:provider/:owner">{children}</Route>
-    </MemoryRouter>
-  </QueryClientProvider>
+  <QueryClientProviderV5 client={queryClientV5}>
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={['/account/gh/codecov-user']}>
+        <Route path="/account/:provider/:owner">
+          <Suspense fallback={<div>Loading</div>}>{children}</Suspense>
+        </Route>
+      </MemoryRouter>
+    </QueryClientProvider>
+  </QueryClientProviderV5>
 )
 
 const mockUser = {
@@ -26,12 +38,19 @@ const mockUser = {
 }
 
 const server = setupServer()
-beforeAll(() => server.listen())
-beforeEach(() => {
-  server.resetHandlers()
-  queryClient.clear()
+beforeAll(() => {
+  server.listen()
 })
-afterAll(() => server.close())
+
+afterEach(() => {
+  queryClient.clear()
+  queryClientV5.clear()
+  server.resetHandlers()
+})
+
+afterAll(() => {
+  server.close()
+})
 
 describe('Profile', () => {
   function setup() {

--- a/src/pages/RepoPage/ActivationAlert/ActivationRequiredSelfHosted/ActivationRequiredSelfHosted.tsx
+++ b/src/pages/RepoPage/ActivationAlert/ActivationRequiredSelfHosted/ActivationRequiredSelfHosted.tsx
@@ -1,8 +1,9 @@
+import { useSuspenseQuery as useSuspenseQueryV5 } from '@tanstack/react-queryV5'
+import { useParams } from 'react-router'
+
 import upsideDownUmbrella from 'layouts/shared/NetworkErrorBoundary/assets/error-upsidedown-umbrella.svg'
-import {
-  useSelfHostedCurrentUser,
-  useSelfHostedSeatsConfig,
-} from 'services/selfHosted'
+import { useSelfHostedCurrentUser } from 'services/selfHosted'
+import { SelfHostedSeatsConfigQueryOpts } from 'services/selfHosted/SelfHostedSeatsConfigQueryOpts'
 import A from 'ui/A'
 import Button from 'ui/Button'
 
@@ -55,9 +56,16 @@ function SeatsAvailable({ isAdmin }: { isAdmin: boolean }) {
   )
 }
 
+interface URLParams {
+  provider: string
+}
+
 function ActivationRequiredSelfHosted() {
+  const { provider } = useParams<URLParams>()
   const { data } = useSelfHostedCurrentUser()
-  const { data: selfHostedSeats } = useSelfHostedSeatsConfig()
+  const { data: selfHostedSeats } = useSuspenseQueryV5(
+    SelfHostedSeatsConfigQueryOpts({ provider })
+  )
 
   const hasSelfHostedSeats =
     selfHostedSeats?.seatsUsed &&

--- a/src/pages/RepoPage/CoverageOnboarding/ActivationBanner/ActivationRequiredSelfHosted/ActivationRequiredSelfHosted.test.tsx
+++ b/src/pages/RepoPage/CoverageOnboarding/ActivationBanner/ActivationRequiredSelfHosted/ActivationRequiredSelfHosted.test.tsx
@@ -1,21 +1,36 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import {
+  QueryClientProvider as QueryClientProviderV5,
+  QueryClient as QueryClientV5,
+} from '@tanstack/react-queryV5'
 import { render, screen, waitFor } from '@testing-library/react'
 import { graphql, http, HttpResponse } from 'msw'
 import { setupServer } from 'msw/node'
+import { Suspense } from 'react'
 import { MemoryRouter, Route } from 'react-router-dom'
 
 import ActivationRequiredSelfHosted from './ActivationRequiredSelfHosted'
 
 const queryClient = new QueryClient({
-  defaultOptions: {
-    queries: {
-      retry: false,
-    },
-  },
+  defaultOptions: { queries: { retry: false } },
+})
+const queryClientV5 = new QueryClientV5({
+  defaultOptions: { queries: { retry: false } },
 })
 
-const server = setupServer()
+const wrapper: React.FC<React.PropsWithChildren> = ({ children }) => (
+  <QueryClientProviderV5 client={queryClientV5}>
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={['/gh/codecov/gazebo/new']}>
+        <Route path="/:provider/:owner/:repo/new">
+          <Suspense fallback={<div>Loading</div>}>{children}</Suspense>
+        </Route>
+      </MemoryRouter>
+    </QueryClientProvider>
+  </QueryClientProviderV5>
+)
 
+const server = setupServer()
 beforeAll(() => {
   server.listen({ onUnhandledRequest: 'warn' })
   console.error = () => {}
@@ -23,6 +38,7 @@ beforeAll(() => {
 
 afterEach(() => {
   queryClient.clear()
+  queryClientV5.clear()
   server.resetHandlers()
   vi.clearAllMocks()
 })
@@ -30,14 +46,6 @@ afterEach(() => {
 afterAll(() => {
   server.close()
 })
-
-const wrapper: React.FC<React.PropsWithChildren> = ({ children }) => (
-  <QueryClientProvider client={queryClient}>
-    <MemoryRouter initialEntries={['/gh/codecov/gazebo/new']}>
-      <Route path="/:provider/:owner/:repo/new">{children}</Route>
-    </MemoryRouter>
-  </QueryClientProvider>
-)
 
 describe('ActivationRequiredSelfHosted', () => {
   function setup(isAdmin: boolean, seatsUsed: number, seatsLimit: number) {

--- a/src/pages/RepoPage/CoverageOnboarding/ActivationBanner/ActivationRequiredSelfHosted/ActivationRequiredSelfHosted.tsx
+++ b/src/pages/RepoPage/CoverageOnboarding/ActivationBanner/ActivationRequiredSelfHosted/ActivationRequiredSelfHosted.tsx
@@ -1,7 +1,8 @@
-import {
-  useSelfHostedCurrentUser,
-  useSelfHostedSeatsConfig,
-} from 'services/selfHosted'
+import { useSuspenseQuery as useSuspenseQueryV5 } from '@tanstack/react-queryV5'
+import { useParams } from 'react-router'
+
+import { useSelfHostedCurrentUser } from 'services/selfHosted'
+import { SelfHostedSeatsConfigQueryOpts } from 'services/selfHosted/SelfHostedSeatsConfigQueryOpts'
 import A from 'ui/A'
 import Banner from 'ui/Banner'
 import BannerContent from 'ui/Banner/BannerContent'
@@ -60,9 +61,16 @@ function SeatsAvailable({ isAdmin }: { isAdmin: boolean }) {
   )
 }
 
+interface URLParams {
+  provider: string
+}
+
 function ActivationRequiredSelfHosted() {
+  const { provider } = useParams<URLParams>()
   const { data } = useSelfHostedCurrentUser()
-  const { data: selfHostedSeats } = useSelfHostedSeatsConfig()
+  const { data: selfHostedSeats } = useSuspenseQueryV5(
+    SelfHostedSeatsConfigQueryOpts({ provider })
+  )
 
   const hasSelfHostedSeats =
     selfHostedSeats?.seatsUsed &&

--- a/src/services/selfHosted/SelfHostedSeatsConfigQueryOpts.test.tsx
+++ b/src/services/selfHosted/SelfHostedSeatsConfigQueryOpts.test.tsx
@@ -1,11 +1,13 @@
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import {
+  QueryClientProvider as QueryClientProviderV5,
+  QueryClient as QueryClientV5,
+  useQuery as useQueryV5,
+} from '@tanstack/react-queryV5'
 import { renderHook, waitFor } from '@testing-library/react'
 import { graphql, HttpResponse } from 'msw'
 import { setupServer } from 'msw/node'
-import { PropsWithChildren } from 'react'
-import { MemoryRouter, Route } from 'react-router-dom'
 
-import { useSelfHostedSeatsConfig } from './useSelfHostedSeatsConfig'
+import { SelfHostedSeatsConfigQueryOpts } from './SelfHostedSeatsConfigQueryOpts'
 
 const mockData = {
   config: {
@@ -14,15 +16,13 @@ const mockData = {
   },
 }
 
-const queryClient = new QueryClient({
+const queryClientV5 = new QueryClientV5({
   defaultOptions: { queries: { retry: false } },
 })
-const wrapper: React.FC<PropsWithChildren> = ({ children }) => (
-  <QueryClientProvider client={queryClient}>
-    <MemoryRouter initialEntries={['/gh']}>
-      <Route path="/:provider">{children}</Route>
-    </MemoryRouter>
-  </QueryClientProvider>
+const wrapper: React.FC<React.PropsWithChildren> = ({ children }) => (
+  <QueryClientProviderV5 client={queryClientV5}>
+    {children}
+  </QueryClientProviderV5>
 )
 
 const server = setupServer()
@@ -31,8 +31,8 @@ beforeAll(() => {
 })
 
 beforeEach(() => {
+  queryClientV5.clear()
   server.resetHandlers()
-  queryClient.clear()
 })
 
 afterAll(() => {
@@ -51,9 +51,10 @@ describe('useSelfHostedSeatsConfig', () => {
   describe('when called', () => {
     it('returns data', async () => {
       setup()
-      const { result } = renderHook(() => useSelfHostedSeatsConfig(), {
-        wrapper,
-      })
+      const { result } = renderHook(
+        () => useQueryV5(SelfHostedSeatsConfigQueryOpts({ provider: 'gh' })),
+        { wrapper }
+      )
 
       await waitFor(() =>
         expect(result.current.data).toStrictEqual({

--- a/src/services/selfHosted/index.ts
+++ b/src/services/selfHosted/index.ts
@@ -1,3 +1,2 @@
 export * from './useSelfHostedCurrentUser'
-export * from './useSelfHostedSeatsConfig'
 export * from './useSelfHostedSeatsAndLicense'


### PR DESCRIPTION
# Description

This PR migrates the `useSelfHostedSeatsConfig` to the TS Query V5 queryOptions version `SelfHostedSeatsConfigQueryOpts`

Ticket: codecov/engineering-team#2961

# Notable Changes

- Migrate `useSelfHostedSeatsConfig` to `SelfHostedSeatsConfigQueryOpts`
- Update usage in `SeatDetails`, `ActivationBanner`, `ActivationRequiredSelfHosted`, `ActivationRequiredSelfHosted`
- Fix issue in `Profile` tests