### PR TITLE
feat: Fetch isCached Field with CommitPageDataQueryOpts - Round 2

### DIFF
--- a/src/pages/CommitDetailPage/CommitBundleAnalysis/CommitBundleAnalysis.test.tsx
+++ b/src/pages/CommitDetailPage/CommitBundleAnalysis/CommitBundleAnalysis.test.tsx
@@ -41,6 +41,10 @@ const mockCommitPageData = ({
           __typename: 'Comparison',
         },
         bundleAnalysis: {
+          bundleAnalysisReport: {
+            __typename: 'BundleAnalysisReport',
+            isCached: false,
+          },
           bundleAnalysisCompareWithParent: {
             __typename: firstPullRequest
               ? 'FirstPullRequest'

--- a/src/pages/CommitDetailPage/CommitCoverage/CommitCoverage.test.jsx
+++ b/src/pages/CommitDetailPage/CommitCoverage/CommitCoverage.test.jsx
@@ -317,6 +317,10 @@ const mockCommitPageData = (
                 : 'Comparison',
         },
         bundleAnalysis: {
+          bundleAnalysisReport: {
+            __typename: 'BundleAnalysisReport',
+            isCached: false,
+          },
           bundleAnalysisCompareWithParent: {
             __typename: 'BundleAnalysisComparison',
           },

--- a/src/pages/CommitDetailPage/CommitDetailPage.test.tsx
+++ b/src/pages/CommitDetailPage/CommitDetailPage.test.tsx
@@ -53,6 +53,10 @@ const mockCommitPageData = ({
           __typename: 'Comparison',
         },
         bundleAnalysis: {
+          bundleAnalysisReport: {
+            __typename: 'BundleAnalysisReport',
+            isCached: false,
+          },
           bundleAnalysisCompareWithParent: {
             __typename: 'BundleAnalysisComparison',
           },

--- a/src/pages/CommitDetailPage/queries/CommitPageDataQueryOpts.test.tsx
+++ b/src/pages/CommitDetailPage/queries/CommitPageDataQueryOpts.test.tsx
@@ -23,6 +23,10 @@ const mockCommitData = {
           __typename: 'Comparison',
         },
         bundleAnalysis: {
+          bundleAnalysisReport: {
+            __typename: 'BundleAnalysisReport',
+            isCached: false,
+          },
           bundleAnalysisCompareWithParent: {
             __typename: 'BundleAnalysisComparison',
           },
@@ -89,7 +93,7 @@ interface SetupArgs {
   isNullOwner?: boolean
 }
 
-describe('useCommitPageData', () => {
+describe('CommitPageData', () => {
   function setup({
     isNotFoundError = false,
     isOwnerNotActivatedError = false,
@@ -146,6 +150,10 @@ describe('useCommitPageData', () => {
                 __typename: 'Comparison',
               },
               bundleAnalysis: {
+                bundleAnalysisReport: {
+                  __typename: 'BundleAnalysisReport',
+                  isCached: false,
+                },
                 bundleAnalysisCompareWithParent: {
                   __typename: 'BundleAnalysisComparison',
                 },

--- a/src/pages/CommitDetailPage/queries/CommitPageDataQueryOpts.tsx
+++ b/src/pages/CommitDetailPage/queries/CommitPageDataQueryOpts.tsx
@@ -22,9 +22,9 @@ const BundleAnalysisReportSchema = z.object({
   isCached: z.boolean(),
 })
 
-const BundleAnalysisReportUnion = z.union([
+const BundleAnalysisReportUnion = z.discriminatedUnion('__typename', [
   BundleAnalysisReportSchema,
-  MissingHeadReportSchema.shape.__typename,
+  z.object({ __typename: MissingHeadReportSchema.shape.__typename }),
 ])
 
 const BundleAnalysisComparisonResult = z.union([

--- a/src/pages/CommitDetailPage/queries/CommitPageDataQueryOpts.tsx
+++ b/src/pages/CommitDetailPage/queries/CommitPageDataQueryOpts.tsx
@@ -17,6 +17,16 @@ import Api from 'shared/api'
 import { rejectNetworkError } from 'shared/api/helpers'
 import A from 'ui/A'
 
+const BundleAnalysisReportSchema = z.object({
+  __typename: z.literal('BundleAnalysisReport'),
+  isCached: z.boolean(),
+})
+
+const BundleAnalysisReportUnion = z.union([
+  BundleAnalysisReportSchema,
+  MissingHeadReportSchema.shape.__typename,
+])
+
 const BundleAnalysisComparisonResult = z.union([
   z.literal('BundleAnalysisComparison'),
   FirstPullRequestSchema.shape.__typename,
@@ -54,6 +64,7 @@ const RepositorySchema = z.object({
         .nullable(),
       bundleAnalysis: z
         .object({
+          bundleAnalysisReport: BundleAnalysisReportUnion.nullable(),
           bundleAnalysisCompareWithParent: z
             .object({
               __typename: BundleAnalysisComparisonResult,
@@ -98,6 +109,12 @@ query CommitPageData($owner: String!, $repo: String!, $commitId: String!) {
             __typename
           }
           bundleAnalysis {
+            bundleAnalysisReport {
+              __typename
+              ... on BundleAnalysisReport {
+                isCached
+              }
+            }
             bundleAnalysisCompareWithParent {
               __typename
             }
@@ -112,7 +129,8 @@ query CommitPageData($owner: String!, $repo: String!, $commitId: String!) {
       }
     }
   }
-}`
+}
+`
 
 interface CommitPageDataQueryArgs {
   provider: string


### PR DESCRIPTION
# Description

This PR updates the query for `CommitPageDataQueryOpts` to grab the `isCached` field which will be used in a later PR to create a banner informing the user that there is data in the commit that has been cached from a previous commit.

Ticket: codecov/engineering-team#3152

>[!NOTE]
>This is the second iteration of this PR, as the previous one had an issue with the Zod validation schema and how it handled the union type. This has been resolved in this PR.
>Before:
>```
>const BundleAnalysisReportSchema = z.object({
>  __typename: z.literal('BundleAnalysisReport'),
>  isCached: z.boolean(),
>})
>
>const BundleAnalysisReportUnion = z.union([
>  BundleAnalysisReportSchema,
>  MissingHeadReportSchema.shape.__typename,
>])
>```
>After:
>```ts
>const BundleAnalysisReportSchema = z.object({
>  __typename: z.literal('BundleAnalysisReport'),
>  isCached: z.boolean(),
>})
>
>const BundleAnalysisReportUnion = z.discriminatedUnion('__typename', [
>  BundleAnalysisReportSchema,
>  z.object({ __typename: MissingHeadReportSchema.shape.__typename }),
>])
>```

# Notable Changes

- Update `CommitPageDataQueryOpts` query and validation schema
- Update MSW mock responses