### PR TITLE
ref: Migrate to `isTeamPlan` GQ field 

### DIFF
--- a/src/pages/AccountSettings/AccountSettings.test.jsx
+++ b/src/pages/AccountSettings/AccountSettings.test.jsx
@@ -163,6 +163,9 @@ describe('AccountSettings', () => {
                 value: planValue,
                 isEnterprisePlan: planValue === Plans.USERS_ENTERPRISEM,
                 isFreePlan: planValue === Plans.USERS_BASIC,
+                isTeamPlan:
+                  planValue === Plans.USERS_TEAMM ||
+                  planValue === Plans.USERS_TEAMY,
               },
             },
           },

--- a/src/pages/AccountSettings/AccountSettingsSideMenu.test.jsx
+++ b/src/pages/AccountSettings/AccountSettingsSideMenu.test.jsx
@@ -151,6 +151,9 @@ describe('AccountSettingsSideMenu', () => {
                 value: planValue,
                 isEnterprisePlan: planValue === Plans.USERS_ENTERPRISEM,
                 isFreePlan: planValue === Plans.USERS_BASIC,
+                isTeamPlan:
+                  planValue === Plans.USERS_TEAMM ||
+                  planValue === Plans.USERS_TEAMY,
               },
             },
           },

--- a/src/pages/DefaultOrgSelector/DefaultOrgSelector.test.jsx
+++ b/src/pages/DefaultOrgSelector/DefaultOrgSelector.test.jsx
@@ -214,6 +214,8 @@ describe('DefaultOrgSelector', () => {
                 ...mockTrialData,
                 isEnterprisePlan: false,
                 isFreePlan: false,
+                isTeamPlan:
+                  value === Plans.USERS_TEAMM || value === Plans.USERS_TEAMY,
                 trialStatus,
                 value,
               },

--- a/src/pages/MembersPage/MembersActivation/Activation/Activation.test.jsx
+++ b/src/pages/MembersPage/MembersActivation/Activation/Activation.test.jsx
@@ -28,6 +28,7 @@ const mockedAccountDetails = {
 const mockPlanData = {
   isEnterprisePlan: false,
   isFreePlan: true,
+  isTeamPlan: false,
   baseUnitPrice: 10,
   benefits: [],
   billingRate: BillingRate.MONTHLY,

--- a/src/pages/MembersPage/MembersActivation/MembersActivation.test.jsx
+++ b/src/pages/MembersPage/MembersActivation/MembersActivation.test.jsx
@@ -42,6 +42,7 @@ const mockPlanData = {
   hasSeatsLeft: true,
   isEnterprisePlan: false,
   isFreePlan: false,
+  isTeamPlan: false,
 }
 
 const server = setupServer()

--- a/src/pages/MembersPage/MembersList/MembersList.test.jsx
+++ b/src/pages/MembersPage/MembersList/MembersList.test.jsx
@@ -130,6 +130,9 @@ describe('MembersList', () => {
                 ...mockPlanData,
                 value: planName,
                 isFreePlan: planName === Plans.USERS_BASIC,
+                isTeamPlan:
+                  planName === Plans.USERS_TEAMM ||
+                  planName === Plans.USERS_TEAMY,
                 planUserCount,
                 hasSeatsLeft,
               },

--- a/src/pages/MembersPage/MembersList/MembersTable/MembersTable.test.jsx
+++ b/src/pages/MembersPage/MembersList/MembersTable/MembersTable.test.jsx
@@ -158,6 +158,9 @@ describe('MembersTable', () => {
                 ...mockPlanData,
                 value: planName,
                 isFreePlan: planName === Plans.USERS_BASIC,
+                isTeamPlan:
+                  planName === Plans.USERS_TEAMM ||
+                  planName === Plans.USERS_TEAMY,
                 planUserCount,
                 hasSeatsLeft,
               },

--- a/src/pages/OwnerPage/HeaderBanners/ExceededUploadsAlert/ExceededUploadsAlert.test.jsx
+++ b/src/pages/OwnerPage/HeaderBanners/ExceededUploadsAlert/ExceededUploadsAlert.test.jsx
@@ -39,6 +39,7 @@ const mockPlanDataResponse = {
   hasSeatsLeft: true,
   isEnterprisePlan: false,
   isFreePlan: false,
+  isTeamPlan: false,
 }
 
 beforeAll(() => {

--- a/src/pages/OwnerPage/HeaderBanners/HeaderBanners.test.jsx
+++ b/src/pages/OwnerPage/HeaderBanners/HeaderBanners.test.jsx
@@ -42,6 +42,7 @@ const mockPlanDataResponse = {
   hasSeatsLeft: true,
   isEnterprisePlan: false,
   isFreePlan: false,
+  isTeamPlan: false,
 }
 
 const mockPlanDataResponseNoUploadLimit = {

--- a/src/pages/OwnerPage/HeaderBanners/ReachingUploadLimitAlert/ReachingUploadLimitAlert.test.jsx
+++ b/src/pages/OwnerPage/HeaderBanners/ReachingUploadLimitAlert/ReachingUploadLimitAlert.test.jsx
@@ -32,6 +32,7 @@ const mockPlanDataResponse = {
   value: Plans.USERS_PR_INAPPM,
   isEnterprisePlan: false,
   isFreePlan: false,
+  isTeamPlan: false,
   trialStatus: TrialStatuses.NOT_STARTED,
   trialStartDate: '',
   trialEndDate: '',

--- a/src/pages/OwnerPage/Tabs/TrialReminder/TrialReminder.test.tsx
+++ b/src/pages/OwnerPage/Tabs/TrialReminder/TrialReminder.test.tsx
@@ -103,6 +103,9 @@ describe('TrialReminder', () => {
                 trialEndDate,
                 value: planValue,
                 isFreePlan: planValue === Plans.USERS_BASIC,
+                isTeamPlan:
+                  planValue === Plans.USERS_TEAMM ||
+                  planValue === Plans.USERS_TEAMY,
               },
             },
           },

--- a/src/pages/PlanPage/subRoutes/CancelPlanPage/CancelPlanPage.test.tsx
+++ b/src/pages/PlanPage/subRoutes/CancelPlanPage/CancelPlanPage.test.tsx
@@ -80,6 +80,7 @@ const mockPlanData = {
   hasSeatsLeft: true,
   isEnterprisePlan: false,
   isFreePlan: false,
+  isTeamPlan: false,
 }
 
 const queryClient = new QueryClient({
@@ -157,6 +158,9 @@ describe('CancelPlanPage', () => {
                 value: planValue,
                 isEnterprisePlan: planValue === Plans.USERS_ENTERPRISEM,
                 isFreePlan: planValue === Plans.USERS_BASIC,
+                isTeamPlan:
+                  planValue === Plans.USERS_TEAMM ||
+                  planValue === Plans.USERS_TEAMY,
               },
             },
           },

--- a/src/pages/PlanPage/subRoutes/CurrentOrgPlan/CurrentOrgPlan.test.tsx
+++ b/src/pages/PlanPage/subRoutes/CurrentOrgPlan/CurrentOrgPlan.test.tsx
@@ -52,6 +52,7 @@ const mockPlanDataResponse = {
   hasSeatsLeft: true,
   isEnterprisePlan: false,
   isFreePlan: false,
+  isTeamPlan: false,
 }
 
 const mockEnterpriseAccountDetailsNinetyPercent = {

--- a/src/pages/PlanPage/subRoutes/CurrentOrgPlan/CurrentPlanCard/CurrentPlanCard.test.tsx
+++ b/src/pages/PlanPage/subRoutes/CurrentOrgPlan/CurrentPlanCard/CurrentPlanCard.test.tsx
@@ -26,6 +26,7 @@ const proPlanDetails = {
     billingRate: null,
     isEnterprisePlan: false,
     isFreePlan: false,
+    isTeamPlan: true,
   },
 }
 
@@ -42,6 +43,7 @@ const freePlanDetails = {
     ],
     isEnterprisePlan: false,
     isFreePlan: true,
+    isTeamPlan: false,
   },
 }
 
@@ -58,6 +60,7 @@ const enterprisePlan = {
     ],
     isEnterprisePlan: true,
     isFreePlan: false,
+    isTeamPlan: false,
   },
 }
 
@@ -74,6 +77,7 @@ const usesInvoiceTeamPlan = {
     ],
     isEnterprisePlan: false,
     isFreePlan: false,
+    isTeamPlan: true,
   },
   usesInvoice: true,
 }
@@ -88,6 +92,7 @@ const trialPlanDetails = {
     value: Plans.USERS_TRIAL,
     isEnterprisePlan: false,
     isFreePlan: false,
+    isTeamPlan: true,
   },
 }
 

--- a/src/pages/PlanPage/subRoutes/CurrentOrgPlan/CurrentPlanCard/FreePlanCard/FreePlanCard.test.jsx
+++ b/src/pages/PlanPage/subRoutes/CurrentOrgPlan/CurrentPlanCard/FreePlanCard/FreePlanCard.test.jsx
@@ -127,6 +127,7 @@ const freePlan = {
   monthlyUploadLimit: null,
   isFreePlan: true,
   isEnterprisePlan: false,
+  isTeamPlan: false,
 }
 
 const scheduledPhase = {
@@ -224,6 +225,9 @@ describe('FreePlanCard', () => {
                 value: planValue,
                 planUserCount,
                 isFreePlan: planValue === Plans.USERS_BASIC,
+                isTeamPlan:
+                  planValue === Plans.USERS_TEAMM ||
+                  planValue === Plans.USERS_TEAMY,
               },
               pretrialPlan: mockPreTrialPlanInfo,
             },

--- a/src/pages/PlanPage/subRoutes/CurrentOrgPlan/CurrentPlanCard/FreePlanCard/PlanUpgradeTeam/PlanUpgradeTeam.test.jsx
+++ b/src/pages/PlanPage/subRoutes/CurrentOrgPlan/CurrentPlanCard/FreePlanCard/PlanUpgradeTeam/PlanUpgradeTeam.test.jsx
@@ -15,6 +15,7 @@ vi.mock('shared/plan/BenefitList', () => ({ default: () => 'BenefitsList' }))
 const mockPlanBasic = {
   isEnterprisePlan: false,
   isFreePlan: true,
+  isTeamPlan: false,
   baseUnitPrice: 0,
   benefits: ['Up to # user', 'Unlimited public repositories'],
   billingRate: BillingRate.MONTHLY,
@@ -33,6 +34,7 @@ const mockPlanBasic = {
 const mockPlanPro = {
   isEnterprisePlan: false,
   isFreePlan: false,
+  isTeamPlan: false,
   baseUnitPrice: 10,
   benefits: ['Up to # user', 'Unlimited public repositories'],
   billingRate: BillingRate.MONTHLY,
@@ -51,6 +53,7 @@ const mockPlanPro = {
 const mockPlanTrialing = {
   isEnterprisePlan: false,
   isFreePlan: false,
+  isTeamPlan: false,
   baseUnitPrice: 10,
   benefits: ['Up to # user', 'Unlimited public repositories'],
   billingRate: BillingRate.MONTHLY,

--- a/src/pages/PlanPage/subRoutes/CurrentOrgPlan/CurrentPlanCard/FreePlanCard/ProPlanSubheading/ProPlanSubheading.test.tsx
+++ b/src/pages/PlanPage/subRoutes/CurrentOrgPlan/CurrentPlanCard/FreePlanCard/ProPlanSubheading/ProPlanSubheading.test.tsx
@@ -25,6 +25,7 @@ const mockResponse = {
   hasSeatsLeft: true,
   isEnterprisePlan: false,
   isFreePlan: true,
+  isTeamPlan: false,
 }
 
 const server = setupServer()

--- a/src/pages/PlanPage/subRoutes/CurrentOrgPlan/CurrentPlanCard/PaidPlanCard/PaidPlanCard.test.tsx
+++ b/src/pages/PlanPage/subRoutes/CurrentOrgPlan/CurrentPlanCard/PaidPlanCard/PaidPlanCard.test.tsx
@@ -30,6 +30,7 @@ vi.mock('shared/plan/ScheduledPlanDetails', () => ({
 const mockProPlan = {
   isEnterprisePlan: false,
   isFreePlan: false,
+  isTeamPlan: false,
   marketingName: 'Pro',
   value: Plans.USERS_PR_INAPPM,
   billingRate: BillingRate.MONTHLY,
@@ -48,6 +49,7 @@ const mockProPlan = {
 const mockTeamPlan = {
   isEnterprisePlan: false,
   isFreePlan: false,
+  isTeamPlan: true,
   marketingName: 'Team',
   value: Plans.USERS_TEAMM,
   billingRate: BillingRate.MONTHLY,

--- a/src/pages/PlanPage/subRoutes/CurrentOrgPlan/CurrentPlanCard/PaidPlanCard/PaidPlanCard.tsx
+++ b/src/pages/PlanPage/subRoutes/CurrentOrgPlan/CurrentPlanCard/PaidPlanCard/PaidPlanCard.tsx
@@ -6,7 +6,6 @@ import { PlanPageDataQueryOpts } from 'pages/PlanPage/queries/PlanPageDataQueryO
 import { useAccountDetails, usePlanData } from 'services/account'
 import BenefitList from 'shared/plan/BenefitList'
 import ScheduledPlanDetails from 'shared/plan/ScheduledPlanDetails'
-import { isTeamPlan } from 'shared/utils/billing'
 
 import ActionsBilling from '../shared/ActionsBilling/ActionsBilling'
 import PlanPricing from '../shared/PlanPricing'
@@ -75,7 +74,7 @@ function PaidPlanCard() {
             <ScheduledPlanDetails scheduledPhase={scheduledPhase} />
           ) : null}
         </div>
-        {isNumber(numberOfUploads) && isTeamPlan(plan?.value) ? (
+        {isNumber(numberOfUploads) && plan?.isTeamPlan ? (
           <div>
             <p className="mb-2 text-xs font-semibold">Private repo uploads</p>
             <p className="text-xs text-ds-gray-senary">

--- a/src/pages/PlanPage/subRoutes/CurrentOrgPlan/CurrentPlanCard/shared/ActionsBilling/ActionsBilling.test.jsx
+++ b/src/pages/PlanPage/subRoutes/CurrentOrgPlan/CurrentPlanCard/shared/ActionsBilling/ActionsBilling.test.jsx
@@ -229,6 +229,9 @@ describe('Actions Billing', () => {
                 ...trialPlanData.plan,
                 value: accountDetails.plan.value,
                 isFreePlan: accountDetails.plan.value === Plans.USERS_BASIC,
+                isTeamPlan:
+                  accountDetails.plan.value === Plans.USERS_TEAMM ||
+                  accountDetails.plan.value === Plans.USERS_TEAMY,
               },
               hasPrivateRepos,
             },

--- a/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeDetails/ProPlanDetails/ProPlanDetails.test.jsx
+++ b/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeDetails/ProPlanDetails/ProPlanDetails.test.jsx
@@ -187,6 +187,7 @@ describe('ProPlanDetails', () => {
               plan: {
                 ...mockPlanData,
                 isFreePlan: !isProPlan && !isSentryPlan,
+                isTeamPlan: false,
                 trialStatus: isOngoingTrial
                   ? TrialStatuses.ONGOING
                   : TrialStatuses.CANNOT_TRIAL,

--- a/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeDetails/SentryPlanDetails/SentryPlanDetails.test.jsx
+++ b/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeDetails/SentryPlanDetails/SentryPlanDetails.test.jsx
@@ -180,6 +180,7 @@ describe('SentryPlanDetails', () => {
               plan: {
                 ...mockPlanData,
                 isFreePlan: !isProPlan,
+                isTeamPlan: false,
                 trialStatus: isOngoingTrial
                   ? TrialStatuses.ONGOING
                   : TrialStatuses.CANNOT_TRIAL,

--- a/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeDetails/TeamPlanDetails/TeamPlanDetails.test.jsx
+++ b/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeDetails/TeamPlanDetails/TeamPlanDetails.test.jsx
@@ -93,6 +93,7 @@ const mockPlanData = {
   hasSeatsLeft: true,
   isEnterprisePlan: false,
   isFreePlan: false,
+  isTeamPlan: false,
 }
 
 const server = setupServer()

--- a/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeDetails/UpgradeDetails.tsx
+++ b/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeDetails/UpgradeDetails.tsx
@@ -1,14 +1,17 @@
+import { IndividualPlan } from 'services/account'
 import { isSentryPlan, Plans } from 'shared/utils/billing'
 
 import ProPlanDetails from './ProPlanDetails'
 import SentryPlanDetails from './SentryPlanDetails'
 import TeamPlanDetails from './TeamPlanDetails'
-import { IndividualPlan } from 'services/account'
 
 function UpgradeDetails({ selectedPlan }: { selectedPlan: IndividualPlan }) {
   if (isSentryPlan(selectedPlan.value)) {
     return <SentryPlanDetails />
-  } else if (selectedPlan?.value === Plans.USERS_TEAMM || selectedPlan?.value === Plans.USERS_TEAMY) {
+  } else if (
+    selectedPlan?.value === Plans.USERS_TEAMM ||
+    selectedPlan?.value === Plans.USERS_TEAMY
+  ) {
     return <TeamPlanDetails />
   } else {
     return <ProPlanDetails />

--- a/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeDetails/UpgradeDetails.tsx
+++ b/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeDetails/UpgradeDetails.tsx
@@ -1,14 +1,14 @@
-import { IndividualPlan } from 'services/account'
-import { isSentryPlan, isTeamPlan } from 'shared/utils/billing'
+import { isSentryPlan, Plans } from 'shared/utils/billing'
 
 import ProPlanDetails from './ProPlanDetails'
 import SentryPlanDetails from './SentryPlanDetails'
 import TeamPlanDetails from './TeamPlanDetails'
+import { IndividualPlan } from 'services/account'
 
 function UpgradeDetails({ selectedPlan }: { selectedPlan: IndividualPlan }) {
   if (isSentryPlan(selectedPlan.value)) {
     return <SentryPlanDetails />
-  } else if (isTeamPlan(selectedPlan.value)) {
+  } else if (selectedPlan?.value === Plans.USERS_TEAMM || selectedPlan?.value === Plans.USERS_TEAMY) {
     return <TeamPlanDetails />
   } else {
     return <ProPlanDetails />

--- a/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/Controllers/Controller.tsx
+++ b/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/Controllers/Controller.tsx
@@ -1,8 +1,7 @@
 import { UseFormRegister, UseFormSetValue } from 'react-hook-form'
 
 import { IndividualPlan } from 'services/account'
-import { isSentryPlan } from 'shared/utils/billing'
-import { Plans } from 'shared/utils/billing'
+import { isSentryPlan, Plans } from 'shared/utils/billing'
 
 import ProPlanController from './ProPlanController'
 import SentryPlanController from './SentryPlanController'
@@ -31,7 +30,10 @@ const Controller: React.FC<BillingControlsProps> = ({
   setFormValue,
   setSelectedPlan,
 }) => {
-  if (newPlan?.value === Plans.USERS_TEAMM || newPlan?.value === Plans.USERS_TEAMY) {
+  if (
+    newPlan?.value === Plans.USERS_TEAMM ||
+    newPlan?.value === Plans.USERS_TEAMY
+  ) {
     return (
       <TeamPlanController
         newPlan={newPlan}

--- a/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/Controllers/Controller.tsx
+++ b/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/Controllers/Controller.tsx
@@ -1,7 +1,8 @@
 import { UseFormRegister, UseFormSetValue } from 'react-hook-form'
 
 import { IndividualPlan } from 'services/account'
-import { isSentryPlan, isTeamPlan } from 'shared/utils/billing'
+import { isSentryPlan } from 'shared/utils/billing'
+import { Plans } from 'shared/utils/billing'
 
 import ProPlanController from './ProPlanController'
 import SentryPlanController from './SentryPlanController'
@@ -30,7 +31,7 @@ const Controller: React.FC<BillingControlsProps> = ({
   setFormValue,
   setSelectedPlan,
 }) => {
-  if (isTeamPlan(newPlan?.value)) {
+  if (newPlan?.value === Plans.USERS_TEAMM || newPlan?.value === Plans.USERS_TEAMY) {
     return (
       <TeamPlanController
         newPlan={newPlan}

--- a/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/Controllers/ProPlanController/BillingOptions/BillingOptions.test.tsx
+++ b/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/Controllers/ProPlanController/BillingOptions/BillingOptions.test.tsx
@@ -70,6 +70,7 @@ const mockPlanDataResponse = {
   hasSeatsLeft: true,
   isEnterprisePlan: false,
   isFreePlan: false,
+  isTeamPlan: true,
 }
 
 const server = setupServer()

--- a/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/Controllers/ProPlanController/ProPlanController.test.tsx
+++ b/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/Controllers/ProPlanController/ProPlanController.test.tsx
@@ -130,6 +130,7 @@ const mockPlanDataResponseMonthly = {
   hasSeatsLeft: true,
   isEnterprisePlan: false,
   isFreePlan: false,
+  isTeamPlan: false,
 }
 
 const mockPlanDataResponseYearly = {
@@ -148,6 +149,7 @@ const mockPlanDataResponseYearly = {
   hasSeatsLeft: true,
   isEnterprisePlan: false,
   isFreePlan: false,
+  isTeamPlan: false,
 }
 
 const queryClient = new QueryClient({

--- a/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/Controllers/SentryPlanController/BillingOptions/BillingOptions.test.tsx
+++ b/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/Controllers/SentryPlanController/BillingOptions/BillingOptions.test.tsx
@@ -70,6 +70,7 @@ const mockPlanDataResponse = {
   hasSeatsLeft: true,
   isEnterprisePlan: false,
   isFreePlan: false,
+  isTeamPlan: false,
 }
 
 const server = setupServer()

--- a/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/Controllers/SentryPlanController/SentryPlanController.test.tsx
+++ b/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/Controllers/SentryPlanController/SentryPlanController.test.tsx
@@ -116,6 +116,7 @@ const mockPlanDataResponseMonthly = {
   hasSeatsLeft: true,
   isEnterprisePlan: false,
   isFreePlan: false,
+  isTeamPlan: false,
 }
 
 const mockPlanDataResponseYearly = {
@@ -134,6 +135,7 @@ const mockPlanDataResponseYearly = {
   hasSeatsLeft: true,
   isEnterprisePlan: false,
   isFreePlan: false,
+  isTeamPlan: false,
 }
 
 const queryClient = new QueryClient({

--- a/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/Controllers/TeamPlanController/BillingOptions/BillingOptions.test.tsx
+++ b/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/Controllers/TeamPlanController/BillingOptions/BillingOptions.test.tsx
@@ -60,6 +60,7 @@ const mockPlanDataResponse = {
   planUserCount: 1,
   hasSeatsLeft: true,
   isFreePlan: false,
+  isTeamPlan: true,
 }
 
 const server = setupServer()

--- a/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/Controllers/TeamPlanController/ErrorBanner/ErrorBanner.test.tsx
+++ b/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/Controllers/TeamPlanController/ErrorBanner/ErrorBanner.test.tsx
@@ -134,6 +134,7 @@ describe('ErrorBanner', () => {
           planUserCount: 1,
           isEnterprisePlan: false,
           isFreePlan: false,
+          isTeamPlan: false,
         }
         if (planValue === Plans.USERS_BASIC) {
           return HttpResponse.json({

--- a/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/Controllers/TeamPlanController/TeamPlanController.test.tsx
+++ b/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/Controllers/TeamPlanController/TeamPlanController.test.tsx
@@ -115,6 +115,7 @@ const mockPlanDataResponseMonthly = {
   hasSeatsLeft: true,
   isEnterprisePlan: false,
   isFreePlan: false,
+  isTeamPlan: false,
 }
 
 const mockPlanDataResponseYearly = {
@@ -133,6 +134,7 @@ const mockPlanDataResponseYearly = {
   hasSeatsLeft: true,
   isEnterprisePlan: false,
   isFreePlan: false,
+  isTeamPlan: false,
 }
 
 const queryClient = new QueryClient({

--- a/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/PlanTypeOptions/PlanTypeOptions.test.tsx
+++ b/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/PlanTypeOptions/PlanTypeOptions.test.tsx
@@ -189,6 +189,7 @@ describe('PlanTypeOptions', () => {
           planUserCount: 1,
           isEnterprisePlan: false,
           isFreePlan: false,
+          isTeamPlan: false,
         }
         if (planValue === Plans.USERS_BASIC) {
           return HttpResponse.json({

--- a/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/PlanTypeOptions/PlanTypeOptions.tsx
+++ b/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/PlanTypeOptions/PlanTypeOptions.tsx
@@ -1,11 +1,7 @@
 import { UseFormSetValue } from 'react-hook-form'
 import { useParams } from 'react-router-dom'
 
-import {
-  IndividualPlan,
-  useAvailablePlans,
-  usePlanData,
-} from 'services/account'
+import { IndividualPlan, useAvailablePlans, usePlanData } from 'services/account'
 import { useLocationParams } from 'services/navigation'
 import { TierNames } from 'services/tier'
 import {
@@ -13,8 +9,8 @@ import {
   canApplySentryUpgrade,
   findProPlans,
   findSentryPlans,
+  Plans,
   findTeamPlans,
-  isTeamPlan,
   shouldDisplayTeamCard,
 } from 'shared/utils/billing'
 import { TEAM_PLAN_MAX_ACTIVE_USERS } from 'shared/utils/upgradeForm'
@@ -55,13 +51,13 @@ const PlanTypeOptions: React.FC<PlanTypeOptionsProps> = ({
   const yearlyProPlan = isSentryUpgrade ? sentryPlanYear : proPlanYear
   const monthlyProPlan = isSentryUpgrade ? sentryPlanMonth : proPlanMonth
 
-  const currentFormValue = newPlan?.value
   const monthlyPlan = newPlan?.billingRate === BillingRate.MONTHLY
 
   let planOption = null
   if (
     (hasTeamPlans && planParam === TierNames.TEAM) ||
-    isTeamPlan(currentFormValue)
+    newPlan?.value === Plans.USERS_TEAMM ||
+    newPlan?.value === Plans.USERS_TEAMY
   ) {
     planOption = TierName.TEAM
   } else {

--- a/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/PlanTypeOptions/PlanTypeOptions.tsx
+++ b/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/PlanTypeOptions/PlanTypeOptions.tsx
@@ -1,7 +1,11 @@
 import { UseFormSetValue } from 'react-hook-form'
 import { useParams } from 'react-router-dom'
 
-import { IndividualPlan, useAvailablePlans, usePlanData } from 'services/account'
+import {
+  IndividualPlan,
+  useAvailablePlans,
+  usePlanData,
+} from 'services/account'
 import { useLocationParams } from 'services/navigation'
 import { TierNames } from 'services/tier'
 import {
@@ -9,8 +13,8 @@ import {
   canApplySentryUpgrade,
   findProPlans,
   findSentryPlans,
-  Plans,
   findTeamPlans,
+  Plans,
   shouldDisplayTeamCard,
 } from 'shared/utils/billing'
 import { TEAM_PLAN_MAX_ACTIVE_USERS } from 'shared/utils/upgradeForm'

--- a/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/UpdateBlurb/UpdateBlurb.test.tsx
+++ b/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/UpdateBlurb/UpdateBlurb.test.tsx
@@ -16,6 +16,7 @@ const planChunk = {
   planUserCount: 2,
   isEnterprisePlan: false,
   isFreePlan: false,
+  isTeamPlan: true,
   hasSeatsLeft: true,
   isTeamPlan: false,
 }

--- a/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/UpdateBlurb/UpdateBlurb.test.tsx
+++ b/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/UpdateBlurb/UpdateBlurb.test.tsx
@@ -17,6 +17,7 @@ const planChunk = {
   isEnterprisePlan: false,
   isFreePlan: false,
   hasSeatsLeft: true,
+  isTeamPlan: false,
 }
 
 const proPlanYear = {
@@ -31,6 +32,7 @@ const proPlanYear = {
     'Priority Support',
   ],
   monthlyUploadLimit: null,
+  isTeamPlan: false,
 }
 
 const teamPlanYear = {
@@ -40,6 +42,7 @@ const teamPlanYear = {
   marketingName: 'Users Team',
   monthlyUploadLimit: 2500,
   value: Plans.USERS_TEAMY,
+  isTeamPlan: true,
 }
 
 const teamPlanMonth = {
@@ -49,6 +52,7 @@ const teamPlanMonth = {
   marketingName: 'Users Team',
   monthlyUploadLimit: 2500,
   value: Plans.USERS_TEAMM,
+  isTeamPlan: true,
 }
 
 const freePlan = {
@@ -58,6 +62,7 @@ const freePlan = {
   marketingName: 'Users Team',
   monthlyUploadLimit: 2500,
   value: Plans.USERS_BASIC,
+  isTeamPlan: false,
 }
 
 type WrapperClosure = (
@@ -65,13 +70,13 @@ type WrapperClosure = (
 ) => React.FC<React.PropsWithChildren>
 const wrapper: WrapperClosure =
   (initialEntries = ['/plan/gh/codecov/upgrade']) =>
-  ({ children }) => (
-    <MemoryRouter initialEntries={initialEntries}>
-      <Route path="/plan/:provider/:owner/upgrade">
-        <Suspense fallback={<p>Loading...</p>}>{children}</Suspense>
-      </Route>
-    </MemoryRouter>
-  )
+    ({ children }) => (
+      <MemoryRouter initialEntries={initialEntries}>
+        <Route path="/plan/:provider/:owner/upgrade">
+          <Suspense fallback={<p>Loading...</p>}>{children}</Suspense>
+        </Route>
+      </MemoryRouter>
+    )
 
 describe('UpdateBlurb', () => {
   describe('no diff', () => {

--- a/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/UpdateBlurb/UpdateBlurb.test.tsx
+++ b/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/UpdateBlurb/UpdateBlurb.test.tsx
@@ -118,7 +118,7 @@ describe('UpdateBlurb', () => {
         const seatsBlurb = await screen.findByText(
           'You are changing seats from 2 to [10]'
         )
-        const billingBlurb = await screen.findByText(
+        const billingBlurb = screen.queryByText(
           'You are changing your billing cycle from Monthly to [Annual]'
         )
         const immediateUpdate = await screen.findByText(
@@ -126,7 +126,7 @@ describe('UpdateBlurb', () => {
         )
         expect(planBlurb).toBeInTheDocument()
         expect(seatsBlurb).toBeInTheDocument()
-        expect(billingBlurb).toBeInTheDocument()
+        expect(billingBlurb).not.toBeInTheDocument()
         expect(immediateUpdate).toBeInTheDocument()
       })
     })
@@ -258,10 +258,15 @@ describe('UpdateBlurb', () => {
     })
 
     describe('when user has change from pro to team', () => {
-      it.only('renders next billing cycle blurb', async () => {
+      it('renders next billing cycle blurb', async () => {
         render(
           <UpdateBlurb
-            currentPlan={{ ...proPlanYear, ...planChunk, planUserCount: 10 }}
+            currentPlan={{
+              ...proPlanYear,
+              ...planChunk,
+              planUserCount: 10,
+              isTeamPlan: false,
+            }}
             newPlan={teamPlanYear}
             nextBillingDate={'July 12th, 2024'}
             seats={10}

--- a/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/UpdateBlurb/UpdateBlurb.test.tsx
+++ b/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/UpdateBlurb/UpdateBlurb.test.tsx
@@ -18,7 +18,6 @@ const planChunk = {
   isFreePlan: false,
   isTeamPlan: true,
   hasSeatsLeft: true,
-  isTeamPlan: false,
 }
 
 const proPlanYear = {
@@ -71,13 +70,13 @@ type WrapperClosure = (
 ) => React.FC<React.PropsWithChildren>
 const wrapper: WrapperClosure =
   (initialEntries = ['/plan/gh/codecov/upgrade']) =>
-    ({ children }) => (
-      <MemoryRouter initialEntries={initialEntries}>
-        <Route path="/plan/:provider/:owner/upgrade">
-          <Suspense fallback={<p>Loading...</p>}>{children}</Suspense>
-        </Route>
-      </MemoryRouter>
-    )
+  ({ children }) => (
+    <MemoryRouter initialEntries={initialEntries}>
+      <Route path="/plan/:provider/:owner/upgrade">
+        <Suspense fallback={<p>Loading...</p>}>{children}</Suspense>
+      </Route>
+    </MemoryRouter>
+  )
 
 describe('UpdateBlurb', () => {
   describe('no diff', () => {
@@ -259,7 +258,7 @@ describe('UpdateBlurb', () => {
     })
 
     describe('when user has change from pro to team', () => {
-      it('renders next billing cycle blurb', async () => {
+      it.only('renders next billing cycle blurb', async () => {
         render(
           <UpdateBlurb
             currentPlan={{ ...proPlanYear, ...planChunk, planUserCount: 10 }}

--- a/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/UpdateBlurb/UpdateBlurb.tsx
+++ b/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/UpdateBlurb/UpdateBlurb.tsx
@@ -1,14 +1,11 @@
-import { BillingRate, Plan } from 'shared/utils/billing'
-
 import { IndividualPlan } from 'services/account'
-import { Plans } from 'shared/utils/billing'
+import { BillingRate, Plan , Plans } from 'shared/utils/billing'
 
 const UpdateBlurb = ({
   currentPlan,
   newPlan,
   seats,
   nextBillingDate,
-
 }: {
   currentPlan?: Plan | null
   newPlan?: IndividualPlan
@@ -18,8 +15,7 @@ const UpdateBlurb = ({
   const currentIsFree = currentPlan?.isFreePlan
   const currentIsTeam = currentPlan?.isTeamPlan
   const selectedIsTeam =
-    newPlan?.value === Plans.USERS_TEAMM ||
-    newPlan?.value === Plans.USERS_TEAMY
+    newPlan?.value === Plans.USERS_TEAMM || newPlan?.value === Plans.USERS_TEAMY
   const diffPlanType = currentIsFree || currentIsTeam !== selectedIsTeam
 
   const currentIsAnnual = currentPlan?.billingRate === BillingRate.ANNUALLY
@@ -46,15 +42,17 @@ const UpdateBlurb = ({
     <div>
       <h3 className="pb-2 font-semibold">Review your plan changes</h3>
       {diffPlanType && (
-        <li className="pl-2">{`You are changing from the ${currentIsFree ? 'Developer' : currentIsTeam ? 'Team' : 'Pro'
-          } plan to the [${selectedIsTeam ? 'Team' : 'Pro'} plan]`}</li>
+        <li className="pl-2">{`You are changing from the ${
+          currentIsFree ? 'Developer' : currentIsTeam ? 'Team' : 'Pro'
+        } plan to the [${selectedIsTeam ? 'Team' : 'Pro'} plan]`}</li>
       )}
       {diffSeats && (
         <li className="pl-2">{`You are changing seats from ${currentPlan?.planUserCount} to [${seats}]`}</li>
       )}
-      {diffBillingType && (
-        <li className="pl-2">{`You are changing your billing cycle from ${currentIsAnnual ? 'Annual' : 'Monthly'
-          } to [${currentIsAnnual ? 'Monthly' : 'Annual'}]`}</li>
+      {diffBillingType && !currentIsFree && (
+        <li className="pl-2">{`You are changing your billing cycle from ${
+          currentIsAnnual ? 'Annual' : 'Monthly'
+        } to [${currentIsAnnual ? 'Monthly' : 'Annual'}]`}</li>
       )}
       <br />
 

--- a/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/UpdateBlurb/UpdateBlurb.tsx
+++ b/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/UpdateBlurb/UpdateBlurb.tsx
@@ -1,5 +1,5 @@
 import { IndividualPlan } from 'services/account'
-import { BillingRate, Plan , Plans } from 'shared/utils/billing'
+import { BillingRate, Plan, Plans } from 'shared/utils/billing'
 
 const UpdateBlurb = ({
   currentPlan,

--- a/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/UpdateBlurb/UpdateBlurb.tsx
+++ b/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/UpdateBlurb/UpdateBlurb.tsx
@@ -1,11 +1,14 @@
+import { BillingRate, Plan } from 'shared/utils/billing'
+
 import { IndividualPlan } from 'services/account'
-import { BillingRate, isTeamPlan, Plan } from 'shared/utils/billing'
+import { Plans } from 'shared/utils/billing'
 
 const UpdateBlurb = ({
   currentPlan,
   newPlan,
   seats,
   nextBillingDate,
+
 }: {
   currentPlan?: Plan | null
   newPlan?: IndividualPlan
@@ -13,8 +16,10 @@ const UpdateBlurb = ({
   nextBillingDate: string
 }) => {
   const currentIsFree = currentPlan?.isFreePlan
-  const currentIsTeam = isTeamPlan(currentPlan?.value)
-  const selectedIsTeam = isTeamPlan(newPlan?.value)
+  const currentIsTeam = currentPlan?.isTeamPlan
+  const selectedIsTeam =
+    newPlan?.value === Plans.USERS_TEAMM ||
+    newPlan?.value === Plans.USERS_TEAMY
   const diffPlanType = currentIsFree || currentIsTeam !== selectedIsTeam
 
   const currentIsAnnual = currentPlan?.billingRate === BillingRate.ANNUALLY
@@ -41,17 +46,15 @@ const UpdateBlurb = ({
     <div>
       <h3 className="pb-2 font-semibold">Review your plan changes</h3>
       {diffPlanType && (
-        <li className="pl-2">{`You are changing from the ${
-          currentIsFree ? 'Developer' : currentIsTeam ? 'Team' : 'Pro'
-        } plan to the [${selectedIsTeam ? 'Team' : 'Pro'} plan]`}</li>
+        <li className="pl-2">{`You are changing from the ${currentIsFree ? 'Developer' : currentIsTeam ? 'Team' : 'Pro'
+          } plan to the [${selectedIsTeam ? 'Team' : 'Pro'} plan]`}</li>
       )}
       {diffSeats && (
         <li className="pl-2">{`You are changing seats from ${currentPlan?.planUserCount} to [${seats}]`}</li>
       )}
       {diffBillingType && (
-        <li className="pl-2">{`You are changing your billing cycle from ${
-          currentIsAnnual ? 'Annual' : 'Monthly'
-        } to [${currentIsAnnual ? 'Monthly' : 'Annual'}]`}</li>
+        <li className="pl-2">{`You are changing your billing cycle from ${currentIsAnnual ? 'Annual' : 'Monthly'
+          } to [${currentIsAnnual ? 'Monthly' : 'Annual'}]`}</li>
       )}
       <br />
 

--- a/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/UpdateButton/UpdateButton.test.tsx
+++ b/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/UpdateButton/UpdateButton.test.tsx
@@ -90,6 +90,7 @@ const mockPlanBasic = {
   hasSeatsLeft: true,
   planUserCount: 1,
   isFreePlan: true,
+  isTeamPlan: false,
 }
 
 const mockPlanProMonthly = {
@@ -102,6 +103,7 @@ const mockPlanProMonthly = {
   hasSeatsLeft: true,
   planUserCount: 4,
   isFreePlan: false,
+  isTeamPlan: false,
 }
 
 const mockPlanTeamMonthly = {
@@ -114,6 +116,7 @@ const mockPlanTeamMonthly = {
   hasSeatsLeft: true,
   planUserCount: 3,
   isFreePlan: false,
+  isTeamPlan: true,
 }
 
 interface SetupArgs {

--- a/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/UpgradeForm.test.tsx
+++ b/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/UpgradeForm.test.tsx
@@ -351,6 +351,9 @@ describe('UpgradeForm', () => {
                       : BillingRate.ANNUALLY,
                 isFreePlan: planValue === Plans.USERS_BASIC,
                 isEnterprisePlan: false,
+                isTeamPlan:
+                  planValue === Plans.USERS_TEAMM ||
+                  planValue === Plans.USERS_TEAMY,
                 value: planValue,
                 planUserCount,
               },

--- a/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/UpgradeForm.tsx
+++ b/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/UpgradeForm.tsx
@@ -12,7 +12,7 @@ import {
 import {
   canApplySentryUpgrade,
   getNextBillingDate,
-  isTeamPlan,
+  Plans,
 } from 'shared/utils/billing'
 import {
   getDefaultValuesUpgradeForm,
@@ -53,7 +53,9 @@ function UpgradeForm({ selectedPlan, setSelectedPlan }: UpgradeFormProps) {
     plans,
   })
   const minSeats =
-    isSentryUpgrade && !isTeamPlan(selectedPlan?.value)
+    isSentryUpgrade &&
+      selectedPlan?.value !== Plans.USERS_TEAMM &&
+      selectedPlan?.value !== Plans.USERS_TEAMY
       ? MIN_SENTRY_SEATS
       : MIN_NB_SEATS_PRO
 
@@ -79,7 +81,7 @@ function UpgradeForm({ selectedPlan, setSelectedPlan }: UpgradeFormProps) {
         minSeats,
         trialStatus,
         selectedPlan,
-        planName: planData?.plan?.value,
+        plan: planData?.plan,
       })
     ),
     mode: 'onChange',

--- a/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/UpgradeForm.tsx
+++ b/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/UpgradeForm.tsx
@@ -54,8 +54,8 @@ function UpgradeForm({ selectedPlan, setSelectedPlan }: UpgradeFormProps) {
   })
   const minSeats =
     isSentryUpgrade &&
-      selectedPlan?.value !== Plans.USERS_TEAMM &&
-      selectedPlan?.value !== Plans.USERS_TEAMY
+    selectedPlan?.value !== Plans.USERS_TEAMM &&
+    selectedPlan?.value !== Plans.USERS_TEAMY
       ? MIN_SENTRY_SEATS
       : MIN_NB_SEATS_PRO
 

--- a/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradePlanPage.jsx
+++ b/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradePlanPage.jsx
@@ -8,7 +8,6 @@ import {
   findProPlans,
   findSentryPlans,
   findTeamPlans,
-  isTeamPlan,
   shouldDisplayTeamCard,
 } from 'shared/utils/billing'
 
@@ -38,7 +37,7 @@ function UpgradePlanPage() {
   let defaultPaidYearlyPlan = null
   if (
     (hasTeamPlans && planParam === TierNames.TEAM) ||
-    isTeamPlan(planData?.plan?.value)
+    planData?.plan?.isTeamPlan
   ) {
     defaultPaidYearlyPlan = teamPlanYear
   } else if (isSentryUpgrade) {

--- a/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradePlanPage.test.jsx
+++ b/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradePlanPage.test.jsx
@@ -210,6 +210,9 @@ describe('UpgradePlanPage', () => {
               plan: {
                 ...mockPlanData,
                 isEnterprisePlan: planValue === Plans.USERS_ENTERPRISEM,
+                isTeamPlan:
+                  planValue === Plans.USERS_TEAMM ||
+                  planValue === Plans.USERS_TEAMY,
                 isFreePlan: planValue === Plans.USERS_BASIC,
                 value: planValue,
               },

--- a/src/pages/RepoPage/ActivationAlert/ActivationAlert.test.tsx
+++ b/src/pages/RepoPage/ActivationAlert/ActivationAlert.test.tsx
@@ -86,6 +86,8 @@ describe('ActivationAlert', () => {
                 value,
                 hasSeatsLeft,
                 isFreePlan: value === Plans.USERS_BASIC,
+                isTeamPlan:
+                  value === Plans.USERS_TEAMM || value === Plans.USERS_TEAMY,
               },
               pretrialPlan: {
                 baseUnitPrice: 10,

--- a/src/pages/RepoPage/CoverageOnboarding/ActivationBanner/ActivationBanner.test.tsx
+++ b/src/pages/RepoPage/CoverageOnboarding/ActivationBanner/ActivationBanner.test.tsx
@@ -88,6 +88,8 @@ describe('ActivationBanner', () => {
                 value,
                 hasSeatsLeft,
                 isFreePlan: value === Plans.USERS_BASIC,
+                isTeamPlan:
+                  value === Plans.USERS_TEAMM || value === Plans.USERS_TEAMY,
               },
               pretrialPlan: {
                 baseUnitPrice: 10,

--- a/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/FailedTestsTable/FailedTestsTable.test.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/FailedTestsTable/FailedTestsTable.test.tsx
@@ -161,6 +161,9 @@ describe('FailedTestsTable', () => {
                 plan: {
                   value: planValue,
                   isFreePlan: planValue === Plans.USERS_BASIC,
+                  isTeamPlan:
+                    planValue === Plans.USERS_TEAMM ||
+                    planValue === Plans.USERS_TEAMY,
                 },
                 repository: {
                   __typename: 'Repository',
@@ -188,6 +191,9 @@ describe('FailedTestsTable', () => {
             plan: {
               value: planValue,
               isFreePlan: planValue === Plans.USERS_BASIC,
+              isTeamPlan:
+                planValue === Plans.USERS_TEAMM ||
+                planValue === Plans.USERS_TEAMY,
             },
             repository: {
               __typename: 'Repository',

--- a/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/FailedTestsTable/FailedTestsTable.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/FailedTestsTable/FailedTestsTable.tsx
@@ -15,7 +15,6 @@ import { useInView } from 'react-intersection-observer'
 import { useLocation, useParams } from 'react-router-dom'
 
 import { MeasurementInterval } from 'pages/RepoPage/shared/constants'
-import { isTeamPlan } from 'shared/utils/billing'
 import { formatTimeToNow } from 'shared/utils/dates'
 import Icon from 'ui/Icon'
 import Spinner from 'ui/Spinner'
@@ -229,8 +228,7 @@ const FailedTestsTable = () => {
   })
 
   const isDefaultBranch = testData?.defaultBranch === branch
-  const isTeamOrFreePlan =
-    isTeamPlan(testData?.planName) || testData?.isFreePlan
+  const isTeamOrFreePlan = testData?.isTeamPlan || testData?.isFreePlan
   // Only show flake rate column when on default branch for pro / enterprise plans or public repos
   const hideFlakeRate =
     (isTeamOrFreePlan && testData?.private) || (!!branch && !isDefaultBranch)

--- a/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/MetricsSection/MetricsSection.test.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/MetricsSection/MetricsSection.test.tsx
@@ -20,6 +20,8 @@ const mockAggResponse = (
     plan: {
       value: planValue,
       isFreePlan: planValue === Plans.USERS_BASIC,
+      isTeamPlan:
+        planValue === Plans.USERS_TEAMM || planValue === Plans.USERS_TEAMY,
     },
     repository: {
       __typename: 'Repository',

--- a/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/MetricsSection/MetricsSection.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/MetricsSection/MetricsSection.tsx
@@ -3,7 +3,6 @@ import { useLocation, useParams } from 'react-router-dom'
 
 import { MeasurementInterval } from 'pages/RepoPage/shared/constants'
 import { useLocationParams } from 'services/navigation'
-import { isTeamPlan } from 'shared/utils/billing'
 import { cn } from 'shared/utils/cn'
 import { formatTimeFromSeconds } from 'shared/utils/dates'
 import Badge from 'ui/Badge'
@@ -369,8 +368,7 @@ function MetricsSection() {
     interval: queryParams?.historicalTrend as MeasurementInterval,
   })
   const disabledFlakeAggregates =
-    (isTeamPlan(testResults?.planName) || testResults?.isFreePlan) &&
-    testResults?.private
+    (testResults?.isTeamPlan || testResults?.isFreePlan) && testResults?.private
   const { data: flakeAggregates } = useFlakeAggregates({
     interval: queryParams?.historicalTrend as MeasurementInterval,
     opts: {

--- a/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/hooks/useInfiniteTestResults/useInfiniteTestResults.test.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/hooks/useInfiniteTestResults/useInfiniteTestResults.test.tsx
@@ -12,6 +12,7 @@ const mockTestResults = {
     plan: {
       value: Plans.USERS_ENTERPRISEM,
       isFreePlan: false,
+      isTeamPlan: false,
     },
     repository: {
       __typename: 'Repository',
@@ -84,6 +85,7 @@ const mockNotFoundError = {
     plan: {
       value: Plans.USERS_ENTERPRISEM,
       isFreePlan: false,
+      isTeamPlan: false,
     },
   },
 }
@@ -93,6 +95,7 @@ const mockOwnerNotActivatedError = {
     plan: {
       value: Plans.USERS_ENTERPRISEM,
       isFreePlan: false,
+      isTeamPlan: false,
     },
     repository: {
       __typename: 'OwnerNotActivatedError',

--- a/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/hooks/useInfiniteTestResults/useInfiniteTestResults.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/hooks/useInfiniteTestResults/useInfiniteTestResults.tsx
@@ -66,6 +66,7 @@ const GetTestResultsSchema = z.object({
         .object({
           value: z.nativeEnum(Plans),
           isFreePlan: z.boolean(),
+          isTeamPlan: z.boolean(),
         })
         .nullable(),
       repository: z.discriminatedUnion('__typename', [
@@ -113,6 +114,7 @@ query GetTestResults(
     plan {
       value
       isFreePlan
+      isTeamPlan
     }
     repository: repository(name: $repo) {
       __typename
@@ -188,6 +190,7 @@ interface UseTestResultsArgs {
     defaultBranch: string | null
     totalCount: number | null
     isFirstPullRequest: boolean | null
+    isTeamPlan: boolean | null
   }>
 }
 
@@ -286,6 +289,7 @@ export const useInfiniteTestResults = ({
           private: data?.owner?.repository?.private ?? null,
           planName: data?.owner?.plan?.value ?? null,
           isFreePlan: data?.owner?.plan?.isFreePlan ?? false,
+          isTeamPlan: data?.owner?.plan?.isTeamPlan ?? false,
           defaultBranch: data?.owner?.repository?.defaultBranch ?? null,
           isFirstPullRequest:
             data?.owner?.repository?.isFirstPullRequest ?? null,
@@ -311,6 +315,7 @@ export const useInfiniteTestResults = ({
       private: data?.pages?.[0]?.private ?? null,
       planName: data?.pages?.[0]?.planName ?? null,
       isFreePlan: data?.pages?.[0]?.isFreePlan ?? false,
+      isTeamPlan: data?.pages?.[0]?.isTeamPlan ?? false,
       defaultBranch: data?.pages?.[0]?.defaultBranch ?? null,
       isFirstPullRequest: data?.pages?.[0]?.isFirstPullRequest ?? null,
     },

--- a/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/hooks/useTestResultsAggregates/useTestResultsAggregates.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/hooks/useTestResultsAggregates/useTestResultsAggregates.tsx
@@ -15,6 +15,7 @@ const TestResultsAggregatesSchema = z.object({
         .object({
           value: z.nativeEnum(Plans),
           isFreePlan: z.boolean(),
+          isTeamPlan: z.boolean(),
         })
         .nullable(),
       repository: z.discriminatedUnion('__typename', [
@@ -57,6 +58,7 @@ const query = `
       plan {
         value
         isFreePlan
+        isTeamPlan
       }
       repository: repository(name: $repo) {
         __typename
@@ -139,6 +141,7 @@ export const useTestResultsAggregates = ({
             data?.owner?.repository?.testAnalytics?.testResultsAggregates,
           planName: data?.owner?.plan?.value,
           isFreePlan: data?.owner?.plan?.isFreePlan,
+          isTeamPlan: data?.owner?.plan?.isTeamPlan,
           private: data?.owner?.repository?.private,
           defaultBranch: data?.owner?.repository?.defaultBranch,
         }

--- a/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/hooks/useTestResultsAggregates/useTestsResultsAggregates.test.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/hooks/useTestResultsAggregates/useTestsResultsAggregates.test.tsx
@@ -56,6 +56,7 @@ const mockIncorrectResponse = {
     plan: {
       value: Plans.USERS_BASIC,
       isFreePlan: true,
+      isTeamPlan: false,
     },
   },
 }
@@ -65,6 +66,7 @@ const mockResponse = {
     plan: {
       value: Plans.USERS_BASIC,
       isFreePlan: true,
+      isTeamPlan: false,
     },
     repository: {
       __typename: 'Repository',
@@ -132,6 +134,7 @@ describe('useTestResultsAggregates', () => {
             },
             planName: 'users-basic',
             isFreePlan: true,
+            isTeamPlan: false,
             private: true,
             defaultBranch: 'main',
           })

--- a/src/services/account/usePlanData.test.tsx
+++ b/src/services/account/usePlanData.test.tsx
@@ -25,6 +25,7 @@ const mockTrialData = {
     hasSeatsLeft: true,
     isEnterprisePlan: false,
     isFreePlan: true,
+    isTeamPlan: false,
   },
   pretrialPlan: {
     baseUnitPrice: 10,
@@ -91,6 +92,7 @@ describe('usePlanData', () => {
               hasSeatsLeft: true,
               isEnterprisePlan: false,
               isFreePlan: true,
+              isTeamPlan: false,
               marketingName: 'Users Basic',
               monthlyUploadLimit: 250,
               planUserCount: 1,

--- a/src/services/account/usePlanData.ts
+++ b/src/services/account/usePlanData.ts
@@ -29,6 +29,7 @@ const PlanSchema = z.object({
   hasSeatsLeft: z.boolean(),
   isEnterprisePlan: z.boolean(),
   isFreePlan: z.boolean(),
+  isTeamPlan: z.boolean(),
 })
 
 export type Plan = z.infer<typeof PlanSchema>
@@ -84,6 +85,7 @@ export const query = `
         hasSeatsLeft
         isEnterprisePlan
         isFreePlan
+        isTeamPlan
       }
       pretrialPlan {
         baseUnitPrice

--- a/src/shared/GlobalTopBanners/TrialBanner/TrialBanner.test.tsx
+++ b/src/shared/GlobalTopBanners/TrialBanner/TrialBanner.test.tsx
@@ -32,6 +32,7 @@ const proPlanMonth = {
   planUserCount: 1,
   isEnterprisePlan: false,
   isFreePlan: false,
+  isTeamPlan: false,
 }
 
 const trialPlan = {
@@ -51,6 +52,7 @@ const trialPlan = {
   planUserCount: 1,
   isEnterprisePlan: false,
   isFreePlan: false,
+  isTeamPlan: false,
 }
 
 const basicPlan = {
@@ -69,6 +71,7 @@ const basicPlan = {
   pretrialUsersCount: 0,
   planUserCount: 1,
   isFreePlan: true,
+  isTeamPlan: false,
 }
 
 const queryClient = new QueryClient()
@@ -157,6 +160,7 @@ describe('TrialBanner', () => {
                 hasSeatsLeft: true,
                 isEnterprisePlan: plan.isEnterprisePlan,
                 isFreePlan: plan.isFreePlan,
+                isTeamPlan: false,
               },
             },
           },

--- a/src/shared/utils/billing.test.ts
+++ b/src/shared/utils/billing.test.ts
@@ -15,7 +15,6 @@ import {
   isCodecovProPlan,
   isProPlan,
   isSentryPlan,
-  isTeamPlan,
   isTrialPlan,
   lastTwoDigits,
   Plans,
@@ -504,21 +503,6 @@ describe('isBasicPlan', () => {
     expect(isBasicPlan(Plans.USERS_INAPP)).toBeFalsy()
     expect(isBasicPlan(Plans.USERS_ENTERPRISEM)).toBeFalsy()
     expect(isBasicPlan(Plans.USERS_SENTRYM)).toBeFalsy()
-  })
-})
-
-describe('isTeamPlan', () => {
-  it('returns true when plan is team monthly or yearly', () => {
-    expect(isTeamPlan(Plans.USERS_TEAMM)).toBeTruthy()
-    expect(isTeamPlan(Plans.USERS_TEAMY)).toBeTruthy()
-  })
-
-  it('returns false when plan is not team monthly or yearly', () => {
-    expect(isTeamPlan(Plans.USERS_FREE)).toBeFalsy()
-    expect(isTeamPlan(Plans.USERS_BASIC)).toBeFalsy()
-    expect(isTeamPlan(Plans.USERS_INAPP)).toBeFalsy()
-    expect(isTeamPlan(Plans.USERS_ENTERPRISEM)).toBeFalsy()
-    expect(isTeamPlan(Plans.USERS_SENTRYM)).toBeFalsy()
   })
 })
 

--- a/src/shared/utils/billing.ts
+++ b/src/shared/utils/billing.ts
@@ -50,14 +50,9 @@ export interface Plan {
   hasSeatsLeft: boolean
   isEnterprisePlan: boolean
   isFreePlan: boolean
+  isTeamPlan: boolean
 }
 
-export function isTeamPlan(plan?: PlanName | null) {
-  if (isString(plan)) {
-    if (plan === Plans.USERS_TEAMM || plan === Plans.USERS_TEAMY) return true
-  }
-  return false
-}
 export function isBasicPlan(plan?: PlanName) {
   if (isString(plan)) {
     return plan === Plans.USERS_BASIC

--- a/src/shared/utils/upgradeForm.test.ts
+++ b/src/shared/utils/upgradeForm.test.ts
@@ -170,6 +170,7 @@ describe('getDefaultValuesUpgradeForm', () => {
           billingRate: BillingRate.MONTHLY,
           value: Plans.USERS_TEAMM,
           planUserCount: 1,
+          isTeamPlan: true,
         } as Plan,
       })
 
@@ -192,6 +193,7 @@ describe('getDefaultValuesUpgradeForm', () => {
           billingRate: BillingRate.MONTHLY,
           value: Plans.USERS_SENTRYY,
           planUserCount: 1,
+          isTeamPlan: false,
         } as Plan,
       })
 

--- a/src/shared/utils/upgradeForm.test.ts
+++ b/src/shared/utils/upgradeForm.test.ts
@@ -202,6 +202,7 @@ describe('getDefaultValuesUpgradeForm', () => {
           billingRate: BillingRate.MONTHLY,
           value: Plans.USERS_SENTRYY,
           planUserCount: 1,
+          isTeamPlan: false,
         },
         seats: 5,
       })

--- a/src/shared/utils/upgradeForm.ts
+++ b/src/shared/utils/upgradeForm.ts
@@ -14,7 +14,6 @@ import {
   findSentryPlans,
   findTeamPlans,
   isSentryPlan,
-  isTeamPlan,
   isTrialPlan,
   Plan,
   PlanName,
@@ -64,13 +63,13 @@ export const getSchema = ({
   minSeats = 1,
   trialStatus,
   selectedPlan,
-  planName,
+  plan,
 }: {
   accountDetails?: z.infer<typeof AccountDetailsSchema>
   minSeats?: number
   trialStatus?: TrialStatus
   selectedPlan?: IndividualPlan
-  planName?: PlanName
+  plan?: Plan | null
 }) =>
   z.object({
     seats: z.coerce
@@ -84,8 +83,9 @@ export const getSchema = ({
       })
       .transform((val, ctx) => {
         if (
-          isTeamPlan(selectedPlan?.value) &&
-          val > TEAM_PLAN_MAX_ACTIVE_USERS
+          selectedPlan?.value === Plans.USERS_TEAMM ||
+          (selectedPlan?.value === Plans.USERS_TEAMY &&
+            val > TEAM_PLAN_MAX_ACTIVE_USERS)
         ) {
           ctx.addIssue({
             code: z.ZodIssueCode.custom,
@@ -95,7 +95,7 @@ export const getSchema = ({
 
         if (
           trialStatus === TrialStatuses.ONGOING &&
-          planName === Plans.USERS_TRIAL
+          plan?.value === Plans.USERS_TRIAL
         ) {
           return val
         }
@@ -243,7 +243,7 @@ export const getDefaultValuesUpgradeForm = ({
   let newPlan = proPlanYear
   if (isSentryUpgrade && !isSentryPlan(plan?.value)) {
     newPlan = isMonthlyPlan ? sentryPlanMonth : sentryPlanYear
-  } else if (isTeamPlan(plan?.value) || isTeamPlan(selectedPlan?.value)) {
+  } else if (plan?.isTeamPlan || selectedPlan?.value === Plans.USERS_TEAMM || selectedPlan?.value === Plans.USERS_TEAMY) {
     newPlan = isMonthlyPlan ? teamPlanMonth : teamPlanYear
   } else if (isPaidPlan) {
     newPlan = plan

--- a/src/shared/utils/upgradeForm.ts
+++ b/src/shared/utils/upgradeForm.ts
@@ -83,9 +83,9 @@ export const getSchema = ({
       })
       .transform((val, ctx) => {
         if (
-          selectedPlan?.value === Plans.USERS_TEAMM ||
-          (selectedPlan?.value === Plans.USERS_TEAMY &&
-            val > TEAM_PLAN_MAX_ACTIVE_USERS)
+          (selectedPlan?.value === Plans.USERS_TEAMM ||
+            selectedPlan?.value === Plans.USERS_TEAMY) &&
+          val > TEAM_PLAN_MAX_ACTIVE_USERS
         ) {
           ctx.addIssue({
             code: z.ZodIssueCode.custom,

--- a/src/shared/utils/upgradeForm.ts
+++ b/src/shared/utils/upgradeForm.ts
@@ -243,7 +243,11 @@ export const getDefaultValuesUpgradeForm = ({
   let newPlan = proPlanYear
   if (isSentryUpgrade && !isSentryPlan(plan?.value)) {
     newPlan = isMonthlyPlan ? sentryPlanMonth : sentryPlanYear
-  } else if (plan?.isTeamPlan || selectedPlan?.value === Plans.USERS_TEAMM || selectedPlan?.value === Plans.USERS_TEAMY) {
+  } else if (
+    plan?.isTeamPlan ||
+    selectedPlan?.value === Plans.USERS_TEAMM ||
+    selectedPlan?.value === Plans.USERS_TEAMY
+  ) {
     newPlan = isMonthlyPlan ? teamPlanMonth : teamPlanYear
   } else if (isPaidPlan) {
     newPlan = plan


### PR DESCRIPTION
# Description
This PR aims to remove the isTeamPlan helper function in Gazebo in favor of the new GraphQL field for the same.

fyi we're gonna come back once available plans is refactored to pass down isTeamPlan instead of checking for plans enum for the selected plans, this is just a weird edge case.

# Notable Changes
- updated tests 
- removed helper
- updated the plan 

# Screenshots
nothing visual changed 

issue: [#2998](https://github.com/codecov/engineering-team/issues/2998)

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.