### PR TITLE
Cy/new tos

### DIFF
--- a/src/pages/TermsOfService/TermsOfService.test.tsx
+++ b/src/pages/TermsOfService/TermsOfService.test.tsx
@@ -248,9 +248,6 @@ describe('TermsOfService', () => {
         /I agree to the TOS and privacy policy/i
       )
 
-      const customerIntent = screen.getByRole('radio', { name: /Personal use/ })
-      await user.click(customerIntent)
-
       await user.click(selectedTos)
 
       const submit = await screen.findByRole('button', { name: /Continue/ })
@@ -263,7 +260,7 @@ describe('TermsOfService', () => {
             businessEmail: 'personal@cr.com',
             termsAgreement: true,
             marketingConsent: false,
-            customerIntent: 'PERSONAL',
+            name: 'Chetney',
           },
         })
       )
@@ -298,7 +295,7 @@ describe('TermsOfService', () => {
       'case #1',
       {
         validationDescription:
-          'user has email, signs TOS, submit is now enabled',
+          'user has email and name, signs TOS, submit is now enabled',
         internalUserData: {
           email: 'personal@cr.com',
           termsAgreement: false,
@@ -309,15 +306,15 @@ describe('TermsOfService', () => {
       },
       [expectPageIsReady],
       [expectSubmitIsDisabled],
+      [expectPrepopulatedFields, { email: 'personal@cr.com', name: 'Chetney' }],
       [expectUserSignsTOS],
-      [expectUserToChooseCustomerIntent],
       [expectSubmitIsEnabled],
     ],
     [
       'case #2',
       {
         validationDescription:
-          'user wants to receive emails, signs TOS, submit is now enabled',
+          'user has email and name, user wants to receive emails, signs TOS, submit is now enabled',
         internalUserData: {
           email: 'chetney@cr.com',
           termsAgreement: false,
@@ -327,9 +324,10 @@ describe('TermsOfService', () => {
         },
       },
       [expectPageIsReady],
-      [expectUserSelectsMarketingWithFoundEmail, { email: 'chetney@cr.com' }],
+      [expectPrepopulatedFields, { email: 'chetney@cr.com', name: 'Chetney' }],
       [expectSubmitIsDisabled],
-      [expectUserToChooseCustomerIntent],
+      [expectUserSelectsMarketing],
+      [expectSubmitIsDisabled],
       [expectUserSignsTOS],
       [expectSubmitIsEnabled],
     ],
@@ -337,7 +335,7 @@ describe('TermsOfService', () => {
       'case #3',
       {
         validationDescription:
-          'user has email, user wants to receive emails, signs TOS, submit is now enabled',
+          'has prefilled email and name, signs TOS, decides not to, is warned they must sign and cannot submit',
         internalUserData: {
           email: 'chetney@cr.com',
           termsAgreement: false,
@@ -348,28 +346,7 @@ describe('TermsOfService', () => {
       },
       [expectPageIsReady],
       [expectSubmitIsDisabled],
-      [expectUserSelectsMarketingWithFoundEmail, { email: 'chetney@cr.com' }],
-      [expectSubmitIsDisabled],
-      [expectUserSignsTOS],
-      [expectUserToChooseCustomerIntent],
-      [expectSubmitIsEnabled],
-    ],
-    [
-      'case #4',
-      {
-        validationDescription:
-          'signs TOS, decides not to, is warned they must sign and cannot submit',
-        internalUserData: {
-          email: 'chetney@cr.com',
-          termsAgreement: false,
-          name: 'Chetney',
-          externalId: '1234',
-          owners: null,
-        },
-      },
-      [expectPageIsReady],
-      [expectSubmitIsDisabled],
-      [expectUserToChooseCustomerIntent],
+      [expectPrepopulatedFields, { email: 'chetney@cr.com', name: 'Chetney' }],
       [expectUserSignsTOS],
       [expectSubmitIsEnabled],
       [expectUserSignsTOS],
@@ -377,10 +354,10 @@ describe('TermsOfService', () => {
       [expectUserIsWarnedTOS],
     ],
     [
-      'case #5',
+      'case #4',
       {
         validationDescription:
-          'user checks marketing consent and is required to provide an email, sign TOS (check email validation messages)',
+          'user checks marketing consent and is required to provide an email, provide a name, sign TOS (check email validation messages)',
         internalUserData: {
           termsAgreement: false,
           name: 'Chetney',
@@ -391,21 +368,20 @@ describe('TermsOfService', () => {
       },
       [expectPageIsReady],
       [expectSubmitIsDisabled],
-      [expectEmailRequired],
       [expectUserTextEntryEmailField, { email: 'chetney' }],
       [expectUserIsWarnedForValidEmail],
       [expectSubmitIsDisabled],
-      [expectUserTextEntryEmailField, { email: '@cr.com' }],
+      [expectUserTextEntryEmailField, { email: '@hello.com' }],
       [expectUserIsNotWarnedForValidEmail],
       [expectSubmitIsDisabled],
+      [expectUserTextEntryNameField],
       [expectUserSelectsMarketing],
       [expectSubmitIsDisabled],
-      [expectUserToChooseCustomerIntent],
       [expectUserSignsTOS],
       [expectSubmitIsEnabled],
     ],
     [
-      'case #6',
+      'case #5',
       {
         validationDescription:
           'user checks marketing consent and does not provide an email, sign TOS (check email validation messages)',
@@ -418,29 +394,28 @@ describe('TermsOfService', () => {
         },
       },
       [expectPageIsReady],
-      [expectEmailRequired],
       [expectSubmitIsDisabled],
       [expectUserSignsTOS],
       [expectSubmitIsDisabled],
-      [expectUserToChooseCustomerIntent],
     ],
     [
-      'case #7',
+      'case #6',
       {
         validationDescription: 'server unknown error notification',
         isUnknownError: true,
         internalUserData: {
           termsAgreement: false,
-          email: 'personal@cr.com',
-          name: 'Chetney',
+          email: '',
+          name: '',
           externalId: '1234',
           owners: null,
         },
       },
       [expectPageIsReady],
+      [expectUserTextEntryEmailField, { email: 'personal@cr.com' }],
+      [expectUserTextEntryNameField],
       [expectUserSignsTOS],
       [expectClickSubmit],
-      [expectUserToChooseCustomerIntent],
       [
         expectRendersServerFailureResult,
         {
@@ -456,22 +431,23 @@ describe('TermsOfService', () => {
       ],
     ],
     [
-      'case #8',
+      'case #7',
       {
         validationDescription: 'server failure error notification',
         isUnAuthError: true,
         internalUserData: {
           termsAgreement: false,
-          email: 'personal@cr.com',
-          name: 'Chetney',
+          email: '',
+          name: '',
           externalId: '1234',
           owners: null,
         },
       },
       [expectPageIsReady],
+      [expectUserTextEntryEmailField, { email: 'personal@cr.com' }],
+      [expectUserTextEntryNameField],
       [expectUserSignsTOS],
       [expectClickSubmit],
-      [expectUserToChooseCustomerIntent],
       [
         expectRendersServerFailureResult,
         {
@@ -481,27 +457,28 @@ describe('TermsOfService', () => {
       ],
     ],
     [
-      'case #9',
+      'case #8',
       {
         validationDescription:
           'server validation error notification (saveTerms)',
         isValidationError: true,
         internalUserData: {
           termsAgreement: false,
-          email: 'personal@cr.com',
-          name: 'Chetney',
+          email: '',
+          name: '',
           externalId: '1234',
           owners: null,
         },
       },
       [expectPageIsReady],
+      [expectUserTextEntryEmailField, { email: 'personal@cr.com' }],
+      [expectUserTextEntryNameField],
       [expectUserSignsTOS],
       [expectClickSubmit],
-      [expectUserToChooseCustomerIntent],
       [expectRendersServerFailureResult, 'validation error'],
     ],
     [
-      'case #10',
+      'case #9',
       {
         validationDescription:
           'redirects to main root if user has already synced a provider',
@@ -525,33 +502,6 @@ describe('TermsOfService', () => {
         },
       },
       [expectRedirectTo, '/gh/codecov/cool-repo'],
-    ],
-    [
-      'case #11',
-      {
-        validationDescription: 'provide no customer intent, does not submit',
-        internalUserData: {
-          termsAgreement: true,
-          name: 'Chetney',
-          externalId: '1234',
-          email: '',
-          owners: [
-            {
-              avatarUrl: 'http://roland.com/avatar-url',
-              integrationId: null,
-              name: null,
-              ownerid: 2,
-              stats: null,
-              service: 'github',
-              username: 'roland',
-            },
-          ],
-        },
-      },
-      [expectPageIsReady],
-      [expectSubmitIsDisabled],
-      [expectUserSignsTOS],
-      [expectSubmitIsDisabled],
     ],
   ])(
     'form validation, %s',
@@ -693,10 +643,35 @@ async function expectPageIsReady() {
   expect(welcome).toBeInTheDocument()
 }
 
-async function expectUserToChooseCustomerIntent(user: UserEvent) {
-  const customerIntent = screen.getByRole('radio', { name: /Personal use/ })
+async function expectPrepopulatedFields(
+  user: UserEvent,
+  args: { email: string; name: string }
+) {
+  await waitFor(() => {
+    const emailInput = screen.getByLabelText(
+      /Enter your email/i
+    ) as HTMLInputElement
+    expect(emailInput).toHaveValue(args.email)
+  })
+  await waitFor(() => {
+    const nameInput = screen.getByLabelText(
+      /Enter your name/i
+    ) as HTMLInputElement
+    expect(nameInput).toHaveValue(args.name)
+  })
+}
 
-  await user.click(customerIntent)
+async function expectUserTextEntryNameField(user: UserEvent) {
+  const nameInput = screen.getByLabelText(/Enter your name/i)
+  await user.type(nameInput, 'My name')
+}
+
+async function expectUserTextEntryEmailField(
+  user: UserEvent,
+  args: { email: string }
+) {
+  const emailInput = screen.getByLabelText(/Enter your email/i)
+  await user.type(emailInput, args.email)
 }
 
 async function expectUserSignsTOS(user: UserEvent) {
@@ -707,36 +682,12 @@ async function expectUserSignsTOS(user: UserEvent) {
   await user.click(selectedTos)
 }
 
-async function expectUserSelectsMarketingWithFoundEmail(
-  user: UserEvent,
-  args: { email: string }
-) {
-  const selectedMarketing = screen.getByLabelText(
-    /I would like to receive updates via email/i
-  )
-  const emailIsInTheLabelOfSelectedMarketing = screen.getByText(
-    new RegExp(args.email, 'i')
-  )
-  expect(emailIsInTheLabelOfSelectedMarketing).toBeInTheDocument()
-
-  await user.click(selectedMarketing)
-}
-
 async function expectUserSelectsMarketing(user: UserEvent) {
   const selectedMarketing = screen.getByLabelText(
     /I would like to receive updates via email/i
   )
 
   await user.click(selectedMarketing)
-}
-
-async function expectUserTextEntryEmailField(
-  user: UserEvent,
-  args: { email: string }
-) {
-  const emailInput = screen.getByLabelText(/Contact email/i)
-
-  await user.type(emailInput, args.email)
 }
 
 async function expectSubmitIsDisabled() {
@@ -768,17 +719,6 @@ async function expectClickSubmit(user: UserEvent) {
   const submit = screen.getByRole('button', { name: /Continue/ })
 
   await user.click(submit)
-}
-
-async function expectEmailRequired(user: UserEvent) {
-  const selectedMarketing = screen.getByLabelText(
-    /I would like to receive updates via email/i
-  )
-
-  await user.click(selectedMarketing)
-
-  const emailRequired = screen.getByText(/Contact email/i)
-  expect(emailRequired).toBeInTheDocument()
 }
 
 async function expectRendersServerFailureResult(

--- a/src/pages/TermsOfService/TermsOfService.tsx
+++ b/src/pages/TermsOfService/TermsOfService.tsx
@@ -54,7 +54,7 @@ function NameInput({ register, marketingNameMessage }: NameInputProps) {
       </label>
       <div className="flex max-w-xs flex-col gap-2">
         <TextInput
-          {...register('marketingName')}
+          {...register('marketingName', { required: true })}
           type="text"
           id="marketingName"
           placeholder="John Doe"
@@ -81,7 +81,7 @@ function EmailInput({ register, marketingEmailMessage }: EmailInputProps) {
       </label>
       <div className="flex max-w-xs flex-col gap-2">
         <TextInput
-          {...register('marketingEmail')}
+          {...register('marketingEmail', { required: true })}
           type="text"
           id="marketingEmail"
           placeholder="name@example.com"
@@ -204,7 +204,7 @@ export default function TermsOfService() {
             </div>
             <div className="flex gap-2">
               <input
-                {...register('tos')}
+                {...register('tos', { required: true })}
                 type="checkbox"
                 id="tos"
                 aria-label="I accept the terms of service and privacy policy"

--- a/src/pages/TermsOfService/TermsOfService.tsx
+++ b/src/pages/TermsOfService/TermsOfService.tsx
@@ -103,8 +103,8 @@ export default function TermsOfService() {
     resolver: zodResolver(FormSchema),
     mode: 'onChange',
     defaultValues: {
-      marketingName: currentUser?.name ?? undefined,
-      marketingEmail: currentUser?.email ?? undefined,
+      marketingName: currentUser?.name || '',
+      marketingEmail: currentUser?.email || '',
       marketingConsent: undefined,
       tos: false,
       // this field just used for custom form error
@@ -131,8 +131,8 @@ export default function TermsOfService() {
 
   interface FormValues {
     marketingConsent?: boolean
-    marketingName?: string
-    marketingEmail?: string
+    marketingName: string
+    marketingEmail: string
   }
 
   const onSubmit: SubmitHandler<FormValues> = (data: FormValues) => {
@@ -141,7 +141,7 @@ export default function TermsOfService() {
     mutate({
       businessEmail: data.marketingEmail,
       marketingConsent: data?.marketingConsent,
-      marketingName: data.marketingName,
+      name: data.marketingName,
       termsAgreement: true,
     })
   }

--- a/src/pages/TermsOfService/TermsOfService.tsx
+++ b/src/pages/TermsOfService/TermsOfService.tsx
@@ -203,7 +203,7 @@ export default function TermsOfService() {
                 htmlFor="tos"
                 aria-label="I agree to the TOS and privacy policy"
               >
-                <span className="font-semibold">
+                <span className="font-medium">
                   I agree to{' '}
                   <A
                     hook="terms of service"

--- a/src/pages/TermsOfService/hooks/useTermsOfService.test.tsx
+++ b/src/pages/TermsOfService/hooks/useTermsOfService.test.tsx
@@ -94,7 +94,7 @@ describe('useSaveTermsAgreement', () => {
         result.current.mutate({
           businessEmail: 'test@test.com',
           termsAgreement: true,
-          customerIntent: 'PERSONAL',
+          name: 'Test Name',
         })
 
         await waitFor(() => expect(successFn).toHaveBeenCalledWith('completed'))
@@ -113,7 +113,7 @@ describe('useSaveTermsAgreement', () => {
         result.current.mutate({
           businessEmail: 'test@test.com',
           termsAgreement: true,
-          customerIntent: 'PERSONAL',
+          name: 'Test Name',
         })
 
         await waitFor(() => expect(testLocation.pathname).toEqual('/'))
@@ -140,7 +140,7 @@ describe('useSaveTermsAgreement', () => {
         result.current.mutate({
           businessEmail: 'test@test.com',
           termsAgreement: true,
-          customerIntent: 'PERSONAL',
+          name: 'Test Name',
         })
 
         await waitFor(() => expect(successFn).toHaveBeenCalledWith('completed'))
@@ -159,39 +159,10 @@ describe('useSaveTermsAgreement', () => {
         result.current.mutate({
           businessEmail: 'test@test.com',
           termsAgreement: true,
-          customerIntent: 'PERSONAL',
+          name: 'Test Name',
         })
 
         await waitFor(() => expect(testLocation.pathname).toEqual('/'))
-      })
-    })
-
-    it('proceeds with mutation on missing email', async () => {
-      setup()
-      const invalidateQueries = vi.spyOn(queryClient, 'invalidateQueries')
-      const successFn = vi.fn()
-      const { result } = renderHook(
-        () =>
-          useSaveTermsAgreement({
-            onSuccess: () => {
-              successFn('completed')
-            },
-          }),
-        {
-          wrapper: wrapper(),
-        }
-      )
-
-      result.current.mutate({
-        businessEmail: null,
-        termsAgreement: true,
-        customerIntent: 'PERSONAL',
-      })
-
-      await waitFor(() => expect(successFn).toHaveBeenCalledWith('completed'))
-
-      expect(invalidateQueries).toHaveBeenCalledWith({
-        queryKey: ['InternalUser'],
       })
     })
 
@@ -215,7 +186,7 @@ describe('useSaveTermsAgreement', () => {
         result.current.mutate({
           businessEmail: 'test@test.com',
           termsAgreement: true,
-          customerIntent: 'PERSONAL',
+          name: 'Test Name',
         })
 
         await waitFor(() =>
@@ -249,7 +220,7 @@ describe('useSaveTermsAgreement', () => {
         result.current.mutate({
           businessEmail: 'test@test.com',
           termsAgreement: true,
-          customerIntent: 'PERSONAL',
+          name: 'Test Name',
         })
 
         await waitFor(() => expect(testLocation.pathname).toEqual('/gh'))

--- a/src/pages/TermsOfService/hooks/useTermsOfService.ts
+++ b/src/pages/TermsOfService/hooks/useTermsOfService.ts
@@ -5,10 +5,10 @@ import { z } from 'zod'
 import Api from 'shared/api'
 
 const SaveTermsAgreementInputConfig = z.object({
-  businessEmail: z.string().nullable().optional(),
+  businessEmail: z.string(),
+  marketingName: z.string(),
   termsAgreement: z.boolean(),
   marketingConsent: z.boolean().optional(),
-  customerIntent: z.string(),
 })
 
 export type SaveTermsAgreementInput = z.infer<
@@ -47,12 +47,8 @@ export function useSaveTermsAgreement(options: SaveTermsAgreementOptions = {}) {
     mutationFn: (input: SaveTermsAgreementInput) => {
       const parsedInput = SaveTermsAgreementInputConfig.parse(input)
 
-      const {
-        businessEmail,
-        termsAgreement,
-        marketingConsent,
-        customerIntent,
-      } = parsedInput
+      const { businessEmail, termsAgreement, marketingConsent, marketingName } =
+        parsedInput
 
       const querySignAgreement = `
         mutation SigningTermsAgreement($tosInput: SaveTermsAgreementInput!) {
@@ -72,7 +68,7 @@ export function useSaveTermsAgreement(options: SaveTermsAgreementOptions = {}) {
           businessEmail,
           termsAgreement,
           marketingConsent,
-          customerIntent,
+          marketingName,
         },
       }
       return Api.graphqlMutation({

--- a/src/pages/TermsOfService/hooks/useTermsOfService.ts
+++ b/src/pages/TermsOfService/hooks/useTermsOfService.ts
@@ -6,7 +6,7 @@ import Api from 'shared/api'
 
 const SaveTermsAgreementInputConfig = z.object({
   businessEmail: z.string(),
-  marketingName: z.string(),
+  name: z.string(),
   termsAgreement: z.boolean(),
   marketingConsent: z.boolean().optional(),
 })
@@ -47,7 +47,7 @@ export function useSaveTermsAgreement(options: SaveTermsAgreementOptions = {}) {
     mutationFn: (input: SaveTermsAgreementInput) => {
       const parsedInput = SaveTermsAgreementInputConfig.parse(input)
 
-      const { businessEmail, termsAgreement, marketingConsent, marketingName } =
+      const { businessEmail, termsAgreement, marketingConsent, name } =
         parsedInput
 
       const querySignAgreement = `
@@ -68,7 +68,7 @@ export function useSaveTermsAgreement(options: SaveTermsAgreementOptions = {}) {
           businessEmail,
           termsAgreement,
           marketingConsent,
-          marketingName,
+          name,
         },
       }
       return Api.graphqlMutation({


### PR DESCRIPTION
# Description

Closes https://github.com/codecov/engineering-team/issues/2828

Figma: https://www.figma.com/design/SsoxtY2SB73l0wiLbJ8FhZ/GH-2092?node-id=2288-16704&t=UJWDkZD99C5y1myx-1

Associated API PR: https://github.com/codecov/codecov-api/pull/1094

# Notable Changes

- Modified the TOS screen to ask for both email and name as required fields
- Removed some customerIntent instances as we no longer ask users

# Screenshots

# Link to Sample Entry

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.