### PR TITLE
fix: Remove "to" prop if component is <a>

### DIFF
--- a/src/shared/AppLink/AppLink.tsx
+++ b/src/shared/AppLink/AppLink.tsx
@@ -33,9 +33,7 @@ function useCompleteProps(
 
   const propsLink = pageConfig?.isExternalLink
     ? { href: path }
-    : Component === 'a'
-      ? { href: path }
-      : { to: path || '/' }
+    : { to: path || '/' }
 
   const propsTarget = pageConfig?.openNewTab ? { target: '_blank' } : {}
   const propsActive = Component === NavLink ? { activeClassName } : {}
@@ -45,6 +43,7 @@ function useCompleteProps(
     ...propsTarget,
     ...props,
     ...propsActive,
+    ...(Component === 'a' && { to: undefined }),
   }
 }
 


### PR DESCRIPTION
# Description

Fixing a console issue @nicholas-codecov found while developing locally. A tags don't allow you to have a "to" prop on them

This PR removes / clears out the to prop if it exists and the component is an <a> tag.

# Screenshots

<img width="582" alt="Screenshot 2025-01-13 at 10 33 28 AM" src="https://github.com/user-attachments/assets/99e6170b-1b1c-43ad-90c4-b2bee41cd982" />

<img width="572" alt="Screenshot 2025-01-13 at 10 42 06 AM" src="https://github.com/user-attachments/assets/c66b886b-defd-4a50-b798-8ce5e4fe74b1" />



# Link to Sample Entry

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.