### PR TITLE
fix: Copy when changing plan from free plan

### DIFF
--- a/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/UpdateBlurb/UpdateBlurb.test.tsx
+++ b/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/UpdateBlurb/UpdateBlurb.test.tsx
@@ -115,7 +115,7 @@ describe('UpdateBlurb', () => {
         const seatsBlurb = await screen.findByText(
           'You are changing seats from 2 to [10]'
         )
-        const billingBlurb = await screen.findByText(
+        const billingBlurb = screen.queryByText(
           'You are changing your billing cycle from Monthly to [Annual]'
         )
         const immediateUpdate = await screen.findByText(
@@ -123,7 +123,7 @@ describe('UpdateBlurb', () => {
         )
         expect(planBlurb).toBeInTheDocument()
         expect(seatsBlurb).toBeInTheDocument()
-        expect(billingBlurb).toBeInTheDocument()
+        expect(billingBlurb).not.toBeInTheDocument()
         expect(immediateUpdate).toBeInTheDocument()
       })
     })

--- a/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/UpdateBlurb/UpdateBlurb.tsx
+++ b/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/UpdateBlurb/UpdateBlurb.tsx
@@ -52,7 +52,7 @@ const UpdateBlurb = ({
       {diffSeats && (
         <li className="pl-2">{`You are changing seats from ${currentPlan?.planUserCount} to [${seats}]`}</li>
       )}
-      {diffBillingType && (
+      {diffBillingType && !currentIsFree && (
         <li className="pl-2">{`You are changing your billing cycle from ${
           currentIsAnnual ? 'Annual' : 'Monthly'
         } to [${currentIsAnnual ? 'Monthly' : 'Annual'}]`}</li>


### PR DESCRIPTION
# Description

Free Plan has no billing cycle so we shouldn't say "Changing plan from monthly to annual" if the user wants to upgrade to an annual plan.

We just need to add the "isFreePlan" check to this function and rest we get for free.

# Screenshots

**BEFORE**
<img width="1243" alt="Screenshot 2024-12-18 at 2 55 23 PM" src="https://github.com/user-attachments/assets/99101ac6-4482-4b3f-a996-bf39a8396a06" />



**AFTER**
<img width="1247" alt="Screenshot 2024-12-18 at 2 54 25 PM" src="https://github.com/user-attachments/assets/8fa3d453-745b-4779-8700-7c8edb2b98bc" />


# Link to Sample Entry

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.