### PR TITLE
fix: Fix OtherCI GPG instructions

### DIFF
--- a/src/pages/RepoPage/CoverageOnboarding/OtherCI/TerminalInstructions/InstructionBox.test.tsx
+++ b/src/pages/RepoPage/CoverageOnboarding/OtherCI/TerminalInstructions/InstructionBox.test.tsx
@@ -49,13 +49,27 @@ describe('InstructionBox', () => {
       expect(button).toBeInTheDocument()
     })
 
-    it('renders linux default instructions', () => {
+    it('renders Linux Arm64 button', () => {
       render(<InstructionBox />)
 
-      const instruction = screen.queryByText(
-        'curl -Os https://cli.codecov.io/latest/linux/codecov/'
+      const button = screen.getByRole('button', { name: 'Linux Arm64' })
+      expect(button).toBeInTheDocument()
+    })
+
+    it('renders Alpine Linux Arm64 button', () => {
+      render(<InstructionBox />)
+
+      const button = screen.getByRole('button', { name: 'Alpine Linux Arm64' })
+      expect(button).toBeInTheDocument()
+    })
+
+    it('renders linux default instructions', async () => {
+      render(<InstructionBox />)
+
+      const instruction = await screen.findByText(
+        /curl -Os https:\/\/cli.codecov.io\/latest\/linux\/codecov/
       )
-      expect(instruction).not.toBeInTheDocument()
+      expect(instruction).toBeInTheDocument()
     })
   })
 
@@ -97,6 +111,40 @@ describe('InstructionBox', () => {
 
       const instruction = screen.getByText(
         /curl -Os https:\/\/cli.codecov.io\/latest\/macos\/codecov/
+      )
+      expect(instruction).toBeInTheDocument()
+    })
+  })
+
+  describe('when click on Linux Arm64', () => {
+    it('renders the Linux Arm64 instruction', async () => {
+      const { user } = setup()
+      render(<InstructionBox />)
+
+      const linuxArm64Button = screen.getByRole('button', {
+        name: 'Linux Arm64',
+      })
+      await user.click(linuxArm64Button)
+
+      const instruction = screen.getByText(
+        /curl -Os https:\/\/cli.codecov.io\/latest\/linux-arm64\/codecov/
+      )
+      expect(instruction).toBeInTheDocument()
+    })
+  })
+
+  describe('when click on Alpine Linux Arm64', () => {
+    it('renders the Alpine Linux Arm64 instruction', async () => {
+      const { user } = setup()
+      render(<InstructionBox />)
+
+      const alpineLinuxArm64Button = screen.getByRole('button', {
+        name: 'Alpine Linux Arm64',
+      })
+      await user.click(alpineLinuxArm64Button)
+
+      const instruction = screen.getByText(
+        /curl -Os https:\/\/cli.codecov.io\/latest\/alpine-arm64\/codecov/
       )
       expect(instruction).toBeInTheDocument()
     })

--- a/src/pages/RepoPage/CoverageOnboarding/OtherCI/TerminalInstructions/InstructionBox.tsx
+++ b/src/pages/RepoPage/CoverageOnboarding/OtherCI/TerminalInstructions/InstructionBox.tsx
@@ -4,7 +4,9 @@ import { type MouseEvent, useState } from 'react'
 import { CopyClipboard } from 'ui/CopyClipboard'
 
 import {
+  alpineLinuxArm64Instructions,
   alpineLinuxSystemInstructions,
+  linuxArm64SystemInstructions,
   linuxSystemInstructions,
   macOSSystemInstructions,
   windowsSystemInstructions,
@@ -15,6 +17,8 @@ const systemsEnum = Object.freeze({
   ALPINE: 'Alpine Linux',
   MACOS: 'macOS',
   WINDOWS: 'Windows',
+  LINUXARM64: 'Linux Arm64',
+  ALPINELINUXARM64: 'Alpine Linux Arm64',
 })
 
 const systemsMapper = Object.freeze({
@@ -22,6 +26,8 @@ const systemsMapper = Object.freeze({
   'Alpine Linux': alpineLinuxSystemInstructions,
   macOS: macOSSystemInstructions,
   Windows: windowsSystemInstructions,
+  'Linux Arm64': linuxArm64SystemInstructions,
+  'Alpine Linux Arm64': alpineLinuxArm64Instructions,
 })
 
 const systems = [
@@ -29,6 +35,8 @@ const systems = [
   systemsEnum.ALPINE,
   systemsEnum.MACOS,
   systemsEnum.WINDOWS,
+  systemsEnum.LINUXARM64,
+  systemsEnum.ALPINELINUXARM64,
 ]
 
 export function InstructionBox() {

--- a/src/pages/RepoPage/CoverageOnboarding/OtherCI/TerminalInstructions/instructions.ts
+++ b/src/pages/RepoPage/CoverageOnboarding/OtherCI/TerminalInstructions/instructions.ts
@@ -1,10 +1,4 @@
-export const windowsSystemInstructions = `# download Codecov CLI
-$ProgressPreference = 'SilentlyContinue' 
-Invoke-WebRequest -Uri https://cli.codecov.io/latest/windows/codecov.exe 
--Outfile codecov.exe .\\codecov.exe
-
-# integrity check
-$ProgressPreference = 'SilentlyContinue'
+export const windowsSystemInstructions = `$ProgressPreference = 'SilentlyContinue'
 Invoke-WebRequest -Uri https://keybase.io/codecovsecurity/pgp_keys.asc -OutFile codecov.asc 
 gpg.exe --import codecov.asc
 
@@ -13,48 +7,58 @@ Invoke-WebRequest -Uri https://cli.codecov.io/latest/windows/codecov.exe.SHA256S
 Invoke-WebRequest -Uri https://cli.codecov.io/latest/windows/codecov.exe.SHA256SUM.sig -Outfile codecov.exe.SHA256SUM.sig
 
 gpg.exe --verify codecov.exe.SHA256SUM.sig codecov.exe.SHA256SUM
-If ($(Compare-Object -ReferenceObject  $(($(certUtil -hashfile codecov.exe SHA256)[1], "codecov.exe") -join "  ") -DifferenceObject
-$(Get-Content codecov.exe.SHA256SUM)).length -eq 0) { echo "SHASUM verified" } Else {exit 1}
+If ($(Compare-Object -ReferenceObject  $(($(certUtil -hashfile codecov.exe SHA256)[1], "codecov.exe") -join "  ") -DifferenceObject $(Get-Content codecov.exe.SHA256SUM)).length -eq 0) { echo "SHASUM verified" } Else {exit 1}
 `
 
-export const macOSSystemInstructions = `# download Codecov CLI
-curl -Os https://cli.codecov.io/latest/macos/codecov
-
-# integrity check
-curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.gpg --import # One-time step  
+export const macOSSystemInstructions = `curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.gpg --import # One-time step  
 curl -Os https://cli.codecov.io/latest/macos/codecov
 curl -Os https://cli.codecov.io/latest/macos/codecov.SHA256SUM
 curl -Os https://cli.codecov.io/latest/macos/codecov.SHA256SUM.sig
-gpgv codecov.SHA256SUM.sig codecov.SHA256SUM
+gpg --verify codecov.SHA256SUM.sig codecov.SHA256SUM
+
 shasum -a 256 -c codecov.SHA256SUM 
 sudo chmod +x codecov
 ./codecov --help
 `
 
-export const linuxSystemInstructions = `# download Codecov CLI
-curl -Os https://cli.codecov.io/latest/linux/codecov
-
-# integrity check
-curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.gpg --import # One-time step  
+export const linuxSystemInstructions = `curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.gpg --import # One-time step  
 curl -Os https://cli.codecov.io/latest/linux/codecov
 curl -Os https://cli.codecov.io/latest/linux/codecov.SHA256SUM
 curl -Os https://cli.codecov.io/latest/linux/codecov.SHA256SUM.sig
-gpgv codecov.SHA256SUM.sig codecov.SHA256SUM
+gpg --verify codecov.SHA256SUM.sig codecov.SHA256SUM
 
 shasum -a 256 -c codecov.SHA256SUM
 sudo chmod +x codecov
 ./codecov --help
 `
 
-export const alpineLinuxSystemInstructions = `# download Codecov CLI
-curl -Os https://cli.codecov.io/latest/alpine/codecov
-
-# integrity check
-curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.gpg --import # One-time step  
+export const alpineLinuxSystemInstructions = `curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.gpg --import # One-time step  
 curl -Os https://cli.codecov.io/latest/alpine/codecov
 curl -Os https://cli.codecov.io/latest/alpine/codecov.SHA256SUM
 curl -Os https://cli.codecov.io/latest/alpine/codecov.SHA256SUM.sig
-gpgv codecov.SHA256SUM.sig codecov.SHA256SUM
+gpg --verify codecov.SHA256SUM.sig codecov.SHA256SUM
+
+shasum -a 256 -c codecov.SHA256SUM
+sudo chmod +x codecov
+./codecov --help
+`
+
+export const linuxArm64SystemInstructions = `curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.gpg --import # One-time step  
+curl -Os https://cli.codecov.io/latest/linux-arm64/codecov
+curl -Os https://cli.codecov.io/latest/linux-arm64/codecov.SHA256SUM
+curl -Os https://cli.codecov.io/latest/linux-arm64/codecov.SHA256SUM.sig
+gpg --verify codecov.SHA256SUM.sig codecov.SHA256SUM
+
+shasum -a 256 -c codecov.SHA256SUM
+sudo chmod +x codecov
+./codecov --help
+`
+
+export const alpineLinuxArm64Instructions = `curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.gpg --import # One-time step
+curl -Os https://cli.codecov.io/latest/alpine-arm64/codecov
+curl -Os https://cli.codecov.io/latest/alpine-arm64/codecov.SHA256SUM
+curl -Os https://cli.codecov.io/latest/alpine-arm64/codecov.SHA256SUM.sig
+gpg --verify codecov.SHA256SUM.sig codecov.SHA256SUM
 
 shasum -a 256 -c codecov.SHA256SUM
 sudo chmod +x codecov


### PR DESCRIPTION
Updates the GPG instructions in OtherCI coverage onboarding. Also adds instructions for Linux Arm64 and Alpine Arm64 like we have in the docs.

Closes https://github.com/codecov/engineering-team/issues/2719
