### PR TITLE
ref: Migrate useRepos to TS Query V5

### DIFF
--- a/src/pages/AdminSettings/AdminMembers/MemberList/MemberTable.tsx
+++ b/src/pages/AdminSettings/AdminMembers/MemberList/MemberTable.tsx
@@ -4,9 +4,9 @@ import {
   useQueryClient,
 } from '@tanstack/react-query'
 import {
-  useSuspenseQuery as useSuspenseQueryV5,
   useInfiniteQuery as useInfiniteQueryV5,
   useQueryClient as useQueryClientV5,
+  useSuspenseQuery as useSuspenseQueryV5,
 } from '@tanstack/react-queryV5'
 import {
   createColumnHelper,

--- a/src/pages/AnalyticsPage/AnalyticsPage.jsx
+++ b/src/pages/AnalyticsPage/AnalyticsPage.jsx
@@ -2,7 +2,7 @@ import { useParams } from 'react-router-dom'
 
 import NotFound from 'pages/NotFound'
 import { useLocationParams } from 'services/navigation'
-import { orderingOptions } from 'services/repos'
+import { orderingOptions } from 'services/repos/config'
 import { useOwner } from 'services/user'
 import ReposTable from 'shared/ListRepo/ReposTable'
 

--- a/src/pages/AnalyticsPage/AnalyticsPage.jsx
+++ b/src/pages/AnalyticsPage/AnalyticsPage.jsx
@@ -2,7 +2,7 @@ import { useParams } from 'react-router-dom'
 
 import NotFound from 'pages/NotFound'
 import { useLocationParams } from 'services/navigation'
-import { orderingOptions } from 'services/repos/config'
+import { orderingOptions } from 'services/repos/orderingOptions'
 import { useOwner } from 'services/user'
 import ReposTable from 'shared/ListRepo/ReposTable'
 

--- a/src/pages/AnalyticsPage/ChartSelectors/ChartSelectors.jsx
+++ b/src/pages/AnalyticsPage/ChartSelectors/ChartSelectors.jsx
@@ -61,8 +61,8 @@ function RepoSelector({
     isLoading,
     fetchNextPage,
     hasNextPage,
-  } = useInfiniteQueryV5({
-    ...ReposQueryOpts({
+  } = useInfiniteQueryV5(
+    ReposQueryOpts({
       provider,
       owner,
       sortItem,
@@ -70,8 +70,8 @@ function RepoSelector({
       term: search,
       first: Infinity,
       isPublic: shouldDisplayPublicReposOnly,
-    }),
-  })
+    })
+  )
 
   const reposSelectData = useMemo(() => {
     const data = reposData?.pages?.map((page) => page?.repos).flat()

--- a/src/pages/AnalyticsPage/ChartSelectors/ChartSelectors.jsx
+++ b/src/pages/AnalyticsPage/ChartSelectors/ChartSelectors.jsx
@@ -1,8 +1,9 @@
+import { useInfiniteQuery as useInfiniteQueryV5 } from '@tanstack/react-queryV5'
 import PropTypes from 'prop-types'
 import { useMemo, useRef, useState } from 'react'
 import { useParams } from 'react-router-dom'
 
-import { useRepos } from 'services/repos'
+import { ReposQueryOpts } from 'services/repos/ReposQueryOpts'
 import { TierNames, useTier } from 'services/tier'
 import A from 'ui/A'
 import DateRangePicker from 'ui/DateRangePicker'
@@ -60,15 +61,16 @@ function RepoSelector({
     isLoading,
     fetchNextPage,
     hasNextPage,
-  } = useRepos({
-    provider,
-    owner,
-    sortItem,
-    activated: active,
-    term: search,
-    first: Infinity,
-    suspense: false,
-    isPublic: shouldDisplayPublicReposOnly,
+  } = useInfiniteQueryV5({
+    ...ReposQueryOpts({
+      provider,
+      owner,
+      sortItem,
+      activated: active,
+      term: search,
+      first: Infinity,
+      isPublic: shouldDisplayPublicReposOnly,
+    }),
   })
 
   const reposSelectData = useMemo(() => {

--- a/src/pages/RepoPage/CoverageTab/OverviewTab/subroute/FileExplorer/CodeTreeTable/CodeTreeTable.tsx
+++ b/src/pages/RepoPage/CoverageTab/OverviewTab/subroute/FileExplorer/CodeTreeTable/CodeTreeTable.tsx
@@ -8,7 +8,7 @@ import cs from 'classnames'
 import { useEffect } from 'react'
 import { useInView } from 'react-intersection-observer'
 
-import { OrderingDirection } from 'services/repos'
+import { OrderingDirection } from 'services/repos/config'
 import { useTableDefaultSort } from 'shared/ContentsTable/useTableDefaultSort'
 import { Row } from 'shared/ContentsTable/utils'
 import Icon from 'ui/Icon'

--- a/src/pages/RepoPage/CoverageTab/OverviewTab/subroute/FileExplorer/CodeTreeTable/CodeTreeTable.tsx
+++ b/src/pages/RepoPage/CoverageTab/OverviewTab/subroute/FileExplorer/CodeTreeTable/CodeTreeTable.tsx
@@ -8,7 +8,7 @@ import cs from 'classnames'
 import { useEffect } from 'react'
 import { useInView } from 'react-intersection-observer'
 
-import { OrderingDirection } from 'services/repos/config'
+import { OrderingDirection } from 'services/repos/orderingOptions'
 import { useTableDefaultSort } from 'shared/ContentsTable/useTableDefaultSort'
 import { Row } from 'shared/ContentsTable/utils'
 import Icon from 'ui/Icon'

--- a/src/pages/RepoPage/CoverageTab/OverviewTab/subroute/FileExplorer/FileListTable/FileListTable.tsx
+++ b/src/pages/RepoPage/CoverageTab/OverviewTab/subroute/FileExplorer/FileListTable/FileListTable.tsx
@@ -8,7 +8,7 @@ import cs from 'classnames'
 import { useEffect } from 'react'
 import { useInView } from 'react-intersection-observer'
 
-import { OrderingDirection } from 'services/repos'
+import { OrderingDirection } from 'services/repos/config'
 import { useTableDefaultSort } from 'shared/ContentsTable/useTableDefaultSort'
 import { Row } from 'shared/ContentsTable/utils'
 import Icon from 'ui/Icon'

--- a/src/pages/RepoPage/CoverageTab/OverviewTab/subroute/FileExplorer/FileListTable/FileListTable.tsx
+++ b/src/pages/RepoPage/CoverageTab/OverviewTab/subroute/FileExplorer/FileListTable/FileListTable.tsx
@@ -8,7 +8,7 @@ import cs from 'classnames'
 import { useEffect } from 'react'
 import { useInView } from 'react-intersection-observer'
 
-import { OrderingDirection } from 'services/repos/config'
+import { OrderingDirection } from 'services/repos/orderingOptions'
 import { useTableDefaultSort } from 'shared/ContentsTable/useTableDefaultSort'
 import { Row } from 'shared/ContentsTable/utils'
 import Icon from 'ui/Icon'

--- a/src/services/repos/ReposQueryOpts.test.tsx
+++ b/src/services/repos/ReposQueryOpts.test.tsx
@@ -86,7 +86,7 @@ afterAll(() => {
   server.close()
 })
 
-describe('useRepos', () => {
+describe('ReposQueryOpts', () => {
   function setup({ invalidResponse = false } = {}) {
     server.use(
       graphql.query('ReposForOwner', (info) => {

--- a/src/services/repos/ReposQueryOpts.test.tsx
+++ b/src/services/repos/ReposQueryOpts.test.tsx
@@ -1,23 +1,27 @@
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import {
+  QueryClientProvider as QueryClientProviderV5,
+  QueryClient as QueryClientV5,
+  useInfiniteQuery as useInfiniteQueryV5,
+} from '@tanstack/react-queryV5'
 import { renderHook, waitFor } from '@testing-library/react'
 import { graphql, HttpResponse } from 'msw'
 import { setupServer } from 'msw/node'
 import { MemoryRouter, Route } from 'react-router-dom'
 import { MockInstance } from 'vitest'
 
-import { useRepos } from './useRepos'
+import { ReposQueryOpts } from './ReposQueryOpts'
 
-const queryClient = new QueryClient({
+const queryClientV5 = new QueryClientV5({
   defaultOptions: { queries: { retry: false } },
 })
 const wrapper =
   (initialEntries = '/gh'): React.FC<React.PropsWithChildren> =>
   ({ children }) => (
-    <QueryClientProvider client={queryClient}>
+    <QueryClientProviderV5 client={queryClientV5}>
       <MemoryRouter initialEntries={[initialEntries]}>
         <Route path="/:provider">{children}</Route>
       </MemoryRouter>
-    </QueryClientProvider>
+    </QueryClientProviderV5>
   )
 
 const repo1 = {
@@ -74,7 +78,7 @@ beforeAll(() => {
 })
 
 afterEach(() => {
-  queryClient.clear()
+  queryClientV5.clear()
   server.resetHandlers()
 })
 
@@ -95,16 +99,8 @@ describe('useRepos', () => {
             username: 'codecov',
             repositories: {
               edges: info.variables.after
-                ? [
-                    {
-                      node: repo2,
-                    },
-                  ]
-                : [
-                    {
-                      node: repo1,
-                    },
-                  ],
+                ? [{ node: repo2 }]
+                : [{ node: repo1 }],
               pageInfo: {
                 hasNextPage: info.variables.after ? false : true,
                 endCursor: info.variables.after
@@ -123,10 +119,9 @@ describe('useRepos', () => {
   it('returns repositories of the owner', async () => {
     setup()
     const { result } = renderHook(
-      () => useRepos({ provider: '', owner: 'codecov' }),
-      {
-        wrapper: wrapper(),
-      }
+      () =>
+        useInfiniteQueryV5(ReposQueryOpts({ provider: '', owner: 'codecov' })),
+      { wrapper: wrapper() }
     )
 
     await waitFor(() => {
@@ -146,10 +141,8 @@ describe('useRepos', () => {
     it('returns next set of repositories', async () => {
       setup()
       const { result } = renderHook(
-        () => useRepos({ provider: '', owner: '' }),
-        {
-          wrapper: wrapper(),
-        }
+        () => useInfiniteQueryV5(ReposQueryOpts({ provider: '', owner: '' })),
+        { wrapper: wrapper() }
       )
 
       await waitFor(() => result.current.isFetching)
@@ -190,13 +183,17 @@ describe('useRepos', () => {
     it('throws an error', async () => {
       setup({ invalidResponse: true })
       const { result } = renderHook(
-        () => useRepos({ provider: '', owner: 'owner1' }),
+        () =>
+          useInfiniteQueryV5(ReposQueryOpts({ provider: '', owner: 'owner1' })),
         { wrapper: wrapper() }
       )
 
       await waitFor(() =>
         expect(result.current.error).toEqual(
-          expect.objectContaining({ status: 404 })
+          expect.objectContaining({
+            status: 404,
+            dev: 'ReposQueryOpts - 404 Failed to parse schema',
+          })
         )
       )
     })

--- a/src/services/repos/ReposQueryOpts.tsx
+++ b/src/services/repos/ReposQueryOpts.tsx
@@ -132,7 +132,7 @@ function ReposQueryOpts({
   isPublic = null, // by default, get both public and private repos
 }: ReposQueryArgs) {
   const variables = {
-    filters: { activated, term, repoNames, isPublic: Boolean(isPublic) },
+    filters: { activated, term, repoNames, isPublic },
     ordering: sortItem?.ordering,
     direction: sortItem?.direction,
     first,

--- a/src/services/repos/ReposQueryOpts.tsx
+++ b/src/services/repos/ReposQueryOpts.tsx
@@ -107,7 +107,7 @@ const query = `query ReposForOwner(
   }
 }`
 
-interface UseReposArgs {
+interface ReposQueryArgs {
   provider: string
   owner: string
   activated?: boolean
@@ -130,7 +130,7 @@ function ReposQueryOpts({
   first = 20,
   repoNames,
   isPublic = null, // by default, get both public and private repos
-}: UseReposArgs) {
+}: ReposQueryArgs) {
   const variables = {
     filters: { activated, term, repoNames, isPublic: Boolean(isPublic) },
     ordering: sortItem?.ordering,

--- a/src/services/repos/ReposQueryOpts.tsx
+++ b/src/services/repos/ReposQueryOpts.tsx
@@ -132,7 +132,7 @@ function ReposQueryOpts({
   isPublic = null, // by default, get both public and private repos
 }: UseReposArgs) {
   const variables = {
-    filters: { activated, term, repoNames, isPublic },
+    filters: { activated, term, repoNames, isPublic: Boolean(isPublic) },
     ordering: sortItem?.ordering,
     direction: sortItem?.direction,
     first,
@@ -148,7 +148,7 @@ function ReposQueryOpts({
         variables: {
           ...variables,
           owner,
-          after: pageParam,
+          after: pageParam === '' ? undefined : pageParam,
         },
       }).then((res) => {
         const parsedRes = RequestSchema.safeParse(res?.data)

--- a/src/services/repos/ReposQueryOpts.tsx
+++ b/src/services/repos/ReposQueryOpts.tsx
@@ -1,11 +1,17 @@
-import { useInfiniteQuery } from '@tanstack/react-query'
+import { infiniteQueryOptions as infiniteQueryOptionsV5 } from '@tanstack/react-queryV5'
 import { z } from 'zod'
 
 import { RepositoryConfigSchema } from 'services/repo/useRepoConfig'
 import Api from 'shared/api'
+import { rejectNetworkError } from 'shared/api/helpers'
 import { mapEdges } from 'shared/utils/graphql'
 
-import { orderingOptions } from './orderingOptions'
+import {
+  nonActiveOrderingOptions,
+  OrderingDirection,
+  orderingOptions,
+  TeamOrdering,
+} from './orderingOptions'
 
 const RepositorySchema = z
   .object({
@@ -30,7 +36,7 @@ const RepositorySchema = z
   })
   .nullable()
 
-export type RepositoryResult = z.infer<typeof RepositorySchema>
+type RepositoryResult = z.infer<typeof RepositorySchema>
 
 const RequestSchema = z.object({
   owner: z
@@ -115,7 +121,7 @@ interface UseReposArgs {
   isPublic?: true | false | null
 }
 
-export function useRepos({
+function ReposQueryOpts({
   provider,
   owner,
   activated,
@@ -124,7 +130,6 @@ export function useRepos({
   first = 20,
   repoNames,
   isPublic = null, // by default, get both public and private repos
-  ...options
 }: UseReposArgs) {
   const variables = {
     filters: { activated, term, repoNames, isPublic },
@@ -133,7 +138,7 @@ export function useRepos({
     first,
   }
 
-  return useInfiniteQuery({
+  return infiniteQueryOptionsV5({
     queryKey: ['repos', provider, owner, variables],
     queryFn: ({ pageParam, signal }) => {
       return Api.graphql({
@@ -148,9 +153,11 @@ export function useRepos({
       }).then((res) => {
         const parsedRes = RequestSchema.safeParse(res?.data)
         if (!parsedRes.success) {
-          return Promise.reject({
+          return rejectNetworkError({
             status: 404,
-            data: null,
+            data: {},
+            dev: 'ReposQueryOpts - 404 Failed to parse schema',
+            error: parsedRes.error,
           })
         }
 
@@ -161,9 +168,18 @@ export function useRepos({
         }
       })
     },
-    suspense: false,
-    getNextPageParam: (data) =>
-      data?.pageInfo?.hasNextPage ? data.pageInfo.endCursor : undefined,
-    ...options,
+    initialPageParam: '',
+    getNextPageParam: (data) => {
+      return data?.pageInfo?.hasNextPage ? data.pageInfo.endCursor : null
+    },
   })
+}
+
+export {
+  type RepositoryResult,
+  ReposQueryOpts,
+  orderingOptions,
+  OrderingDirection,
+  TeamOrdering,
+  nonActiveOrderingOptions,
 }

--- a/src/services/repos/ReposQueryOpts.tsx
+++ b/src/services/repos/ReposQueryOpts.tsx
@@ -161,10 +161,9 @@ function ReposQueryOpts({
           })
         }
 
-        const owner = parsedRes?.data?.owner
         return {
-          repos: mapEdges(owner?.repositories),
-          pageInfo: owner?.repositories?.pageInfo,
+          repos: mapEdges(parsedRes?.data?.owner?.repositories),
+          pageInfo: parsedRes?.data?.owner?.repositories?.pageInfo,
         }
       })
     },

--- a/src/services/repos/ReposTeamQueryOpts.test.tsx
+++ b/src/services/repos/ReposTeamQueryOpts.test.tsx
@@ -100,7 +100,7 @@ afterAll(() => {
   server.close()
 })
 
-describe('useReposTeam', () => {
+describe('ReposTeamQueryOpts', () => {
   function setup({ invalidResponse = false } = {}) {
     server.use(
       graphql.query('GetReposTeam', (info) => {

--- a/src/services/repos/ReposTeamQueryOpts.test.tsx
+++ b/src/services/repos/ReposTeamQueryOpts.test.tsx
@@ -156,7 +156,7 @@ describe('ReposTeamQueryOpts', () => {
               },
             },
           ],
-          pageParams: [undefined],
+          pageParams: [''],
         })
       )
     })
@@ -200,7 +200,7 @@ describe('ReposTeamQueryOpts', () => {
               pageInfo: { hasNextPage: false, endCursor: 'aa' },
             },
           ],
-          pageParams: [undefined, 'MjAyMC0wOC0xMSAxNzozMDowMiswMDowMHwxMDA='],
+          pageParams: ['', 'MjAyMC0wOC0xMSAxNzozMDowMiswMDowMHwxMDA='],
         })
       )
     })

--- a/src/services/repos/ReposTeamQueryOpts.tsx
+++ b/src/services/repos/ReposTeamQueryOpts.tsx
@@ -136,7 +136,7 @@ function ReposTeamQueryOpts({
         variables: {
           ...variables,
           owner,
-          after: pageParam,
+          after: pageParam === '' ? undefined : pageParam,
         },
       }).then((res) => {
         const parsedRes = RequestSchema.safeParse(res?.data)

--- a/src/services/repos/ReposTeamQueryOpts.tsx
+++ b/src/services/repos/ReposTeamQueryOpts.tsx
@@ -159,7 +159,7 @@ function ReposTeamQueryOpts({
         }
       })
     },
-    initialPageParam: undefined as string | undefined,
+    initialPageParam: '',
     getNextPageParam: (data) => {
       if (data?.pageInfo?.hasNextPage) {
         return data.pageInfo.endCursor

--- a/src/services/repos/index.ts
+++ b/src/services/repos/index.ts
@@ -1,2 +1,0 @@
-export * from './useRepos'
-export * from './orderingOptions'

--- a/src/shared/ListRepo/ListRepo.jsx
+++ b/src/shared/ListRepo/ListRepo.jsx
@@ -4,7 +4,7 @@ import { Suspense, useContext } from 'react'
 import { useParams } from 'react-router-dom'
 
 import { useLocationParams } from 'services/navigation'
-import { orderingOptions } from 'services/repos/config'
+import { orderingOptions } from 'services/repos/orderingOptions'
 import { TierNames, useTier } from 'services/tier'
 import { useUser } from 'services/user'
 import { ActiveContext } from 'shared/context'

--- a/src/shared/ListRepo/ListRepo.jsx
+++ b/src/shared/ListRepo/ListRepo.jsx
@@ -4,7 +4,7 @@ import { Suspense, useContext } from 'react'
 import { useParams } from 'react-router-dom'
 
 import { useLocationParams } from 'services/navigation'
-import { orderingOptions } from 'services/repos'
+import { orderingOptions } from 'services/repos/config'
 import { TierNames, useTier } from 'services/tier'
 import { useUser } from 'services/user'
 import { ActiveContext } from 'shared/context'

--- a/src/shared/ListRepo/OrgControlTable/OrgControlTable.test.jsx
+++ b/src/shared/ListRepo/OrgControlTable/OrgControlTable.test.jsx
@@ -1,7 +1,7 @@
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 
-import { orderingOptions } from 'services/repos'
+import { orderingOptions } from 'services/repos/config'
 
 import OrgControlTable from './OrgControlTable'
 

--- a/src/shared/ListRepo/OrgControlTable/OrgControlTable.test.jsx
+++ b/src/shared/ListRepo/OrgControlTable/OrgControlTable.test.jsx
@@ -1,7 +1,7 @@
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 
-import { orderingOptions } from 'services/repos/config'
+import { orderingOptions } from 'services/repos/orderingOptions'
 
 import OrgControlTable from './OrgControlTable'
 

--- a/src/shared/ListRepo/ReposTable/ReposTable.test.tsx
+++ b/src/shared/ListRepo/ReposTable/ReposTable.test.tsx
@@ -1,5 +1,9 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import {
+  QueryClientProvider as QueryClientProviderV5,
+  QueryClient as QueryClientV5,
+} from '@tanstack/react-queryV5'
+import {
   render,
   screen,
   waitFor,
@@ -19,10 +23,6 @@ import ReposTable from './ReposTable'
 
 import { repoDisplayOptions } from '../ListRepo'
 
-const queryClient = new QueryClient({
-  defaultOptions: { queries: { retry: false } },
-})
-const server = setupServer()
 const mockRepositories = (
   {
     coverageEnabled = true,
@@ -151,16 +151,12 @@ const mockUser = {
   },
 }
 
-beforeAll(() => {
-  server.listen()
-  console.error = () => {}
+const queryClient = new QueryClient({
+  defaultOptions: { queries: { retry: false } },
 })
-afterEach(() => {
-  queryClient.clear()
-  server.resetHandlers()
+const queryClientV5 = new QueryClientV5({
+  defaultOptions: { queries: { retry: false } },
 })
-afterAll(() => server.close)
-
 const wrapper =
   (
     repoDisplay: string,
@@ -168,16 +164,30 @@ const wrapper =
     path: string = '/:provider'
   ): React.FC<React.PropsWithChildren> =>
   ({ children }) => (
-    <QueryClientProvider client={queryClient}>
-      <MemoryRouter initialEntries={[url]}>
-        <Route path={path}>
-          <ActiveContext.Provider value={repoDisplay}>
-            {children}
-          </ActiveContext.Provider>
-        </Route>
-      </MemoryRouter>
-    </QueryClientProvider>
+    <QueryClientProviderV5 client={queryClientV5}>
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter initialEntries={[url]}>
+          <Route path={path}>
+            <ActiveContext.Provider value={repoDisplay}>
+              {children}
+            </ActiveContext.Provider>
+          </Route>
+        </MemoryRouter>
+      </QueryClientProvider>
+    </QueryClientProviderV5>
   )
+
+const server = setupServer()
+beforeAll(() => {
+  server.listen()
+  console.error = () => {}
+})
+afterEach(() => {
+  queryClient.clear()
+  queryClientV5.clear()
+  server.resetHandlers()
+})
+afterAll(() => server.close)
 
 interface SetupArgs {
   edges?: any[]

--- a/src/shared/ListRepo/ReposTable/ReposTable.tsx
+++ b/src/shared/ListRepo/ReposTable/ReposTable.tsx
@@ -1,3 +1,4 @@
+import { useInfiniteQuery as useInfiniteQueryV5 } from '@tanstack/react-queryV5'
 import {
   flexRender,
   getCoreRowModel,
@@ -13,7 +14,10 @@ import { useParams } from 'react-router-dom'
 
 import config from 'config'
 
-import { OrderingDirection, useRepos } from 'services/repos'
+import {
+  OrderingDirection,
+  ReposQueryOpts,
+} from 'services/repos/ReposQueryOpts'
 import { TierNames, useTier } from 'services/tier'
 import { useOwner, useUser } from 'services/user'
 import { ActiveContext } from 'shared/context'
@@ -134,23 +138,27 @@ const ReposTable = ({
     hasNextPage,
     isLoading: isReposLoading,
     isFetchingNextPage,
-  } = useRepos({
-    provider,
-    owner,
-    activated,
-    sortItem: getOrderingDirection(sorting),
-    term: searchValue,
-    repoNames: filterValues,
-    isPublic: shouldDisplayPublicReposOnly,
-  })
+  } = useInfiniteQueryV5(
+    ReposQueryOpts({
+      provider,
+      owner,
+      activated,
+      sortItem: getOrderingDirection(sorting),
+      term: searchValue,
+      repoNames: filterValues,
+      isPublic: shouldDisplayPublicReposOnly,
+    })
+  )
 
   // fetch demo repo(s)
-  const { data: demoReposData } = useRepos({
-    provider: DEMO_REPO.provider,
-    owner: DEMO_REPO.owner,
-    activated,
-    repoNames: [DEMO_REPO.repo],
-  })
+  const { data: demoReposData } = useInfiniteQueryV5(
+    ReposQueryOpts({
+      provider: DEMO_REPO.provider,
+      owner: DEMO_REPO.owner,
+      activated,
+      repoNames: [DEMO_REPO.repo],
+    })
+  )
 
   const isMyOwnerPage = currentUser?.user?.username === owner
 

--- a/src/shared/ListRepo/ReposTable/getReposColumnsHelper.tsx
+++ b/src/shared/ListRepo/ReposTable/getReposColumnsHelper.tsx
@@ -1,6 +1,6 @@
 import { createColumnHelper } from '@tanstack/react-table'
 
-import { RepositoryResult } from 'services/repos'
+import { RepositoryResult } from 'services/repos/ReposQueryOpts'
 import { formatTimeToNow } from 'shared/utils/dates'
 import TotalsNumber from 'ui/TotalsNumber'
 

--- a/src/shared/ListRepo/ReposTableTeam/ReposTableTeam.test.tsx
+++ b/src/shared/ListRepo/ReposTableTeam/ReposTableTeam.test.tsx
@@ -10,7 +10,7 @@ import { graphql, HttpResponse } from 'msw'
 import { setupServer } from 'msw/node'
 import { MemoryRouter, Route } from 'react-router-dom'
 
-import { OrderingDirection, TeamOrdering } from 'services/repos/config'
+import { OrderingDirection, TeamOrdering } from 'services/repos/orderingOptions'
 import { ActiveContext } from 'shared/context'
 
 import ReposTableTeam, { getSortingOption } from './ReposTableTeam'

--- a/src/shared/ListRepo/ReposTableTeam/ReposTableTeam.test.tsx
+++ b/src/shared/ListRepo/ReposTableTeam/ReposTableTeam.test.tsx
@@ -10,7 +10,7 @@ import { graphql, HttpResponse } from 'msw'
 import { setupServer } from 'msw/node'
 import { MemoryRouter, Route } from 'react-router-dom'
 
-import { OrderingDirection, TeamOrdering } from 'services/repos'
+import { OrderingDirection, TeamOrdering } from 'services/repos/config'
 import { ActiveContext } from 'shared/context'
 
 import ReposTableTeam, { getSortingOption } from './ReposTableTeam'

--- a/src/shared/utils/demo.ts
+++ b/src/shared/utils/demo.ts
@@ -1,6 +1,6 @@
 import { ReposQueryOpts } from 'services/repos/ReposQueryOpts'
 
-import { ExtractInfiniteQueryDataFromQueryFn } from './queries'
+import { ExtractInfiniteQueryDataType } from './queries'
 
 export const DEMO_REPO = {
   provider: 'github',
@@ -9,33 +9,33 @@ export const DEMO_REPO = {
   displayName: 'Codecov demo',
 }
 
-type ReposQueryData = ExtractInfiniteQueryDataFromQueryFn<
-  ReturnType<typeof ReposQueryOpts>['queryFn']
->
+type ReposQueryData = ExtractInfiniteQueryDataType<typeof ReposQueryOpts>
 
 export function formatDemoRepos(
-  demoReposData: ReposQueryData,
+  demoReposData: ReposQueryData | undefined,
   searchValue: string
 ) {
-  return (
-    demoReposData?.pages
-      .flatMap((page) => page.repos)
-      .filter(isNotNull)
-      .map(
-        // tag the repo as demo and overwrite its display name
-        (repo) => ({
-          ...repo,
-          isDemo: true,
-          name: DEMO_REPO.displayName,
-        })
-      )
-      .filter(
-        // filter if name does not match the search value
-        (repo: { name: string }) =>
-          !searchValue ||
-          repo.name.toLowerCase().includes(searchValue.toLowerCase())
-      ) ?? []
-  )
+  if (!demoReposData) {
+    return []
+  }
+
+  return demoReposData?.pages
+    .flatMap((page) => page.repos)
+    .filter(isNotNull)
+    .map(
+      // tag the repo as demo and overwrite its display name
+      (repo) => ({
+        ...repo,
+        isDemo: true,
+        name: DEMO_REPO.displayName,
+      })
+    )
+    .filter(
+      // filter if name does not match the search value
+      (repo: { name: string }) =>
+        !searchValue ||
+        repo.name.toLowerCase().includes(searchValue.toLowerCase())
+    )
 }
 
 // isNotNull can be used in filter to exclude null elements while conveying to

--- a/src/shared/utils/demo.ts
+++ b/src/shared/utils/demo.ts
@@ -1,4 +1,6 @@
-import { useRepos } from 'services/repos'
+import { ReposQueryOpts } from 'services/repos/ReposQueryOpts'
+
+import { ExtractInfiniteQueryDataFromQueryFn } from './queries'
 
 export const DEMO_REPO = {
   provider: 'github',
@@ -7,10 +9,12 @@ export const DEMO_REPO = {
   displayName: 'Codecov demo',
 }
 
-type UseReposData = ReturnType<typeof useRepos>['data']
+type ReposQueryData = ExtractInfiniteQueryDataFromQueryFn<
+  ReturnType<typeof ReposQueryOpts>['queryFn']
+>
 
 export function formatDemoRepos(
-  demoReposData: UseReposData,
+  demoReposData: ReposQueryData,
   searchValue: string
 ) {
   return (

--- a/src/shared/utils/queries.ts
+++ b/src/shared/utils/queries.ts
@@ -1,0 +1,37 @@
+import { InfiniteData, QueryFunction } from '@tanstack/react-queryV5'
+
+/**
+ * Extracts the infinite query data from a query function - **Only works for TanStack Query V5**.
+ *
+ * @param T - The query function to extract the infinite query data from.
+ * @returns The type of infinite query data.
+ *
+ * @example
+ * ```ts
+ * import { InfiniteQueryOpts } from './InfiniteQueryOpts'
+ *
+ * type ReturnData = ExtractInfiniteQueryDataFromQueryFn<
+ *   ReturnType<typeof InfiniteQueryOpts>['queryFn']>
+ * ```
+ */
+export type ExtractInfiniteQueryDataFromQueryFn<
+  T extends QueryFunction<any, any, any> | undefined,
+> = InfiniteData<Awaited<ReturnType<NonNullable<T>>>>
+
+/**
+ * Extracts the query data from a query function - **Only works for TanStack Query V5**.
+ *
+ * @param T - The query function to extract the query data from.
+ * @returns The type of the query data.
+ *
+ * @example
+ * ```ts
+ * import { QueryOpts } from './QueryOpts'
+ *
+ * type ReturnData = ExtractQueryDataFromQueryFn<
+ *   ReturnType<typeof QueryOpts>['queryFn']>
+ * ```
+ */
+export type ExtractQueryDataFromQueryFn<
+  T extends QueryFunction<any, any, never> | undefined,
+> = Awaited<ReturnType<NonNullable<T>>>

--- a/src/shared/utils/queries.ts
+++ b/src/shared/utils/queries.ts
@@ -1,4 +1,14 @@
-import { InfiniteData, QueryFunction } from '@tanstack/react-queryV5'
+import {
+  InfiniteData,
+  UseInfiniteQueryOptions,
+  UseQueryOptions,
+} from '@tanstack/react-queryV5'
+
+type AnyFunction = (...args: any) => any
+
+type KnownInfiniteQueryFnReturn<
+  T extends (...args: any) => UseInfiniteQueryOptions,
+> = NonNullable<ReturnType<T>['queryFn']>
 
 /**
  * Extracts the infinite query data from a query function - **Only works for TanStack Query V5**.
@@ -10,14 +20,17 @@ import { InfiniteData, QueryFunction } from '@tanstack/react-queryV5'
  * ```ts
  * import { InfiniteQueryOpts } from './InfiniteQueryOpts'
  *
- * type ReturnData = ExtractInfiniteQueryDataFromQueryFn<
- *   ReturnType<typeof InfiniteQueryOpts>['queryFn']>
- * >
+ * type ReturnData = ExtractInfiniteQueryDataType<typeof InfiniteQueryOpts>
  * ```
  */
-export type ExtractInfiniteQueryDataFromQueryFn<
-  T extends QueryFunction<any, any, any> | undefined,
-> = InfiniteData<Awaited<ReturnType<NonNullable<T>>>>
+export type ExtractInfiniteQueryDataType<T extends AnyFunction> = InfiniteData<
+  Awaited<ReturnType<KnownInfiniteQueryFnReturn<T>>>
+>
+
+// -----------------------------------------------------------------------------
+
+type KnownQueryFnReturn<T extends (...args: any) => UseQueryOptions> =
+  NonNullable<ReturnType<T>['queryFn']>
 
 /**
  * Extracts the query data from a query function - **Only works for TanStack Query V5**.
@@ -29,11 +42,9 @@ export type ExtractInfiniteQueryDataFromQueryFn<
  * ```ts
  * import { QueryOpts } from './QueryOpts'
  *
- * type ReturnData = ExtractQueryDataFromQueryFn<
- *   ReturnType<typeof QueryOpts>['queryFn']>
- * >
+ * type ReturnData = ExtractQueryDataType<typeof QueryOpts>
  * ```
  */
-export type ExtractQueryDataFromQueryFn<
-  T extends QueryFunction<any, any, never> | undefined,
-> = Awaited<ReturnType<NonNullable<T>>>
+export type ExtractQueryDataType<T extends AnyFunction> = Awaited<
+  ReturnType<KnownQueryFnReturn<T>>
+>

--- a/src/shared/utils/queries.ts
+++ b/src/shared/utils/queries.ts
@@ -12,6 +12,7 @@ import { InfiniteData, QueryFunction } from '@tanstack/react-queryV5'
  *
  * type ReturnData = ExtractInfiniteQueryDataFromQueryFn<
  *   ReturnType<typeof InfiniteQueryOpts>['queryFn']>
+ * >
  * ```
  */
 export type ExtractInfiniteQueryDataFromQueryFn<
@@ -30,6 +31,7 @@ export type ExtractInfiniteQueryDataFromQueryFn<
  *
  * type ReturnData = ExtractQueryDataFromQueryFn<
  *   ReturnType<typeof QueryOpts>['queryFn']>
+ * >
  * ```
  */
 export type ExtractQueryDataFromQueryFn<


### PR DESCRIPTION
# Description

This PR migrates the `useRepos` hook over to the `infiniteQueryOptions` version `ReposQueryOpts` and to TS Query V5. 

~~There's some changes with how the imports from the `repos/config.ts` file that will be cleaned up once the prior PR #3615 has been migrated, and this PR can be rebased off of it.~~

Ticket: codecov/engineering-team#2969

# Notable Changes

- Migrate `useRepos` to `ReposQueryOpts`
- Update usage in `ReposTable` and `ChartSelectors`
- Update imports from `services/repos/config` (removing barrel file)
- Update/refactor tests