### PR TITLE
feat: Fetch isCached Field in PullPageDataQueryOpts

### DIFF
--- a/src/pages/PullRequestPage/PullBundleAnalysis/PullBundleAnalysis.test.tsx
+++ b/src/pages/PullRequestPage/PullBundleAnalysis/PullBundleAnalysis.test.tsx
@@ -48,6 +48,8 @@ const mockPullPageData = (
           bundleAnalysis: {
             bundleAnalysisReport: {
               __typename: headBundleType,
+              isCached:
+                headBundleType === 'BundleAnalysisReport' ? false : undefined,
             },
           },
         },

--- a/src/pages/PullRequestPage/PullCoverage/PullCoverageTabs/PullCoverageTabs.test.jsx
+++ b/src/pages/PullRequestPage/PullCoverage/PullCoverageTabs/PullCoverageTabs.test.jsx
@@ -96,6 +96,7 @@ const mockPullData = {
           bundleAnalysis: {
             bundleAnalysisReport: {
               __typename: 'BundleAnalysisReport',
+              isCached: false,
             },
           },
         },

--- a/src/pages/PullRequestPage/PullCoverage/PullCoverageTabs/useTabsCounts.test.tsx
+++ b/src/pages/PullRequestPage/PullCoverage/PullCoverageTabs/useTabsCounts.test.tsx
@@ -26,6 +26,7 @@ const mockPullData = {
           bundleAnalysis: {
             bundleAnalysisReport: {
               __typename: 'BundleAnalysisReport',
+              isCached: false,
             },
           },
         },

--- a/src/pages/PullRequestPage/PullCoverage/routes/FileViewer/FileViewer.test.jsx
+++ b/src/pages/PullRequestPage/PullCoverage/routes/FileViewer/FileViewer.test.jsx
@@ -102,6 +102,7 @@ const mockPullData = {
         bundleAnalysis: {
           bundleAnalysisReport: {
             __typename: 'BundleAnalysisReport',
+            isCached: false,
           },
         },
       },

--- a/src/pages/PullRequestPage/PullRequestPage.test.tsx
+++ b/src/pages/PullRequestPage/PullRequestPage.test.tsx
@@ -49,6 +49,7 @@ const mockPullPageData = {
     bundleAnalysis: {
       bundleAnalysisReport: {
         __typename: 'BundleAnalysisReport',
+        isCached: false,
       },
     },
   },
@@ -75,6 +76,7 @@ const mockPullPageDataTeam = {
     bundleAnalysis: {
       bundleAnalysisReport: {
         __typename: 'BundleAnalysisReport',
+        isCached: false,
       },
     },
   },

--- a/src/pages/PullRequestPage/queries/PullPageDataQueryOpts.test.tsx
+++ b/src/pages/PullRequestPage/queries/PullPageDataQueryOpts.test.tsx
@@ -25,6 +25,7 @@ const mockPullData = {
           bundleAnalysis: {
             bundleAnalysisReport: {
               __typename: 'BundleAnalysisReport',
+              isCached: false,
             },
           },
         },
@@ -60,6 +61,7 @@ const mockPullDataTeam = {
           bundleAnalysis: {
             bundleAnalysisReport: {
               __typename: 'BundleAnalysisReport',
+              isCached: false,
             },
           },
         },
@@ -195,6 +197,7 @@ describe('PullPageDataQueryOpts', () => {
                   bundleAnalysis: {
                     bundleAnalysisReport: {
                       __typename: 'BundleAnalysisReport',
+                      isCached: false,
                     },
                   },
                 },
@@ -402,6 +405,7 @@ describe('PullPageDataQueryOpts', () => {
                 bundleAnalysis: {
                   bundleAnalysisReport: {
                     __typename: 'BundleAnalysisReport',
+                    isCached: false,
                   },
                 },
               },

--- a/src/pages/PullRequestPage/queries/PullPageDataQueryOpts.tsx
+++ b/src/pages/PullRequestPage/queries/PullPageDataQueryOpts.tsx
@@ -22,6 +22,11 @@ const BundleAnalysisReportSchema = z.object({
   isCached: z.boolean(),
 })
 
+const BundleAnalysisReportUnion = z.discriminatedUnion('__typename', [
+  BundleAnalysisReportSchema,
+  z.object({ __typename: MissingHeadReportSchema.shape.__typename }),
+])
+
 const BundleAnalysisComparisonResult = z.union([
   z.literal('BundleAnalysisComparison'),
   FirstPullRequestSchema.shape.__typename,
@@ -53,12 +58,7 @@ const RepositorySchema = z.object({
           commitid: z.string(),
           bundleAnalysis: z
             .object({
-              bundleAnalysisReport: z
-                .discriminatedUnion('__typename', [
-                  BundleAnalysisReportSchema,
-                  z.object({ __typename: z.literal('MissingHeadReport') }),
-                ])
-                .nullable(),
+              bundleAnalysisReport: BundleAnalysisReportUnion.nullable(),
             })
             .nullable(),
         })

--- a/src/pages/PullRequestPage/queries/PullPageDataQueryOpts.tsx
+++ b/src/pages/PullRequestPage/queries/PullPageDataQueryOpts.tsx
@@ -17,6 +17,11 @@ import Api from 'shared/api'
 import { rejectNetworkError } from 'shared/api/helpers'
 import A from 'ui/A'
 
+const BundleAnalysisReportSchema = z.object({
+  __typename: z.literal('BundleAnalysisReport'),
+  isCached: z.boolean(),
+})
+
 const BundleAnalysisComparisonResult = z.union([
   z.literal('BundleAnalysisComparison'),
   FirstPullRequestSchema.shape.__typename,
@@ -50,7 +55,7 @@ const RepositorySchema = z.object({
             .object({
               bundleAnalysisReport: z
                 .discriminatedUnion('__typename', [
-                  z.object({ __typename: z.literal('BundleAnalysisReport') }),
+                  BundleAnalysisReportSchema,
                   z.object({ __typename: z.literal('MissingHeadReport') }),
                 ])
                 .nullable(),
@@ -122,6 +127,12 @@ query PullPageData(
             bundleAnalysis {
               bundleAnalysisReport {
                 __typename
+                ... on BundleAnalysisReport {
+                  isCached
+                }
+              }
+              bundleAnalysisReport {
+                __typename
               }
             }
           }
@@ -155,6 +166,7 @@ query PullPageData(
           }
           bundleAnalysisCompareWithBase {
             __typename
+            
           }
         }
       }


### PR DESCRIPTION
# Description

This PR updates the query and validation schema for `PullPageDataQueryOpts` to include the `isCached` field for some upcoming work to inform users when a given pull request has data that has been cached from a previous commit included in it.

Tickets: codecov/engineering-team#3152

# Notable Changes

- Update query string and validation schema for `PullPageDataQueryOpts`
- Add in new field in MSW tests