### PR TITLE
dev: Clean up some unneccesary mocks to speed up gazebo tests

### DIFF
--- a/src/pages/DefaultOrgSelector/DefaultOrgSelector.test.jsx
+++ b/src/pages/DefaultOrgSelector/DefaultOrgSelector.test.jsx
@@ -159,6 +159,7 @@ const wrapper =
   )
 
 beforeAll(() => {
+  console.error = () => {}
   server.listen({
     onUnhandledRequest: 'warn',
   })
@@ -169,6 +170,7 @@ afterEach(() => {
 })
 afterAll(() => {
   server.close()
+  vi.resetAllMocks()
 })
 
 describe('DefaultOrgSelector', () => {
@@ -1294,7 +1296,7 @@ describe('DefaultOrgSelector', () => {
 
   describe('on fetch next page', () => {
     it('renders next page', async () => {
-      const { user, fetchNextPage } = setup({
+      const { fetchNextPage } = setup({
         useUserData: mockUserData,
         myOrganizationsData: {
           me: {
@@ -1315,12 +1317,6 @@ describe('DefaultOrgSelector', () => {
 
       render(<DefaultOrgSelector />, { wrapper: wrapper() })
       mocks.useIntersection.mockReturnValue({ isIntersecting: true })
-
-      const selectOrg = await screen.findByRole('button', {
-        name: 'Select an organization',
-      })
-
-      await user.click(selectOrg)
 
       await waitFor(() => expect(fetchNextPage).toHaveBeenCalled())
       await waitFor(() => expect(fetchNextPage).toHaveBeenCalledWith('MTI='))

--- a/src/pages/RepoPage/CommitsTab/CommitsTab.test.jsx
+++ b/src/pages/RepoPage/CommitsTab/CommitsTab.test.jsx
@@ -333,16 +333,6 @@ describe('CommitsTab', () => {
     })
 
     describe('when select onLoadMore is triggered', () => {
-      beforeEach(() => {
-        mocks.useIntersection.mockReturnValue({
-          isIntersecting: true,
-        })
-      })
-
-      afterEach(() => {
-        vi.clearAllMocks()
-      })
-
       describe('when there is not a next page', () => {
         it('does not call fetchNextPage', async () => {
           const { user, fetchNextPage } = setup({ hasNextPage: false })
@@ -359,11 +349,11 @@ describe('CommitsTab', () => {
 
       describe('when there is a next page', () => {
         it('calls fetchNextPage', async () => {
-          const { fetchNextPage, user } = setup({ hasNextPage: true })
+          const { fetchNextPage } = setup({ hasNextPage: true })
+          mocks.useIntersection.mockReturnValue({
+            isIntersecting: true,
+          })
           render(<CommitsTab />, { wrapper })
-
-          const select = await screen.findByText('Select branch')
-          await user.click(select)
 
           await waitFor(() =>
             expect(fetchNextPage).toHaveBeenCalledWith('some cursor')

--- a/src/pages/RepoPage/CoverageTab/OverviewTab/Summary/Summary.test.jsx
+++ b/src/pages/RepoPage/CoverageTab/OverviewTab/Summary/Summary.test.jsx
@@ -363,7 +363,7 @@ describe('Summary', () => {
     describe('there is a next page', () => {
       it('calls fetchNextPage', async () => {
         const mockSetNewPath = vi.fn()
-        const { fetchNextPage, user } = setup({
+        const { fetchNextPage } = setup({
           hasNextPage: true,
           coverageRedirectData: {
             redirectState: {
@@ -377,11 +377,6 @@ describe('Summary', () => {
           isIntersecting: true,
         })
         render(<Summary />, { wrapper: wrapper() })
-
-        const select = await screen.findByRole('button', {
-          name: 'select branch',
-        })
-        await user.click(select)
 
         await waitFor(() => expect(fetchNextPage).toHaveBeenCalled())
       })

--- a/src/pages/RepoPage/CoverageTab/OverviewTab/SummaryTeamPlan/SummaryTeamPlan.test.tsx
+++ b/src/pages/RepoPage/CoverageTab/OverviewTab/SummaryTeamPlan/SummaryTeamPlan.test.tsx
@@ -348,7 +348,7 @@ describe('Summary', () => {
     describe('there is a next page', () => {
       it('calls fetchNextPage', async () => {
         const mockSetNewPath = vi.fn()
-        const { fetchNextPage, user } = setup({
+        const { fetchNextPage } = setup({
           isIntersecting: true,
           hasNextPage: true,
           coverageRedirectData: {
@@ -360,11 +360,6 @@ describe('Summary', () => {
           },
         })
         render(<SummaryTeamPlan />, { wrapper: wrapper() })
-
-        const select = await screen.findByRole('button', {
-          name: 'select branch',
-        })
-        await user.click(select)
 
         await waitFor(() => expect(fetchNextPage).toHaveBeenCalled())
       })

--- a/src/ui/FileViewer/ToggleHeader/ToggleHeader.test.tsx
+++ b/src/ui/FileViewer/ToggleHeader/ToggleHeader.test.tsx
@@ -6,19 +6,6 @@ import { MemoryRouter, Route } from 'react-router-dom'
 
 import ToggleHeader from './ToggleHeader'
 
-const mocks = vi.hoisted(() => ({
-  useIntersection: vi.fn(),
-}))
-
-vi.mock('react-use', async () => {
-  const original = await vi.importActual('react-use')
-
-  return {
-    ...original,
-    useIntersection: mocks.useIntersection,
-  }
-})
-
 const mockFlagResponse = {
   owner: {
     repository: {


### PR DESCRIPTION
# Description

Friday afternoon "chores" had me looking at the Test Analytics tool on Codecov for the Gazebo repo just because I hadn't in a while. I was surprised to see that some tests were taking over 5 seconds to run, with one being an even more abnormal "18 seconds."

<img width="1445" alt="Screenshot 2024-12-20 at 2 16 50 PM" src="https://github.com/user-attachments/assets/346a5f76-ecb6-4d95-b1a4-20f5b0786b9c" />

**Screenshot of initial test analytics page**


I used the historical selector in the top to narrow my search to the last 7 days to see if it was just a blip of some weird data or if there was actually something abnormal going on here. To my surprise, even at 7 days I was seeing some similarly high test times and had to do a double check locally to see if I could reproduce those exact tests.

<img width="1419" alt="Screenshot 2024-12-20 at 2 16 02 PM" src="https://github.com/user-attachments/assets/5d03c51b-bee7-4300-a1b6-cabf8ab344b5" />

**Screenshot of last 7 days data**

Locally, I booted up the Commit.jsx test suite to see if I was also seeing some slow test suite run times since I wasn't completely convinced still. Lo and behold, I was seeing "13 seconds" as a pretty routine runtime for that suite. Using cursor, I  literally just plugged in, any idea what I can do to make this test suite run faster? Cursor immediately spat back out, "yeah you probably don't need this mock," which after double checking I _think_ is correct? **if someone else could double check these aren't just poorly written tests,** I think this just works? In any case, the test suite passed and I was able to do a similar fix for the rest of the tests that were 

So yes, test analytics works, and hopefully we get a little extra speed from our test suite now as well! Oh and cursor works too I guess.


### Screenshots of the test runs before and after

<img width="1108" alt="Screenshot 2024-12-20 at 2 02 28 PM" src="https://github.com/user-attachments/assets/03bfd96e-5010-41e6-9155-1210116a7bec" />
<img width="1106" alt="Screenshot 2024-12-20 at 2 03 46 PM" src="https://github.com/user-attachments/assets/7baf77e8-580e-4665-a9c1-e1ac68cbab3c" />
<img width="1099" alt="Screenshot 2024-12-20 at 2 06 52 PM" src="https://github.com/user-attachments/assets/94d9229b-d479-4dd6-9392-b9798214b96e" />
<img width="1110" alt="Screenshot 2024-12-20 at 2 09 05 PM" src="https://github.com/user-attachments/assets/9430eeb2-e732-40a1-9746-6f7039c42d66" />


# Link to Sample Entry

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.