### PR TITLE
fix: background color on trend selector container for dark mode

### DIFF
--- a/src/ui/Select/Select.jsx
+++ b/src/ui/Select/Select.jsx
@@ -30,7 +30,7 @@ const UlVariantClass = {
 const ButtonVariantClass = {
   default: `w-full h-8 px-3 border border-ds-gray-tertiary rounded-md bg-ds-background disabled:text-ds-gray-quaternary disabled:bg-ds-gray-primary disabled:border-ds-gray-tertiary`,
   gray: `w-full h-8 px-3 border border-ds-gray-tertiary rounded-md bg-ds-container disabled:text-ds-gray-quaternary disabled:bg-ds-gray-primary disabled:border-ds-gray-tertiary`,
-  text: `flex-init text-ds-blue-default`,
+  text: `flex-init bg-transparent text-ds-blue-default`,
   defaultOrgSelector: `w-full h-12 px-3 border border-ds-gray-tertiary rounded-md bg-ds-background disabled:text-ds-gray-quaternary disabled:bg-ds-gray-primary disabled:border-ds-gray-tertiary`,
 }
 


### PR DESCRIPTION
# Description

This PR fixes a background style on the trend selector elements for both the coverage overview and bundle overview pages.

Just settings it to transparent, pics before and after.

# Screenshots

**COVERAGE PAGE**
![Screenshot 2025-01-08 at 2 54 00 PM](https://github.com/user-attachments/assets/83bf471a-5376-47c5-a15d-054ebee0559f)
![Screenshot 2025-01-08 at 2 53 50 PM](https://github.com/user-attachments/assets/ebe72744-eb77-48a6-bea1-f6eb9b2a2492)

**BUNDLE PAGE**
![Screenshot 2025-01-08 at 2 59 16 PM](https://github.com/user-attachments/assets/c20e8410-649d-4140-b82b-267d759bc06d)
![Screenshot 2025-01-08 at 2 59 06 PM](https://github.com/user-attachments/assets/a86e0819-bc80-4133-a0e4-1166b76dc335)


# Link to Sample Entry

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.