### PR TITLE
feat: Add Cache Bundle Banner to Pulls Page

### DIFF
--- a/src/pages/PullRequestPage/PullBundleAnalysis/PullBundleAnalysis.test.tsx
+++ b/src/pages/PullRequestPage/PullBundleAnalysis/PullBundleAnalysis.test.tsx
@@ -6,6 +6,7 @@ import {
 import {
   render,
   screen,
+  waitFor,
   waitForElementToBeRemoved,
 } from '@testing-library/react'
 import { graphql, HttpResponse } from 'msw'
@@ -16,6 +17,14 @@ import { MemoryRouter, Route } from 'react-router-dom'
 import PullBundleAnalysis from './PullBundleAnalysis'
 
 import { TBundleAnalysisComparisonResult } from '../queries/PullPageDataQueryOpts'
+
+const mocks = vi.hoisted(() => ({
+  useFlags: vi.fn(),
+}))
+
+vi.mock('shared/featureFlags', () => ({
+  useFlags: mocks.useFlags,
+}))
 
 vi.mock('./EmptyTable', () => ({
   default: () => <div>EmptyTable</div>,
@@ -31,7 +40,8 @@ const mockPullPageData = (
   compareType: TBundleAnalysisComparisonResult = 'BundleAnalysisComparison',
   headBundleType: string = 'BundleAnalysisReport',
   coverageEnabled: boolean = true,
-  bundleAnalysisEnabled: boolean = true
+  bundleAnalysisEnabled: boolean = true,
+  hasCachedBundle = false
 ) => ({
   owner: {
     repository: {
@@ -49,7 +59,9 @@ const mockPullPageData = (
             bundleAnalysisReport: {
               __typename: headBundleType,
               isCached:
-                headBundleType === 'BundleAnalysisReport' ? false : undefined,
+                headBundleType === 'BundleAnalysisReport'
+                  ? hasCachedBundle
+                  : undefined,
             },
           },
         },
@@ -146,6 +158,8 @@ interface SetupArgs {
   headBundleType?: string
   coverageEnabled?: boolean
   bundleAnalysisEnabled?: boolean
+  hasCachedBundle?: boolean
+  featureFlag?: boolean
 }
 
 describe('PullBundleAnalysis', () => {
@@ -154,7 +168,11 @@ describe('PullBundleAnalysis', () => {
     headBundleType = 'BundleAnalysisReport',
     coverageEnabled = false,
     bundleAnalysisEnabled = false,
+    hasCachedBundle = false,
+    featureFlag = false,
   }: SetupArgs) {
+    mocks.useFlags.mockReturnValue({ displayCachedBundleBanner: featureFlag })
+
     server.use(
       graphql.query('PullPageData', () => {
         return HttpResponse.json({
@@ -162,7 +180,8 @@ describe('PullBundleAnalysis', () => {
             compareType,
             headBundleType,
             coverageEnabled,
-            bundleAnalysisEnabled
+            bundleAnalysisEnabled,
+            hasCachedBundle
           ),
         })
       }),
@@ -196,6 +215,45 @@ describe('PullBundleAnalysis', () => {
 
         const table = await screen.findByText('PullBundleComparisonTable')
         expect(table).toBeInTheDocument()
+      })
+
+      describe('feature flag is enabled', () => {
+        describe('there is a cached bundle', () => {
+          it('renders the CachedBundleContentBanner', async () => {
+            setup({
+              coverageEnabled: true,
+              bundleAnalysisEnabled: true,
+              hasCachedBundle: true,
+              featureFlag: true,
+            })
+            render(<PullBundleAnalysis />, { wrapper })
+
+            const cachedBundleContentBanner = await screen.findByText(
+              'The reported bundle size includes cached data from previous commits'
+            )
+            expect(cachedBundleContentBanner).toBeInTheDocument()
+          })
+        })
+
+        describe('there is not a cached bundle', () => {
+          it('does not render the CachedBundleContentBanner', async () => {
+            setup({
+              coverageEnabled: true,
+              bundleAnalysisEnabled: true,
+              hasCachedBundle: false,
+              featureFlag: true,
+            })
+            render(<PullBundleAnalysis />, { wrapper })
+
+            await waitFor(() => queryClientV5.isFetching())
+            await waitFor(() => !queryClientV5.isFetching())
+
+            const cachedBundleContentBanner = screen.queryByText(
+              'The reported bundle size includes cached data from previous commits'
+            )
+            expect(cachedBundleContentBanner).not.toBeInTheDocument()
+          })
+        })
       })
     })
 
@@ -311,6 +369,45 @@ describe('PullBundleAnalysis', () => {
 
         const table = await screen.findByText('PullBundleComparisonTable')
         expect(table).toBeInTheDocument()
+      })
+
+      describe('feature flag is enabled', () => {
+        describe('there is a cached bundle', () => {
+          it('renders the CachedBundleContentBanner', async () => {
+            setup({
+              coverageEnabled: false,
+              bundleAnalysisEnabled: true,
+              hasCachedBundle: true,
+              featureFlag: true,
+            })
+            render(<PullBundleAnalysis />, { wrapper })
+
+            const cachedBundleContentBanner = await screen.findByText(
+              'The reported bundle size includes cached data from previous commits'
+            )
+            expect(cachedBundleContentBanner).toBeInTheDocument()
+          })
+        })
+
+        describe('there is not a cached bundle', () => {
+          it('does not render the CachedBundleContentBanner', async () => {
+            setup({
+              coverageEnabled: false,
+              bundleAnalysisEnabled: true,
+              hasCachedBundle: false,
+              featureFlag: true,
+            })
+            render(<PullBundleAnalysis />, { wrapper })
+
+            await waitFor(() => queryClientV5.isFetching())
+            await waitFor(() => !queryClientV5.isFetching())
+
+            const cachedBundleContentBanner = screen.queryByText(
+              'The reported bundle size includes cached data from previous commits'
+            )
+            expect(cachedBundleContentBanner).not.toBeInTheDocument()
+          })
+        })
       })
     })
 

--- a/src/pages/PullRequestPage/PullBundleAnalysis/PullBundleAnalysis.tsx
+++ b/src/pages/PullRequestPage/PullBundleAnalysis/PullBundleAnalysis.tsx
@@ -2,7 +2,9 @@ import { useSuspenseQuery as useSuspenseQueryV5 } from '@tanstack/react-queryV5'
 import { lazy, Suspense } from 'react'
 import { useParams } from 'react-router-dom'
 
+import { CachedBundleContentBanner } from 'shared/CachedBundleContentBanner/CachedBundleContentBanner'
 import ComparisonErrorBanner from 'shared/ComparisonErrorBanner'
+import { useFlags } from 'shared/featureFlags'
 import { ReportUploadType } from 'shared/utils/comparison'
 import Spinner from 'ui/Spinner'
 
@@ -35,13 +37,19 @@ const Loader = () => (
 
 interface BundleContentProps {
   bundleCompareType?: TBundleAnalysisComparisonResult
-  headHasBundle?: boolean
+  headHasBundle: boolean
+  hasCachedBundle: boolean
 }
 
 const BundleContent: React.FC<BundleContentProps> = ({
   bundleCompareType,
   headHasBundle,
+  hasCachedBundle,
 }) => {
+  const { displayCachedBundleBanner } = useFlags({
+    displayCachedBundleBanner: false,
+  })
+
   if (bundleCompareType === 'FirstPullRequest') {
     return (
       <>
@@ -76,9 +84,14 @@ const BundleContent: React.FC<BundleContentProps> = ({
   }
 
   return (
-    <Suspense fallback={<Loader />}>
-      <PullBundleComparisonTable />
-    </Suspense>
+    <>
+      {hasCachedBundle && displayCachedBundleBanner ? (
+        <CachedBundleContentBanner />
+      ) : null}
+      <Suspense fallback={<Loader />}>
+        <PullBundleComparisonTable />
+      </Suspense>
+    </>
   )
 }
 
@@ -98,15 +111,24 @@ const PullBundleAnalysis: React.FC = () => {
 
   const bundleCompareType =
     data?.pull?.bundleAnalysisCompareWithBase?.__typename
-  const headHasBundle =
+
+  let headHasBundle = false
+  let hasCachedBundle = false
+  if (
     data?.pull?.head?.bundleAnalysis?.bundleAnalysisReport?.__typename ===
     'BundleAnalysisReport'
+  ) {
+    headHasBundle = true
+    hasCachedBundle =
+      data?.pull?.head?.bundleAnalysis?.bundleAnalysisReport?.isCached
+  }
 
   if (data?.coverageEnabled && data?.bundleAnalysisEnabled) {
     return (
       <BundleContent
         bundleCompareType={bundleCompareType}
         headHasBundle={headHasBundle}
+        hasCachedBundle={hasCachedBundle}
       />
     )
   }
@@ -119,6 +141,7 @@ const PullBundleAnalysis: React.FC = () => {
       <BundleContent
         bundleCompareType={bundleCompareType}
         headHasBundle={headHasBundle}
+        hasCachedBundle={hasCachedBundle}
       />
     </>
   )


### PR DESCRIPTION
# Description

This PR adds in the cached bundle banner to the pulls page, when there is cached data included on the page. This is currently behind a feature flag, so it can be released at the same time as the commit page one.

Ticket: codecov/engineering-team#3153

# Notable Changes

- Add banner to commit bundle component behind a feature flag
- Add in tests

# Screenshots

>[!note]
>These screenshots are forced as there aren't any examples on staging where caching is enabled.

![Screenshot 2025-01-07 at 10 10 12](https://github.com/user-attachments/assets/7e316cfb-36be-4201-b893-7b58b960ddd2)