### PR TITLE
fix: Change Pro Team to Pro

### DIFF
--- a/src/pages/MembersPage/MembersActivation/Activation/Activation.jsx
+++ b/src/pages/MembersPage/MembersActivation/Activation/Activation.jsx
@@ -56,7 +56,7 @@ function Activation() {
             available seats{' '}
           </p>
           <p className="text-xs">
-            Your org trialed Pro Team plan{' '}
+            Your org trialed Pro plan{' '}
             <span className="font-semibold">
               <A to={{ pageName: 'upgradeOrgPlan' }}>upgrade</A>
             </span>

--- a/src/pages/MembersPage/MembersActivation/Activation/Activation.test.jsx
+++ b/src/pages/MembersPage/MembersActivation/Activation/Activation.test.jsx
@@ -237,7 +237,7 @@ describe('Activation', () => {
         render(<Activation />, { wrapper: wrapper() })
 
         const orgTrialedText = await screen.findByText(
-          /Your org trialed Pro Team plan/
+          /Your org trialed Pro plan/
         )
         expect(orgTrialedText).toBeInTheDocument()
       })


### PR DESCRIPTION
# Description

No such thing as a pro team plan, just pro or team lol. This fixes that

# Screenshots

<img width="332" alt="Screenshot 2024-12-18 at 2 47 34 PM" src="https://github.com/user-attachments/assets/fb0703a9-0b8e-4ff5-9ef6-471117848ca5" />


# Link to Sample Entry

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.