### PR TITLE
feat: Add in CachedBundlesQueryOpts

### DIFF
--- a/src/services/bundleAnalysis/CachedBundlesQueryOpts.test.tsx
+++ b/src/services/bundleAnalysis/CachedBundlesQueryOpts.test.tsx
@@ -1,0 +1,290 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import {
+  QueryClientProvider as QueryClientProviderV5,
+  QueryClient as QueryClientV5,
+  useQuery as useQueryV5,
+  useSuspenseQuery as useSuspenseQueryV5,
+} from '@tanstack/react-queryV5'
+import { renderHook, waitFor } from '@testing-library/react'
+import { graphql, HttpResponse } from 'msw'
+import { setupServer } from 'msw/node'
+import { Suspense } from 'react'
+import { MockInstance } from 'vitest'
+
+import { CachedBundlesQueryOpts } from './CachedBundlesQueryOpts'
+
+const mockBranchBundles = {
+  owner: {
+    repository: {
+      __typename: 'Repository',
+      branch: {
+        head: {
+          bundleAnalysis: {
+            bundleAnalysisReport: {
+              __typename: 'BundleAnalysisReport',
+              bundles: [{ name: 'bundle1', isCached: true }],
+            },
+          },
+        },
+      },
+    },
+  },
+}
+
+const mockUnsuccessfulParseError = {}
+
+const mockNullOwner = { owner: null }
+
+const mockRepoNotFound = {
+  owner: {
+    repository: {
+      __typename: 'NotFoundError',
+      message: 'Repository not found',
+    },
+  },
+}
+
+const mockOwnerNotActivated = {
+  owner: {
+    repository: {
+      __typename: 'OwnerNotActivatedError',
+      message: 'Owner not activated',
+    },
+  },
+}
+
+const server = setupServer()
+const queryClient = new QueryClient({
+  defaultOptions: { queries: { retry: false, suspense: true } },
+})
+const queryClientV5 = new QueryClientV5({
+  defaultOptions: { queries: { retry: false } },
+})
+
+const wrapper: React.FC<React.PropsWithChildren> = ({ children }) => (
+  <QueryClientProviderV5 client={queryClientV5}>
+    <QueryClientProvider client={queryClient}>
+      <Suspense fallback={<p>loading</p>}>{children}</Suspense>
+    </QueryClientProvider>
+  </QueryClientProviderV5>
+)
+
+beforeAll(() => {
+  server.listen()
+})
+
+afterEach(() => {
+  vi.clearAllMocks()
+  queryClient.clear()
+  queryClientV5.clear()
+  server.resetHandlers()
+})
+
+afterAll(() => {
+  server.close()
+})
+
+interface SetupArgs {
+  isNotFoundError?: boolean
+  isOwnerNotActivatedError?: boolean
+  isUnsuccessfulParseError?: boolean
+  isNullOwner?: boolean
+}
+
+describe('CachedBundlesQueryOpts', () => {
+  function setup({
+    isNotFoundError = false,
+    isOwnerNotActivatedError = false,
+    isUnsuccessfulParseError = false,
+    isNullOwner = false,
+  }: SetupArgs) {
+    const passedBranch = vi.fn()
+
+    server.use(
+      graphql.query('CachedBundleList', (info) => {
+        if (info.variables?.branch) {
+          passedBranch(info.variables?.branch)
+        }
+
+        if (isNotFoundError) {
+          return HttpResponse.json({ data: mockRepoNotFound })
+        } else if (isOwnerNotActivatedError) {
+          return HttpResponse.json({ data: mockOwnerNotActivated })
+        } else if (isUnsuccessfulParseError) {
+          return HttpResponse.json({ data: mockUnsuccessfulParseError })
+        } else if (isNullOwner) {
+          return HttpResponse.json({ data: mockNullOwner })
+        }
+
+        return HttpResponse.json({ data: mockBranchBundles })
+      })
+    )
+
+    return { passedBranch }
+  }
+
+  describe('returns repository typename of repository', () => {
+    describe('there is valid data', () => {
+      it('returns the bundle summary', async () => {
+        setup({})
+        const { result } = renderHook(
+          () =>
+            useSuspenseQueryV5(
+              CachedBundlesQueryOpts({
+                provider: 'gh',
+                owner: 'codecov',
+                repo: 'codecov',
+                branch: 'cool-branch',
+              })
+            ),
+          { wrapper }
+        )
+
+        const expectedResponse = {
+          bundles: [{ bundleName: 'bundle1', isCached: true }],
+        }
+
+        await waitFor(() =>
+          expect(result.current.data).toStrictEqual(expectedResponse)
+        )
+      })
+    })
+
+    describe('there is invalid data', () => {
+      it('returns a null value', async () => {
+        setup({ isNullOwner: true })
+        const { result } = renderHook(
+          () =>
+            useSuspenseQueryV5(
+              CachedBundlesQueryOpts({
+                provider: 'gh',
+                owner: 'codecov',
+                repo: 'codecov',
+                branch: 'cool-branch',
+              })
+            ),
+          { wrapper }
+        )
+
+        const expectedResponse = {
+          bundles: [],
+        }
+
+        await waitFor(() =>
+          expect(result.current.data).toStrictEqual(expectedResponse)
+        )
+      })
+    })
+  })
+
+  describe('returns NotFoundError __typename', () => {
+    let consoleSpy: MockInstance
+
+    beforeEach(() => {
+      consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => null)
+    })
+
+    afterEach(() => {
+      consoleSpy.mockRestore()
+    })
+
+    it('throws a 404', async () => {
+      setup({ isNotFoundError: true })
+      const { result } = renderHook(
+        () =>
+          useQueryV5(
+            CachedBundlesQueryOpts({
+              provider: 'gh',
+              owner: 'codecov',
+              repo: 'codecov',
+              branch: 'main',
+            })
+          ),
+        { wrapper }
+      )
+
+      await waitFor(() => expect(result.current.isError).toBeTruthy())
+      await waitFor(() =>
+        expect(result.current.error).toEqual(
+          expect.objectContaining({
+            status: 404,
+          })
+        )
+      )
+    })
+  })
+
+  describe('returns OwnerNotActivatedError __typename', () => {
+    let consoleSpy: MockInstance
+
+    beforeEach(() => {
+      consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => null)
+    })
+
+    afterEach(() => {
+      consoleSpy.mockRestore()
+    })
+
+    it('throws a 403', async () => {
+      setup({ isOwnerNotActivatedError: true })
+      const { result } = renderHook(
+        () =>
+          useQueryV5(
+            CachedBundlesQueryOpts({
+              provider: 'gh',
+              owner: 'codecov',
+              repo: 'codecov',
+              branch: 'main',
+            })
+          ),
+        { wrapper }
+      )
+
+      await waitFor(() => expect(result.current.isError).toBeTruthy())
+      await waitFor(() =>
+        expect(result.current.error).toEqual(
+          expect.objectContaining({
+            status: 403,
+          })
+        )
+      )
+    })
+  })
+
+  describe('unsuccessful parse of zod schema', () => {
+    let consoleSpy: MockInstance
+
+    beforeEach(() => {
+      consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => null)
+    })
+
+    afterEach(() => {
+      consoleSpy.mockRestore()
+    })
+
+    it('throws a 404', async () => {
+      setup({ isUnsuccessfulParseError: true })
+      const { result } = renderHook(
+        () =>
+          useQueryV5(
+            CachedBundlesQueryOpts({
+              provider: 'gh',
+              owner: 'codecov',
+              repo: 'codecov',
+              branch: 'main',
+            })
+          ),
+        { wrapper }
+      )
+
+      await waitFor(() => expect(result.current.isError).toBeTruthy())
+      await waitFor(() =>
+        expect(result.current.error).toEqual(
+          expect.objectContaining({
+            status: 404,
+          })
+        )
+      )
+    })
+  })
+})

