### PR TITLE
chore: Migrate useSelfHostedCurrentUser to TS Query V5

### DIFF
--- a/src/layouts/Header/components/AdminLink/AdminLink.test.tsx
+++ b/src/layouts/Header/components/AdminLink/AdminLink.test.tsx
@@ -1,10 +1,18 @@
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { render, screen } from '@testing-library/react'
+import {
+  QueryClientProvider as QueryClientProviderV5,
+  QueryClient as QueryClientV5,
+} from '@tanstack/react-queryV5'
+import { render, screen, waitFor } from '@testing-library/react'
 import { http, HttpResponse } from 'msw'
 import { setupServer } from 'msw/node'
+import { Suspense } from 'react'
 import { MemoryRouter, Route } from 'react-router-dom'
 
 import AdminLink from './AdminLink'
+
+const queryClientV5 = new QueryClientV5({
+  defaultOptions: { queries: { retry: false } },
+})
 
 const wrapper: ({
   initialEntries,
@@ -13,27 +21,23 @@ const wrapper: ({
 }) => React.FC<React.PropsWithChildren> =
   ({ initialEntries = '/gh' }) =>
   ({ children }) => (
-    <QueryClientProvider client={queryClient}>
+    <QueryClientProviderV5 client={queryClientV5}>
       <MemoryRouter initialEntries={[initialEntries]}>
         <Route path="/:provider" exact>
-          {children}
+          <Suspense fallback={<div>Loading</div>}>{children}</Suspense>
         </Route>
       </MemoryRouter>
-    </QueryClientProvider>
+    </QueryClientProviderV5>
   )
-
-const queryClient = new QueryClient({
-  defaultOptions: { queries: { retry: false } },
-})
 
 const server = setupServer()
 beforeAll(() => {
   server.listen()
 })
 
-beforeEach(() => {
+afterEach(() => {
+  queryClientV5.clear()
   server.resetHandlers()
-  queryClient.clear()
 })
 
 afterAll(() => {
@@ -69,7 +73,7 @@ describe('AdminLink', () => {
   })
 
   describe('user is not an admin', () => {
-    it('renders nothing', () => {
+    it('renders nothing', async () => {
       setup({
         activated: false,
         email: 'codecov@codecov.io',
@@ -80,7 +84,7 @@ describe('AdminLink', () => {
       })
 
       const { container } = render(<AdminLink />, { wrapper: wrapper({}) })
-      expect(container).toBeEmptyDOMElement()
+      await waitFor(() => expect(container).toBeEmptyDOMElement())
     })
   })
 })

--- a/src/layouts/Header/components/AdminLink/AdminLink.tsx
+++ b/src/layouts/Header/components/AdminLink/AdminLink.tsx
@@ -1,9 +1,19 @@
-import { useSelfHostedCurrentUser } from 'services/selfHosted'
+import { useSuspenseQuery as useSuspenseQueryV5 } from '@tanstack/react-queryV5'
+import { useParams } from 'react-router'
+
+import { SelfHostedCurrentUserQueryOpts } from 'services/selfHosted/SelfHostedCurrentUserQueryOpts'
 import A from 'ui/A'
 import Icon from 'ui/Icon'
 
+interface URLParams {
+  provider: string
+}
+
 function AdminLink() {
-  const { data: user } = useSelfHostedCurrentUser()
+  const { provider } = useParams<URLParams>()
+  const { data: user } = useSuspenseQueryV5(
+    SelfHostedCurrentUserQueryOpts({ provider })
+  )
 
   if (!user?.isAdmin) {
     return null

--- a/src/pages/AccountSettings/tabs/Profile/ActivationBanner/ActivationBanner.jsx
+++ b/src/pages/AccountSettings/tabs/Profile/ActivationBanner/ActivationBanner.jsx
@@ -2,8 +2,8 @@ import { useQueryClient } from '@tanstack/react-query'
 import { useSuspenseQuery as useSuspenseQueryV5 } from '@tanstack/react-queryV5'
 import { useParams } from 'react-router'
 
-import { useSelfHostedCurrentUser } from 'services/selfHosted'
 import { SelfHostedSeatsConfigQueryOpts } from 'services/selfHosted/SelfHostedSeatsConfigQueryOpts'
+import { SelfHostedCurrentUserQueryOpts } from 'services/selfHosted/SelfHostedCurrentUserQueryOpts'
 import A from 'ui/A'
 import Banner from 'ui/Banner'
 import BannerContent from 'ui/Banner/BannerContent'
@@ -41,9 +41,12 @@ function canChangeActivation({ seatConfig, currentUser }) {
 function ActivationBanner() {
   const { provider } = useParams()
   const queryClient = useQueryClient()
-  const { data: currentUser } = useSelfHostedCurrentUser()
+
   const { data: seatConfig } = useSuspenseQueryV5(
     SelfHostedSeatsConfigQueryOpts({ provider })
+  )
+  const { data: currentUser } = useSuspenseQueryV5(
+    SelfHostedCurrentUserQueryOpts({ provider })
   )
 
   const { canChange, displaySeatMsg } = canChangeActivation({

--- a/src/pages/AccountSettings/tabs/Profile/ActivationBanner/ActivationBanner.jsx
+++ b/src/pages/AccountSettings/tabs/Profile/ActivationBanner/ActivationBanner.jsx
@@ -1,9 +1,8 @@
-import { useQueryClient } from '@tanstack/react-query'
 import { useSuspenseQuery as useSuspenseQueryV5 } from '@tanstack/react-queryV5'
 import { useParams } from 'react-router'
 
-import { SelfHostedSeatsConfigQueryOpts } from 'services/selfHosted/SelfHostedSeatsConfigQueryOpts'
 import { SelfHostedCurrentUserQueryOpts } from 'services/selfHosted/SelfHostedCurrentUserQueryOpts'
+import { SelfHostedSeatsConfigQueryOpts } from 'services/selfHosted/SelfHostedSeatsConfigQueryOpts'
 import A from 'ui/A'
 import Banner from 'ui/Banner'
 import BannerContent from 'ui/Banner/BannerContent'
@@ -40,7 +39,6 @@ function canChangeActivation({ seatConfig, currentUser }) {
 
 function ActivationBanner() {
   const { provider } = useParams()
-  const queryClient = useQueryClient()
 
   const { data: seatConfig } = useSuspenseQueryV5(
     SelfHostedSeatsConfigQueryOpts({ provider })
@@ -55,7 +53,6 @@ function ActivationBanner() {
   })
 
   const { mutate } = useSelfActivationMutation({
-    queryClient,
     canChange,
   })
 

--- a/src/pages/AccountSettings/tabs/Profile/Profile.jsx
+++ b/src/pages/AccountSettings/tabs/Profile/Profile.jsx
@@ -1,7 +1,8 @@
+import { useSuspenseQuery as useSuspenseQueryV5 } from '@tanstack/react-queryV5'
 import PropTypes from 'prop-types'
 import { Redirect } from 'react-router-dom'
 
-import { useSelfHostedCurrentUser } from 'services/selfHosted'
+import { SelfHostedCurrentUserQueryOpts } from 'services/selfHosted/SelfHostedCurrentUserQueryOpts'
 
 import ActivationBanner from './ActivationBanner'
 import AdminBanner from './AdminBanner'
@@ -10,7 +11,9 @@ import NameEmailCard from './NameEmailCard'
 
 function Profile({ provider, owner }) {
   const yamlTab = `/account/${provider}/${owner}/yaml/`
-  const { data: currentUser } = useSelfHostedCurrentUser()
+  const { data: currentUser } = useSuspenseQueryV5(
+    SelfHostedCurrentUserQueryOpts({ provider })
+  )
 
   const isPersonalSettings =
     currentUser?.username?.toLowerCase() === owner?.toLowerCase()

--- a/src/pages/AdminSettings/AdminSettings.jsx
+++ b/src/pages/AdminSettings/AdminSettings.jsx
@@ -1,10 +1,11 @@
+import { useSuspenseQuery as useSuspenseQueryV5 } from '@tanstack/react-queryV5'
 import { lazy, Suspense } from 'react'
 import { Redirect, Switch, useParams } from 'react-router-dom'
 
 import { SentryRoute } from 'sentry'
 
 import SidebarLayout from 'layouts/SidebarLayout'
-import { useSelfHostedCurrentUser } from 'services/selfHosted'
+import { SelfHostedCurrentUserQueryOpts } from 'services/selfHosted/SelfHostedCurrentUserQueryOpts'
 import LoadingLogo from 'ui/LoadingLogo'
 import Spinner from 'ui/Spinner'
 
@@ -27,7 +28,9 @@ const SpinnerLoader = (
 
 function AdminSettings() {
   const { provider } = useParams()
-  const { data, isLoading } = useSelfHostedCurrentUser()
+  const { data, isLoading } = useSuspenseQueryV5(
+    SelfHostedCurrentUserQueryOpts({ provider })
+  )
 
   const redirectTo = `/admin/${provider}/access`
 

--- a/src/pages/AdminSettings/AdminSettings.test.jsx
+++ b/src/pages/AdminSettings/AdminSettings.test.jsx
@@ -1,7 +1,12 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import {
+  QueryClientProvider as QueryClientProviderV5,
+  QueryClient as QueryClientV5,
+} from '@tanstack/react-queryV5'
 import { render, screen, waitFor } from '@testing-library/react'
 import { graphql, http, HttpResponse } from 'msw'
 import { setupServer } from 'msw/node'
+import { Suspense } from 'react'
 import { MemoryRouter, Route } from 'react-router-dom'
 
 import AdminSettings from './AdminSettings'
@@ -21,23 +26,30 @@ const user = {
 const queryClient = new QueryClient({
   defaultOptions: { queries: { retry: false } },
 })
+const queryClientV5 = new QueryClientV5({
+  defaultOptions: { queries: { retry: false } },
+})
 
 let testLocation
 const wrapper =
   ({ initialEntries, path }) =>
   ({ children }) => (
-    <QueryClientProvider client={queryClient}>
-      <MemoryRouter initialEntries={initialEntries}>
-        <Route path={path}>{children}</Route>
-        <Route
-          path="*"
-          render={({ location }) => {
-            testLocation = location
-            return null
-          }}
-        />
-      </MemoryRouter>
-    </QueryClientProvider>
+    <QueryClientProviderV5 client={queryClientV5}>
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter initialEntries={initialEntries}>
+          <Suspense fallback={<div>Loading</div>}>
+            <Route path={path}>{children}</Route>
+            <Route
+              path="*"
+              render={({ location }) => {
+                testLocation = location
+                return null
+              }}
+            />
+          </Suspense>
+        </MemoryRouter>
+      </QueryClientProvider>
+    </QueryClientProviderV5>
   )
 
 const server = setupServer()
@@ -45,9 +57,10 @@ beforeAll(() => {
   server.listen()
 })
 
-beforeEach(() => {
-  server.resetHandlers()
+afterEach(() => {
   queryClient.clear()
+  queryClientV5.clear()
+  server.resetHandlers()
 })
 
 afterAll(() => {

--- a/src/pages/RepoPage/ActivationAlert/ActivationRequiredSelfHosted/ActivationRequiredSelfHosted.test.tsx
+++ b/src/pages/RepoPage/ActivationAlert/ActivationRequiredSelfHosted/ActivationRequiredSelfHosted.test.tsx
@@ -13,11 +13,8 @@ import { vi } from 'vitest'
 import ActivationRequiredSelfHosted from './ActivationRequiredSelfHosted'
 
 const queryClient = new QueryClient({
-  defaultOptions: {
-    queries: { retry: false, suspense: false },
-  },
+  defaultOptions: { queries: { retry: false, suspense: false } },
 })
-
 const queryClientV5 = new QueryClientV5({
   defaultOptions: { queries: { retry: false } },
 })
@@ -35,7 +32,6 @@ const wrapper: React.FC<React.PropsWithChildren> = ({ children }) => (
 )
 
 const server = setupServer()
-
 beforeAll(() => {
   server.listen({ onUnhandledRequest: 'warn' })
   console.error = () => {}

--- a/src/pages/RepoPage/ActivationAlert/ActivationRequiredSelfHosted/ActivationRequiredSelfHosted.tsx
+++ b/src/pages/RepoPage/ActivationAlert/ActivationRequiredSelfHosted/ActivationRequiredSelfHosted.tsx
@@ -2,7 +2,7 @@ import { useSuspenseQuery as useSuspenseQueryV5 } from '@tanstack/react-queryV5'
 import { useParams } from 'react-router'
 
 import upsideDownUmbrella from 'layouts/shared/NetworkErrorBoundary/assets/error-upsidedown-umbrella.svg'
-import { useSelfHostedCurrentUser } from 'services/selfHosted'
+import { SelfHostedCurrentUserQueryOpts } from 'services/selfHosted/SelfHostedCurrentUserQueryOpts'
 import { SelfHostedSeatsConfigQueryOpts } from 'services/selfHosted/SelfHostedSeatsConfigQueryOpts'
 import A from 'ui/A'
 import Button from 'ui/Button'
@@ -62,9 +62,11 @@ interface URLParams {
 
 function ActivationRequiredSelfHosted() {
   const { provider } = useParams<URLParams>()
-  const { data } = useSelfHostedCurrentUser()
   const { data: selfHostedSeats } = useSuspenseQueryV5(
     SelfHostedSeatsConfigQueryOpts({ provider })
+  )
+  const { data } = useSuspenseQueryV5(
+    SelfHostedCurrentUserQueryOpts({ provider })
   )
 
   const hasSelfHostedSeats =

--- a/src/pages/RepoPage/CoverageOnboarding/ActivationBanner/ActivationRequiredSelfHosted/ActivationRequiredSelfHosted.test.tsx
+++ b/src/pages/RepoPage/CoverageOnboarding/ActivationBanner/ActivationRequiredSelfHosted/ActivationRequiredSelfHosted.test.tsx
@@ -17,7 +17,6 @@ const queryClient = new QueryClient({
 const queryClientV5 = new QueryClientV5({
   defaultOptions: { queries: { retry: false } },
 })
-
 const wrapper: React.FC<React.PropsWithChildren> = ({ children }) => (
   <QueryClientProviderV5 client={queryClientV5}>
     <QueryClientProvider client={queryClient}>

--- a/src/pages/RepoPage/CoverageOnboarding/ActivationBanner/ActivationRequiredSelfHosted/ActivationRequiredSelfHosted.tsx
+++ b/src/pages/RepoPage/CoverageOnboarding/ActivationBanner/ActivationRequiredSelfHosted/ActivationRequiredSelfHosted.tsx
@@ -1,7 +1,7 @@
 import { useSuspenseQuery as useSuspenseQueryV5 } from '@tanstack/react-queryV5'
 import { useParams } from 'react-router'
 
-import { useSelfHostedCurrentUser } from 'services/selfHosted'
+import { SelfHostedCurrentUserQueryOpts } from 'services/selfHosted/SelfHostedCurrentUserQueryOpts'
 import { SelfHostedSeatsConfigQueryOpts } from 'services/selfHosted/SelfHostedSeatsConfigQueryOpts'
 import A from 'ui/A'
 import Banner from 'ui/Banner'
@@ -67,9 +67,11 @@ interface URLParams {
 
 function ActivationRequiredSelfHosted() {
   const { provider } = useParams<URLParams>()
-  const { data } = useSelfHostedCurrentUser()
   const { data: selfHostedSeats } = useSuspenseQueryV5(
     SelfHostedSeatsConfigQueryOpts({ provider })
+  )
+  const { data } = useSuspenseQueryV5(
+    SelfHostedCurrentUserQueryOpts({ provider })
   )
 
   const hasSelfHostedSeats =

--- a/src/services/selfHosted/SelfHostedCurrentUserQueryOpts.ts
+++ b/src/services/selfHosted/SelfHostedCurrentUserQueryOpts.ts
@@ -1,9 +1,8 @@
-import { useQuery } from '@tanstack/react-query'
-import { useParams } from 'react-router-dom'
+import { queryOptions as queryOptionsV5 } from '@tanstack/react-queryV5'
 import { z } from 'zod'
 
 import Api from 'shared/api'
-import { NetworkErrorObject, rejectNetworkError } from 'shared/api/helpers'
+import { rejectNetworkError } from 'shared/api/helpers'
 
 const SelfHostedCurrentUserSchema = z
   .object({
@@ -16,14 +15,14 @@ const SelfHostedCurrentUserSchema = z
   })
   .nullable()
 
-interface URLParams {
+interface SelfHostedCurrentUserQueryArgs {
   provider: string
 }
 
-export const useSelfHostedCurrentUser = (options = {}) => {
-  const { provider } = useParams<URLParams>()
-
-  return useQuery({
+export const SelfHostedCurrentUserQueryOpts = ({
+  provider,
+}: SelfHostedCurrentUserQueryArgs) => {
+  return queryOptionsV5({
     queryKey: ['SelfHostedCurrentUser', provider],
     queryFn: ({ signal }) =>
       Api.get({ provider, path: '/users/current', signal }).then((res) => {
@@ -33,11 +32,11 @@ export const useSelfHostedCurrentUser = (options = {}) => {
           return rejectNetworkError({
             status: 404,
             data: {},
-            dev: 'useSelfHostedCurrentUser - 404 schema parsing failed',
-          } satisfies NetworkErrorObject)
+            dev: 'SelfHostedCurrentUserQueryOpts - 404 schema parsing failed',
+            error: parsedData.error,
+          })
         }
         return parsedData.data
       }),
-    ...options,
   })
 }

--- a/src/services/selfHosted/index.ts
+++ b/src/services/selfHosted/index.ts
@@ -1,1 +1,0 @@
-export * from './useSelfHostedCurrentUser'


### PR DESCRIPTION
# Description

This PR migrates the `useSelfHostedCurrentUser` to the TS Query V5 queryOptions API version `SelfHostedCurrentUserQueryOpts`

Ticket: codecov/engineering-team#2961

# Notable Changes

- Migrate `useSelfHostedCurrentUser` to `SelfHostedCurrentUserQueryOpts`
- Migrate `useSelfActivationMutation` to TS Query V5
- Update usage in `AdminLink`, `Profile`, `ActivationBanner`, `useSelfActivationMutation`, `AdminSettings`, ActivationRequiredSelfHosted` x 2