### PR TITLE
feat: Create CachedBundleContentBanner Component

### DIFF
--- a/src/shared/CachedBundleContentBanner/CachedBundleContentBanner.test.tsx
+++ b/src/shared/CachedBundleContentBanner/CachedBundleContentBanner.test.tsx
@@ -1,0 +1,14 @@
+import { render, screen } from '@testing-library/react'
+
+import { CachedBundleContentBanner } from './CachedBundleContentBanner'
+
+describe('CachedBundleContentBanner', () => {
+  it('should render the banner', () => {
+    render(<CachedBundleContentBanner />)
+
+    const banner = screen.getByText(
+      'The reported bundle size includes cached data from previous commits'
+    )
+    expect(banner).toBeInTheDocument()
+  })
+})

--- a/src/shared/CachedBundleContentBanner/CachedBundleContentBanner.tsx
+++ b/src/shared/CachedBundleContentBanner/CachedBundleContentBanner.tsx
@@ -1,0 +1,11 @@
+import { Alert } from 'ui/Alert'
+
+export const CachedBundleContentBanner = () => {
+  return (
+    <Alert variant="info">
+      <Alert.Description>
+        The reported bundle size includes cached data from previous commits
+      </Alert.Description>
+    </Alert>
+  )
+}


### PR DESCRIPTION
# Description

This PR creates the banner component that will be used in upcoming PRs, adding it to the Commit, and Pull pages.

Ticket: codecov/engineering-team#3153

# Notable Changes

- Create new `CachedBundleContentBanner` component
- Add in tests

# Screenshots

![Screenshot 2025-01-06 at 10 34 41](https://github.com/user-attachments/assets/fe783e5a-6e79-46b5-a860-748307d1d92d)