### PR TITLE
feat: Add Cache Bundle Banner to Commits Page

### DIFF
--- a/src/pages/CommitDetailPage/CommitBundleAnalysis/CommitBundleAnalysis.test.tsx
+++ b/src/pages/CommitDetailPage/CommitBundleAnalysis/CommitBundleAnalysis.test.tsx
@@ -3,13 +3,21 @@ import {
   QueryClientProvider as QueryClientProviderV5,
   QueryClient as QueryClientV5,
 } from '@tanstack/react-queryV5'
-import { render, screen } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
 import { graphql, HttpResponse } from 'msw'
 import { setupServer } from 'msw/node'
 import { Suspense } from 'react'
 import { MemoryRouter, Route } from 'react-router-dom'
 
 import CommitBundleAnalysis from './CommitBundleAnalysis'
+
+const mocks = vi.hoisted(() => ({
+  useFlags: vi.fn(),
+}))
+
+vi.mock('shared/featureFlags', () => ({
+  useFlags: mocks.useFlags,
+}))
 
 vi.mock('./CommitBundleAnalysisTable', () => ({
   default: () => <div>CommitBundleAnalysisTable</div>,
@@ -22,11 +30,13 @@ const mockCommitPageData = ({
   coverageEnabled = true,
   firstPullRequest = false,
   comparisonError = false,
+  hasCachedBundle = false,
 }: {
   bundleAnalysisEnabled?: boolean
   coverageEnabled?: boolean
   firstPullRequest?: boolean
   comparisonError?: boolean
+  hasCachedBundle?: boolean
 }) => ({
   owner: {
     isCurrentUserPartOfOrg: true,
@@ -43,7 +53,7 @@ const mockCommitPageData = ({
         bundleAnalysis: {
           bundleAnalysisReport: {
             __typename: 'BundleAnalysisReport',
-            isCached: false,
+            isCached: hasCachedBundle,
           },
           bundleAnalysisCompareWithParent: {
             __typename: firstPullRequest
@@ -179,6 +189,8 @@ interface SetupArgs {
   noData?: boolean
   firstPullRequest?: boolean
   comparisonError?: boolean
+  hasCachedBundle?: boolean
+  featureFlag?: boolean
 }
 
 describe('CommitBundleAnalysis', () => {
@@ -190,6 +202,8 @@ describe('CommitBundleAnalysis', () => {
       noData = false,
       firstPullRequest = false,
       comparisonError = false,
+      hasCachedBundle = false,
+      featureFlag = false,
     }: SetupArgs = {
       coverageEnabled: true,
       bundleAnalysisEnabled: true,
@@ -197,8 +211,12 @@ describe('CommitBundleAnalysis', () => {
       noData: false,
       firstPullRequest: false,
       comparisonError: false,
+      hasCachedBundle: false,
+      featureFlag: false,
     }
   ) {
+    mocks.useFlags.mockReturnValue({ displayCachedBundleBanner: featureFlag })
+
     server.use(
       graphql.query('CommitPageData', () => {
         return HttpResponse.json({
@@ -207,6 +225,7 @@ describe('CommitBundleAnalysis', () => {
             bundleAnalysisEnabled,
             firstPullRequest,
             comparisonError,
+            hasCachedBundle,
           }),
         })
       }),
@@ -238,6 +257,35 @@ describe('CommitBundleAnalysis', () => {
         'CommitBundleAnalysisTable'
       )
       expect(commitBundleAnalysisTable).toBeInTheDocument()
+    })
+
+    describe('feature flag is enabled', () => {
+      describe('there are cached bundles', () => {
+        it('renders CachedBundleContentBanner', async () => {
+          setup({ featureFlag: true, hasCachedBundle: true })
+          render(<CommitBundleAnalysis />, { wrapper })
+
+          const cachedBundleContentBanner = await screen.findByText(
+            'The reported bundle size includes cached data from previous commits'
+          )
+          expect(cachedBundleContentBanner).toBeInTheDocument()
+        })
+      })
+
+      describe('there are no cached bundles', () => {
+        it('does not render CachedBundleContentBanner', async () => {
+          setup({ featureFlag: true, hasCachedBundle: false })
+          render(<CommitBundleAnalysis />, { wrapper })
+
+          await waitFor(() => queryClientV5.isFetching())
+          await waitFor(() => !queryClientV5.isFetching())
+
+          const cachedBundleContentBanner = screen.queryByText(
+            'The reported bundle size includes cached data from previous commits'
+          )
+          expect(cachedBundleContentBanner).not.toBeInTheDocument()
+        })
+      })
     })
 
     describe('there is no data', () => {
@@ -510,6 +558,35 @@ describe('CommitBundleAnalysis', () => {
 
           const emptyTable = await screen.findByText(/EmptyTable/)
           expect(emptyTable).toBeInTheDocument()
+        })
+      })
+    })
+
+    describe('feature flag is enabled', () => {
+      describe('there are cached bundles', () => {
+        it('renders CachedBundleContentBanner', async () => {
+          setup({ featureFlag: true, hasCachedBundle: true })
+          render(<CommitBundleAnalysis />, { wrapper })
+
+          const cachedBundleContentBanner = await screen.findByText(
+            'The reported bundle size includes cached data from previous commits'
+          )
+          expect(cachedBundleContentBanner).toBeInTheDocument()
+        })
+      })
+
+      describe('there are no cached bundles', () => {
+        it('does not render CachedBundleContentBanner', async () => {
+          setup({ featureFlag: true, hasCachedBundle: false })
+          render(<CommitBundleAnalysis />, { wrapper })
+
+          await waitFor(() => queryClientV5.isFetching())
+          await waitFor(() => !queryClientV5.isFetching())
+
+          const cachedBundleContentBanner = screen.queryByText(
+            'The reported bundle size includes cached data from previous commits'
+          )
+          expect(cachedBundleContentBanner).not.toBeInTheDocument()
         })
       })
     })


### PR DESCRIPTION
# Description

This PR adds in the newly added cached bundles banner to the commits page behind a feature flag so that we can roll it out together once the work has been done for the pulls page.

Ticket: codecov/engineering-team#3153

# Notable Changes

- Add banner to commit bundle component behind a feature flag
- Add in tests

# Screenshots

>[!note]
>These screenshots are forced as there aren't any examples on staging where caching is enabled.

Coverage and BA enabled:

![Screenshot 2025-01-06 at 14 47 07](https://github.com/user-attachments/assets/ec5fb17f-7e46-4194-a209-5a6282a8c392)

BA only:

![Screenshot 2025-01-06 at 14 47 44](https://github.com/user-attachments/assets/8020f66c-0dd9-4214-8dec-f6eabea7062c)