### PR TITLE
Appless non-PAT org dropdown clarity changes

### DIFF
--- a/src/ui/ContextSwitcher/ContextSwitcher.test.jsx
+++ b/src/ui/ContextSwitcher/ContextSwitcher.test.jsx
@@ -218,6 +218,7 @@ describe('ContextSwitcher', () => {
           ]}
           currentUser={{
             defaultOrgUsername: 'spotify',
+            username: 'laudna',
           }}
           src="imageUrl"
           isLoading={false}
@@ -232,7 +233,9 @@ describe('ContextSwitcher', () => {
       )
       await user.click(button)
 
-      const laudnaUsers = await screen.findAllByText('laudna')
+      const laudnaUsers = await screen.findAllByText(
+        "laudna's personal organization"
+      )
       expect(laudnaUsers.length).toBe(2)
 
       const codecovOwner = await screen.findByText('codecov')

--- a/src/ui/ContextSwitcher/ContextSwitcher.test.jsx
+++ b/src/ui/ContextSwitcher/ContextSwitcher.test.jsx
@@ -290,7 +290,9 @@ describe('ContextSwitcher', () => {
         { wrapper: wrapper() }
       )
 
-      const installCopy = await screen.findByText(/Install Codecov GitHub app/)
+      const installCopy = await screen.findByText(
+        /To add another organization, install Codecov GitHub App/
+      )
       expect(installCopy).toBeInTheDocument()
       expect(installCopy).toHaveAttribute(
         'href',
@@ -761,7 +763,9 @@ describe('ContextSwitcher', () => {
         }
       )
 
-      const installCopy = await screen.findByText(/Install Codecov GitHub app/)
+      const installCopy = await screen.findByText(
+        /To add another organization, install Codecov GitHub App/
+      )
       expect(installCopy).toBeInTheDocument()
       expect(installCopy).toHaveAttribute(
         'href',

--- a/src/ui/ContextSwitcher/ContextSwitcher.tsx
+++ b/src/ui/ContextSwitcher/ContextSwitcher.tsx
@@ -43,6 +43,7 @@ interface ContextItemProps {
     owner: { username: string | null } | null
     pageName: string
   }
+  currentUserUsername: string | null
   defaultOrgUsername: string | null
   setToggle: (arg: boolean) => void
   owner?: string
@@ -50,6 +51,7 @@ interface ContextItemProps {
 
 function ContextItem({
   context,
+  currentUserUsername,
   defaultOrgUsername,
   setToggle,
   owner,
@@ -77,7 +79,9 @@ function ContextItem({
       >
         <Avatar user={contextOwner} />
         <div className={cs('mx-1', { 'font-semibold': owner === orgUsername })}>
-          {orgUsername}
+          {!!orgUsername && orgUsername === currentUserUsername
+            ? `${orgUsername}'s personal organization`
+            : orgUsername || ''}
         </div>
       </Button>
     </li>
@@ -142,6 +146,8 @@ export interface Props {
   contexts: Context[]
   currentUser: {
     defaultOrgUsername: string | null
+    username: string | null
+    avatarUrl: string
   }
   activeContext: {
     avatarUrl: string
@@ -169,6 +175,7 @@ function ContextSwitcher({
   const wrapperRef = useCloseOnLooseFocus({ setToggle })
   const intersectionRef = useLoadMore({ onLoadMore })
   const defaultOrgUsername = currentUser?.defaultOrgUsername
+  const currentUserUsername = currentUser?.username
 
   const isGh = providerToName(provider) === 'Github'
   const isSelfHosted = config.IS_SELF_HOSTED
@@ -177,6 +184,7 @@ function ContextSwitcher({
   // self-hosted cannot use default "codecov" app (must set up custom one)
   const shouldShowGitHubInstallLink =
     isGh && (isSelfHosted ? isCustomGitHubApp : true)
+  const displayUsername = activeContext?.username ?? owner
 
   return (
     <div id="context-switcher" className="relative text-sm" ref={wrapperRef}>
@@ -193,7 +201,12 @@ function ContextSwitcher({
         onClick={() => setToggle((toggle) => !toggle)}
       >
         <Avatar user={activeContext} />
-        <p className="ml-1">{activeContext?.username ?? owner}</p>
+        <p className="ml-1">
+          {displayUsername}
+          {displayUsername === currentUserUsername
+            ? "'s personal organization"
+            : ''}
+        </p>
         <span
           aria-hidden="true"
           className={cs('transition-transform', {
@@ -221,12 +234,13 @@ function ContextSwitcher({
               hook="context-switcher-gh-install-link"
             >
               <Icon name="plusCircle" />
-              Install Codecov GitHub app
+              To add another organization, install Codecov GitHub App
             </A>
           </li>
         ) : null}
         {contexts.map((context) => (
           <ContextItem
+            currentUserUsername={currentUserUsername}
             defaultOrgUsername={defaultOrgUsername}
             context={context}
             key={context?.owner?.username}


### PR DESCRIPTION
# Description

Closes https://github.com/codecov/engineering-team/issues/2734

Figma: https://www.figma.com/design/SsoxtY2SB73l0wiLbJ8FhZ/GH-2092?node-id=2288-16704&t=Ae9VxfEVoCH7C8je-1

# Notable Changes

# Screenshots
<img width="640" alt="Screenshot 2025-01-08 at 4 39 21 PM" src="https://github.com/user-attachments/assets/ca5c2ef7-b52e-49d2-9f27-ec1de8411691" />


# Link to Sample Entry

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.