### PR TITLE
fix: Pin demo repo to top during sort

### DIFF
--- a/src/shared/ListRepo/ReposTable/ReposTable.tsx
+++ b/src/shared/ListRepo/ReposTable/ReposTable.tsx
@@ -153,18 +153,34 @@ const ReposTable = ({
   })
 
   const isMyOwnerPage = currentUser?.user?.username === owner
-  const includeDemo = mayIncludeDemo && !config.IS_SELF_HOSTED && isMyOwnerPage
 
   const tableData = useMemo(() => {
     const repos =
       reposData?.pages.flatMap((page) => page?.repos).filter(isNotNull) ?? []
+
+    const configuredRepos = repos.reduce(
+      (acc, repo) => (repo.coverageEnabled ? acc + 1 : acc),
+      0
+    )
+
+    const includeDemo =
+      mayIncludeDemo &&
+      !config.IS_SELF_HOSTED &&
+      isMyOwnerPage &&
+      configuredRepos < 2
 
     const demoRepos = includeDemo
       ? formatDemoRepos(demoReposData, searchValue)
       : []
 
     return [...demoRepos, ...repos]
-  }, [reposData?.pages, demoReposData, includeDemo, searchValue])
+  }, [
+    reposData?.pages,
+    demoReposData,
+    searchValue,
+    isMyOwnerPage,
+    mayIncludeDemo,
+  ])
 
   useEffect(() => {
     if (inView && hasNextPage) {

--- a/src/shared/ListRepo/ReposTable/ReposTable.tsx
+++ b/src/shared/ListRepo/ReposTable/ReposTable.tsx
@@ -186,6 +186,7 @@ const ReposTable = ({
     onSortingChange: setSorting,
     getSortedRowModel: getSortedRowModel(),
     enableSortingRemoval: false,
+    manualSorting: true,
   })
 
   if (!isReposLoading && isEmpty(tableData)) {


### PR DESCRIPTION
Pins the demo repo to the top of the repo list during sorts. Also hides the demo if two or more repos are configured.

Closes https://github.com/codecov/engineering-team/issues/2827