--- a/src/services/bundleAnalysis/CachedBundlesQueryOpts.tsx
+++ b/src/services/bundleAnalysis/CachedBundlesQueryOpts.tsx
@@ -1,0 +1,173 @@
+import { queryOptions as queryOptionsV5 } from '@tanstack/react-queryV5'
+import { z } from 'zod'
+
+import { MissingHeadReportSchema } from 'services/comparison'
+import {
+  RepoNotFoundErrorSchema,
+  RepoOwnerNotActivatedErrorSchema,
+} from 'services/repo'
+import Api from 'shared/api'
+import { rejectNetworkError } from 'shared/api/helpers'
+import A from 'ui/A'
+
+const BundleSchema = z.object({
+  name: z.string(),
+  isCached: z.boolean(),
+})
+
+const BundleAnalysisReportSchema = z.object({
+  __typename: z.literal('BundleAnalysisReport'),
+  bundles: z.array(BundleSchema),
+})
+
+const BundleReportSchema = z.discriminatedUnion('__typename', [
+  BundleAnalysisReportSchema,
+  MissingHeadReportSchema,
+])
+
+const RepositorySchema = z.object({
+  __typename: z.literal('Repository'),
+  branch: z
+    .object({
+      head: z
+        .object({
+          bundleAnalysis: z
+            .object({
+              bundleAnalysisReport: BundleReportSchema.nullable(),
+            })
+            .nullable(),
+        })
+        .nullable(),
+    })
+    .nullable(),
+})
+
+const BranchBundleSummaryDataSchema = z.object({
+  owner: z
+    .object({
+      repository: z
+        .discriminatedUnion('__typename', [
+          RepositorySchema,
+          RepoNotFoundErrorSchema,
+          RepoOwnerNotActivatedErrorSchema,
+        ])
+        .nullable(),
+    })
+    .nullable(),
+})
+
+const query = `query CachedBundleList(
+  $owner: String!
+  $repo: String!
+  $branch: String!
+) {
+  owner(username: $owner) {
+    repository(name: $repo) {
+      __typename
+      ... on Repository {
+        branch(name: $branch) {
+          head {
+            bundleAnalysis {
+              bundleAnalysisReport {
+                __typename
+                ... on BundleAnalysisReport {
+                  bundles {
+                    name
+                    isCached
+                  }
+                }
+                ... on MissingHeadReport {
+                  message
+                }
+              }
+            }
+          }
+        }
+      }
+      ... on NotFoundError {
+        message
+      }
+      ... on OwnerNotActivatedError {
+        message
+      }
+    }
+  }
+}`
+
+interface CachedBundlesQueryOptsArgs {
+  provider: string
+  owner: string
+  repo: string
+  branch: string
+}
+
+export const CachedBundlesQueryOpts = ({
+  provider,
+  owner,
+  repo,
+  branch,
+}: CachedBundlesQueryOptsArgs) =>
+  queryOptionsV5({
+    queryKey: ['CachedBundles', provider, owner, repo, branch],
+    queryFn: ({ signal }) => {
+      const variables = { owner, repo, branch }
+
+      return Api.graphql({
+        provider,
+        query,
+        signal,
+        variables,
+      }).then((res) => {
+        const parsedData = BranchBundleSummaryDataSchema.safeParse(res?.data)
+
+        if (!parsedData.success) {
+          return rejectNetworkError({
+            status: 404,
+            data: {},
+            dev: 'CachedBundlesQueryOpts - 404 Failed to parse',
+            error: parsedData.error,
+          })
+        }
+
+        const data = parsedData.data
+
+        if (data?.owner?.repository?.__typename === 'NotFoundError') {
+          return rejectNetworkError({
+            status: 404,
+            data: {},
+            dev: 'CachedBundlesQueryOpts - 404 Repository not found',
+          })
+        }
+
+        if (data?.owner?.repository?.__typename === 'OwnerNotActivatedError') {
+          return rejectNetworkError({
+            status: 403,
+            data: {
+              detail: (
+                <p>
+                  Activation is required to view this repo, please{' '}
+                  {/* @ts-expect-error - A hasn't been typed yet */}
+                  <A to={{ pageName: 'membersTab' }}>click here </A> to activate
+                  your account.
+                </p>
+              ),
+            },
+            dev: 'CachedBundlesQueryOpts - 403 Owner not activated',
+          })
+        }
+
+        let bundles: Array<{ bundleName: string; isCached: boolean }> = []
+        if (
+          data?.owner?.repository?.branch?.head?.bundleAnalysis
+            ?.bundleAnalysisReport?.__typename === 'BundleAnalysisReport'
+        ) {
+          bundles =
+            data.owner.repository.branch.head.bundleAnalysis?.bundleAnalysisReport?.bundles?.map(
+              ({ name, isCached }) => ({ bundleName: name, isCached })
+            )
+        }
+
+        return { bundles }
+      })
+    },
+  })


### PR DESCRIPTION
# Description

This PR adds in a new query that is used to collect the list of bundles and their cache status for the future modal to configure bundle caching settings.

Closes: codecov/engineering-team#3155

# Notable Changes

- Create `CachedBundlesQueryOpts`
- Add in tests