### PR TITLE
[chore] Add rule to make provider casing more consistent

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -21,6 +21,7 @@ module.exports = {
     'plugin:tailwindcss/recommended',
   ],
   plugins: ['@vitest', 'jsx-a11y', 'import'],
+
   globals: {
     vi: true,
   },
@@ -504,9 +505,10 @@ module.exports = {
     'no-restricted-syntax': [
       'warn',
       {
-        selector: "Literal[value=/\\bGithub\\b|\\bGitlab\\b/]",
+        selector: "JSXText[value=/\\bGithub\\b|\\bGitlab\\b/]",
         message: "Use correct casing (GitHub, GitLab)"
       }
     ]
+
   },
 }

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -505,7 +505,7 @@ module.exports = {
     'no-restricted-syntax': [
       'warn',
       {
-        selector: "Literal[value=Github|Gitlab]",
+        selector: "Literal[value=/\\bGithub\\b|\\bGitlab\\b/]",
         message: "Use correct casing (GitHub, GitLab)"
       }
     ]

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -21,6 +21,7 @@ module.exports = {
     'plugin:tailwindcss/recommended',
   ],
   plugins: ['@vitest', 'jsx-a11y', 'import'],
+
   globals: {
     vi: true,
   },
@@ -500,5 +501,14 @@ module.exports = {
     // https://github.com/facebook/react/tree/main/packages/eslint-plugin-react-hooks
     'react-hooks/rules-of-hooks': 'error',
     'react-hooks/exhaustive-deps': 'warn',
+
+    'no-restricted-syntax': [
+      'warn',
+      {
+        selector: "Literal[value=Github|Gitlab]",
+        message: "Use correct casing (GitHub, GitLab)"
+      }
+    ]
+
   },
 }

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -505,7 +505,7 @@ module.exports = {
       'warn',
       {
         selector: "JSXText[value=/\\bGithub\\b|\\bGitlab\\b|\\bBitBucket\\b/]",
-        message: "Use correct casing (GitHub, GitLab)"
+        message: "Use correct casing (GitHub, GitLab, Bitbucket)"
       }
     ]
   },

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -505,7 +505,7 @@ module.exports = {
     'no-restricted-syntax': [
       'warn',
       {
-        selector: "JSXText[value=/\\bGithub\\b|\\bGitlab\\b/]",
+        selector: "JSXText[value=/\\bGithub\\b|\\bGitlab\\b|\\bBitBucket\\b/]",
         message: "Use correct casing (GitHub, GitLab)"
       }
     ]

--- a/src/pages/AccountSettings/tabs/Admin/GithubIntegrationSection/GithubIntegrationSection.jsx
+++ b/src/pages/AccountSettings/tabs/Admin/GithubIntegrationSection/GithubIntegrationSection.jsx
@@ -47,7 +47,7 @@ function GithubIntegrationSection() {
 
   return (
     <div className="flex flex-col gap-2">
-      <h2 className="text-lg font-semibold"> Gitlab Integration </h2>
+      <h2 className="text-lg font-semibold">GitHub Integration</h2>
       <GithubIntegrationCopy integrationId={accountDetails?.integrationId} />
     </div>
   )

--- a/src/pages/AccountSettings/tabs/Admin/GithubIntegrationSection/GithubIntegrationSection.jsx
+++ b/src/pages/AccountSettings/tabs/Admin/GithubIntegrationSection/GithubIntegrationSection.jsx
@@ -47,7 +47,7 @@ function GithubIntegrationSection() {
 
   return (
     <div className="flex flex-col gap-2">
-      <h2 className="text-lg font-semibold">Github Integration</h2>
+      <h2 className="text-lg font-semibold"> Gitlab Integration </h2>
       <GithubIntegrationCopy integrationId={accountDetails?.integrationId} />
     </div>
   )

--- a/src/pages/AccountSettings/tabs/Admin/GithubIntegrationSection/GithubIntegrationSection.test.jsx
+++ b/src/pages/AccountSettings/tabs/Admin/GithubIntegrationSection/GithubIntegrationSection.test.jsx
@@ -146,7 +146,7 @@ describe('GithubIntegrationSection', () => {
       render(<GithubIntegrationSection />, { wrapper: wrapper() })
 
       const link = await screen.findByRole('link', {
-        name: /Github/i,
+        name: /GitHub/i,
       })
       expect(link).toBeInTheDocument()
     })

--- a/src/pages/AccountSettings/tabs/Admin/ManageAdminCard/AdminTable/AdminTable.tsx
+++ b/src/pages/AccountSettings/tabs/Admin/ManageAdminCard/AdminTable/AdminTable.tsx
@@ -163,7 +163,7 @@ export default function AdminTable() {
   if (!isLoading && !tableData?.length) {
     return (
       <p>
-        No admins yet. Note that admins in your Github organization are
+        No admins yet. Note that admins in your GitHub organization are
         automatically considered admins.
       </p>
     )

--- a/src/pages/AccountSettings/tabs/Admin/ManageAdminCard/ManageAdminCard.test.jsx
+++ b/src/pages/AccountSettings/tabs/Admin/ManageAdminCard/ManageAdminCard.test.jsx
@@ -110,7 +110,7 @@ describe('ManageAdminCard', () => {
       render(<ManageAdminCard />, { wrapper })
 
       const noAdmins = await screen.findByText(
-        /No admins yet. Note that admins in your Github organization are automatically considered admins./
+        /No admins yet. Note that admins in your GitHub organization are automatically considered admins./
       )
       expect(noAdmins).toBeInTheDocument()
     })
@@ -123,7 +123,7 @@ describe('ManageAdminCard', () => {
       render(<ManageAdminCard />, { wrapper })
 
       const noAdmins = await screen.findByText(
-        /No admins yet. Note that admins in your Github organization are automatically considered admins./
+        /No admins yet. Note that admins in your GitHub organization are automatically considered admins./
       )
       expect(noAdmins).toBeInTheDocument()
     })

--- a/src/pages/CommitDetailPage/CommitCoverage/BotErrorBanner/BotErrorBanner.jsx
+++ b/src/pages/CommitDetailPage/CommitCoverage/BotErrorBanner/BotErrorBanner.jsx
@@ -11,7 +11,7 @@ import BannerHeading from 'ui/Banner/BannerHeading'
 export const ProvidersEnum = Object.freeze({
   Github: 'GitHub',
   Gitlab: 'GitLab',
-  BitBucket: 'BitBucket',
+  Bitbucket: 'Bitbucket',
 })
 
 function useProviderSetting() {
@@ -28,7 +28,7 @@ function useProviderSetting() {
   const ghWithNoApp =
     !accountDetails?.integrationId && provider === ProvidersEnum.Github
 
-  const bbProvider = provider === ProvidersEnum.BitBucket
+  const bbProvider = provider === ProvidersEnum.Bitbucket
   const glProvider = provider === ProvidersEnum.Gitlab
 
   return { ghWithNoApp, bbProvider, glProvider, ghWithApp }
@@ -83,7 +83,7 @@ const BotErrorHeading = () => {
 
   if (ghWithApp) {
     return (
-      <p className="font-semibold">There was an issue with the Github app</p>
+      <p className="font-semibold">There was an issue with the GitHub app</p>
     )
   }
 

--- a/src/pages/CommitDetailPage/CommitCoverage/BotErrorBanner/BotErrorBanner.jsx
+++ b/src/pages/CommitDetailPage/CommitCoverage/BotErrorBanner/BotErrorBanner.jsx
@@ -37,7 +37,7 @@ function useProviderSetting() {
 const BotErrorContent = () => {
   const { ghWithNoApp, bbProvider, glProvider, ghWithApp } =
     useProviderSetting()
-
+  console.log('Github')
   if (ghWithNoApp) {
     return (
       <p>

--- a/src/pages/CommitDetailPage/CommitCoverage/BotErrorBanner/BotErrorBanner.jsx
+++ b/src/pages/CommitDetailPage/CommitCoverage/BotErrorBanner/BotErrorBanner.jsx
@@ -37,7 +37,7 @@ function useProviderSetting() {
 const BotErrorContent = () => {
   const { ghWithNoApp, bbProvider, glProvider, ghWithApp } =
     useProviderSetting()
-  console.log('Github')
+
   if (ghWithNoApp) {
     return (
       <p>

--- a/src/pages/CommitDetailPage/CommitCoverage/BotErrorBanner/BotErrorBanner.test.jsx
+++ b/src/pages/CommitDetailPage/CommitCoverage/BotErrorBanner/BotErrorBanner.test.jsx
@@ -59,7 +59,7 @@ describe('BotErrorBanner', () => {
       })
 
       const title = await screen.findByText(
-        'There was an issue with the Github app'
+        'There was an issue with the GitHub app'
       )
       expect(title).toBeInTheDocument()
     })

--- a/src/pages/EnterpriseLandingPage/EnterpriseLandingPage.test.tsx
+++ b/src/pages/EnterpriseLandingPage/EnterpriseLandingPage.test.tsx
@@ -106,7 +106,7 @@ describe('EnterpriseLandingPage', () => {
     it('displays bitbucket card', async () => {
       render(<EnterpriseLandingPage />, { wrapper })
 
-      const element = await screen.findByRole('heading', { name: 'BitBucket' })
+      const element = await screen.findByRole('heading', { name: 'Bitbucket' })
       expect(element).toBeInTheDocument()
     })
 
@@ -138,7 +138,7 @@ describe('EnterpriseLandingPage', () => {
     it('displays bitbucket button', () => {
       render(<EnterpriseLandingPage />, { wrapper })
 
-      expect(screen.queryByText('BitBucket')).toBeNull()
+      expect(screen.queryByText('Bitbucket')).toBeNull()
     })
   })
 })

--- a/src/pages/EnterpriseLandingPage/ProviderCard/ProviderCard.test.tsx
+++ b/src/pages/EnterpriseLandingPage/ProviderCard/ProviderCard.test.tsx
@@ -27,7 +27,7 @@ describe('ProviderCard', () => {
         )
 
         const element = screen.getByRole('link', {
-          name: 'Login via BitBucket',
+          name: 'Login via Bitbucket',
         })
         expect(element).toBeInTheDocument()
         expect(element).toHaveAttribute('href', '/login/bb')
@@ -43,7 +43,7 @@ describe('ProviderCard', () => {
         )
 
         const element = screen.getByRole('link', {
-          name: 'Login via BitBucket Server',
+          name: 'Login via Bitbucket Server',
         })
         expect(element).toBeInTheDocument()
         expect(element).toHaveAttribute('href', '/login/bbs')

--- a/src/pages/RepoPage/FailedTestsTab/CodecovCLI/CodecovCLI.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/CodecovCLI/CodecovCLI.tsx
@@ -83,7 +83,7 @@ function Step4() {
       </Card.Header>
       <Card.Content className="flex flex-col gap-4">
         <p>
-          Codecov offers existing wrappers for the CLI (Github Actions, Circle
+          Codecov offers existing wrappers for the CLI (GitHub Actions, Circle
           CI Orb, Bitrise Step) that makes uploading coverage to Codecov easy,
           as described{' '}
           <A
@@ -164,7 +164,7 @@ function Step6() {
           tests result on the following areas:
         </p>
         <ul className="list-inside list-disc">
-          <li>Github pull request comment</li>
+          <li>GitHub pull request comment</li>
           <li>Failed tests dashboard here.</li>
         </ul>
       </Card.Content>

--- a/src/pages/RepoPage/FailedTestsTab/GitHubActions/GitHubActions.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/GitHubActions/GitHubActions.tsx
@@ -157,7 +157,7 @@ function Step4() {
           tests result on the following areas:
         </p>
         <ul className="list-inside list-disc">
-          <li>Github pull request comment</li>
+          <li>GitHub pull request comment</li>
           <li>Failed tests dashboard here.</li>
         </ul>
       </Card.Content>

--- a/src/pages/SyncProviderPage/SyncButton.test.tsx
+++ b/src/pages/SyncProviderPage/SyncButton.test.tsx
@@ -38,7 +38,7 @@ describe('SyncButton', () => {
     it('renders sync button', () => {
       render(<SyncButton provider="bb" />, { wrapper })
 
-      const link = screen.getByRole('link', { name: /Sync with BitBucket/ })
+      const link = screen.getByRole('link', { name: /Sync with Bitbucket/ })
 
       const expectedRedirect = encodeURIComponent('http://localhost:3000/bb')
       expect(link).toBeInTheDocument()
@@ -79,7 +79,7 @@ describe('SyncButton', () => {
       render(<SyncButton provider="bbs" />, { wrapper })
 
       const link = screen.getByRole('link', {
-        name: /Sync with BitBucket Server/,
+        name: /Sync with Bitbucket Server/,
       })
 
       const expectedRedirect = encodeURIComponent('http://localhost:3000/bbs')

--- a/src/shared/GlobalBanners/GitHubRateLimitExceeded/GitHubRateLimitExceededBanner.test.tsx
+++ b/src/shared/GlobalBanners/GitHubRateLimitExceeded/GitHubRateLimitExceededBanner.test.tsx
@@ -24,7 +24,7 @@ describe('GitHubRateLimitExceededBanner', () => {
       const description = screen.getByText(/Unable to calculate/)
       expect(description).toBeInTheDocument()
 
-      const link = screen.getByRole('link', { name: 'Github documentation.' })
+      const link = screen.getByRole('link', { name: 'GitHub documentation.' })
       expect(link).toBeInTheDocument()
       expect(link).toHaveAttribute(
         'href',

--- a/src/shared/GlobalBanners/GitHubRateLimitExceeded/GitHubRateLimitExceededBanner.tsx
+++ b/src/shared/GlobalBanners/GitHubRateLimitExceeded/GitHubRateLimitExceededBanner.tsx
@@ -28,7 +28,7 @@ const GitHubRateLimitExceededBanner = () => {
             hook={undefined}
             isExternal={true}
           >
-            Github documentation.
+            GitHub documentation.
           </A>
         </Alert.Description>
       </Alert>

--- a/src/shared/ListRepo/OrgControlTable/RepoOrgNotFound/RepoOrgNotFound.tsx
+++ b/src/shared/ListRepo/OrgControlTable/RepoOrgNotFound/RepoOrgNotFound.tsx
@@ -34,7 +34,7 @@ function ResyncButton() {
           isExternal={true}
           className="inline underline"
         >
-          Github rate limits.
+          GitHub rate limits.
         </A>
       </div>
     )

--- a/src/shared/utils/loginProviders.ts
+++ b/src/shared/utils/loginProviders.ts
@@ -11,12 +11,12 @@ import sentryLogo from 'assets/providers/sentry-icon.svg'
 export const LoginProvidersEnum = {
   BITBUCKET: {
     provider: 'bb',
-    name: 'BitBucket',
+    name: 'Bitbucket',
     external: 'BITBUCKET',
     externalKey: 'bb',
     selfHosted: 'BITBUCKET_SERVER',
     selfHostedKey: 'bbs',
-    selfHostedName: 'BitBucket Server',
+    selfHostedName: 'Bitbucket Server',
     variant: 'bitbucket',
   },
   GITHUB: {
@@ -71,17 +71,17 @@ export function loginProviderToShortName(loginProvider?: string) {
 
 export const LOGIN_PROVIDER_NAMES = {
   gh: 'GitHub',
-  bb: 'BitBucket',
+  bb: 'Bitbucket',
   gl: 'GitLab',
   ghe: 'GitHub Enterprise',
   gle: 'GitLab Enterprise',
-  bbs: 'BitBucket Server',
+  bbs: 'Bitbucket Server',
   github: 'GitHub',
-  bitbucket: 'BitBucket',
+  bitbucket: 'Bitbucket',
   gitlab: 'GitLab',
   github_enterprise: 'GitHub Enterprise',
   gitlab_enterprise: 'GitLab Enterprise',
-  bitbucket_server: 'BitBucket Server',
+  bitbucket_server: 'Bitbucket Server',
   sentry: 'Sentry',
   okta: 'Okta',
 } as const
@@ -99,10 +99,10 @@ export function loginProviderToName(loginProvider?: string) {
 export const LOGIN_PROVIDER_IMAGES = {
   GitHub: githubLogo,
   GitLab: gitlabLogo,
-  BitBucket: bitbucketLogo,
+  Bitbucket: bitbucketLogo,
   'GitHub Enterprise': githubLogo,
   'GitLab Enterprise': gitlabLogo,
-  'BitBucket Server': bitbucketLogo,
+  'Bitbucket Server': bitbucketLogo,
   Sentry: sentryLogo,
   Okta: oktaLogo,
 } as const
@@ -110,10 +110,10 @@ export const LOGIN_PROVIDER_IMAGES = {
 export const LOGIN_PROVIDER_DARK_MODE_IMAGES = {
   GitHub: githubLogoWhite,
   GitLab: gitlabLogo,
-  BitBucket: bitbucketLogo,
+  Bitbucket: bitbucketLogo,
   'GitHub Enterprise': githubLogoWhite,
   'GitLab Enterprise': gitlabLogo,
-  'BitBucket Server': bitbucketLogo,
+  'Bitbucket Server': bitbucketLogo,
   Sentry: sentryLogoWhite,
   Okta: oktaLogo,
 } as const

--- a/src/shared/utils/provider.test.ts
+++ b/src/shared/utils/provider.test.ts
@@ -11,74 +11,74 @@ vi.mock('config')
 
 describe('providerToName', () => {
   describe('when called with gh', () => {
-    it('returns Github', () => {
+    it('returns GitHub', () => {
       expect(providerToName('gh')).toBe('GitHub')
     })
   })
 
   describe('when called with gl', () => {
-    it('returns Gitlab', () => {
+    it('returns GitLab', () => {
       expect(providerToName('gl')).toBe('GitLab')
     })
   })
 
   describe('when called with bb', () => {
-    it('returns BitBucket', () => {
-      expect(providerToName('bb')).toBe('BitBucket')
+    it('returns Bitbucket', () => {
+      expect(providerToName('bb')).toBe('Bitbucket')
     })
   })
 
   describe('when called with ghe', () => {
-    it('returns Github Enterprise', () => {
+    it('returns GitHub Enterprise', () => {
       expect(providerToName('ghe')).toBe('GitHub Enterprise')
     })
   })
 
   describe('when called with gle', () => {
-    it('returns Gitlab Enterprise', () => {
+    it('returns GitLab Enterprise', () => {
       expect(providerToName('gle')).toBe('GitLab Enterprise')
     })
   })
 
   describe('when called with bbs', () => {
-    it('returns BitBucket Server', () => {
-      expect(providerToName('bbs')).toBe('BitBucket Server')
+    it('returns Bitbucket Server', () => {
+      expect(providerToName('bbs')).toBe('Bitbucket Server')
     })
   })
 
-  describe('when called with Github', () => {
-    it('returns Github', () => {
+  describe('when called with GitHub', () => {
+    it('returns GitHub', () => {
       expect(providerToName('github')).toBe('GitHub')
     })
   })
 
-  describe('when called with Gitlab', () => {
-    it('returns Gitlab', () => {
+  describe('when called with GitLab', () => {
+    it('returns GitLab', () => {
       expect(providerToName('gitlab')).toBe('GitLab')
     })
   })
 
-  describe('when called with BitBucket', () => {
-    it('returns BitBucket', () => {
-      expect(providerToName('bitbucket')).toBe('BitBucket')
+  describe('when called with Bitbucket', () => {
+    it('returns Bitbucket', () => {
+      expect(providerToName('bitbucket')).toBe('Bitbucket')
     })
   })
 
   describe('when called with github_enterprise', () => {
-    it('returns Github Enterprise', () => {
+    it('returns GitHub Enterprise', () => {
       expect(providerToName('github_enterprise')).toBe('GitHub Enterprise')
     })
   })
 
   describe('when called with gitlab-enterprise', () => {
-    it('returns Gitlab Enterprise', () => {
+    it('returns GitLab Enterprise', () => {
       expect(providerToName('gitlab_enterprise')).toBe('GitLab Enterprise')
     })
   })
 
   describe('when called with bitbucket_server', () => {
-    it('returns BitBucket Server', () => {
-      expect(providerToName('bitbucket_server')).toBe('BitBucket Server')
+    it('returns Bitbucket Server', () => {
+      expect(providerToName('bitbucket_server')).toBe('Bitbucket Server')
     })
   })
 })
@@ -203,19 +203,19 @@ describe('providerToInternalProvider', () => {
     })
   })
 
-  describe('when called with Github', () => {
+  describe('when called with GitHub', () => {
     it('returns github', () => {
       expect(providerToInternalProvider('github')).toBe('github')
     })
   })
 
-  describe('when called with Gitlab', () => {
+  describe('when called with GitLab', () => {
     it('returns gitlab', () => {
       expect(providerToInternalProvider('gitlab')).toBe('gitlab')
     })
   })
 
-  describe('when called with BitBucket', () => {
+  describe('when called with Bitbucket', () => {
     it('returns bitbucket', () => {
       expect(providerToInternalProvider('bitbucket')).toBe('bitbucket')
     })

--- a/src/shared/utils/provider.ts
+++ b/src/shared/utils/provider.ts
@@ -6,17 +6,17 @@ import { Provider } from 'shared/api/helpers'
 export function providerToName(provider: Provider) {
   return {
     gh: 'GitHub',
-    bb: 'BitBucket',
+    bb: 'Bitbucket',
     gl: 'GitLab',
     ghe: 'GitHub Enterprise',
     gle: 'GitLab Enterprise',
-    bbs: 'BitBucket Server',
+    bbs: 'Bitbucket Server',
     github: 'GitHub',
-    bitbucket: 'BitBucket',
+    bitbucket: 'Bitbucket',
     gitlab: 'GitLab',
     github_enterprise: 'GitHub Enterprise',
     gitlab_enterprise: 'GitLab Enterprise',
-    bitbucket_server: 'BitBucket Server',
+    bitbucket_server: 'Bitbucket Server',
   }[provider.toLowerCase()]
 }
 
@@ -50,11 +50,11 @@ export function getProviderCommitURL({
 }) {
   return {
     GitHub: `https://github.com/${owner}/${repo}/commit/${commit}`,
-    BitBucket: `https://bitbucket.org/${owner}/${repo}/commits/${commit}`,
+    Bitbucket: `https://bitbucket.org/${owner}/${repo}/commits/${commit}`,
     GitLab: `https://gitlab.com/${owner}/${repo}/-/commit/${commit}`,
     'GitHub Enterprise': `${config.GHE_URL}/${owner}/${repo}/commit/${commit}`,
     'GitLab Enterprise': `${config.GLE_URL}/${owner}/${repo}/-/commit/${commit}`,
-    'BitBucket Server': `${config.BBS_URL}/${owner}/${repo}/commits/${commit}`,
+    'Bitbucket Server': `${config.BBS_URL}/${owner}/${repo}/commits/${commit}`,
     // @ts-expect-error - provider could be undefined but it should be fine
   }[providerToName(provider)]
 }
@@ -72,11 +72,11 @@ export function getProviderPullURL({
 }) {
   return {
     GitHub: `https://github.com/${owner}/${repo}/pull/${pullId}`,
-    BitBucket: `https://bitbucket.org/${owner}/${repo}/pull-requests/${pullId}`,
+    Bitbucket: `https://bitbucket.org/${owner}/${repo}/pull-requests/${pullId}`,
     GitLab: `https://gitlab.com/${owner}/${repo}/-/merge_requests/${pullId}`,
     'GitHub Enterprise': `${config.GHE_URL}/${owner}/${repo}/pull/${pullId}`,
     'GitLab Enterprise': `${config.GLE_URL}/${owner}/${repo}/-/merge_requests/${pullId}`,
-    'BitBucket Server': `${config.BBS_URL}/${owner}/${repo}/pull-requests/${pullId}`,
+    'Bitbucket Server': `${config.BBS_URL}/${owner}/${repo}/pull-requests/${pullId}`,
     // @ts-expect-error - provider could be undefined but it should be fine
   }[providerToName(provider)]
 }


### PR DESCRIPTION
The linter will now warn if we use Github instead of GitHub, same for GitLab. Also fixes casing errors for Bitbucket. 

This closes https://github.com/codecov/engineering-team/issues/3175


![Screenshot 2025-01-08 at 11 18 59 AM](https://github.com/user-attachments/assets/7325e43e-64f1-4f11-beb3-91fe0e3404d3)
