### PR TITLE
chore: Remove new repo flag in LD

### DIFF
--- a/src/pages/RepoPage/CoverageOnboarding/CircleCI/CircleCI.tsx
+++ b/src/pages/RepoPage/CoverageOnboarding/CircleCI/CircleCI.tsx
@@ -9,7 +9,6 @@ import {
 import { useOrgUploadToken } from 'services/orgUploadToken'
 import { useRepo } from 'services/repo'
 import { Provider } from 'shared/api/helpers'
-import { useFlags } from 'shared/featureFlags'
 import { providerToInternalProvider } from 'shared/utils/provider'
 import A from 'ui/A'
 import { Card } from 'ui/Card'
@@ -40,16 +39,12 @@ interface URLParams {
 }
 
 function CircleCI() {
-  const { newRepoFlag: showOrgToken } = useFlags({
-    newRepoFlag: false,
-  })
   const { provider, owner, repo } = useParams<URLParams>()
   const providerName = providerToInternalProvider(provider)
   const { data } = useRepo({ provider, owner, repo })
   const { data: orgUploadToken } = useOrgUploadToken({
     provider,
     owner,
-    enabled: showOrgToken,
   })
 
   const uploadToken = orgUploadToken ?? data?.repository?.uploadToken ?? ''

--- a/src/pages/RepoPage/CoverageOnboarding/GitHubActions/GitHubActions.tsx
+++ b/src/pages/RepoPage/CoverageOnboarding/GitHubActions/GitHubActions.tsx
@@ -5,7 +5,6 @@ import { useOrgUploadToken } from 'services/orgUploadToken'
 import { useRepo } from 'services/repo'
 import { useUploadTokenRequired } from 'services/uploadTokenRequired'
 import { Provider } from 'shared/api/helpers'
-import { useFlags } from 'shared/featureFlags'
 import A from 'ui/A'
 import { Card } from 'ui/Card'
 
@@ -27,14 +26,10 @@ interface URLParams {
 }
 
 function GitHubActions() {
-  const { newRepoFlag: showOrgToken } = useFlags({
-    newRepoFlag: false,
-  })
   const { provider, owner, repo } = useParams<URLParams>()
   const { data: orgUploadToken } = useOrgUploadToken({
     provider,
     owner,
-    enabled: showOrgToken,
   })
 
   const [isUsingGlobalToken, setIsUsingGlobalToken] = useState<boolean>(true)

--- a/src/pages/RepoPage/CoverageOnboarding/GitHubActions/TokenStep.tsx
+++ b/src/pages/RepoPage/CoverageOnboarding/GitHubActions/TokenStep.tsx
@@ -16,7 +16,6 @@ import { useRepo } from 'services/repo'
 import { useUploadTokenRequired } from 'services/uploadTokenRequired'
 import { useIsCurrentUserAnAdmin } from 'services/user'
 import { Provider } from 'shared/api/helpers'
-import { useFlags } from 'shared/featureFlags'
 import { Theme, useThemeContext } from 'shared/ThemeContext'
 import A from 'ui/A'
 import Button from 'ui/Button'
@@ -186,14 +185,10 @@ const AddTokenStep = ({
   stepNum: number
   isUsingGlobalToken: boolean
 }) => {
-  const { newRepoFlag: showOrgToken } = useFlags({
-    newRepoFlag: false,
-  })
   const { provider, owner, repo } = useParams<URLParams>()
   const { data: orgUploadToken } = useOrgUploadToken({
     provider,
     owner,
-    enabled: showOrgToken,
   })
   const { data } = useRepo({ provider, owner, repo })
   const repoUploadToken = data?.repository?.uploadToken ?? ''
@@ -249,9 +244,6 @@ function TokenStepSection({
   showAddTokenStep,
   showTokenSelector,
 }: TokenStepSectionProps) {
-  const { newRepoFlag: showOrgToken } = useFlags({
-    newRepoFlag: false,
-  })
   const { provider, owner } = useParams<URLParams>()
   const { data: uploadTokenRequiredData } = useUploadTokenRequired({
     provider,
@@ -261,7 +253,6 @@ function TokenStepSection({
   const { data: orgUploadToken } = useOrgUploadToken({
     provider,
     owner,
-    enabled: showOrgToken,
   })
 
   const handleValueChange = (value: string) => {

--- a/src/pages/RepoPage/CoverageOnboarding/GitHubActions/WorkflowYMLStep.tsx
+++ b/src/pages/RepoPage/CoverageOnboarding/GitHubActions/WorkflowYMLStep.tsx
@@ -6,7 +6,6 @@ import {
 } from 'services/codecovEventMetrics'
 import { useOrgUploadToken } from 'services/orgUploadToken'
 import { Provider } from 'shared/api/helpers'
-import { useFlags } from 'shared/featureFlags'
 import A from 'ui/A'
 import { Card } from 'ui/Card'
 import { CodeSnippet } from 'ui/CodeSnippet'
@@ -33,13 +32,9 @@ function WorkflowYMLStep({
 }: WorkflowYMLStepProps) {
   const { mutate: storeEventMetric } = useStoreCodecovEventMetric()
   const { provider, owner, repo } = useParams<URLParams>()
-  const { newRepoFlag: showOrgToken } = useFlags({
-    newRepoFlag: false,
-  })
   const { data: orgUploadToken } = useOrgUploadToken({
     provider,
     owner,
-    enabled: showOrgToken,
   })
 
   const workflowYMLConfig = `- name: Upload coverage reports to Codecov

--- a/src/pages/RepoPage/CoverageOnboarding/OtherCI/OtherCI.test.tsx
+++ b/src/pages/RepoPage/CoverageOnboarding/OtherCI/OtherCI.test.tsx
@@ -7,18 +7,6 @@ import { MemoryRouter, Route } from 'react-router-dom'
 
 import OtherCI from './OtherCI'
 
-const mocks = vi.hoisted(() => ({
-  useFlags: vi.fn(),
-}))
-
-vi.mock('shared/featureFlags', async () => {
-  const actual = await vi.importActual('shared/featureFlags')
-  return {
-    ...actual,
-    useFlags: mocks.useFlags,
-  }
-})
-
 const mockGetRepo = {
   owner: {
     isAdmin: null,
@@ -41,6 +29,12 @@ const mockGetRepo = {
 const mockGetOrgUploadToken = {
   owner: {
     orgUploadToken: 'org-token-asdf-1234',
+  },
+}
+
+const mockNoUploadToken = {
+  owner: {
+    orgUploadToken: null,
   },
 }
 
@@ -86,16 +80,15 @@ interface SetupArgs {
 describe('OtherCI', () => {
   function setup({ hasOrgUploadToken = false }: SetupArgs) {
     const user = userEvent.setup()
-    mocks.useFlags.mockReturnValue({
-      newRepoFlag: hasOrgUploadToken,
-    })
 
     server.use(
       graphql.query('GetRepo', () => {
         return HttpResponse.json({ data: mockGetRepo })
       }),
       graphql.query('GetOrgUploadToken', () => {
-        return HttpResponse.json({ data: mockGetOrgUploadToken })
+        return HttpResponse.json({
+          data: hasOrgUploadToken ? mockGetOrgUploadToken : mockNoUploadToken,
+        })
       })
     )
 

--- a/src/pages/RepoPage/CoverageOnboarding/OtherCI/OtherCI.tsx
+++ b/src/pages/RepoPage/CoverageOnboarding/OtherCI/OtherCI.tsx
@@ -5,7 +5,6 @@ import config from 'config'
 
 import { useOrgUploadToken } from 'services/orgUploadToken'
 import { useRepo } from 'services/repo'
-import { useFlags } from 'shared/featureFlags'
 import A from 'ui/A'
 import { Card } from 'ui/Card'
 import { CodeSnippet } from 'ui/CodeSnippet'
@@ -27,15 +26,11 @@ interface URLParams {
 }
 
 function OtherCI() {
-  const { newRepoFlag: showOrgToken } = useFlags({
-    newRepoFlag: false,
-  })
   const { provider, owner, repo } = useParams<URLParams>()
   const { data } = useRepo({ provider, owner, repo })
   const { data: orgUploadToken } = useOrgUploadToken({
     provider,
     owner,
-    enabled: showOrgToken,
   })
 
   const uploadToken = orgUploadToken ?? data?.repository?.uploadToken ?? ''

--- a/src/services/orgUploadToken/useOrgUploadToken.ts
+++ b/src/services/orgUploadToken/useOrgUploadToken.ts
@@ -21,14 +21,9 @@ const query = `query GetOrgUploadToken ($owner: String!) {
 interface UseOrgUploadTokenArgs {
   provider: string
   owner: string
-  enabled?: boolean
 }
 
-export const useOrgUploadToken = ({
-  provider,
-  owner,
-  enabled = true,
-}: UseOrgUploadTokenArgs) =>
+export const useOrgUploadToken = ({ provider, owner }: UseOrgUploadTokenArgs) =>
   useQuery({
     queryKey: ['GetOrgUploadToken', provider, owner],
     queryFn: ({ signal }) =>
@@ -52,5 +47,4 @@ export const useOrgUploadToken = ({
 
         return parsedRes?.data?.owner?.orgUploadToken ?? null
       }),
-    enabled,
   })


### PR DESCRIPTION
# Description

This PR removes the new repo flag which has been on in LD at 100% since Feb 2024. Safe to say it's probably good to remove at this point; also had to update a few tests in the process.

[Flag in LD](https://app.launchdarkly.com/projects/dashboard/flags/new-repo-flag/targeting?env=test&env=production&selected-env=production)

# Link to Sample Entry

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.