### PR TITLE
fix: Rewrite infinite queries to be consist using undefined over null

### DIFF
--- a/src/pages/PlanPage/subRoutes/CurrentOrgPlan/queries/InfiniteAccountOrganizationsQueryOpts.ts
+++ b/src/pages/PlanPage/subRoutes/CurrentOrgPlan/queries/InfiniteAccountOrganizationsQueryOpts.ts
@@ -36,9 +36,9 @@ const RequestSchema = z.object({
 })
 
 const query = `query InfiniteAccountOrganizations(
-  $owner: String!, 
-  $after: String, 
-  $first: Int!, 
+  $owner: String!,
+  $after: String,
+  $first: Int!,
   $direction: OrderingDirection!
 ) {
   owner(username: $owner) {
@@ -85,15 +85,17 @@ export function InfiniteAccountOrganizationsQueryOpts({
 
   return infiniteQueryOptionsV5({
     queryKey: ['InfiniteAccountOrganizations', provider, owner, variables],
-    queryFn: ({ pageParam, signal }) =>
-      Api.graphql({
+    queryFn: ({ pageParam, signal }) => {
+      const after = pageParam ? pageParam : undefined
+
+      return Api.graphql({
         provider,
         signal,
         query,
         variables: {
           ...variables,
           owner,
-          after: pageParam,
+          after,
         },
       }).then((res) => {
         const parsedRes = RequestSchema.safeParse(res.data)
@@ -121,10 +123,11 @@ export function InfiniteAccountOrganizationsQueryOpts({
           organizations: mapEdges(account.organizations),
           pageInfo: account.organizations.pageInfo,
         }
-      }),
+      })
+    },
     initialPageParam: '',
     getNextPageParam: (data) => {
-      return data?.pageInfo?.hasNextPage ? data?.pageInfo?.endCursor : null
+      return data?.pageInfo?.hasNextPage ? data?.pageInfo?.endCursor : undefined
     },
   })
 }

--- a/src/services/bundleAnalysis/BundleAssetsQueryOpts.tsx
+++ b/src/services/bundleAnalysis/BundleAssetsQueryOpts.tsx
@@ -258,6 +258,8 @@ export const BundleAssetsQueryOpts = ({
       orderingDirection,
     ],
     queryFn: ({ signal, pageParam }) => {
+      const assetsAfter = pageParam ? pageParam : undefined
+
       return Api.graphql({
         query,
         provider,
@@ -271,7 +273,7 @@ export const BundleAssetsQueryOpts = ({
           dateBefore,
           dateAfter,
           filters,
-          assetsAfter: pageParam,
+          assetsAfter,
           ordering,
           orderingDirection,
         },
@@ -353,6 +355,6 @@ export const BundleAssetsQueryOpts = ({
     // matches the type for initialPageParam.
     initialPageParam: '',
     getNextPageParam: (data) => {
-      return data?.pageInfo?.hasNextPage ? data?.pageInfo?.endCursor : null
+      return data?.pageInfo?.hasNextPage ? data?.pageInfo?.endCursor : undefined
     },
   })

--- a/src/services/repos/ReposQueryOpts.tsx
+++ b/src/services/repos/ReposQueryOpts.tsx
@@ -141,6 +141,8 @@ function ReposQueryOpts({
   return infiniteQueryOptionsV5({
     queryKey: ['repos', provider, owner, variables],
     queryFn: ({ pageParam, signal }) => {
+      const after = pageParam === '' ? undefined : pageParam
+
       return Api.graphql({
         provider,
         query,
@@ -148,7 +150,7 @@ function ReposQueryOpts({
         variables: {
           ...variables,
           owner,
-          after: pageParam === '' ? undefined : pageParam,
+          after,
         },
       }).then((res) => {
         const parsedRes = RequestSchema.safeParse(res?.data)
@@ -169,7 +171,7 @@ function ReposQueryOpts({
     },
     initialPageParam: '',
     getNextPageParam: (data) => {
-      return data?.pageInfo?.hasNextPage ? data.pageInfo.endCursor : null
+      return data?.pageInfo?.hasNextPage ? data.pageInfo.endCursor : undefined
     },
   })
 }

--- a/src/services/repos/ReposTeamQueryOpts.tsx
+++ b/src/services/repos/ReposTeamQueryOpts.tsx
@@ -129,6 +129,8 @@ function ReposTeamQueryOpts({
   return infiniteQueryOptionsV5({
     queryKey: ['GetReposTeam', provider, variables, owner],
     queryFn: ({ pageParam, signal }) => {
+      const after = pageParam === '' ? undefined : pageParam
+
       return Api.graphql({
         provider,
         query,
@@ -136,7 +138,7 @@ function ReposTeamQueryOpts({
         variables: {
           ...variables,
           owner,
-          after: pageParam === '' ? undefined : pageParam,
+          after,
         },
       }).then((res) => {
         const parsedRes = RequestSchema.safeParse(res?.data)
@@ -161,10 +163,7 @@ function ReposTeamQueryOpts({
     },
     initialPageParam: '',
     getNextPageParam: (data) => {
-      if (data?.pageInfo?.hasNextPage) {
-        return data.pageInfo.endCursor
-      }
-      return null
+      return data?.pageInfo?.hasNextPage ? data.pageInfo.endCursor : undefined
     },
   })
 }

--- a/src/services/selfHosted/SelfHostedUserListQueryOpts.ts
+++ b/src/services/selfHosted/SelfHostedUserListQueryOpts.ts
@@ -67,7 +67,7 @@ export const SelfHostedUserListQueryOpts = ({
         const { searchParams } = new URL(data.next)
         return searchParams.get('page')
       }
-      return null
+      return undefined
     },
   })
 }


### PR DESCRIPTION
# Description

This PR is a quick fix to ensure that these infinite query options are more consist in the way they handle `pageParam`'s to reduce potential issues down the road, the docs in notion have also been updated accordingly.

# Notable Changes

- Update all TS Query V5 implementations that differ