### PR TITLE
feat: Add coverage generation step to CircleCI and OtherCI onboarding

### DIFF
--- a/src/pages/RepoPage/CoverageOnboarding/CircleCI/CircleCI.test.tsx
+++ b/src/pages/RepoPage/CoverageOnboarding/CircleCI/CircleCI.test.tsx
@@ -108,12 +108,37 @@ describe('CircleCI', () => {
     return { mockMetricMutationVariables, user }
   }
 
-  describe('step one', () => {
+  describe('output coverage step', () => {
     it('renders header', async () => {
       setup({})
       render(<CircleCI />, { wrapper })
 
-      const header = await screen.findByRole('heading', { name: /Step 1/ })
+      const header = await screen.findByText(
+        /Step \d: Output a Coverage report file in your CI/
+      )
+      expect(header).toBeInTheDocument()
+    })
+
+    it('renders body', async () => {
+      setup({})
+      render(<CircleCI />, { wrapper })
+
+      const body = await screen.findByText(/Select your language below/)
+      expect(body).toBeInTheDocument()
+
+      const jest = await screen.findByText(/Jest/)
+      expect(jest).toBeInTheDocument()
+    })
+  })
+
+  describe('token step', () => {
+    it('renders header', async () => {
+      setup({})
+      render(<CircleCI />, { wrapper })
+
+      const header = await screen.findByRole('heading', {
+        name: /Step \d: add repository token to environment variables/,
+      })
       expect(header).toBeInTheDocument()
     })
 
@@ -204,13 +229,15 @@ describe('CircleCI', () => {
     })
   })
 
-  describe('step two', () => {
+  describe('orb yaml step', () => {
     beforeEach(() => setup({}))
 
     it('renders header', async () => {
       render(<CircleCI />, { wrapper })
 
-      const header = await screen.findByRole('heading', { name: /Step 2/ })
+      const header = await screen.findByRole('heading', {
+        name: /Step \d: add Codecov orb to CircleCI/,
+      })
       expect(header).toBeInTheDocument()
 
       const CircleCIJSWorkflowLink = await screen.findByRole('link', {
@@ -252,8 +279,18 @@ describe('CircleCI', () => {
     })
   })
 
-  describe('step three', () => {
+  describe('merge step', () => {
     beforeEach(() => setup({}))
+
+    it('renders header', async () => {
+      render(<CircleCI />, { wrapper })
+
+      const header = await screen.findByText(
+        /Step \d: merge to main or your preferred feature branch/
+      )
+      expect(header).toBeInTheDocument()
+    })
+
     it('renders body', async () => {
       render(<CircleCI />, { wrapper })
 
@@ -299,6 +336,7 @@ describe('CircleCI', () => {
 
   describe('user copies text', () => {
     it('stores codecov metric', async () => {
+      // will be removing this stuff soon, backend for this doesn't exist anymore
       const { mockMetricMutationVariables } = setup({})
       const user = userEvent.setup()
       render(<CircleCI />, { wrapper })
@@ -306,13 +344,13 @@ describe('CircleCI', () => {
       const copyCommands = await screen.findAllByTestId(
         'clipboard-code-snippet'
       )
-      expect(copyCommands.length).toEqual(3)
+      expect(copyCommands.length).toEqual(5)
 
       await user.click(copyCommands[1] as HTMLElement)
 
       await user.click(copyCommands[2] as HTMLElement)
       await waitFor(() =>
-        expect(mockMetricMutationVariables).toHaveBeenCalledTimes(2)
+        expect(mockMetricMutationVariables).toHaveBeenCalledTimes(1)
       )
     })
   })

--- a/src/pages/RepoPage/CoverageOnboarding/CircleCI/CircleCI.tsx
+++ b/src/pages/RepoPage/CoverageOnboarding/CircleCI/CircleCI.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react'
 import { useParams } from 'react-router-dom'
 
 import envVarScreenshot from 'assets/onboarding/env_variable_screenshot.png'
@@ -17,6 +18,11 @@ import { ExpandableSection } from 'ui/ExpandableSection'
 
 import ExampleBlurb from '../ExampleBlurb'
 import LearnMoreBlurb from '../LearnMoreBlurb'
+import OutputCoverageStep from '../OutputCoverageStep/OutputCoverageStep'
+import {
+  Framework,
+  UseFrameworkInstructions,
+} from '../UseFrameworkInstructions'
 
 const orbsString = `orbs:
   codecov: codecov/codecov@5
@@ -49,15 +55,28 @@ function CircleCI() {
   const uploadToken = orgUploadToken ?? data?.repository?.uploadToken ?? ''
   const tokenCopy = orgUploadToken ? 'global' : 'repository'
 
+  const [framework, setFramework] = useState<Framework>('Jest')
+  const frameworkInstructions = UseFrameworkInstructions({
+    orgUploadToken,
+    owner,
+    repo,
+  })
+
   return (
     <div className="flex flex-col gap-5">
-      <Step1
+      <OutputCoverageStep
+        framework={framework}
+        frameworkInstructions={frameworkInstructions}
+        owner={owner}
+        setFramework={setFramework}
+      />
+      <TokenStep
         tokenCopy={tokenCopy}
         uploadToken={uploadToken}
         providerName={providerName!}
       />
-      <Step2 defaultBranch={data?.repository?.defaultBranch ?? ''} />
-      <Step3 />
+      <OrbYAMLStep defaultBranch={data?.repository?.defaultBranch ?? ''} />
+      <MergeStep />
       <FeedbackCTA />
       <LearnMoreBlurb />
     </div>
@@ -66,20 +85,20 @@ function CircleCI() {
 
 export default CircleCI
 
-interface Step1Props {
+interface TokenStepProps {
   tokenCopy: string
   uploadToken: string
   providerName: string
 }
 
-function Step1({ tokenCopy, uploadToken, providerName }: Step1Props) {
+function TokenStep({ tokenCopy, uploadToken, providerName }: TokenStepProps) {
   const { mutate: storeEventMetric } = useStoreCodecovEventMetric()
   const { owner } = useParams<URLParams>()
   return (
     <Card>
       <Card.Header>
         <Card.Title size="base">
-          Step 1: add {tokenCopy} token to environment variables
+          Step 2: add {tokenCopy} token to environment variables
         </Card.Title>
       </Card.Header>
       <Card.Content className="flex flex-col gap-4">
@@ -133,18 +152,18 @@ function Step1({ tokenCopy, uploadToken, providerName }: Step1Props) {
   )
 }
 
-interface Step2Props {
+interface OrbYAMLStepProps {
   defaultBranch: string
 }
 
-function Step2({ defaultBranch }: Step2Props) {
+function OrbYAMLStep({ defaultBranch }: OrbYAMLStepProps) {
   const { mutate: storeEventMetric } = useStoreCodecovEventMetric()
   const { owner } = useParams<URLParams>()
   return (
     <Card>
       <Card.Header>
         <Card.Title size="base">
-          Step 2: add Codecov orb to CircleCI{' '}
+          Step 3: add Codecov orb to CircleCI{' '}
           <A
             hook="circleCIyamlLink"
             isExternal
@@ -180,12 +199,12 @@ function Step2({ defaultBranch }: Step2Props) {
   )
 }
 
-function Step3() {
+function MergeStep() {
   return (
     <Card>
       <Card.Header>
         <Card.Title size="base">
-          Step 3: merge to main or your preferred feature branch
+          Step 4: merge to main or your preferred feature branch
         </Card.Title>
       </Card.Header>
       <Card.Content className="flex flex-col gap-4">

--- a/src/pages/RepoPage/CoverageOnboarding/GitHubActions/GitHubActions.tsx
+++ b/src/pages/RepoPage/CoverageOnboarding/GitHubActions/GitHubActions.tsx
@@ -10,12 +10,16 @@ import A from 'ui/A'
 import { Card } from 'ui/Card'
 
 import MergeStep from './MergeStep'
-import OutputCoverageStep from './OutputCoverageStep'
 import TokenStep from './TokenStep'
-import { Framework } from './types'
 import WorkflowYMLStep from './WorkflowYMLStep'
 
 import LearnMoreBlurb from '../LearnMoreBlurb'
+import OutputCoverageStep from '../OutputCoverageStep/OutputCoverageStep'
+import {
+  Framework,
+  UseFrameworkInstructions,
+} from '../UseFrameworkInstructions'
+
 interface URLParams {
   provider: Provider
   owner: string
@@ -60,161 +64,12 @@ function GitHubActions() {
   }
 
   const [framework, setFramework] = useState<Framework>('Jest')
+  const frameworkInstructions = UseFrameworkInstructions({
+    orgUploadToken,
+    owner,
+    repo,
+  })
 
-  const frameworkInstructions = {
-    Jest: {
-      install: 'npm install --save-dev jest',
-      run: 'npx jest --coverage',
-      workflow: `name: Run tests and upload coverage
-
-on: 
-  push
-
-jobs:
-  test:
-    name: Run tests and collect coverage
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Set up Node
-        uses: actions/setup-node@v4
-
-      - name: Install dependencies
-        run: npm install
-
-      - name: Run tests
-        run: npx jest --coverage
-
-      - name: Upload results to Codecov
-        uses: codecov/codecov-action@v5
-        with:
-          token: \${{ secrets.CODECOV_TOKEN }}${
-            orgUploadToken
-              ? `
-          slug: ${owner}/${repo}`
-              : ''
-          }
-`,
-    },
-    Vitest: {
-      install: 'npm install --save-dev vitest @vitest/coverage-v8',
-      run: 'npx vitest run --coverage',
-      workflow: `name: Run tests and upload coverage
-
-on: 
-  push
-
-jobs:
-  test:
-    name: Run tests and collect coverage
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Set up Node
-        uses: actions/setup-node@v4
-
-      - name: Install dependencies
-        run: npm install
-
-      - name: Run tests
-        run: npx vitest run --coverage
-
-      - name: Upload results to Codecov
-        uses: codecov/codecov-action@v5
-        with:
-          token: \${{ secrets.CODECOV_TOKEN }}${
-            orgUploadToken
-              ? `
-          slug: ${owner}/${repo}`
-              : ''
-          }
-`,
-    },
-    Pytest: {
-      install: 'pip install pytest pytest-cov',
-      run: 'pytest --cov --cov-report=xml',
-      workflow: `name: Run tests and upload coverage
-
-on: 
-  push
-
-jobs:
-  test:
-    name: Run tests and collect coverage
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Set up Python
-        uses: actions/setup-python@v4
-
-      - name: Install dependencies
-        run: pip install pytest pytest-cov
-
-      - name: Run tests
-        run: pytest --cov --cov-report=xml
-
-      - name: Upload results to Codecov
-        uses: codecov/codecov-action@v5
-        with:
-          token: \${{ secrets.CODECOV_TOKEN }}${
-            orgUploadToken
-              ? `
-          slug: ${owner}/${repo}`
-              : ''
-          }
-`,
-    },
-    Go: {
-      install: undefined,
-      run: 'go test -coverprofile=coverage.txt',
-      workflow: `name: Run tests and upload coverage
-
-on: 
-  push
-
-jobs:
-  test:
-    name: Run tests and collect coverage
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Set up Go
-        uses: actions/setup-go@v5
-
-      - name: Install dependencies
-        run: go mod download
-
-      - name: Run tests
-        run: go test -coverprofile=coverage.txt
-
-      - name: Upload results to Codecov
-        uses: codecov/codecov-action@v5
-        with:
-          token: \${{ secrets.CODECOV_TOKEN }}${
-            orgUploadToken
-              ? `
-          slug: ${owner}/${repo}`
-              : ''
-          }
-`,
-    },
-  }
   return (
     <div className="flex flex-col gap-5">
       <OutputCoverageStep

--- a/src/pages/RepoPage/CoverageOnboarding/GitHubActions/WorkflowYMLStep.tsx
+++ b/src/pages/RepoPage/CoverageOnboarding/GitHubActions/WorkflowYMLStep.tsx
@@ -12,7 +12,7 @@ import { Card } from 'ui/Card'
 import { CodeSnippet } from 'ui/CodeSnippet'
 import { ExpandableSection } from 'ui/ExpandableSection'
 
-import { Framework, FrameworkInstructions } from './types'
+import { Framework, FrameworkInstructions } from '../UseFrameworkInstructions'
 
 interface WorkflowYMLStepProps {
   framework: Framework
@@ -89,7 +89,7 @@ function WorkflowYMLStep({
         </ExpandableSection.Trigger>
         <ExpandableSection.Content>
           <CodeSnippet
-            clipboard={frameworkInstructions[framework].workflow}
+            clipboard={frameworkInstructions[framework].githubActionsWorkflow}
             clipboardOnClick={() =>
               storeEventMetric({
                 owner,
@@ -98,7 +98,7 @@ function WorkflowYMLStep({
               })
             }
           >
-            {frameworkInstructions[framework].workflow}
+            {frameworkInstructions[framework].githubActionsWorkflow}
           </CodeSnippet>
           <p className="pt-4">
             <A

--- a/src/pages/RepoPage/CoverageOnboarding/GitHubActions/types.ts
+++ b/src/pages/RepoPage/CoverageOnboarding/GitHubActions/types.ts
@@ -1,4 +1,0 @@
-export type Framework = 'Jest' | 'Vitest' | 'Pytest' | 'Go'
-export type FrameworkInstructions = {
-  [key in Framework]: { install?: string; run?: string; workflow?: string }
-}

--- a/src/pages/RepoPage/CoverageOnboarding/OtherCI/OtherCI.test.tsx
+++ b/src/pages/RepoPage/CoverageOnboarding/OtherCI/OtherCI.test.tsx
@@ -102,12 +102,37 @@ describe('OtherCI', () => {
     return { user }
   }
 
-  describe('step one', () => {
+  describe('output coverage step', () => {
     it('renders header', async () => {
       setup({})
       render(<OtherCI />, { wrapper })
 
-      const header = await screen.findByText(/Step 1/)
+      const header = await screen.findByText(
+        /Step \d: Output a Coverage report file in your CI/
+      )
+      expect(header).toBeInTheDocument()
+    })
+
+    it('renders body', async () => {
+      setup({})
+      render(<OtherCI />, { wrapper })
+
+      const body = await screen.findByText(/Select your language below/)
+      expect(body).toBeInTheDocument()
+
+      const jest = await screen.findByText(/Jest/)
+      expect(jest).toBeInTheDocument()
+    })
+  })
+
+  describe('token step', () => {
+    it('renders header', async () => {
+      setup({})
+      render(<OtherCI />, { wrapper })
+
+      const header = await screen.findByText(
+        /Step \d: add repository token as a secret to your CI Provider/
+      )
       expect(header).toBeInTheDocument()
     })
 
@@ -151,12 +176,12 @@ describe('OtherCI', () => {
     })
   })
 
-  describe('step two', () => {
+  describe('install step', () => {
     beforeEach(() => setup({}))
     it('renders header', async () => {
       render(<OtherCI />, { wrapper })
 
-      const header = await screen.findByText(/Step 2/)
+      const header = await screen.findByText(/Step \d: add the/)
       expect(header).toBeInTheDocument()
 
       const headerLink = await screen.findByRole('link', {
@@ -177,12 +202,14 @@ describe('OtherCI', () => {
     })
   })
 
-  describe('step three', () => {
+  describe('upload step', () => {
     it('renders header', async () => {
       setup({})
       render(<OtherCI />, { wrapper })
 
-      const header = await screen.findByText(/Step 3/)
+      const header = await screen.findByText(
+        /Step \d: upload coverage to Codecov via the CLI after your tests have run/
+      )
       expect(header).toBeInTheDocument()
     })
 
@@ -231,8 +258,17 @@ describe('OtherCI', () => {
     })
   })
 
-  describe('step four', () => {
+  describe('merge step', () => {
     beforeEach(() => setup({}))
+    it('renders header', async () => {
+      render(<OtherCI />, { wrapper })
+
+      const header = await screen.findByText(
+        /Step \d: merge to main or your preferred feature branch/
+      )
+      expect(header).toBeInTheDocument()
+    })
+
     it('renders body', async () => {
       render(<OtherCI />, { wrapper })
 

--- a/src/pages/RepoPage/CoverageOnboarding/OtherCI/OtherCI.tsx
+++ b/src/pages/RepoPage/CoverageOnboarding/OtherCI/OtherCI.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react'
 import { useParams } from 'react-router-dom'
 
 import config from 'config'
@@ -13,6 +14,11 @@ import { InstructionBox } from './TerminalInstructions'
 
 import ExampleBlurb from '../ExampleBlurb'
 import LearnMoreBlurb from '../LearnMoreBlurb'
+import OutputCoverageStep from '../OutputCoverageStep/OutputCoverageStep'
+import {
+  Framework,
+  UseFrameworkInstructions,
+} from '../UseFrameworkInstructions'
 
 interface URLParams {
   provider: string
@@ -40,12 +46,25 @@ function OtherCI() {
     orgUploadToken ? ` -r ${owner}/${repo}` : ''
   }`
 
+  const [framework, setFramework] = useState<Framework>('Jest')
+  const frameworkInstruction = UseFrameworkInstructions({
+    orgUploadToken,
+    owner,
+    repo,
+  })
+
   return (
     <div className="flex flex-col gap-5">
-      <Step1 tokenCopy={tokenCopy} uploadToken={uploadToken} />
-      <Step2 />
-      <Step3 uploadCommand={uploadCommand} />
-      <Step4 />
+      <OutputCoverageStep
+        framework={framework}
+        frameworkInstructions={frameworkInstruction}
+        owner={owner}
+        setFramework={setFramework}
+      />
+      <TokenStep tokenCopy={tokenCopy} uploadToken={uploadToken} />
+      <InstallStep />
+      <UploadStep uploadCommand={uploadCommand} />
+      <MergeStep />
       <FeedbackCTA />
       <LearnMoreBlurb />
     </div>
@@ -54,17 +73,17 @@ function OtherCI() {
 
 export default OtherCI
 
-interface Step1Props {
+interface TokenStepProps {
   tokenCopy: string
   uploadToken: string
 }
 
-function Step1({ tokenCopy, uploadToken }: Step1Props) {
+function TokenStep({ tokenCopy, uploadToken }: TokenStepProps) {
   return (
     <Card>
       <Card.Header>
         <Card.Title size="base">
-          Step 1: add {tokenCopy} token as a secret to your CI Provider
+          Step 2: add {tokenCopy} token as a secret to your CI Provider
         </Card.Title>
       </Card.Header>
       <Card.Content className="flex flex-col gap-4">
@@ -81,12 +100,12 @@ function Step1({ tokenCopy, uploadToken }: Step1Props) {
   )
 }
 
-function Step2() {
+function InstallStep() {
   return (
     <Card>
       <Card.Header>
         <Card.Title size="base">
-          Step 2: add the{' '}
+          Step 3: add the{' '}
           <A
             to={{ pageName: 'uploader' }}
             data-testid="uploader"
@@ -105,16 +124,16 @@ function Step2() {
   )
 }
 
-interface Step3Props {
+interface UploadStepProps {
   uploadCommand: string
 }
 
-function Step3({ uploadCommand }: Step3Props) {
+function UploadStep({ uploadCommand }: UploadStepProps) {
   return (
     <Card>
       <Card.Header>
         <Card.Title size="base">
-          Step 3: upload coverage to Codecov via the CLI after your tests have
+          Step 4: upload coverage to Codecov via the CLI after your tests have
           run
         </Card.Title>
       </Card.Header>
@@ -126,12 +145,12 @@ function Step3({ uploadCommand }: Step3Props) {
   )
 }
 
-function Step4() {
+function MergeStep() {
   return (
     <Card>
       <Card.Header>
         <Card.Title size="base">
-          Step 4: merge to main or your preferred feature branch
+          Step 5: merge to main or your preferred feature branch
         </Card.Title>
       </Card.Header>
       <Card.Content className="flex flex-col gap-4">

--- a/src/pages/RepoPage/CoverageOnboarding/OutputCoverageStep/OutputCoverageStep.test.tsx
+++ b/src/pages/RepoPage/CoverageOnboarding/OutputCoverageStep/OutputCoverageStep.test.tsx
@@ -12,6 +12,8 @@ import { ThemeContextProvider } from 'shared/ThemeContext'
 
 import OutputCoverageStep from './OutputCoverageStep'
 
+import { Framework, FrameworkInstructions } from '../UseFrameworkInstructions'
+
 vi.mock('config')
 
 const server = setupServer()
@@ -69,27 +71,27 @@ describe('OutputCoverageStep', () => {
     }
   }
 
-  const framework = 'Jest'
-  const frameworkInstructions = {
+  const framework: Framework = 'Jest'
+  const frameworkInstructions: FrameworkInstructions = {
     Jest: {
       install: 'npm install --save-dev jest',
       run: 'npx jest --coverage',
-      workflow: undefined,
+      githubActionsWorkflow: '',
     },
     Vitest: {
       install: '',
       run: '',
-      workflow: undefined,
+      githubActionsWorkflow: '',
     },
     Pytest: {
       install: '',
       run: '',
-      workflow: undefined,
+      githubActionsWorkflow: '',
     },
     Go: {
       install: undefined,
       run: 'go test -coverprofile=coverage.txt',
-      workflow: undefined,
+      githubActionsWorkflow: '',
     },
   }
   const setFramework = vi.fn()

--- a/src/pages/RepoPage/CoverageOnboarding/OutputCoverageStep/OutputCoverageStep.tsx
+++ b/src/pages/RepoPage/CoverageOnboarding/OutputCoverageStep/OutputCoverageStep.tsx
@@ -7,7 +7,7 @@ import { Card } from 'ui/Card'
 import { CodeSnippet } from 'ui/CodeSnippet'
 import Select from 'ui/Select'
 
-import { Framework, FrameworkInstructions } from './types'
+import { Framework, FrameworkInstructions } from '../UseFrameworkInstructions'
 
 interface OutputCoverageStepProps {
   framework: Framework

--- a/src/pages/RepoPage/CoverageOnboarding/UseFrameworkInstructions.tsx
+++ b/src/pages/RepoPage/CoverageOnboarding/UseFrameworkInstructions.tsx
@@ -22,36 +22,36 @@ export function UseFrameworkInstructions({
         githubActionsWorkflow: `name: Run tests and upload coverage
 
 on: 
-push
+  push
 
 jobs:
-test:
-name: Run tests and collect coverage
-runs-on: ubuntu-latest
-steps:
-- name: Checkout
-uses: actions/checkout@v4
-with:
-fetch-depth: 0
+  test:
+    name: Run tests and collect coverage
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
-- name: Set up Node
-uses: actions/setup-node@v4
+      - name: Set up Node
+        uses: actions/setup-node@v4
 
-- name: Install dependencies
-run: npm install
+      - name: Install dependencies
+        run: npm install
 
-- name: Run tests
-run: npx jest --coverage
+      - name: Run tests
+        run: npx jest --coverage
 
-- name: Upload results to Codecov
-uses: codecov/codecov-action@v5
-with:
-token: \${{ secrets.CODECOV_TOKEN }}${
-          orgUploadToken
-            ? `
-slug: ${owner}/${repo}`
-            : ''
-        }
+      - name: Upload results to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: \${{ secrets.CODECOV_TOKEN }}${
+            orgUploadToken
+              ? `
+          slug: ${owner}/${repo}`
+              : ''
+          }
 `,
       },
       Vitest: {
@@ -60,36 +60,36 @@ slug: ${owner}/${repo}`
         githubActionsWorkflow: `name: Run tests and upload coverage
 
 on: 
-push
+  push
 
 jobs:
-test:
-name: Run tests and collect coverage
-runs-on: ubuntu-latest
-steps:
-- name: Checkout
-uses: actions/checkout@v4
-with:
-fetch-depth: 0
+  test:
+    name: Run tests and collect coverage
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
-- name: Set up Node
-uses: actions/setup-node@v4
+      - name: Set up Node
+        uses: actions/setup-node@v4
 
-- name: Install dependencies
-run: npm install
+      - name: Install dependencies
+        run: npm install
 
-- name: Run tests
-run: npx vitest run --coverage
+      - name: Run tests
+        run: npx vitest run --coverage
 
-- name: Upload results to Codecov
-uses: codecov/codecov-action@v5
-with:
-token: \${{ secrets.CODECOV_TOKEN }}${
-          orgUploadToken
-            ? `
-slug: ${owner}/${repo}`
-            : ''
-        }
+      - name: Upload results to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: \${{ secrets.CODECOV_TOKEN }}${
+            orgUploadToken
+              ? `
+          slug: ${owner}/${repo}`
+              : ''
+          }
 `,
       },
       Pytest: {
@@ -98,36 +98,36 @@ slug: ${owner}/${repo}`
         githubActionsWorkflow: `name: Run tests and upload coverage
 
 on: 
-push
+  push
 
 jobs:
-test:
-name: Run tests and collect coverage
-runs-on: ubuntu-latest
-steps:
-- name: Checkout
-uses: actions/checkout@v4
-with:
-fetch-depth: 0
+  test:
+    name: Run tests and collect coverage
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
-- name: Set up Python
-uses: actions/setup-python@v4
+      - name: Set up Python
+        uses: actions/setup-python@v4
 
-- name: Install dependencies
-run: pip install pytest pytest-cov
+      - name: Install dependencies
+        run: pip install pytest pytest-cov
 
-- name: Run tests
-run: pytest --cov-branch --cov-report=xml
+      - name: Run tests
+        run: pytest --cov-branch --cov-report=xml
 
-- name: Upload results to Codecov
-uses: codecov/codecov-action@v5
-with:
-token: \${{ secrets.CODECOV_TOKEN }}${
-          orgUploadToken
-            ? `
-slug: ${owner}/${repo}`
-            : ''
-        }
+      - name: Upload results to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: \${{ secrets.CODECOV_TOKEN }}${
+            orgUploadToken
+              ? `
+          slug: ${owner}/${repo}`
+              : ''
+          }
 `,
       },
       Go: {
@@ -136,36 +136,36 @@ slug: ${owner}/${repo}`
         githubActionsWorkflow: `name: Run tests and upload coverage
 
 on: 
-push
+  push
 
 jobs:
-test:
-name: Run tests and collect coverage
-runs-on: ubuntu-latest
-steps:
-- name: Checkout
-uses: actions/checkout@v4
-with:
-fetch-depth: 0
+  test:
+    name: Run tests and collect coverage
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
-- name: Set up Go
-uses: actions/setup-go@v5
+      - name: Set up Go
+        uses: actions/setup-go@v5
 
-- name: Install dependencies
-run: go mod download
+      - name: Install dependencies
+        run: go mod download
 
-- name: Run tests
-run: go test -coverprofile=coverage.txt
+      - name: Run tests
+        run: go test -coverprofile=coverage.txt
 
-- name: Upload results to Codecov
-uses: codecov/codecov-action@v5
-with:
-token: \${{ secrets.CODECOV_TOKEN }}${
-          orgUploadToken
-            ? `
-slug: ${owner}/${repo}`
-            : ''
-        }
+      - name: Upload results to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: \${{ secrets.CODECOV_TOKEN }}${
+            orgUploadToken
+              ? `
+          slug: ${owner}/${repo}`
+              : ''
+          }
 `,
       },
     }),

--- a/src/pages/RepoPage/CoverageOnboarding/UseFrameworkInstructions.tsx
+++ b/src/pages/RepoPage/CoverageOnboarding/UseFrameworkInstructions.tsx
@@ -1,0 +1,174 @@
+import { useMemo } from 'react'
+
+export type Framework = 'Jest' | 'Vitest' | 'Pytest' | 'Go'
+export type FrameworkInstructions = ReturnType<typeof UseFrameworkInstructions>
+
+interface UseFrameworkInstructionsArgs {
+  orgUploadToken?: string | null
+  owner: string
+  repo: string
+}
+
+export function UseFrameworkInstructions({
+  orgUploadToken,
+  owner,
+  repo,
+}: UseFrameworkInstructionsArgs) {
+  return useMemo(
+    () => ({
+      Jest: {
+        install: 'npm install --save-dev jest',
+        run: 'npx jest --coverage',
+        githubActionsWorkflow: `name: Run tests and upload coverage
+
+on: 
+push
+
+jobs:
+test:
+name: Run tests and collect coverage
+runs-on: ubuntu-latest
+steps:
+- name: Checkout
+uses: actions/checkout@v4
+with:
+fetch-depth: 0
+
+- name: Set up Node
+uses: actions/setup-node@v4
+
+- name: Install dependencies
+run: npm install
+
+- name: Run tests
+run: npx jest --coverage
+
+- name: Upload results to Codecov
+uses: codecov/codecov-action@v5
+with:
+token: \${{ secrets.CODECOV_TOKEN }}${
+          orgUploadToken
+            ? `
+slug: ${owner}/${repo}`
+            : ''
+        }
+`,
+      },
+      Vitest: {
+        install: 'npm install --save-dev vitest @vitest/coverage-v8',
+        run: 'npx vitest run --coverage',
+        githubActionsWorkflow: `name: Run tests and upload coverage
+
+on: 
+push
+
+jobs:
+test:
+name: Run tests and collect coverage
+runs-on: ubuntu-latest
+steps:
+- name: Checkout
+uses: actions/checkout@v4
+with:
+fetch-depth: 0
+
+- name: Set up Node
+uses: actions/setup-node@v4
+
+- name: Install dependencies
+run: npm install
+
+- name: Run tests
+run: npx vitest run --coverage
+
+- name: Upload results to Codecov
+uses: codecov/codecov-action@v5
+with:
+token: \${{ secrets.CODECOV_TOKEN }}${
+          orgUploadToken
+            ? `
+slug: ${owner}/${repo}`
+            : ''
+        }
+`,
+      },
+      Pytest: {
+        install: 'pip install pytest pytest-cov',
+        run: 'pytest --cov --cov-report=xml',
+        githubActionsWorkflow: `name: Run tests and upload coverage
+
+on: 
+push
+
+jobs:
+test:
+name: Run tests and collect coverage
+runs-on: ubuntu-latest
+steps:
+- name: Checkout
+uses: actions/checkout@v4
+with:
+fetch-depth: 0
+
+- name: Set up Python
+uses: actions/setup-python@v4
+
+- name: Install dependencies
+run: pip install pytest pytest-cov
+
+- name: Run tests
+run: pytest --cov --cov-report=xml
+
+- name: Upload results to Codecov
+uses: codecov/codecov-action@v5
+with:
+token: \${{ secrets.CODECOV_TOKEN }}${
+          orgUploadToken
+            ? `
+slug: ${owner}/${repo}`
+            : ''
+        }
+`,
+      },
+      Go: {
+        install: undefined,
+        run: 'go test -coverprofile=coverage.txt',
+        githubActionsWorkflow: `name: Run tests and upload coverage
+
+on: 
+push
+
+jobs:
+test:
+name: Run tests and collect coverage
+runs-on: ubuntu-latest
+steps:
+- name: Checkout
+uses: actions/checkout@v4
+with:
+fetch-depth: 0
+
+- name: Set up Go
+uses: actions/setup-go@v5
+
+- name: Install dependencies
+run: go mod download
+
+- name: Run tests
+run: go test -coverprofile=coverage.txt
+
+- name: Upload results to Codecov
+uses: codecov/codecov-action@v5
+with:
+token: \${{ secrets.CODECOV_TOKEN }}${
+          orgUploadToken
+            ? `
+slug: ${owner}/${repo}`
+            : ''
+        }
+`,
+      },
+    }),
+    [orgUploadToken, owner, repo]
+  )
+}

--- a/src/pages/RepoPage/CoverageOnboarding/UseFrameworkInstructions.tsx
+++ b/src/pages/RepoPage/CoverageOnboarding/UseFrameworkInstructions.tsx
@@ -94,7 +94,7 @@ slug: ${owner}/${repo}`
       },
       Pytest: {
         install: 'pip install pytest pytest-cov',
-        run: 'pytest --cov --cov-report=xml',
+        run: 'pytest --cov-branch --cov-report=xml',
         githubActionsWorkflow: `name: Run tests and upload coverage
 
 on: 
@@ -117,7 +117,7 @@ uses: actions/setup-python@v4
 run: pip install pytest pytest-cov
 
 - name: Run tests
-run: pytest --cov --cov-report=xml
+run: pytest --cov-branch --cov-report=xml
 
 - name: Upload results to Codecov
 uses: codecov/codecov-action@v5


### PR DESCRIPTION
This PR adds the framework coverage generation step from GHA to circle ci and other ci onboarding. To facilitate this, I pulled the OutputCoverageStep component and the FrameworkInstruction definition out of the GHA directory up a level into the shared onboarding directory and made the necessary changes to GHA onboarding.

Closes https://github.com/codecov/engineering-team/issues/2697

<img width="810" alt="Screenshot 2024-12-19 at 10 52 36" src="https://github.com/user-attachments/assets/c752226d-df88-421e-b200-34b9af71862a" />

<img width="838" alt="Screenshot 2024-12-19 at 10 52 45" src="https://github.com/user-attachments/assets/8d1ebcfd-9f1f-4d98-81fe-836feda19265" />
