### PR TITLE
ref: Convert isBasicPlan to isFreePlan GQL property

### DIFF
--- a/src/pages/DefaultOrgSelector/DefaultOrgSelector.jsx
+++ b/src/pages/DefaultOrgSelector/DefaultOrgSelector.jsx
@@ -17,7 +17,6 @@ import { useUpdateDefaultOrganization } from 'services/defaultOrganization'
 import { useStaticNavLinks } from 'services/navigation'
 import { useStartTrial } from 'services/trial'
 import { CustomerIntent, useUser } from 'services/user'
-import { isBasicPlan } from 'shared/utils/billing'
 import { mapEdges } from 'shared/utils/graphql'
 import { providerToName } from 'shared/utils/provider'
 import A from 'ui/A/A'
@@ -133,7 +132,7 @@ function DefaultOrgSelector() {
       jsonPayload: { action: 'Selected Default Org' },
     })
     if (
-      isBasicPlan(planData?.plan?.value) &&
+      planData?.plan?.isFreePlan &&
       selectedOrg !== currentUser?.user?.username &&
       isNewTrial &&
       planData?.hasPrivateRepos

--- a/src/pages/DefaultOrgSelector/DefaultOrgSelector.test.jsx
+++ b/src/pages/DefaultOrgSelector/DefaultOrgSelector.test.jsx
@@ -213,7 +213,7 @@ describe('DefaultOrgSelector', () => {
               plan: {
                 ...mockTrialData,
                 isEnterprisePlan: false,
-                isFreePlan: false,
+                isFreePlan: value === Plans.USERS_BASIC,
                 trialStatus,
                 value,
               },

--- a/src/pages/RepoPage/CoverageOnboarding/ActivationBanner/ActivationBanner.tsx
+++ b/src/pages/RepoPage/CoverageOnboarding/ActivationBanner/ActivationBanner.tsx
@@ -3,7 +3,6 @@ import { useParams } from 'react-router-dom'
 import config from 'config'
 
 import { TrialStatuses, usePlanData } from 'services/account'
-import { isBasicPlan } from 'shared/utils/billing'
 
 import ActivationRequiredBanner from './ActivationRequiredBanner'
 import ActivationRequiredSelfHosted from './ActivationRequiredSelfHosted'
@@ -24,9 +23,7 @@ function ActivationBanner() {
   })
   const isNewTrial = planData?.plan?.trialStatus === TrialStatuses.NOT_STARTED
   const isTrialEligible =
-    isBasicPlan(planData?.plan?.value) &&
-    planData?.hasPrivateRepos &&
-    isNewTrial
+    planData?.plan?.isFreePlan && planData?.hasPrivateRepos && isNewTrial
   const seatsLimitReached = !planData?.plan?.hasSeatsLeft
   const isFreePlanValue = planData?.plan?.isFreePlan
 

--- a/src/shared/utils/billing.test.ts
+++ b/src/shared/utils/billing.test.ts
@@ -11,7 +11,6 @@ import {
   formatNumberToUSD,
   formatTimestampToCalendarDate,
   getNextBillingDate,
-  isBasicPlan,
   isCodecovProPlan,
   isProPlan,
   isSentryPlan,
@@ -491,19 +490,6 @@ describe('canApplySentryUpgrade', () => {
     })
 
     expect(result).toBeFalsy()
-  })
-})
-
-describe('isBasicPlan', () => {
-  it('returns true when plan is basic', () => {
-    expect(isBasicPlan(Plans.USERS_BASIC)).toBeTruthy()
-  })
-
-  it('returns false when plan is not basic', () => {
-    expect(isBasicPlan(Plans.USERS_FREE)).toBeFalsy()
-    expect(isBasicPlan(Plans.USERS_INAPP)).toBeFalsy()
-    expect(isBasicPlan(Plans.USERS_ENTERPRISEM)).toBeFalsy()
-    expect(isBasicPlan(Plans.USERS_SENTRYM)).toBeFalsy()
   })
 })
 

--- a/src/shared/utils/billing.ts
+++ b/src/shared/utils/billing.ts
@@ -58,12 +58,6 @@ export function isTeamPlan(plan?: PlanName | null) {
   }
   return false
 }
-export function isBasicPlan(plan?: PlanName) {
-  if (isString(plan)) {
-    return plan === Plans.USERS_BASIC
-  }
-  return false
-}
 
 export function isSentryPlan(plan?: PlanName | null) {
   if (isString(plan)) {


### PR DESCRIPTION
# Description

isBasicPlan looked to only be used in two places, both related to trials. After talking with @aj-codecov and @adrian-codecov we thought that shifting to all free plans, as long as they haven't trialed before, made sense to us allowing us to remove some extra overhead with logic and just rely on isFreePlan in a few more places.

Luckily because the schemas all stayed the same this PR remained pretty lightweight.

Closes https://github.com/codecov/engineering-team/issues/3002

# Link to Sample Entry

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.