### PR TITLE
fix: Update copy for tokenless tab

### DIFF
--- a/src/pages/AccountSettings/tabs/OrgUploadToken/TokenlessSection/TokenlessSection.test.tsx
+++ b/src/pages/AccountSettings/tabs/OrgUploadToken/TokenlessSection/TokenlessSection.test.tsx
@@ -99,7 +99,9 @@ describe('TokenlessSection', () => {
     setup()
     render(<TokenlessSection />, { wrapper })
 
-    const title = await screen.findByText('Token authentication')
+    const title = await screen.findByText(
+      'Token authentication for public repositories'
+    )
     expect(title).toBeInTheDocument()
   })
 
@@ -126,7 +128,7 @@ describe('TokenlessSection', () => {
     render(<TokenlessSection />, { wrapper })
 
     const notRequiredDescription = await screen.findByText(
-      'When a token is not required, your team can upload coverage reports without one. Existing tokens will still work, and no action is needed for past uploads. Designed for public open-source projects.'
+      'When a token is not required, your team can upload coverage reports without one. Existing tokens will still work, and no action is needed for past uploads.'
     )
     expect(notRequiredDescription).toBeInTheDocument()
   })
@@ -136,7 +138,7 @@ describe('TokenlessSection', () => {
     render(<TokenlessSection />, { wrapper })
 
     const requiredDescription = await screen.findByText(
-      'When a token is required, your team must use a global or repo-specific token for uploads. Designed for private repositories and closed-source projects.'
+      'When a token is required, your team must use a global or repo-specific token for uploads.'
     )
     expect(requiredDescription).toBeInTheDocument()
   })

--- a/src/pages/AccountSettings/tabs/OrgUploadToken/TokenlessSection/TokenlessSection.tsx
+++ b/src/pages/AccountSettings/tabs/OrgUploadToken/TokenlessSection/TokenlessSection.tsx
@@ -54,7 +54,9 @@ const TokenlessSection: React.FC = () => {
     <Card>
       <Card.Header>
         <div className="flex items-center gap-2">
-          <h2 className="text-sm font-semibold">Token authentication</h2>
+          <h2 className="text-sm font-semibold">
+            Token authentication for public repositories
+          </h2>
           <A
             to={{
               pageName: 'tokenlessDocs',
@@ -85,8 +87,7 @@ const TokenlessSection: React.FC = () => {
             <RadioTileGroup.Description>
               When a token is not required, your team can upload coverage
               reports without one. Existing tokens will still work, and no
-              action is needed for past uploads. Designed for public open-source
-              projects.
+              action is needed for past uploads.
             </RadioTileGroup.Description>
           </RadioTileGroup.Item>
           <RadioTileGroup.Item
@@ -96,8 +97,7 @@ const TokenlessSection: React.FC = () => {
             <RadioTileGroup.Label>Required</RadioTileGroup.Label>
             <RadioTileGroup.Description>
               When a token is required, your team must use a global or
-              repo-specific token for uploads. Designed for private repositories
-              and closed-source projects.
+              repo-specific token for uploads.
             </RadioTileGroup.Description>
           </RadioTileGroup.Item>
         </RadioTileGroup>


### PR DESCRIPTION
# Description
a quick fix for copy in the tokenless tab

# Screenshots
<img width="1108" alt="Screenshot 2025-01-06 at 4 48 29 PM" src="https://github.com/user-attachments/assets/e1b88f87-a590-4a78-98a5-9b106bf3582c" />

closes: [UI copy updates for token auth](https://github.com/codecov/engineering-team/issues/3060)

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.