### PR TITLE
chore: Clean up bundle caching feature flag

### DIFF
--- a/src/pages/RepoPage/BundlesTab/BundleContent/BundleSelection/BundleSelection.test.tsx
+++ b/src/pages/RepoPage/BundlesTab/BundleContent/BundleSelection/BundleSelection.test.tsx
@@ -13,14 +13,6 @@ import { MemoryRouter, Route } from 'react-router-dom'
 
 import BundleSelection from './BundleSelection'
 
-const mocks = vi.hoisted(() => ({
-  useFlags: vi.fn().mockReturnValue({ displayBundleCachingModal: true }),
-}))
-
-vi.mock('shared/featureFlags', () => ({
-  useFlags: mocks.useFlags,
-}))
-
 const mockRepoOverview = {
   __typename: 'Repository',
   private: false,

--- a/src/pages/RepoPage/BundlesTab/BundleContent/BundleSelection/BundleSelection.tsx
+++ b/src/pages/RepoPage/BundlesTab/BundleContent/BundleSelection/BundleSelection.tsx
@@ -1,7 +1,6 @@
 import { lazy, useCallback, useRef, useState } from 'react'
 
 import { ConfigureCachedBundleModal } from 'pages/RepoPage/shared/ConfigureCachedBundleModal/ConfigureCachedBundleModal'
-import { useFlags } from 'shared/featureFlags'
 import Icon from 'ui/Icon'
 
 import BranchSelector from './BranchSelector'
@@ -15,10 +14,6 @@ const BundleSelection: React.FC = () => {
   const loadingSelectRef = useRef<{ resetSelected: () => void }>(null)
 
   const [showBundleCachingModal, setShowBundleCachingModal] = useState(false)
-
-  const { displayBundleCachingModal } = useFlags({
-    displayBundleCachingModal: false,
-  })
 
   const resetFilterSelects = useCallback(() => {
     typesSelectRef.current?.resetSelected()
@@ -40,21 +35,19 @@ const BundleSelection: React.FC = () => {
         />
         <TypeSelector ref={typesSelectRef} />
         <LoadSelector ref={loadingSelectRef} />
-        {displayBundleCachingModal ? (
-          <div className="flex w-full justify-end self-start md:w-auto">
-            <button
-              onClick={() => setShowBundleCachingModal(true)}
-              className="flex items-center gap-0.5 text-xs font-semibold text-ds-blue-darker hover:cursor-pointer hover:underline"
-            >
-              <Icon name="cog" size="sm" variant="outline" />
-              Configure data caching
-            </button>
-            <ConfigureCachedBundleModal
-              isOpen={showBundleCachingModal}
-              setIsOpen={setShowBundleCachingModal}
-            />
-          </div>
-        ) : null}
+        <div className="flex w-full justify-end self-start md:w-auto">
+          <button
+            onClick={() => setShowBundleCachingModal(true)}
+            className="flex items-center gap-0.5 text-xs font-semibold text-ds-blue-darker hover:cursor-pointer hover:underline"
+          >
+            <Icon name="cog" size="sm" variant="outline" />
+            Configure data caching
+          </button>
+          <ConfigureCachedBundleModal
+            isOpen={showBundleCachingModal}
+            setIsOpen={setShowBundleCachingModal}
+          />
+        </div>
       </div>
     </div>
   )

--- a/src/pages/RepoPage/ConfigTab/tabs/ConfigurationManager/ConfigurationManager.test.tsx
+++ b/src/pages/RepoPage/ConfigTab/tabs/ConfigurationManager/ConfigurationManager.test.tsx
@@ -14,14 +14,6 @@ import { MemoryRouter, Route } from 'react-router'
 import ConfigurationManager from './ConfigurationManager'
 import { RepositoryConfiguration } from './hooks/useRepoConfigurationStatus/RepoConfigurationStatusQueryOpts'
 
-const mocks = vi.hoisted(() => ({
-  useFlags: vi.fn().mockReturnValue({ displayBundleCachingModal: true }),
-}))
-
-vi.mock('shared/featureFlags', () => ({
-  useFlags: mocks.useFlags,
-}))
-
 interface mockRepoConfigArgs {
   isTeamPlan?: boolean
   flags?: boolean

--- a/src/pages/RepoPage/ConfigTab/tabs/ConfigurationManager/ConfigurationManager.tsx
+++ b/src/pages/RepoPage/ConfigTab/tabs/ConfigurationManager/ConfigurationManager.tsx
@@ -3,7 +3,6 @@ import { useState } from 'react'
 import { useParams } from 'react-router'
 
 import { ConfigureCachedBundleModal } from 'pages/RepoPage/shared/ConfigureCachedBundleModal/ConfigureCachedBundleModal'
-import { useFlags } from 'shared/featureFlags'
 import Icon from 'ui/Icon'
 
 import FeatureGroup from './components/FeatureGroup'
@@ -144,10 +143,6 @@ function TestAnalyticsConfiguration({
 function BundleAnalysisConfiguration({
   repoConfiguration,
 }: ConfigurationGroupProps) {
-  const { displayBundleCachingModal } = useFlags({
-    displayBundleCachingModal: false,
-  })
-
   const [showBundleCachingModal, setShowBundleCachingModal] = useState(false)
   const jsOrTsPresent = !!repoConfiguration?.repository?.languages?.some(
     (lang) =>
@@ -177,21 +172,19 @@ function BundleAnalysisConfiguration({
         >
           Track, monitor, and manage your bundle
         </FeatureItem>
-        {displayBundleCachingModal ? (
-          <div>
-            <button
-              onClick={() => setShowBundleCachingModal(true)}
-              className="flex items-center gap-0.5 text-xs font-semibold text-ds-blue-darker hover:cursor-pointer hover:underline"
-            >
-              <Icon name="cog" size="sm" variant="outline" />
-              Configure data caching
-            </button>
-            <ConfigureCachedBundleModal
-              isOpen={showBundleCachingModal}
-              setIsOpen={setShowBundleCachingModal}
-            />
-          </div>
-        ) : null}
+        <div>
+          <button
+            onClick={() => setShowBundleCachingModal(true)}
+            className="flex items-center gap-0.5 text-xs font-semibold text-ds-blue-darker hover:cursor-pointer hover:underline"
+          >
+            <Icon name="cog" size="sm" variant="outline" />
+            Configure data caching
+          </button>
+          <ConfigureCachedBundleModal
+            isOpen={showBundleCachingModal}
+            setIsOpen={setShowBundleCachingModal}
+          />
+        </div>
       </FeatureGroup.UniversalItems>
     </FeatureGroup>
   )


### PR DESCRIPTION
# Description

This PR just removes the `displayBundleCachingModal` from the codebase cleaning up things once everything has been fully released.

Closes codecov/engineering-team#3157

# Notable Changes

- Clean up feature flag in `BundleSelection` and `ConfigurationManager`