### PR TITLE
remove flare graph from pr comment

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -18,7 +18,7 @@ github_checks:
   annotations: false
 
 comment:
-  layout: 'reach, diff, flags, files, components, footer'
+  layout: 'diff, flags, files, components, footer'
   behavior: default
   require_changes: false
   require_base: false


### PR DESCRIPTION
# Description
I've been investigating the static graphs made from `flare`, we'd like to reduce or eliminate them. Do you all find the `tree` graph in the cc pr comment helpful? If not, let's pull it.

# Screenshots
![Screenshot 2024-12-13 at 11 55 22 AM](https://github.com/user-attachments/assets/596bc298-a103-4d07-a997-b72b465b4130)
The part in the red box is a flare graph.