### PR TITLE
ref: Remove tier name, use isTeamPlan 

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -217,7 +217,7 @@ describe('App', () => {
       graphql.query('GetPlanData', () => {
         return HttpResponse.json({ data: {} })
       }),
-      graphql.query('OwnerTier', () => {
+      graphql.query('OwnerPlan', () => {
         return HttpResponse.json({ data: {} })
       }),
       graphql.query('Seats', () => {

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -217,7 +217,7 @@ describe('App', () => {
       graphql.query('GetPlanData', () => {
         return HttpResponse.json({ data: {} })
       }),
-      graphql.query('OwnerPlan', () => {
+      graphql.query('IsTeamPlan', () => {
         return HttpResponse.json({ data: {} })
       }),
       graphql.query('Seats', () => {

--- a/src/pages/AnalyticsPage/Chart/Chart.test.tsx
+++ b/src/pages/AnalyticsPage/Chart/Chart.test.tsx
@@ -115,7 +115,7 @@ describe('Analytics coverage chart', () => {
 
         return HttpResponse.json({ data: mockDataPoints })
       }),
-      graphql.query('OwnerPlan', () =>
+      graphql.query('IsTeamPlan', () =>
         HttpResponse.json({ data: { owner: { plan: { isTeamPlan: false } } } })
       )
     )

--- a/src/pages/AnalyticsPage/Chart/Chart.test.tsx
+++ b/src/pages/AnalyticsPage/Chart/Chart.test.tsx
@@ -115,8 +115,8 @@ describe('Analytics coverage chart', () => {
 
         return HttpResponse.json({ data: mockDataPoints })
       }),
-      graphql.query('OwnerTier', () =>
-        HttpResponse.json({ data: { owner: { plan: { tierName: 'pro' } } } })
+      graphql.query('OwnerPlan', () =>
+        HttpResponse.json({ data: { owner: { plan: { isTeamPlan: false } } } })
       )
     )
   }

--- a/src/pages/AnalyticsPage/Chart/useCoverage.test.tsx
+++ b/src/pages/AnalyticsPage/Chart/useCoverage.test.tsx
@@ -4,8 +4,6 @@ import { graphql, HttpResponse } from 'msw'
 import { setupServer } from 'msw/node'
 import { MemoryRouter, Route } from 'react-router-dom'
 
-import { TierNames, TTierNames } from 'services/tier'
-
 import { useCoverage } from './useCoverage'
 
 vi.mock('services/charts')
@@ -65,14 +63,14 @@ afterAll(() => {
 
 interface SetupArgs {
   nullFirstVal?: boolean
-  tierValue?: TTierNames
+  isTeamPlan?: boolean
 }
 
 describe('useCoverage', () => {
   function setup(
-    { nullFirstVal, tierValue }: SetupArgs = {
+    { nullFirstVal, isTeamPlan }: SetupArgs = {
       nullFirstVal: false,
-      tierValue: TierNames.PRO,
+      isTeamPlan: false,
     }
   ) {
     server.use(
@@ -85,9 +83,9 @@ describe('useCoverage', () => {
         }
         return HttpResponse.json({ data: mockRepoMeasurements })
       }),
-      graphql.query('OwnerTier', () => {
+      graphql.query('OwnerPlan', () => {
         return HttpResponse.json({
-          data: { owner: { plan: { tierName: tierValue } } },
+          data: { owner: { plan: { isTeamPlan } } },
         })
       })
     )
@@ -140,7 +138,7 @@ describe('useCoverage', () => {
 
   describe('owner is on a team plan', () => {
     it('gets public repos from useReposCoverageMeasurements', async () => {
-      setup({ tierValue: TierNames.TEAM })
+      setup({ isTeamPlan: true })
       const { result } = renderHook(
         () =>
           useCoverage({

--- a/src/pages/AnalyticsPage/Chart/useCoverage.test.tsx
+++ b/src/pages/AnalyticsPage/Chart/useCoverage.test.tsx
@@ -83,7 +83,7 @@ describe('useCoverage', () => {
         }
         return HttpResponse.json({ data: mockRepoMeasurements })
       }),
-      graphql.query('OwnerPlan', () => {
+      graphql.query('IsTeamPlan', () => {
         return HttpResponse.json({
           data: { owner: { plan: { isTeamPlan } } },
         })

--- a/src/pages/AnalyticsPage/Chart/useCoverage.ts
+++ b/src/pages/AnalyticsPage/Chart/useCoverage.ts
@@ -2,7 +2,7 @@ import { useMemo } from 'react'
 import { useParams } from 'react-router-dom'
 
 import { useReposCoverageMeasurements } from 'services/charts/useReposCoverageMeasurements'
-import { TierNames, useTier } from 'services/tier'
+import { useIsTeamPlan } from 'services/useIsTeamPlan'
 import { analyticsQuery } from 'shared/utils/timeseriesCharts'
 
 interface URLParams {
@@ -28,9 +28,7 @@ export const useCoverage = ({
 }: UseCoverageArgs) => {
   const { provider, owner } = useParams<URLParams>()
 
-  const { data: tierName } = useTier({ provider, owner })
-  const shouldDisplayPublicReposOnly =
-    tierName === TierNames.TEAM ? true : undefined
+  const { data: isTeamPlan } = useIsTeamPlan({ provider, owner })
 
   const queryVars = analyticsQuery({ startDate, endDate, repositories })
 
@@ -41,7 +39,7 @@ export const useCoverage = ({
     repos: queryVars?.repositories,
     before: queryVars?.endDate,
     after: queryVars?.startDate,
-    isPublic: shouldDisplayPublicReposOnly,
+    isPublic: isTeamPlan ?? false,
     opts: {
       staleTime: 30000,
       keepPreviousData: false,

--- a/src/pages/AnalyticsPage/ChartSelectors/ChartSelectors.jsx
+++ b/src/pages/AnalyticsPage/ChartSelectors/ChartSelectors.jsx
@@ -4,7 +4,7 @@ import { useMemo, useRef, useState } from 'react'
 import { useParams } from 'react-router-dom'
 
 import { ReposQueryOpts } from 'services/repos/ReposQueryOpts'
-import { TierNames, useTier } from 'services/tier'
+import { useIsTeamPlan } from 'services/useIsTeamPlan'
 import A from 'ui/A'
 import DateRangePicker from 'ui/DateRangePicker'
 import MultiSelect from 'ui/MultiSelect'
@@ -53,8 +53,7 @@ function RepoSelector({
     updateParams({ repositories: item })
   }
 
-  const { data: tierName } = useTier({ provider, owner })
-  const shouldDisplayPublicReposOnly = tierName === TierNames.TEAM ? true : null
+  const { data: isTeamPlan } = useIsTeamPlan({ provider, owner })
 
   const {
     data: reposData,
@@ -69,7 +68,7 @@ function RepoSelector({
       activated: active,
       term: search,
       first: Infinity,
-      isPublic: shouldDisplayPublicReposOnly,
+      isPublic: isTeamPlan,
     })
   )
 
@@ -114,7 +113,7 @@ function ChartSelectors({ params, updateParams, active, sortItem }) {
   const { repositories, startDate, endDate } = params
   const [selectedRepos, setSelectedRepos] = useState(repositories)
 
-  const { data: tierData } = useTier({ provider, owner })
+  const { data: isTeamPlan } = useIsTeamPlan({ provider, owner })
 
   if (selectedRepos.length > 0 && repositories.length === 0) {
     setSelectedRepos([])
@@ -151,7 +150,7 @@ function ChartSelectors({ params, updateParams, active, sortItem }) {
       >
         Clear filters
       </button>
-      {tierData === TierNames.TEAM ? (
+      {isTeamPlan ? (
         <p className="self-end">
           Public repos only. <A to={{ pageName: 'upgradeOrgPlan' }}>Upgrade</A>{' '}
           to Pro to include private repos.

--- a/src/pages/AnalyticsPage/ChartSelectors/ChartSelectors.test.jsx
+++ b/src/pages/AnalyticsPage/ChartSelectors/ChartSelectors.test.jsx
@@ -132,7 +132,7 @@ describe('ChartSelectors', () => {
     const searchTerm = vi.fn()
 
     server.use(
-      graphql.query('OwnerPlan', () => {
+      graphql.query('IsTeamPlan', () => {
         return HttpResponse.json({
           data: { owner: { plan: { isTeamPlan } } },
         })

--- a/src/pages/AnalyticsPage/ChartSelectors/ChartSelectors.test.jsx
+++ b/src/pages/AnalyticsPage/ChartSelectors/ChartSelectors.test.jsx
@@ -10,8 +10,6 @@ import { setupServer } from 'msw/node'
 import { Suspense } from 'react'
 import { MemoryRouter, Route } from 'react-router-dom'
 
-import { TierNames } from 'services/tier'
-
 import ChartSelectors from './ChartSelectors'
 
 class ResizeObserverMock {
@@ -127,16 +125,16 @@ describe('ChartSelectors', () => {
     vi.clearAllMocks()
   })
 
-  function setup({ hasNextPage = false, tierValue = TierNames.PRO }) {
+  function setup({ hasNextPage = false, isTeamPlan = false }) {
     // https://github.com/testing-library/user-event/issues/1034
     const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
     const fetchNextPage = vi.fn()
     const searchTerm = vi.fn()
 
     server.use(
-      graphql.query('OwnerTier', () => {
+      graphql.query('OwnerPlan', () => {
         return HttpResponse.json({
-          data: { owner: { plan: { tierName: tierValue } } },
+          data: { owner: { plan: { isTeamPlan } } },
         })
       }),
       graphql.query('ReposForOwner', ({ variables }) => {
@@ -526,7 +524,7 @@ describe('ChartSelectors', () => {
 
   describe('owner is on a team plan', () => {
     it('renders upgrade cta', async () => {
-      setup({ hasNextPage: false, tierValue: TierNames.TEAM })
+      setup({ hasNextPage: false, isTeamPlan: true })
       render(
         <ChartSelectors
           active={true}

--- a/src/pages/CommitDetailPage/CommitCoverage/CommitCoverage.jsx
+++ b/src/pages/CommitDetailPage/CommitCoverage/CommitCoverage.jsx
@@ -8,7 +8,7 @@ import { SentryRoute } from 'sentry'
 import { useCommit } from 'services/commit'
 import { useCommitErrors } from 'services/commitErrors'
 import { useRepoOverview, useRepoRateLimitStatus } from 'services/repo'
-import { TierNames, useTier } from 'services/tier'
+import { useIsTeamPlan } from 'services/useIsTeamPlan'
 import { useOwner } from 'services/user'
 import ComparisonErrorBanner from 'shared/ComparisonErrorBanner'
 import GitHubRateLimitExceededBanner from 'shared/GlobalBanners/GitHubRateLimitExceeded/GitHubRateLimitExceededBanner'
@@ -44,7 +44,7 @@ const Loader = () => (
 
 function CommitRoutes() {
   const { provider, owner, repo, commit: commitSha } = useParams()
-  const { data: tierName } = useTier({ owner, provider })
+  const { data: isTeamPlan } = useIsTeamPlan({ owner, provider })
   const { data: overview } = useRepoOverview({ provider, owner, repo })
   const { data: commitPageData } = useSuspenseQueryV5(
     CommitPageDataQueryOpts({
@@ -74,7 +74,7 @@ function CommitRoutes() {
   // is still useful info to the user
   const isMissingBaseCommit = compareTypeName === 'MissingBaseCommit'
 
-  const showIndirectChanges = !(overview.private && tierName === TierNames.TEAM)
+  const showIndirectChanges = !(overview.private && isTeamPlan)
 
   return (
     <Suspense fallback={<Loader />}>
@@ -174,7 +174,7 @@ function CommitCoverageRoutes() {
 
 function CommitCoverage() {
   const { provider, owner, repo, commit: commitSha } = useParams()
-  const { data: tierName } = useTier({ owner, provider })
+  const { data: isTeamPlan } = useIsTeamPlan({ owner, provider })
   const { data: overview } = useRepoOverview({ provider, owner, repo })
   const { data: rateLimit } = useRepoRateLimitStatus({ provider, owner, repo })
   const { data: commitPageData } = useSuspenseQueryV5(
@@ -186,7 +186,7 @@ function CommitCoverage() {
     })
   )
 
-  const showCommitSummary = !(overview.private && tierName === TierNames.TEAM)
+  const showCommitSummary = !(overview.private && isTeamPlan)
   const showFirstPullBanner =
     commitPageData?.commit?.compareWithParent?.__typename === 'FirstPullRequest'
   return (

--- a/src/pages/CommitDetailPage/CommitCoverage/CommitCoverage.test.jsx
+++ b/src/pages/CommitDetailPage/CommitCoverage/CommitCoverage.test.jsx
@@ -198,7 +198,7 @@ const mockRepoSettingsTeamData = (isPrivate = false) => ({
   },
 })
 
-const mockOwnerPlan = (isTeamPlan = false) => ({
+const mockIsTeamPlan = (isTeamPlan = false) => ({
   owner: {
     plan: {
       isTeamPlan,
@@ -442,8 +442,8 @@ describe('CommitCoverage', () => {
           }),
         })
       }),
-      graphql.query('OwnerPlan', () => {
-        return HttpResponse.json({ data: mockOwnerPlan(isTeamPlan) })
+      graphql.query('IsTeamPlan', () => {
+        return HttpResponse.json({ data: mockIsTeamPlan(isTeamPlan) })
       }),
       graphql.query('BackfillFlagMemberships', () => {
         return HttpResponse.json({ data: mockRepoBackfilledData })

--- a/src/pages/CommitDetailPage/CommitCoverage/CommitCoverage.test.jsx
+++ b/src/pages/CommitDetailPage/CommitCoverage/CommitCoverage.test.jsx
@@ -13,7 +13,6 @@ import { setupServer } from 'msw/node'
 import { Suspense } from 'react'
 import { MemoryRouter, Route } from 'react-router-dom'
 
-import { TierNames } from 'services/tier/useTier'
 import { UploadStateEnum } from 'shared/utils/commit'
 
 import CommitCoverage from './CommitCoverage'
@@ -199,10 +198,10 @@ const mockRepoSettingsTeamData = (isPrivate = false) => ({
   },
 })
 
-const mockOwnerTier = (tier = TierNames.PRO) => ({
+const mockOwnerPlan = (isTeamPlan = false) => ({
   owner: {
     plan: {
-      tierName: tier,
+      isTeamPlan,
     },
   },
 })
@@ -396,7 +395,7 @@ describe('CommitCoverage', () => {
   function setup(
     {
       isPrivate = false,
-      tierName = TierNames.PRO,
+      isTeamPlan = false,
       hasCommitErrors = false,
       hasErroredUploads = false,
       hasCommitPageMissingCommitDataError = false,
@@ -407,7 +406,7 @@ describe('CommitCoverage', () => {
       isGithubRateLimited = false,
     } = {
       isPrivate: false,
-      tierName: TierNames.PRO,
+      isTeamPlan: false,
       hasCommitErrors: false,
       hasErroredUploads: false,
       hasCommitPageMissingCommitDataError: false,
@@ -443,8 +442,8 @@ describe('CommitCoverage', () => {
           }),
         })
       }),
-      graphql.query('OwnerTier', () => {
-        return HttpResponse.json({ data: mockOwnerTier(tierName) })
+      graphql.query('OwnerPlan', () => {
+        return HttpResponse.json({ data: mockOwnerPlan(isTeamPlan) })
       }),
       graphql.query('BackfillFlagMemberships', () => {
         return HttpResponse.json({ data: mockRepoBackfilledData })
@@ -582,7 +581,7 @@ describe('CommitCoverage', () => {
     describe('user is on a team plan', () => {
       it('does not render commit coverage summary', async () => {
         const { queryClient, queryClientV5 } = setup({
-          tierName: TierNames.TEAM,
+          isTeamPlan: true,
           isPrivate: true,
         })
         render(<CommitCoverage />, {
@@ -598,7 +597,7 @@ describe('CommitCoverage', () => {
 
       it('does not render indirect changes tab', async () => {
         const { queryClient, queryClientV5 } = setup({
-          tierName: TierNames.TEAM,
+          isTeamPlan: true,
           isPrivate: true,
         })
         render(<CommitCoverage />, {

--- a/src/pages/CommitDetailPage/CommitCoverage/CommitCoverageTabs/CommitCoverageTabs.jsx
+++ b/src/pages/CommitDetailPage/CommitCoverage/CommitCoverageTabs/CommitCoverageTabs.jsx
@@ -8,7 +8,7 @@ import {
   commitTreeviewString,
 } from 'pages/RepoPage/utils'
 import { useRepoSettingsTeam } from 'services/repo'
-import { TierNames, useTier } from 'services/tier'
+import { useIsTeamPlan } from 'services/useIsTeamPlan'
 import TabNavigation from 'ui/TabNavigation'
 
 function CommitCoverageTabs({
@@ -18,12 +18,10 @@ function CommitCoverageTabs({
 }) {
   const { provider, owner, repo } = useParams()
   const location = useLocation()
-  const { data: tierName } = useTier({ owner, provider })
+  const { data: isTeamPlan } = useIsTeamPlan({ owner, provider })
   const { data: repoData } = useRepoSettingsTeam()
 
-  const showIndirectChanges = !(
-    repoData?.repository?.private && tierName === TierNames.TEAM
-  )
+  const showIndirectChanges = !(repoData?.repository?.private && isTeamPlan)
 
   const params = qs.parse(location.search, {
     ignoreQueryPrefix: true,

--- a/src/pages/CommitDetailPage/CommitCoverage/CommitCoverageTabs/CommitCoverageTabs.test.jsx
+++ b/src/pages/CommitDetailPage/CommitCoverage/CommitCoverageTabs/CommitCoverageTabs.test.jsx
@@ -116,7 +116,7 @@ describe('CommitCoverageTabs', () => {
       graphql.query('BackfillFlagMemberships', () => {
         return HttpResponse.json({ data: mockBackfillResponse })
       }),
-      graphql.query('OwnerPlan', () => {
+      graphql.query('IsTeamPlan', () => {
         return HttpResponse.json({
           data: { owner: { plan: { isTeamPlan } } },
         })

--- a/src/pages/CommitDetailPage/CommitCoverage/CommitCoverageTabs/CommitCoverageTabs.test.jsx
+++ b/src/pages/CommitDetailPage/CommitCoverage/CommitCoverageTabs/CommitCoverageTabs.test.jsx
@@ -6,8 +6,6 @@ import qs from 'qs'
 import { Suspense } from 'react'
 import { MemoryRouter, Route } from 'react-router-dom'
 
-import { TierNames } from 'services/tier'
-
 import CommitCoverageTabs from './CommitCoverageTabs'
 
 const mockRepoSettings = (isPrivate) => ({
@@ -110,12 +108,7 @@ afterAll(() => {
 })
 
 describe('CommitCoverageTabs', () => {
-  function setup(
-    { tierValue = TierNames.PRO, isPrivate = false } = {
-      tierValue: TierNames.PRO,
-      isPrivate: false,
-    }
-  ) {
+  function setup({ isTeamPlan = false, isPrivate = false } = {}) {
     server.use(
       graphql.query('FlagsSelect', () => {
         return HttpResponse.json({ data: mockFlagsResponse })
@@ -123,9 +116,9 @@ describe('CommitCoverageTabs', () => {
       graphql.query('BackfillFlagMemberships', () => {
         return HttpResponse.json({ data: mockBackfillResponse })
       }),
-      graphql.query('OwnerTier', () => {
+      graphql.query('OwnerPlan', () => {
         return HttpResponse.json({
-          data: { owner: { plan: { tierName: tierValue } } },
+          data: { owner: { plan: { isTeamPlan } } },
         })
       }),
       graphql.query('GetRepoSettingsTeam', () => {
@@ -137,7 +130,7 @@ describe('CommitCoverageTabs', () => {
   describe('user is on a team plan', () => {
     describe('repo is public', () => {
       it('does not render the indirect changes tab', async () => {
-        setup({ tierValue: TierNames.TEAM, isPrivate: false })
+        setup({ isTeamPlan: true, isPrivate: false })
         render(<CommitCoverageTabs commitSha="sha256" />, {
           wrapper: wrapper(),
         })
@@ -154,7 +147,7 @@ describe('CommitCoverageTabs', () => {
     })
     describe('repo is private', () => {
       it('does not render the indirect changes tab', async () => {
-        setup({ tierValue: TierNames.TEAM, isPrivate: true })
+        setup({ isTeamPlan: true, isPrivate: true })
         render(<CommitCoverageTabs commitSha="sha256" />, {
           wrapper: wrapper(),
         })

--- a/src/pages/CommitDetailPage/CommitCoverage/UploadsCard/useUploads/useUploads.test.tsx
+++ b/src/pages/CommitDetailPage/CommitCoverage/UploadsCard/useUploads/useUploads.test.tsx
@@ -61,7 +61,7 @@ describe('useUploads', () => {
     server.use(query, compareTotalsEmpty)
 
     server.use(
-      graphql.query('OwnerPlan', () => {
+      graphql.query('IsTeamPlan', () => {
         return HttpResponse.json({
           data: {
             owner: { plan: { isTeamPlan } },

--- a/src/pages/CommitDetailPage/CommitCoverage/UploadsCard/useUploads/useUploads.test.tsx
+++ b/src/pages/CommitDetailPage/CommitCoverage/UploadsCard/useUploads/useUploads.test.tsx
@@ -12,7 +12,6 @@ import {
   commitOnePending,
   compareTotalsEmpty,
 } from 'services/commit/mocks'
-import { TierNames, TTierNames } from 'services/tier'
 
 import { useUploads } from './useUploads'
 
@@ -58,14 +57,14 @@ afterEach(() => {
 afterAll(() => server.close())
 
 describe('useUploads', () => {
-  function setup(query: RequestHandler, tierValue: TTierNames = TierNames.PRO) {
+  function setup(query: RequestHandler, isTeamPlan = false) {
     server.use(query, compareTotalsEmpty)
 
     server.use(
-      graphql.query('OwnerTier', () => {
+      graphql.query('OwnerPlan', () => {
         return HttpResponse.json({
           data: {
-            owner: { plan: { tierName: tierValue } },
+            owner: { plan: { isTeamPlan } },
           },
         })
       }),
@@ -332,7 +331,7 @@ describe('useUploads', () => {
 
   describe('user is on team plan', () => {
     beforeEach(() => {
-      setup(commitOnePending, TierNames.TEAM)
+      setup(commitOnePending, true)
     })
 
     afterEach(() => {

--- a/src/pages/CommitDetailPage/CommitCoverage/UploadsCard/useUploads/useUploads.ts
+++ b/src/pages/CommitDetailPage/CommitCoverage/UploadsCard/useUploads/useUploads.ts
@@ -2,7 +2,7 @@ import { useParams } from 'react-router-dom'
 
 import { useCommit } from 'services/commit'
 import { useRepoOverview } from 'services/repo'
-import { TierNames, useTier } from 'services/tier'
+import { useIsTeamPlan } from 'services/useIsTeamPlan'
 import { extractUploads } from 'shared/utils/extractUploads'
 
 import { UploadFilters } from '../UploadsCard'
@@ -21,17 +21,15 @@ interface UseUploadsArgs {
 export function useUploads({ filters }: UseUploadsArgs) {
   const { provider, owner, repo, commit } = useParams<URLParams>()
   const { data: overview } = useRepoOverview({ provider, owner, repo })
-  const { data: tierData } = useTier({ provider, owner })
+  const { data: isTeamPlan } = useIsTeamPlan({ provider, owner })
 
   // TODO: We need backend functionality to properly manage access to carryforward flags for team tier members
-  const isTeamPlan = tierData === TierNames.TEAM && overview?.private
-
   const { data } = useCommit({
     provider,
     owner,
     repo,
     commitid: commit,
-    isTeamPlan,
+    isTeamPlan: (isTeamPlan && overview?.private) ?? false,
   })
 
   const {

--- a/src/pages/CommitDetailPage/CommitCoverage/routes/CommitDetailFileExplorer/CommitDetailFileExplorerTable.test.tsx
+++ b/src/pages/CommitDetailPage/CommitCoverage/routes/CommitDetailFileExplorer/CommitDetailFileExplorerTable.test.tsx
@@ -159,14 +159,6 @@ const mockOverview = {
   },
 }
 
-const mockOwnerTier = {
-  owner: {
-    plan: {
-      tierName: 'pro',
-    },
-  },
-}
-
 const mockFlagsResponse = {
   owner: {
     repository: {
@@ -263,8 +255,16 @@ describe('CommitDetailFileExplorerTable', () => {
       graphql.query('GetRepoOverview', () => {
         return HttpResponse.json({ data: mockOverview })
       }),
-      graphql.query('OwnerTier', () => {
-        return HttpResponse.json({ data: mockOwnerTier })
+      graphql.query('OwnerPlan', () => {
+        return HttpResponse.json({
+          data: {
+            owner: {
+              plan: {
+                isTeamPlan: false,
+              },
+            },
+          },
+        })
       }),
       graphql.query('FlagsSelect', () => {
         return HttpResponse.json({ data: mockFlagsResponse })

--- a/src/pages/CommitDetailPage/CommitCoverage/routes/CommitDetailFileExplorer/CommitDetailFileExplorerTable.test.tsx
+++ b/src/pages/CommitDetailPage/CommitCoverage/routes/CommitDetailFileExplorer/CommitDetailFileExplorerTable.test.tsx
@@ -255,7 +255,7 @@ describe('CommitDetailFileExplorerTable', () => {
       graphql.query('GetRepoOverview', () => {
         return HttpResponse.json({ data: mockOverview })
       }),
-      graphql.query('OwnerPlan', () => {
+      graphql.query('IsTeamPlan', () => {
         return HttpResponse.json({
           data: {
             owner: {

--- a/src/pages/CommitDetailPage/CommitCoverage/routes/CommitDetailFileViewer/CommitDetailFileViewer.test.jsx
+++ b/src/pages/CommitDetailPage/CommitCoverage/routes/CommitDetailFileViewer/CommitDetailFileViewer.test.jsx
@@ -123,7 +123,7 @@ describe('CommitDetailFileViewer', () => {
           data: { owner: { repository: mockCoverage } },
         })
       }),
-      graphql.query('OwnerPlan', () => {
+      graphql.query('IsTeamPlan', () => {
         return HttpResponse.json({ data: { owner: null } })
       }),
       graphql.query('BackfillFlagMemberships', () => {

--- a/src/pages/CommitDetailPage/CommitCoverage/routes/CommitDetailFileViewer/CommitDetailFileViewer.test.jsx
+++ b/src/pages/CommitDetailPage/CommitCoverage/routes/CommitDetailFileViewer/CommitDetailFileViewer.test.jsx
@@ -123,7 +123,7 @@ describe('CommitDetailFileViewer', () => {
           data: { owner: { repository: mockCoverage } },
         })
       }),
-      graphql.query('OwnerTier', () => {
+      graphql.query('OwnerPlan', () => {
         return HttpResponse.json({ data: { owner: null } })
       }),
       graphql.query('BackfillFlagMemberships', () => {

--- a/src/pages/CommitDetailPage/CommitCoverage/routes/FilesChangedTab/FilesChangedTab.test.tsx
+++ b/src/pages/CommitDetailPage/CommitCoverage/routes/FilesChangedTab/FilesChangedTab.test.tsx
@@ -69,7 +69,7 @@ interface SetupArgs {
 describe('FilesChangedTab', () => {
   function setup({ isTeamPlan, isPrivate = false }: SetupArgs) {
     server.use(
-      graphql.query('OwnerPlan', () => {
+      graphql.query('IsTeamPlan', () => {
         return HttpResponse.json({
           data: {
             owner: {

--- a/src/pages/CommitDetailPage/CommitCoverage/routes/FilesChangedTab/FilesChangedTab.test.tsx
+++ b/src/pages/CommitDetailPage/CommitCoverage/routes/FilesChangedTab/FilesChangedTab.test.tsx
@@ -4,8 +4,6 @@ import { graphql, HttpResponse } from 'msw'
 import { setupServer } from 'msw/node'
 import { MemoryRouter, Route } from 'react-router-dom'
 
-import { TierNames } from 'services/tier'
-
 import FilesChangedTab from './FilesChangedTab'
 
 const mocks = vi.hoisted(() => {
@@ -20,22 +18,6 @@ vi.mock('./FilesChangedTable', () => ({
 vi.mock('./FilesChangedTableTeam', () => ({
   default: () => 'FilesChangedTableTeam',
 }))
-
-const mockTeamTier = {
-  owner: {
-    plan: {
-      tierName: TierNames.TEAM,
-    },
-  },
-}
-
-const mockProTier = {
-  owner: {
-    plan: {
-      tierName: TierNames.PRO,
-    },
-  },
-}
 
 const mockRepoSettings = (isPrivate: boolean) => ({
   owner: {
@@ -80,19 +62,23 @@ afterAll(() => {
 })
 
 interface SetupArgs {
-  planValue: 'team' | 'pro'
+  isTeamPlan: boolean
   isPrivate?: boolean
 }
 
 describe('FilesChangedTab', () => {
-  function setup({ planValue, isPrivate = false }: SetupArgs) {
+  function setup({ isTeamPlan, isPrivate = false }: SetupArgs) {
     server.use(
-      graphql.query('OwnerTier', () => {
-        if (planValue === 'team') {
-          return HttpResponse.json({ data: mockTeamTier })
-        }
-
-        return HttpResponse.json({ data: mockProTier })
+      graphql.query('OwnerPlan', () => {
+        return HttpResponse.json({
+          data: {
+            owner: {
+              plan: {
+                isTeamPlan,
+              },
+            },
+          },
+        })
       }),
       graphql.query('GetRepoSettingsTeam', () => {
         return HttpResponse.json({ data: mockRepoSettings(isPrivate) })
@@ -104,9 +90,9 @@ describe('FilesChangedTab', () => {
     mocks.filesChangedTable.mockImplementation(() => 'FilesChangedTable')
   })
 
-  describe('user has pro tier', () => {
+  describe('user has pro plan', () => {
     it('renders files changed table', async () => {
-      setup({ planValue: TierNames.PRO })
+      setup({ isTeamPlan: false })
       render(<FilesChangedTab />, { wrapper })
 
       const table = await screen.findByText('FilesChangedTable')
@@ -114,10 +100,10 @@ describe('FilesChangedTab', () => {
     })
   })
 
-  describe('user has team tier', () => {
+  describe('user has team plan', () => {
     describe('repo is private', () => {
       it('renders team files changed table', async () => {
-        setup({ planValue: TierNames.TEAM, isPrivate: true })
+        setup({ isTeamPlan: true, isPrivate: true })
 
         render(<FilesChangedTab />, { wrapper })
 
@@ -128,7 +114,7 @@ describe('FilesChangedTab', () => {
 
     describe('repo is public', () => {
       it('renders files changed table', async () => {
-        setup({ planValue: TierNames.TEAM, isPrivate: false })
+        setup({ isTeamPlan: true, isPrivate: false })
         render(<FilesChangedTab />, { wrapper })
 
         const table = await screen.findByText('FilesChangedTable')

--- a/src/pages/CommitDetailPage/CommitCoverage/routes/FilesChangedTab/FilesChangedTab.tsx
+++ b/src/pages/CommitDetailPage/CommitCoverage/routes/FilesChangedTab/FilesChangedTab.tsx
@@ -3,7 +3,7 @@ import { useParams } from 'react-router-dom'
 
 import ToggleHeader from 'pages/CommitDetailPage/Header/ToggleHeader/ToggleHeader'
 import { useRepoSettingsTeam } from 'services/repo'
-import { TierNames, useTier } from 'services/tier'
+import { useIsTeamPlan } from 'services/useIsTeamPlan'
 import Spinner from 'ui/Spinner'
 
 const FilesChangedTable = lazy(() => import('./FilesChangedTable'))
@@ -24,9 +24,9 @@ function FilesChanged() {
   const { provider, owner } = useParams<URLParams>()
   const { data: repoSettings } = useRepoSettingsTeam()
 
-  const { data: tierData } = useTier({ provider, owner })
+  const { data: isTeamPlan } = useIsTeamPlan({ provider, owner })
 
-  if (tierData === TierNames.TEAM && !!repoSettings?.repository?.private) {
+  if (isTeamPlan && !!repoSettings?.repository?.private) {
     return (
       <Suspense fallback={<Loader />}>
         <ToggleHeader />

--- a/src/pages/CommitDetailPage/Header/Header.test.tsx
+++ b/src/pages/CommitDetailPage/Header/Header.test.tsx
@@ -54,7 +54,7 @@ interface SetupArgs {
 describe('Header', () => {
   function setup({ isTeamPlan = false, isPrivate = false }: SetupArgs) {
     server.use(
-      graphql.query('OwnerPlan', () => {
+      graphql.query('IsTeamPlan', () => {
         if (isTeamPlan) {
           return HttpResponse.json({
             data: { owner: { plan: { isTeamPlan: true } } },

--- a/src/pages/CommitDetailPage/Header/Header.test.tsx
+++ b/src/pages/CommitDetailPage/Header/Header.test.tsx
@@ -4,8 +4,6 @@ import { graphql, HttpResponse } from 'msw'
 import { setupServer } from 'msw/node'
 import { MemoryRouter, Route } from 'react-router-dom'
 
-import { TierNames } from 'services/tier'
-
 import Header from './Header'
 
 vi.mock('./HeaderDefault', () => ({ default: () => 'Default Header' }))
@@ -49,21 +47,21 @@ afterEach(() => {
 })
 afterAll(() => server.close())
 interface SetupArgs {
-  teamPlan: boolean
+  isTeamPlan: boolean
   isPrivate?: boolean
 }
 
 describe('Header', () => {
-  function setup({ teamPlan = false, isPrivate = false }: SetupArgs) {
+  function setup({ isTeamPlan = false, isPrivate = false }: SetupArgs) {
     server.use(
-      graphql.query('OwnerTier', () => {
-        if (teamPlan) {
+      graphql.query('OwnerPlan', () => {
+        if (isTeamPlan) {
           return HttpResponse.json({
-            data: { owner: { plan: { tierName: TierNames.TEAM } } },
+            data: { owner: { plan: { isTeamPlan: true } } },
           })
         }
         return HttpResponse.json({
-          data: { owner: { plan: { tierName: TierNames.PRO } } },
+          data: { owner: { plan: { isTeamPlan: false } } },
         })
       }),
       graphql.query('GetRepoSettingsTeam', () => {
@@ -72,9 +70,9 @@ describe('Header', () => {
     )
   }
 
-  describe('when rendered and customer is not team tier', () => {
+  describe('when rendered and customer is not team plan', () => {
     beforeEach(() => {
-      setup({ teamPlan: false })
+      setup({ isTeamPlan: false })
     })
 
     it('renders the default header component', async () => {
@@ -88,10 +86,10 @@ describe('Header', () => {
     })
   })
 
-  describe('when rendered and customer has team tier', () => {
+  describe('when rendered and customer has team plan', () => {
     describe('when the repository is private', () => {
       beforeEach(() => {
-        setup({ teamPlan: true, isPrivate: true })
+        setup({ isTeamPlan: true, isPrivate: true })
       })
 
       it('renders the team header component', async () => {
@@ -107,7 +105,7 @@ describe('Header', () => {
 
     describe('when the repository is public', () => {
       beforeEach(() => {
-        setup({ teamPlan: true, isPrivate: false })
+        setup({ isTeamPlan: true, isPrivate: false })
       })
 
       it('renders the default team component', async () => {

--- a/src/pages/CommitDetailPage/Header/Header.tsx
+++ b/src/pages/CommitDetailPage/Header/Header.tsx
@@ -1,7 +1,7 @@
 import { useParams } from 'react-router-dom'
 
 import { useRepoSettingsTeam } from 'services/repo'
-import { TierNames, useTier } from 'services/tier'
+import { useIsTeamPlan } from 'services/useIsTeamPlan'
 
 import HeaderDefault from './HeaderDefault'
 import HeaderTeam from './HeaderTeam'
@@ -13,10 +13,10 @@ interface URLParams {
 
 function Header() {
   const { provider, owner } = useParams<URLParams>()
-  const { data: tierData } = useTier({ provider, owner })
+  const { data: isTeamPlan } = useIsTeamPlan({ provider, owner })
   const { data: repoSettingsTeam } = useRepoSettingsTeam()
 
-  if (repoSettingsTeam?.repository?.private && tierData === TierNames.TEAM) {
+  if (repoSettingsTeam?.repository?.private && isTeamPlan) {
     return <HeaderTeam />
   }
 

--- a/src/pages/CommitDetailPage/Header/ToggleHeader/ToggleHeader.tsx
+++ b/src/pages/CommitDetailPage/Header/ToggleHeader/ToggleHeader.tsx
@@ -3,7 +3,7 @@ import { useParams } from 'react-router-dom'
 
 import ComponentsSelector from 'pages/CommitDetailPage/CommitCoverage/routes/ComponentsSelector'
 import { useRepoOverview } from 'services/repo'
-import { TierNames, useTier } from 'services/tier'
+import { useIsTeamPlan } from 'services/useIsTeamPlan'
 import { LINE_STATE } from 'shared/utils/fileviewer'
 import {
   TitleCoverage,
@@ -22,8 +22,8 @@ function ToggleHeader({ showHitCount = true, noBottomBorder = false }) {
 
   const { data: overview } = useRepoOverview({ provider, owner, repo })
 
-  const { data: tierData } = useTier({ provider, owner })
-  const isTeamPlan = tierData === TierNames.TEAM && overview?.private
+  const { data: isTeamPlan } = useIsTeamPlan({ provider, owner })
+  const showTeamPlan = isTeamPlan && overview?.private
 
   const containerClasses = cs(
     'flex w-full flex-1 flex-wrap items-start gap-2 bg-ds-container sm:flex-row sm:items-center md:mb-1 lg:w-auto lg:flex-none',
@@ -43,7 +43,7 @@ function ToggleHeader({ showHitCount = true, noBottomBorder = false }) {
         <TitleCoverage coverage={LINE_STATE.COVERED} />
       </div>
       <div className="ml-auto flex w-full flex-wrap items-center justify-end gap-2 md:mt-2 md:w-auto">
-        {!isTeamPlan && (
+        {!showTeamPlan && (
           <>
             <TitleFlags commitDetailView={true} />
             <ComponentsSelector />

--- a/src/pages/PlanPage/subRoutes/CancelPlanPage/subRoutes/TeamPlanSpecialOffer/TeamPlanCard/TeamPlanCard.tsx
+++ b/src/pages/PlanPage/subRoutes/CancelPlanPage/subRoutes/TeamPlanSpecialOffer/TeamPlanCard/TeamPlanCard.tsx
@@ -1,7 +1,6 @@
 import { useParams } from 'react-router-dom'
 
 import { useAvailablePlans } from 'services/account'
-import { TierNames } from 'services/useIsTeamPlan'
 import BenefitList from 'shared/plan/BenefitList'
 import { findTeamPlans } from 'shared/utils/billing'
 import Button from 'ui/Button'
@@ -25,7 +24,7 @@ const TeamPlanCard: React.FC = () => {
           <Button
             to={{
               pageName: 'upgradeOrgPlan',
-              options: { params: { plan: TierNames.TEAM } },
+              options: { params: { plan: 'team' } },
             }}
             variant="primary"
             disabled={undefined}

--- a/src/pages/PlanPage/subRoutes/CancelPlanPage/subRoutes/TeamPlanSpecialOffer/TeamPlanCard/TeamPlanCard.tsx
+++ b/src/pages/PlanPage/subRoutes/CancelPlanPage/subRoutes/TeamPlanSpecialOffer/TeamPlanCard/TeamPlanCard.tsx
@@ -1,7 +1,7 @@
 import { useParams } from 'react-router-dom'
 
 import { useAvailablePlans } from 'services/account'
-import { TierNames } from 'services/tier'
+import { TierNames } from 'services/useIsTeamPlan'
 import BenefitList from 'shared/plan/BenefitList'
 import { findTeamPlans } from 'shared/utils/billing'
 import Button from 'ui/Button'

--- a/src/pages/PlanPage/subRoutes/CurrentOrgPlan/CurrentPlanCard/FreePlanCard/PlanUpgradeTeam/PlanUpgradeTeam.jsx
+++ b/src/pages/PlanPage/subRoutes/CurrentOrgPlan/CurrentPlanCard/FreePlanCard/PlanUpgradeTeam/PlanUpgradeTeam.jsx
@@ -1,7 +1,6 @@
 import { useParams } from 'react-router-dom'
 
 import { useAvailablePlans, usePlanData } from 'services/account'
-import { TierNames } from 'services/useIsTeamPlan'
 import BenefitList from 'shared/plan/BenefitList'
 import { findTeamPlans } from 'shared/utils/billing'
 import A from 'ui/A'
@@ -42,7 +41,7 @@ function PlanUpgradeTeam() {
               to={{
                 pageName: 'upgradeOrgPlan',
                 options: {
-                  params: { plan: TierNames.TEAM },
+                  params: { plan: 'team' },
                 },
               }}
               variant="primary"

--- a/src/pages/PlanPage/subRoutes/CurrentOrgPlan/CurrentPlanCard/FreePlanCard/PlanUpgradeTeam/PlanUpgradeTeam.jsx
+++ b/src/pages/PlanPage/subRoutes/CurrentOrgPlan/CurrentPlanCard/FreePlanCard/PlanUpgradeTeam/PlanUpgradeTeam.jsx
@@ -1,7 +1,7 @@
 import { useParams } from 'react-router-dom'
 
 import { useAvailablePlans, usePlanData } from 'services/account'
-import { TierNames } from 'services/tier'
+import { TierNames } from 'services/useIsTeamPlan'
 import BenefitList from 'shared/plan/BenefitList'
 import { findTeamPlans } from 'shared/utils/billing'
 import A from 'ui/A'

--- a/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/PlanTypeOptions/PlanTypeOptions.tsx
+++ b/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/PlanTypeOptions/PlanTypeOptions.tsx
@@ -7,7 +7,7 @@ import {
   usePlanData,
 } from 'services/account'
 import { useLocationParams } from 'services/navigation'
-import { TierNames } from 'services/tier'
+import { TierNames } from 'services/useIsTeamPlan'
 import {
   BillingRate,
   canApplySentryUpgrade,

--- a/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/PlanTypeOptions/PlanTypeOptions.tsx
+++ b/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/PlanTypeOptions/PlanTypeOptions.tsx
@@ -7,14 +7,13 @@ import {
   usePlanData,
 } from 'services/account'
 import { useLocationParams } from 'services/navigation'
-import { TierNames } from 'services/useIsTeamPlan'
-import {
-  BillingRate,
+import { BillingRate ,
   canApplySentryUpgrade,
   findProPlans,
   findSentryPlans,
   findTeamPlans,
   shouldDisplayTeamCard,
+  TierNames,
 } from 'shared/utils/billing'
 import { TEAM_PLAN_MAX_ACTIVE_USERS } from 'shared/utils/upgradeForm'
 import OptionButton from 'ui/OptionButton'

--- a/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/PlanTypeOptions/PlanTypeOptions.tsx
+++ b/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/PlanTypeOptions/PlanTypeOptions.tsx
@@ -7,7 +7,8 @@ import {
   usePlanData,
 } from 'services/account'
 import { useLocationParams } from 'services/navigation'
-import { BillingRate ,
+import {
+  BillingRate,
   canApplySentryUpgrade,
   findProPlans,
   findSentryPlans,

--- a/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradePlanPage.jsx
+++ b/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradePlanPage.jsx
@@ -2,7 +2,8 @@ import { useLayoutEffect, useState } from 'react'
 import { Redirect, useParams } from 'react-router-dom'
 
 import { useAvailablePlans, usePlanData } from 'services/account'
-import { canApplySentryUpgrade ,
+import {
+  canApplySentryUpgrade,
   findProPlans,
   findSentryPlans,
   findTeamPlans,

--- a/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradePlanPage.jsx
+++ b/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradePlanPage.jsx
@@ -2,7 +2,7 @@ import { useLayoutEffect, useState } from 'react'
 import { Redirect, useParams } from 'react-router-dom'
 
 import { useAvailablePlans, usePlanData } from 'services/account'
-import { TierNames } from 'services/tier'
+import { TierNames } from 'services/useIsTeamPlan'
 import {
   canApplySentryUpgrade,
   findProPlans,

--- a/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradePlanPage.jsx
+++ b/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradePlanPage.jsx
@@ -2,13 +2,12 @@ import { useLayoutEffect, useState } from 'react'
 import { Redirect, useParams } from 'react-router-dom'
 
 import { useAvailablePlans, usePlanData } from 'services/account'
-import { TierNames } from 'services/useIsTeamPlan'
-import {
-  canApplySentryUpgrade,
+import { canApplySentryUpgrade ,
   findProPlans,
   findSentryPlans,
   findTeamPlans,
   shouldDisplayTeamCard,
+  TierNames,
 } from 'shared/utils/billing'
 
 import UpgradeDetails from './UpgradeDetails'

--- a/src/pages/PullRequestPage/Header/Header.test.tsx
+++ b/src/pages/PullRequestPage/Header/Header.test.tsx
@@ -55,7 +55,7 @@ interface SetupArgs {
 describe('Header', () => {
   function setup({ isTeamPlan = false, isPrivate = false }: SetupArgs) {
     server.use(
-      graphql.query('OwnerPlan', () => {
+      graphql.query('IsTeamPlan', () => {
         return HttpResponse.json({
           data: {
             owner: {

--- a/src/pages/PullRequestPage/Header/Header.test.tsx
+++ b/src/pages/PullRequestPage/Header/Header.test.tsx
@@ -4,8 +4,6 @@ import { graphql, HttpResponse } from 'msw'
 import { setupServer } from 'msw/node'
 import { MemoryRouter, Route } from 'react-router-dom'
 
-import { TierNames } from 'services/tier'
-
 import Header from './Header'
 
 vi.mock('./HeaderDefault', () => ({ default: () => 'Default Header' }))
@@ -48,22 +46,22 @@ afterEach(() => {
   server.resetHandlers()
 })
 afterAll(() => server.close())
+
 interface SetupArgs {
-  isTeam?: boolean
+  isTeamPlan?: boolean
   isPrivate?: boolean
 }
 
 describe('Header', () => {
-  function setup({ isTeam = false, isPrivate = false }: SetupArgs) {
+  function setup({ isTeamPlan = false, isPrivate = false }: SetupArgs) {
     server.use(
-      graphql.query('OwnerTier', () => {
-        if (isTeam) {
-          return HttpResponse.json({
-            data: { owner: { plan: { tierName: TierNames.TEAM } } },
-          })
-        }
+      graphql.query('OwnerPlan', () => {
         return HttpResponse.json({
-          data: { owner: { plan: { tierName: TierNames.PRO } } },
+          data: {
+            owner: {
+              plan: { isTeamPlan },
+            },
+          },
         })
       }),
       graphql.query('GetRepoSettingsTeam', () => {
@@ -74,9 +72,9 @@ describe('Header', () => {
     )
   }
 
-  describe('when rendered and customer is not team tier', () => {
+  describe('when rendered and customer is not on team plan', () => {
     beforeEach(() => {
-      setup({ isTeam: false })
+      setup({ isTeamPlan: false })
     })
 
     it('renders the default header component', async () => {
@@ -90,10 +88,10 @@ describe('Header', () => {
     })
   })
 
-  describe('when rendered and customer has team tier', () => {
+  describe('when rendered and customer is on team plan', () => {
     describe('when the repository is private', () => {
       beforeEach(() => {
-        setup({ isTeam: true, isPrivate: true })
+        setup({ isTeamPlan: true, isPrivate: true })
       })
 
       it('renders the team header component', async () => {
@@ -109,7 +107,7 @@ describe('Header', () => {
 
     describe('when the repository is public', () => {
       beforeEach(() => {
-        setup({ isTeam: true, isPrivate: false })
+        setup({ isTeamPlan: true, isPrivate: false })
       })
 
       it('renders the default team component', async () => {

--- a/src/pages/PullRequestPage/Header/Header.tsx
+++ b/src/pages/PullRequestPage/Header/Header.tsx
@@ -1,7 +1,7 @@
 import { useParams } from 'react-router-dom'
 
 import { useRepoSettingsTeam } from 'services/repo'
-import { TierNames, useTier } from 'services/tier'
+import { useIsTeamPlan } from 'services/useIsTeamPlan'
 
 import HeaderDefault from './HeaderDefault'
 import HeaderTeam from './HeaderTeam'
@@ -13,10 +13,10 @@ interface URLParams {
 
 function Header() {
   const { provider, owner } = useParams<URLParams>()
-  const { data: tierData } = useTier({ provider, owner })
+  const { data: isTeamPlan } = useIsTeamPlan({ provider, owner })
   const { data: repoSettingsTeam } = useRepoSettingsTeam()
 
-  if (repoSettingsTeam?.repository?.private && tierData === TierNames.TEAM) {
+  if (repoSettingsTeam?.repository?.private && isTeamPlan) {
     return <HeaderTeam />
   }
 

--- a/src/pages/PullRequestPage/Header/ToggleHeader/ToggleHeader.tsx
+++ b/src/pages/PullRequestPage/Header/ToggleHeader/ToggleHeader.tsx
@@ -2,7 +2,7 @@ import { useParams } from 'react-router-dom'
 
 import ComponentsMultiSelect from 'pages/PullRequestPage/PullCoverage/routes/ComponentsSelector'
 import { useRepoOverview } from 'services/repo'
-import { TierNames, useTier } from 'services/tier'
+import { useIsTeamPlan } from 'services/useIsTeamPlan'
 import { LINE_STATE } from 'shared/utils/fileviewer'
 import {
   TitleCoverage,
@@ -24,8 +24,8 @@ function ToggleHeader({ showHitCount = false, noBottomBorder = false }) {
 
   const { data: overview } = useRepoOverview({ provider, owner, repo })
 
-  const { data: tierData } = useTier({ provider, owner })
-  const isTeamPlan = tierData === TierNames.TEAM && overview?.private
+  const { data: isTeamPlan } = useIsTeamPlan({ provider, owner })
+  const showTeamPlan = isTeamPlan && overview?.private
 
   return (
     <div
@@ -38,8 +38,8 @@ function ToggleHeader({ showHitCount = false, noBottomBorder = false }) {
         <TitleCoverage coverage={LINE_STATE.COVERED} />
       </div>
       <div className="ml-auto flex w-full flex-wrap items-center justify-between gap-2 md:mt-2 md:w-auto">
-        {!isTeamPlan ? <TitleFlags /> : null}
-        {!isTeamPlan ? <ComponentsMultiSelect /> : null}
+        {!showTeamPlan ? <TitleFlags /> : null}
+        {!showTeamPlan ? <ComponentsMultiSelect /> : null}
       </div>
     </div>
   )

--- a/src/pages/PullRequestPage/PullCoverage/PullCoverage.jsx
+++ b/src/pages/PullRequestPage/PullCoverage/PullCoverage.jsx
@@ -6,7 +6,7 @@ import { SentryRoute } from 'sentry'
 
 import SilentNetworkErrorWrapper from 'layouts/shared/SilentNetworkErrorWrapper'
 import { useRepoOverview, useRepoRateLimitStatus } from 'services/repo'
-import { TierNames, useTier } from 'services/tier'
+import { useIsTeamPlan } from 'services/useIsTeamPlan'
 import ComparisonErrorBanner from 'shared/ComparisonErrorBanner'
 import GitHubRateLimitExceededBanner from 'shared/GlobalBanners/GitHubRateLimitExceeded/GitHubRateLimitExceededBanner'
 import { ComparisonReturnType, ReportUploadType } from 'shared/utils/comparison'
@@ -37,9 +37,7 @@ const Loader = () => (
 function PullCoverageContent() {
   const { owner, repo, pullId, provider } = useParams()
   const { data: overview } = useRepoOverview({ provider, owner, repo })
-  const { data: tierData } = useTier({ provider, owner })
-
-  const isTeamPlan = tierData === TierNames.TEAM && overview?.private
+  const { data: isTeamPlan } = useIsTeamPlan({ provider, owner })
 
   const { data } = useSuspenseQueryV5(
     PullPageDataQueryOpts({
@@ -47,7 +45,7 @@ function PullCoverageContent() {
       owner,
       repo,
       pullId,
-      isTeamPlan,
+      isTeamPlan: (isTeamPlan && overview?.private) ?? false,
     })
   )
 
@@ -127,10 +125,8 @@ function PullCoverageContent() {
 function PullCoverage() {
   const { owner, repo, pullId, provider } = useParams()
   const { data: overview } = useRepoOverview({ provider, owner, repo })
-  const { data: tierData } = useTier({ provider, owner })
+  const { data: isTeamPlan } = useIsTeamPlan({ provider, owner })
   const { data: rateLimit } = useRepoRateLimitStatus({ provider, owner, repo })
-
-  const isTeamPlan = tierData === TierNames.TEAM && overview?.private
 
   const { data } = useSuspenseQueryV5(
     PullPageDataQueryOpts({
@@ -138,7 +134,7 @@ function PullCoverage() {
       owner,
       repo,
       pullId,
-      isTeamPlan,
+      isTeamPlan: isTeamPlan && overview?.private,
     })
   )
 

--- a/src/pages/PullRequestPage/PullCoverage/PullCoverage.test.jsx
+++ b/src/pages/PullRequestPage/PullCoverage/PullCoverage.test.jsx
@@ -244,7 +244,7 @@ describe('PullRequestPageContent', () => {
           }),
         })
       }),
-      graphql.query('OwnerPlan', () => {
+      graphql.query('IsTeamPlan', () => {
         return HttpResponse.json({
           data: {
             owner: { plan: { isTeamPlan } },

--- a/src/pages/PullRequestPage/PullCoverage/PullCoverage.test.jsx
+++ b/src/pages/PullRequestPage/PullCoverage/PullCoverage.test.jsx
@@ -9,7 +9,6 @@ import { setupServer } from 'msw/node'
 import { Suspense } from 'react'
 import { MemoryRouter, Route } from 'react-router-dom'
 
-import { TierNames } from 'services/tier'
 import { ComparisonReturnType } from 'shared/utils/comparison'
 
 import PullRequestPageContent from './PullCoverage'
@@ -218,13 +217,13 @@ describe('PullRequestPageContent', () => {
   function setup(
     {
       resultType = ComparisonReturnType.SUCCESSFUL_COMPARISON,
-      tierValue = TierNames.BASIC,
+      isTeamPlan = false,
       bundleAnalysisEnabled = false,
       coverageEnabled = false,
       isGithubRateLimited = false,
     } = {
       resultType: ComparisonReturnType.SUCCESSFUL_COMPARISON,
-      tierValue: TierNames.BASIC,
+      isTeamPlan: false,
       bundleAnalysisEnabled: false,
       coverageEnabled: false,
       isGithubRateLimited: false,
@@ -245,10 +244,10 @@ describe('PullRequestPageContent', () => {
           }),
         })
       }),
-      graphql.query('OwnerTier', () => {
+      graphql.query('OwnerPlan', () => {
         return HttpResponse.json({
           data: {
-            owner: { plan: { tierName: tierValue } },
+            owner: { plan: { isTeamPlan } },
           },
         })
       }),
@@ -410,7 +409,7 @@ describe('PullRequestPageContent', () => {
     it('returns a valid response', async () => {
       setup({
         resultType: ComparisonReturnType.SUCCESSFUL_COMPARISON,
-        tierValue: TierNames.TEAM,
+        isTeamPlan: true,
       })
       render(<PullRequestPageContent />, {
         wrapper: wrapper(),

--- a/src/pages/PullRequestPage/PullCoverage/PullCoverageTabs/PullCoverageTabs.jsx
+++ b/src/pages/PullRequestPage/PullCoverage/PullCoverageTabs/PullCoverageTabs.jsx
@@ -6,7 +6,7 @@ import {
   pullTreeviewString,
 } from 'pages/PullRequestPage/utils'
 import { useRepoOverview } from 'services/repo'
-import { TierNames, useTier } from 'services/tier'
+import { useIsTeamPlan } from 'services/useIsTeamPlan'
 import TabNavigation from 'ui/TabNavigation'
 
 import { useTabsCounts } from './useTabsCounts'
@@ -28,7 +28,7 @@ function PullCoverageTabs() {
     repo,
   })
 
-  const { data: tierData, isLoading } = useTier({ provider, owner })
+  const { data: isTeamPlan, isLoading } = useIsTeamPlan({ provider, owner })
   const searchParams = qs.parse(search, { ignoreQueryPrefix: true })
   const flags = searchParams?.flags ?? []
 
@@ -51,7 +51,7 @@ function PullCoverageTabs() {
     return null
   }
 
-  if (tierData === TierNames.TEAM && overview?.private) {
+  if (isTeamPlan && overview?.private) {
     return (
       <TabNavigation
         tabs={[

--- a/src/pages/PullRequestPage/PullCoverage/PullCoverageTabs/PullCoverageTabs.test.jsx
+++ b/src/pages/PullRequestPage/PullCoverage/PullCoverageTabs/PullCoverageTabs.test.jsx
@@ -205,7 +205,7 @@ describe('PullCoverageTabs', () => {
       graphql.query('GetCommits', () => {
         return HttpResponse.json({ data: mockCommits })
       }),
-      graphql.query('OwnerPlan', () => {
+      graphql.query('IsTeamPlan', () => {
         return HttpResponse.json({
           data: {
             owner: { plan: { isTeamPlan } },

--- a/src/pages/PullRequestPage/PullCoverage/PullCoverageTabs/PullCoverageTabs.test.jsx
+++ b/src/pages/PullRequestPage/PullCoverage/PullCoverageTabs/PullCoverageTabs.test.jsx
@@ -8,8 +8,6 @@ import { graphql, HttpResponse } from 'msw'
 import { setupServer } from 'msw/node'
 import { MemoryRouter, Route } from 'react-router-dom'
 
-import { TierNames } from 'services/tier'
-
 import PullCoverageTabs from './PullCoverageTabs'
 
 const mockOverview = (privateRepo = false) => ({
@@ -195,8 +193,8 @@ afterAll(() => {
 
 describe('PullCoverageTabs', () => {
   function setup(
-    { tierValue = TierNames.BASIC, privateRepo = false } = {
-      tierValue: TierNames.BASIC,
+    { isTeamPlan = false, privateRepo = false } = {
+      isTeamPlan: false,
       privateRepo: false,
     }
   ) {
@@ -207,10 +205,10 @@ describe('PullCoverageTabs', () => {
       graphql.query('GetCommits', () => {
         return HttpResponse.json({ data: mockCommits })
       }),
-      graphql.query('OwnerTier', () => {
+      graphql.query('OwnerPlan', () => {
         return HttpResponse.json({
           data: {
-            owner: { plan: { tierName: tierValue.toLowerCase() } },
+            owner: { plan: { isTeamPlan } },
           },
         })
       }),
@@ -414,7 +412,7 @@ describe('PullCoverageTabs', () => {
     describe('is a team plan on a public repo', () => {
       beforeEach(() =>
         setup({
-          tierValue: TierNames.TEAM,
+          isTeamPlan: true,
           privateRepo: false,
         })
       )
@@ -445,7 +443,7 @@ describe('PullCoverageTabs', () => {
     describe('is a team plan on a private repo', () => {
       beforeEach(() =>
         setup({
-          tierValue: TierNames.TEAM,
+          isTeamPlan: true,
           privateRepo: true,
         })
       )
@@ -483,7 +481,7 @@ describe('PullCoverageTabs', () => {
     describe('is a pro plan on a public repo', () => {
       beforeEach(() =>
         setup({
-          tierValue: TierNames.PRO,
+          isTeamPlan: false,
           privateRepo: false,
         })
       )
@@ -514,7 +512,7 @@ describe('PullCoverageTabs', () => {
     describe('is a pro plan on a private repo', () => {
       beforeEach(() =>
         setup({
-          tierValue: TierNames.PRO,
+          isTeamPlan: false,
           privateRepo: true,
         })
       )

--- a/src/pages/PullRequestPage/PullCoverage/Summary/Summary.test.tsx
+++ b/src/pages/PullRequestPage/PullCoverage/Summary/Summary.test.tsx
@@ -5,8 +5,6 @@ import { setupServer } from 'msw/node'
 import { Suspense } from 'react'
 import { MemoryRouter, Route } from 'react-router-dom'
 
-import { TierNames } from 'services/tier'
-
 import Summary from './Summary'
 
 const queryClient = new QueryClient({
@@ -41,21 +39,21 @@ afterAll(() => {
 })
 
 interface SetupOptions {
-  tierValue?: (typeof TierNames)[keyof typeof TierNames]
+  isTeamPlan?: boolean
   privateRepo?: boolean
 }
 describe('Summary', () => {
   function setup(
-    { tierValue = TierNames.BASIC, privateRepo = false }: SetupOptions = {
-      tierValue: TierNames.BASIC,
+    { isTeamPlan = false, privateRepo = false }: SetupOptions = {
+      isTeamPlan: false,
       privateRepo: false,
     }
   ) {
     server.use(
-      graphql.query('OwnerTier', () => {
+      graphql.query('OwnerPlan', () => {
         return HttpResponse.json({
           data: {
-            owner: { plan: { tierName: tierValue.toLowerCase() } },
+            owner: { plan: { isTeamPlan } },
           },
         })
       }),
@@ -83,13 +81,13 @@ describe('Summary', () => {
     )
   }
   describe.each`
-    tierValue          | privateRepo
-    ${TierNames.BASIC} | ${true}
-    ${TierNames.BASIC} | ${false}
-    ${TierNames.TEAM}  | ${false}
-  `('renders the normal summary', ({ tierValue, privateRepo }) => {
-    it(`tierValue: ${tierValue}, privateRepo: ${privateRepo}`, async () => {
-      setup({ tierValue, privateRepo })
+    isTeamPlan | privateRepo
+    ${false}   | ${true}
+    ${false}   | ${false}
+    ${false}   | ${false}
+  `('renders the normal summary', ({ isTeamPlan, privateRepo }) => {
+    it(`isTeamPlan: ${isTeamPlan}, privateRepo: ${privateRepo}`, async () => {
+      setup({ isTeamPlan, privateRepo })
       render(<Summary />, { wrapper: wrapper() })
 
       await waitFor(() =>
@@ -109,7 +107,7 @@ describe('Summary', () => {
 
   it('renders the team summary', async () => {
     setup({
-      tierValue: TierNames.TEAM,
+      isTeamPlan: true,
       privateRepo: true,
     })
     render(<Summary />, { wrapper: wrapper() })

--- a/src/pages/PullRequestPage/PullCoverage/Summary/Summary.test.tsx
+++ b/src/pages/PullRequestPage/PullCoverage/Summary/Summary.test.tsx
@@ -50,7 +50,7 @@ describe('Summary', () => {
     }
   ) {
     server.use(
-      graphql.query('OwnerPlan', () => {
+      graphql.query('IsTeamPlan', () => {
         return HttpResponse.json({
           data: {
             owner: { plan: { isTeamPlan } },

--- a/src/pages/PullRequestPage/PullCoverage/Summary/Summary.test.tsx
+++ b/src/pages/PullRequestPage/PullCoverage/Summary/Summary.test.tsx
@@ -84,7 +84,6 @@ describe('Summary', () => {
     isTeamPlan | privateRepo
     ${false}   | ${true}
     ${false}   | ${false}
-    ${false}   | ${false}
   `('renders the normal summary', ({ isTeamPlan, privateRepo }) => {
     it(`isTeamPlan: ${isTeamPlan}, privateRepo: ${privateRepo}`, async () => {
       setup({ isTeamPlan, privateRepo })

--- a/src/pages/PullRequestPage/PullCoverage/Summary/Summary.tsx
+++ b/src/pages/PullRequestPage/PullCoverage/Summary/Summary.tsx
@@ -1,7 +1,7 @@
 import { useParams } from 'react-router-dom'
 
 import { useRepoSettingsTeam } from 'services/repo'
-import { TierNames, useTier } from 'services/tier'
+import { useIsTeamPlan } from 'services/useIsTeamPlan'
 import Spinner from 'ui/Spinner'
 
 import CompareSummary from './CompareSummary'
@@ -14,13 +14,13 @@ interface Params {
 function Summary() {
   const { provider, owner } = useParams<Params>()
   const { data: settings, isLoading: settingsLoading } = useRepoSettingsTeam()
-  const { data: tierData, isLoading } = useTier({ provider, owner })
+  const { data: isTeamPlan, isLoading } = useIsTeamPlan({ provider, owner })
 
   if (isLoading || settingsLoading) {
     return <Spinner />
   }
 
-  if (tierData === TierNames.TEAM && settings?.repository?.private) {
+  if (isTeamPlan && settings?.repository?.private) {
     return null
   } else {
     return <CompareSummary />

--- a/src/pages/PullRequestPage/PullCoverage/routes/FileExplorer/FileExplorer.test.tsx
+++ b/src/pages/PullRequestPage/PullCoverage/routes/FileExplorer/FileExplorer.test.tsx
@@ -5,8 +5,6 @@ import { graphql, HttpResponse } from 'msw'
 import { setupServer } from 'msw/node'
 import { MemoryRouter, Route } from 'react-router-dom'
 
-import { TierNames } from 'services/tier'
-
 import FileExplorer from './FileExplorer'
 
 const queryClient = new QueryClient({
@@ -301,9 +299,9 @@ describe('FileExplorer', () => {
       graphql.query('BackfillFlagMemberships', () => {
         return HttpResponse.json({ data: mockBackfillData })
       }),
-      graphql.query('OwnerTier', () => {
+      graphql.query('OwnerPlan', () => {
         return HttpResponse.json({
-          data: { owner: { plan: { tierName: TierNames.PRO } } },
+          data: { owner: { plan: { isTeamPlan: false } } },
         })
       }),
       graphql.query('GetRepoSettingsTeam', () => {

--- a/src/pages/PullRequestPage/PullCoverage/routes/FileExplorer/FileExplorer.test.tsx
+++ b/src/pages/PullRequestPage/PullCoverage/routes/FileExplorer/FileExplorer.test.tsx
@@ -299,7 +299,7 @@ describe('FileExplorer', () => {
       graphql.query('BackfillFlagMemberships', () => {
         return HttpResponse.json({ data: mockBackfillData })
       }),
-      graphql.query('OwnerPlan', () => {
+      graphql.query('IsTeamPlan', () => {
         return HttpResponse.json({
           data: { owner: { plan: { isTeamPlan: false } } },
         })

--- a/src/pages/PullRequestPage/PullCoverage/routes/FileViewer/FileViewer.test.jsx
+++ b/src/pages/PullRequestPage/PullCoverage/routes/FileViewer/FileViewer.test.jsx
@@ -174,7 +174,7 @@ describe('FileViewer', () => {
       graphql.query('BackfillFlagMemberships', () => {
         return HttpResponse.json({ data: { owner: null } })
       }),
-      graphql.query('OwnerPlan', () => {
+      graphql.query('IsTeamPlan', () => {
         return HttpResponse.json({ data: { owner: null } })
       }),
       graphql.query('GetRepoOverview', () => {

--- a/src/pages/PullRequestPage/PullCoverage/routes/FileViewer/FileViewer.test.jsx
+++ b/src/pages/PullRequestPage/PullCoverage/routes/FileViewer/FileViewer.test.jsx
@@ -174,7 +174,7 @@ describe('FileViewer', () => {
       graphql.query('BackfillFlagMemberships', () => {
         return HttpResponse.json({ data: { owner: null } })
       }),
-      graphql.query('OwnerTier', () => {
+      graphql.query('OwnerPlan', () => {
         return HttpResponse.json({ data: { owner: null } })
       }),
       graphql.query('GetRepoOverview', () => {

--- a/src/pages/PullRequestPage/PullCoverage/routes/FilesChangedTab/FilesChangedTab.test.tsx
+++ b/src/pages/PullRequestPage/PullCoverage/routes/FilesChangedTab/FilesChangedTab.test.tsx
@@ -91,7 +91,7 @@ interface SetupArgs {
 describe('FilesChangedTab', () => {
   function setup({ isTeamPlan, privateRepo }: SetupArgs) {
     server.use(
-      graphql.query('OwnerPlan', () => {
+      graphql.query('IsTeamPlan', () => {
         return HttpResponse.json({ data: { owner: { plan: { isTeamPlan } } } })
       }),
       graphql.query('GetPullTeam', () => {

--- a/src/pages/PullRequestPage/PullCoverage/routes/FilesChangedTab/FilesChangedTab.test.tsx
+++ b/src/pages/PullRequestPage/PullCoverage/routes/FilesChangedTab/FilesChangedTab.test.tsx
@@ -4,8 +4,6 @@ import { graphql, HttpResponse } from 'msw'
 import { setupServer } from 'msw/node'
 import { MemoryRouter, Route } from 'react-router-dom'
 
-import { TierNames } from 'services/tier'
-
 import FilesChangedTab from './FilesChangedTab'
 
 vi.mock('./FilesChanged', () => ({ default: () => 'FilesChanged' }))
@@ -15,22 +13,6 @@ vi.mock('./FilesChanged/TableTeam', () => ({
 vi.mock('../ComponentsSelector', () => ({
   default: () => 'ComponentsSelector',
 }))
-
-const mockTeamTier = {
-  owner: {
-    plan: {
-      tierName: TierNames.TEAM,
-    },
-  },
-}
-
-const mockProTier = {
-  owner: {
-    plan: {
-      tierName: TierNames.PRO,
-    },
-  },
-}
 
 const mockCompareData = {
   owner: {
@@ -102,19 +84,15 @@ afterAll(() => {
 })
 
 interface SetupArgs {
-  planValue: (typeof TierNames)[keyof typeof TierNames]
+  isTeamPlan: boolean
   privateRepo: boolean
 }
 
 describe('FilesChangedTab', () => {
-  function setup({ planValue, privateRepo }: SetupArgs) {
+  function setup({ isTeamPlan, privateRepo }: SetupArgs) {
     server.use(
-      graphql.query('OwnerTier', () => {
-        if (planValue === TierNames.TEAM) {
-          return HttpResponse.json({ data: mockTeamTier })
-        }
-
-        return HttpResponse.json({ data: mockProTier })
+      graphql.query('OwnerPlan', () => {
+        return HttpResponse.json({ data: { owner: { plan: { isTeamPlan } } } })
       }),
       graphql.query('GetPullTeam', () => {
         return HttpResponse.json({ data: mockCompareData })
@@ -147,13 +125,13 @@ describe('FilesChangedTab', () => {
   }
 
   describe.each`
-    planValue          | privateRepo
-    ${TierNames.BASIC} | ${true}
-    ${TierNames.BASIC} | ${false}
-    ${TierNames.TEAM}  | ${false}
-  `('renders the full files changed table', ({ planValue, privateRepo }) => {
-    it(`planValue: ${planValue}, privateRepo: ${privateRepo}`, async () => {
-      setup({ planValue, privateRepo })
+    isTeamPlan | privateRepo
+    ${false}   | ${true}
+    ${false}   | ${false}
+    ${true}    | ${false}
+  `('renders the full files changed table', ({ isTeamPlan, privateRepo }) => {
+    it(`isTeamPlan: ${isTeamPlan}, privateRepo: ${privateRepo}`, async () => {
+      setup({ isTeamPlan, privateRepo })
       render(<FilesChangedTab />, { wrapper })
 
       const table = await screen.findByText('FilesChanged')
@@ -162,11 +140,11 @@ describe('FilesChangedTab', () => {
   })
 
   describe.each`
-    planValue         | privateRepo
-    ${TierNames.TEAM} | ${true}
-  `('renders the team files changed table', ({ planValue, privateRepo }) => {
-    it(`planValue: ${planValue}, privateRepo: ${privateRepo}`, async () => {
-      setup({ planValue, privateRepo })
+    isTeamPlan | privateRepo
+    ${true}    | ${true}
+  `('renders the team files changed table', ({ isTeamPlan, privateRepo }) => {
+    it(`isTeamPlan: ${isTeamPlan}, privateRepo: ${privateRepo}`, async () => {
+      setup({ isTeamPlan, privateRepo })
       render(<FilesChangedTab />, { wrapper })
 
       const table = await screen.findByText('TeamFilesChanged')
@@ -177,7 +155,7 @@ describe('FilesChangedTab', () => {
   describe('when impacted files is rendered', () => {
     it('renders ComponentsSelector', async () => {
       setup({
-        planValue: TierNames.BASIC,
+        isTeamPlan: false,
         privateRepo: true,
       })
       render(<FilesChangedTab />, { wrapper })

--- a/src/pages/PullRequestPage/PullCoverage/routes/FilesChangedTab/FilesChangedTab.tsx
+++ b/src/pages/PullRequestPage/PullCoverage/routes/FilesChangedTab/FilesChangedTab.tsx
@@ -3,7 +3,7 @@ import { useParams } from 'react-router-dom'
 
 import ToggleHeader from 'pages/PullRequestPage/Header/ToggleHeader/ToggleHeader'
 import { useRepoSettingsTeam } from 'services/repo'
-import { TierNames, useTier } from 'services/tier'
+import { useIsTeamPlan } from 'services/useIsTeamPlan'
 import Spinner from 'ui/Spinner'
 
 const FilesChangedTable = lazy(() => import('./FilesChanged'))
@@ -24,13 +24,13 @@ function FilesChangedTab() {
   const { provider, owner } = useParams<URLParams>()
 
   const { data: repoSettingsTeam } = useRepoSettingsTeam()
-  const { data: tierData, isLoading } = useTier({ provider, owner })
+  const { data: isTeamPlan, isLoading } = useIsTeamPlan({ provider, owner })
 
   if (isLoading) {
     return <Loader />
   }
 
-  if (tierData === TierNames.TEAM && repoSettingsTeam?.repository?.private) {
+  if (isTeamPlan && repoSettingsTeam?.repository?.private) {
     return (
       <Suspense fallback={<Loader />}>
         <ToggleHeader />

--- a/src/pages/PullRequestPage/PullCoverage/routes/IndirectChangesTab/IndirectChangedFiles/IndirectChangedFiles.test.tsx
+++ b/src/pages/PullRequestPage/PullCoverage/routes/IndirectChangesTab/IndirectChangedFiles/IndirectChangedFiles.test.tsx
@@ -229,7 +229,7 @@ describe('IndirectChangedFiles', () => {
       graphql.query('BackfillFlagMemberships', () => {
         return HttpResponse.json({ data: { owner: null } })
       }),
-      graphql.query('OwnerPlan', () => {
+      graphql.query('IsTeamPlan', () => {
         return HttpResponse.json({ data: { owner: null } })
       })
     )

--- a/src/pages/PullRequestPage/PullCoverage/routes/IndirectChangesTab/IndirectChangedFiles/IndirectChangedFiles.test.tsx
+++ b/src/pages/PullRequestPage/PullCoverage/routes/IndirectChangesTab/IndirectChangedFiles/IndirectChangedFiles.test.tsx
@@ -229,7 +229,7 @@ describe('IndirectChangedFiles', () => {
       graphql.query('BackfillFlagMemberships', () => {
         return HttpResponse.json({ data: { owner: null } })
       }),
-      graphql.query('OwnerTier', () => {
+      graphql.query('OwnerPlan', () => {
         return HttpResponse.json({ data: { owner: null } })
       })
     )

--- a/src/pages/PullRequestPage/PullRequestPage.test.tsx
+++ b/src/pages/PullRequestPage/PullRequestPage.test.tsx
@@ -236,7 +236,7 @@ describe('PullRequestPage', () => {
       graphql.query('GetRepoOverview', () => {
         return HttpResponse.json({ data: mockOverview(privateRepo) })
       }),
-      graphql.query('OwnerPlan', () => {
+      graphql.query('IsTeamPlan', () => {
         return HttpResponse.json({
           data: {
             owner: { plan: { isTeamPlan } },

--- a/src/pages/PullRequestPage/PullRequestPage.test.tsx
+++ b/src/pages/PullRequestPage/PullRequestPage.test.tsx
@@ -10,7 +10,6 @@ import { Suspense } from 'react'
 import { MemoryRouter, Route } from 'react-router-dom'
 
 import { RepoBreadcrumbProvider } from 'pages/RepoPage/context'
-import { TierNames, TTierNames } from 'services/tier'
 
 import PullRequestPage from './PullRequestPage'
 
@@ -187,7 +186,7 @@ afterAll(() => {
 
 interface SetupArgs {
   pullData?: typeof mockPullPageData | null
-  tierValue?: TTierNames
+  isTeamPlan?: boolean
   privateRepo?: boolean
   coverageEnabled?: boolean
   bundleAnalysisEnabled?: boolean
@@ -196,7 +195,7 @@ interface SetupArgs {
 describe('PullRequestPage', () => {
   function setup({
     pullData = mockPullPageData,
-    tierValue = TierNames.BASIC,
+    isTeamPlan = false,
     privateRepo = false,
     coverageEnabled = true,
     bundleAnalysisEnabled = false,
@@ -237,10 +236,10 @@ describe('PullRequestPage', () => {
       graphql.query('GetRepoOverview', () => {
         return HttpResponse.json({ data: mockOverview(privateRepo) })
       }),
-      graphql.query('OwnerTier', () => {
+      graphql.query('OwnerPlan', () => {
         return HttpResponse.json({
           data: {
-            owner: { plan: { tierName: tierValue } },
+            owner: { plan: { isTeamPlan } },
           },
         })
       }),

--- a/src/pages/PullRequestPage/PullRequestPage.tsx
+++ b/src/pages/PullRequestPage/PullRequestPage.tsx
@@ -6,7 +6,7 @@ import { useLocation, useParams } from 'react-router-dom'
 import NotFound from 'pages/NotFound'
 import { useCrumbs } from 'pages/RepoPage/context'
 import { useRepoOverview } from 'services/repo'
-import { TierNames, useTier } from 'services/tier'
+import { useIsTeamPlan } from 'services/useIsTeamPlan'
 import Icon from 'ui/Icon'
 import Spinner from 'ui/Spinner'
 import SummaryDropdown from 'ui/SummaryDropdown'
@@ -90,7 +90,7 @@ function PullRequestPage() {
   const location = useLocation()
   const { provider, owner, repo, pullId } = useParams<URLParams>()
   const { data: overview } = useRepoOverview({ provider, owner, repo })
-  const { data: tierData } = useTier({ provider, owner })
+  const { data: isTeamPlan } = useIsTeamPlan({ provider, owner })
 
   usePRPageBreadCrumbs({
     owner,
@@ -99,15 +99,13 @@ function PullRequestPage() {
     isPrivate: overview?.private ?? false,
   })
 
-  const isTeamPlan = tierData === TierNames.TEAM && overview?.private
-
   const { data, isPending } = useSuspenseQueryV5(
     PullPageDataQueryOpts({
       provider,
       owner,
       repo,
       pullId,
-      isTeamPlan,
+      isTeamPlan: (isTeamPlan && overview?.private) ?? false,
     })
   )
 

--- a/src/pages/RepoPage/CommitsTab/CommitsTab.test.jsx
+++ b/src/pages/RepoPage/CommitsTab/CommitsTab.test.jsx
@@ -6,8 +6,6 @@ import { setupServer } from 'msw/node'
 import { Suspense } from 'react'
 import { MemoryRouter, Route } from 'react-router-dom'
 
-import { TierNames } from 'services/useIsTeamPlan'
-
 import CommitsTab from './CommitsTab'
 
 import { RepoBreadcrumbProvider } from '../context'
@@ -509,7 +507,6 @@ describe('CommitsTab', () => {
           const { user } = setup({
             hasNextPage: false,
             returnBranch: 'main',
-            tierValue: TierNames.TEAM,
             isPrivate: true,
           })
           render(<CommitsTab />, { wrapper })
@@ -537,7 +534,6 @@ describe('CommitsTab', () => {
           const { user } = setup({
             hasNextPage: false,
             returnBranch: 'main',
-            tierValue: TierNames.TEAM,
             isPrivate: true,
           })
           render(<CommitsTab />, { wrapper })
@@ -563,7 +559,7 @@ describe('CommitsTab', () => {
 
     describe('user selects from the CI states multiselect', () => {
       it('selects the option', async () => {
-        const { user } = setup({ tierValue: TierNames.TEAM, isPrivate: true })
+        const { user } = setup({ isPrivate: true })
         render(<CommitsTab />, { wrapper })
 
         const select = await screen.findByRole('button', {
@@ -586,7 +582,7 @@ describe('CommitsTab', () => {
       it('fetches request with search term', async () => {
         const { branchSearch, user } = setup({
           hasNextPage: false,
-          tierValue: TierNames.TEAM,
+
           isPrivate: true,
         })
         render(<CommitsTab />, { wrapper })
@@ -606,7 +602,7 @@ describe('CommitsTab', () => {
       it('hides All branches from list', async () => {
         const { branchSearch, user } = setup({
           hasNextPage: false,
-          tierValue: TierNames.TEAM,
+
           isPrivate: true,
         })
         render(<CommitsTab />, { wrapper })
@@ -630,7 +626,7 @@ describe('CommitsTab', () => {
       it('fetches commits request with search term', async () => {
         const { commitSearch, user } = setup({
           hasNextPage: false,
-          tierValue: TierNames.TEAM,
+
           isPrivate: true,
         })
         render(<CommitsTab />, { wrapper })

--- a/src/pages/RepoPage/CommitsTab/CommitsTab.test.jsx
+++ b/src/pages/RepoPage/CommitsTab/CommitsTab.test.jsx
@@ -6,7 +6,7 @@ import { setupServer } from 'msw/node'
 import { Suspense } from 'react'
 import { MemoryRouter, Route } from 'react-router-dom'
 
-import { TierNames } from 'services/tier'
+import { TierNames } from 'services/useIsTeamPlan'
 
 import CommitsTab from './CommitsTab'
 

--- a/src/pages/RepoPage/ConfigTab/tabs/ConfigurationManager/ConfigurationManager.test.tsx
+++ b/src/pages/RepoPage/ConfigTab/tabs/ConfigurationManager/ConfigurationManager.test.tsx
@@ -11,8 +11,6 @@ import { Suspense } from 'react'
 import { Toaster } from 'react-hot-toast'
 import { MemoryRouter, Route } from 'react-router'
 
-import { TierNames, TierNamesType } from 'services/useIsTeamPlan'
-
 import ConfigurationManager from './ConfigurationManager'
 import { RepositoryConfiguration } from './hooks/useRepoConfigurationStatus/RepoConfigurationStatusQueryOpts'
 
@@ -25,7 +23,7 @@ vi.mock('shared/featureFlags', () => ({
 }))
 
 interface mockRepoConfigArgs {
-  tierName?: TierNamesType
+  isTeamPlan?: boolean
   flags?: boolean
   components?: boolean
   coverage?: boolean
@@ -38,7 +36,7 @@ interface mockRepoConfigArgs {
 const yamlWithProjectStatus = 'coverage:\n  status:\n    project: true\n'
 
 function mockRepoConfig({
-  tierName = TierNames.PRO,
+  isTeamPlan = false,
   flags = false,
   components = false,
   coverage = false,
@@ -49,7 +47,7 @@ function mockRepoConfig({
 }: mockRepoConfigArgs): RepositoryConfiguration {
   return {
     plan: {
-      tierName: tierName,
+      isTeamPlan,
     },
     repository: {
       __typename: 'Repository',
@@ -264,7 +262,7 @@ describe('Configuration Manager', () => {
 
     describe('when not on team plan', () => {
       it('does not render upgrade to pro messaging', async () => {
-        setup({ repoConfig: mockRepoConfig({ tierName: 'pro' }) })
+        setup({ repoConfig: mockRepoConfig({ isTeamPlan: false }) })
         render(<ConfigurationManager />, { wrapper })
 
         await waitFor(() =>
@@ -278,7 +276,7 @@ describe('Configuration Manager', () => {
 
     describe('when on team plan', () => {
       it('renders upgrade to pro message', async () => {
-        setup({ repoConfig: mockRepoConfig({ tierName: 'team' }) })
+        setup({ repoConfig: mockRepoConfig({ isTeamPlan: true }) })
         render(<ConfigurationManager />, { wrapper })
 
         const upgrade = await screen.findByText('Available with Pro Plan')
@@ -288,7 +286,7 @@ describe('Configuration Manager', () => {
       it('hides configured status for pro only items', async () => {
         setup({
           repoConfig: mockRepoConfig({
-            tierName: 'team',
+            isTeamPlan: true,
             coverage: true,
             yaml: yamlWithProjectStatus,
             flags: true,
@@ -303,7 +301,7 @@ describe('Configuration Manager', () => {
 
       it('hides unconfigured status for pro only items', async () => {
         setup({
-          repoConfig: mockRepoConfig({ tierName: 'team', coverage: true }),
+          repoConfig: mockRepoConfig({ isTeamPlan: true, coverage: true }),
         })
         render(<ConfigurationManager />, { wrapper })
 

--- a/src/pages/RepoPage/ConfigTab/tabs/ConfigurationManager/ConfigurationManager.test.tsx
+++ b/src/pages/RepoPage/ConfigTab/tabs/ConfigurationManager/ConfigurationManager.test.tsx
@@ -11,7 +11,7 @@ import { Suspense } from 'react'
 import { Toaster } from 'react-hot-toast'
 import { MemoryRouter, Route } from 'react-router'
 
-import { TierNames, TTierNames } from 'services/tier'
+import { TierNames, TierNamesType } from 'services/useIsTeamPlan'
 
 import ConfigurationManager from './ConfigurationManager'
 import { RepositoryConfiguration } from './hooks/useRepoConfigurationStatus/RepoConfigurationStatusQueryOpts'
@@ -25,7 +25,7 @@ vi.mock('shared/featureFlags', () => ({
 }))
 
 interface mockRepoConfigArgs {
-  tierName?: TTierNames
+  tierName?: TierNamesType
   flags?: boolean
   components?: boolean
   coverage?: boolean

--- a/src/pages/RepoPage/ConfigTab/tabs/ConfigurationManager/ConfigurationManager.tsx
+++ b/src/pages/RepoPage/ConfigTab/tabs/ConfigurationManager/ConfigurationManager.tsx
@@ -3,7 +3,7 @@ import { useState } from 'react'
 import { useParams } from 'react-router'
 
 import { ConfigureCachedBundleModal } from 'pages/RepoPage/shared/ConfigureCachedBundleModal/ConfigureCachedBundleModal'
-import { TierNames } from 'services/tier'
+import { TierNames } from 'services/useIsTeamPlan'
 import { useFlags } from 'shared/featureFlags'
 import Icon from 'ui/Icon'
 

--- a/src/pages/RepoPage/ConfigTab/tabs/ConfigurationManager/ConfigurationManager.tsx
+++ b/src/pages/RepoPage/ConfigTab/tabs/ConfigurationManager/ConfigurationManager.tsx
@@ -3,7 +3,6 @@ import { useState } from 'react'
 import { useParams } from 'react-router'
 
 import { ConfigureCachedBundleModal } from 'pages/RepoPage/shared/ConfigureCachedBundleModal/ConfigureCachedBundleModal'
-import { TierNames } from 'services/useIsTeamPlan'
 import { useFlags } from 'shared/featureFlags'
 import Icon from 'ui/Icon'
 
@@ -48,7 +47,7 @@ interface ConfigurationGroupProps {
 
 function CoverageConfiguration({ repoConfiguration }: ConfigurationGroupProps) {
   const coverageEnabled = !!repoConfiguration?.repository?.coverageEnabled
-  const isTeamPlan = repoConfiguration?.plan?.tierName === TierNames.TEAM
+  const isTeamPlan = repoConfiguration?.plan?.isTeamPlan
   const yaml = repoConfiguration?.repository?.yaml
   const hasProjectStatus = !!yaml && yaml.includes('project:')
   const hasFlags =

--- a/src/pages/RepoPage/ConfigTab/tabs/ConfigurationManager/hooks/useRepoConfigurationStatus/RepoConfigurationStatusQueryOpts.test.tsx
+++ b/src/pages/RepoPage/ConfigTab/tabs/ConfigurationManager/hooks/useRepoConfigurationStatus/RepoConfigurationStatusQueryOpts.test.tsx
@@ -36,7 +36,7 @@ const mockNullOwner = {
 const mockGoodResponse = {
   owner: {
     plan: {
-      tierName: 'pro',
+      isTeamPlan: false,
     },
     repository: {
       __typename: 'Repository',
@@ -226,7 +226,7 @@ describe('RepoConfigurationStatusQueryOpts', () => {
     await waitFor(() =>
       expect(result.current.data).toMatchObject({
         plan: {
-          tierName: 'pro',
+          isTeamPlan: false,
         },
         repository: {
           __typename: 'Repository',

--- a/src/pages/RepoPage/ConfigTab/tabs/ConfigurationManager/hooks/useRepoConfigurationStatus/RepoConfigurationStatusQueryOpts.tsx
+++ b/src/pages/RepoPage/ConfigTab/tabs/ConfigurationManager/hooks/useRepoConfigurationStatus/RepoConfigurationStatusQueryOpts.tsx
@@ -5,7 +5,6 @@ import {
   RepoNotFoundErrorSchema,
   RepoOwnerNotActivatedErrorSchema,
 } from 'services/repo'
-import { TierNames } from 'services/useIsTeamPlan'
 import Api from 'shared/api/api'
 import { rejectNetworkError } from 'shared/api/helpers'
 import A from 'ui/A'
@@ -27,7 +26,7 @@ const RepositorySchema = z.object({
 
 const PlanSchema = z
   .object({
-    tierName: z.nativeEnum(TierNames),
+    isTeamPlan: z.boolean(),
   })
   .nullable()
 
@@ -55,7 +54,7 @@ const query = `
 query GetRepoConfigurationStatus($owner: String!, $repo: String!) {
   owner(username: $owner) {
     plan {
-      tierName
+      isTeamPlan
     }
     repository(name:$repo) {
       __typename

--- a/src/pages/RepoPage/ConfigTab/tabs/ConfigurationManager/hooks/useRepoConfigurationStatus/RepoConfigurationStatusQueryOpts.tsx
+++ b/src/pages/RepoPage/ConfigTab/tabs/ConfigurationManager/hooks/useRepoConfigurationStatus/RepoConfigurationStatusQueryOpts.tsx
@@ -5,7 +5,7 @@ import {
   RepoNotFoundErrorSchema,
   RepoOwnerNotActivatedErrorSchema,
 } from 'services/repo'
-import { TierNames } from 'services/tier'
+import { TierNames } from 'services/useIsTeamPlan'
 import Api from 'shared/api/api'
 import { rejectNetworkError } from 'shared/api/helpers'
 import A from 'ui/A'

--- a/src/pages/RepoPage/ConfigTab/tabs/GeneralTab/GeneralTab.jsx
+++ b/src/pages/RepoPage/ConfigTab/tabs/GeneralTab/GeneralTab.jsx
@@ -1,6 +1,6 @@
 import { useParams } from 'react-router-dom'
 
-import { TierNames, useTier } from 'services/tier'
+import { useIsTeamPlan } from 'services/useIsTeamPlan'
 
 import DangerZone from './DangerZone'
 import DefaultBranch from './DefaultBranch'
@@ -14,10 +14,10 @@ function GeneralTab() {
     owner,
     repo,
   })
-  const { data: tierData } = useTier({ provider, owner })
+  const { data: isTeamPlan } = useIsTeamPlan({ provider, owner })
   const defaultBranch = repoData?.defaultBranch
   const isPrivate = repoData?.private
-  const showTokensTeam = isPrivate && tierData === TierNames.TEAM
+  const showTokensTeam = isPrivate && isTeamPlan
 
   return (
     <div className="flex flex-col gap-6 lg:w-3/4">

--- a/src/pages/RepoPage/ConfigTab/tabs/GeneralTab/GeneralTab.test.jsx
+++ b/src/pages/RepoPage/ConfigTab/tabs/GeneralTab/GeneralTab.test.jsx
@@ -77,7 +77,7 @@ describe('GeneralTab', () => {
           },
         })
       }),
-      graphql.query('OwnerPlan', () => {
+      graphql.query('IsTeamPlan', () => {
         return HttpResponse.json({
           data: { owner: { plan: { isTeamPlan } } },
         })

--- a/src/pages/RepoPage/ConfigTab/tabs/GeneralTab/GeneralTab.test.jsx
+++ b/src/pages/RepoPage/ConfigTab/tabs/GeneralTab/GeneralTab.test.jsx
@@ -4,8 +4,6 @@ import { graphql, HttpResponse } from 'msw'
 import { setupServer } from 'msw/node'
 import { MemoryRouter, Route } from 'react-router-dom'
 
-import { TierNames } from 'services/tier'
-
 import GeneralTab from './GeneralTab'
 
 vi.mock('./Tokens/TokensTeam', () => ({
@@ -46,13 +44,10 @@ afterAll(() => server.close())
 
 describe('GeneralTab', () => {
   function setup(
-    {
-      hasDefaultBranch = false,
-      tierValue = TierNames.PRO,
-      isPrivate = false,
-    } = {
+    { hasDefaultBranch = false, isTeamPlan = false, isPrivate = false } = {
       hasDefaultBranch: false,
-      tierValue: TierNames.PRO,
+      isTeamPlan: false,
+      isPrivate: false,
     }
   ) {
     server.use(
@@ -82,14 +77,9 @@ describe('GeneralTab', () => {
           },
         })
       }),
-      graphql.query('OwnerTier', () => {
-        if (tierValue === TierNames.TEAM) {
-          return HttpResponse.json({
-            data: { owner: { plan: { tierName: TierNames.TEAM } } },
-          })
-        }
+      graphql.query('OwnerPlan', () => {
         return HttpResponse.json({
-          data: { owner: { plan: { tierName: TierNames.PRO } } },
+          data: { owner: { plan: { isTeamPlan } } },
         })
       })
     )
@@ -123,7 +113,7 @@ describe('GeneralTab', () => {
     })
 
     it('render tokens component', () => {
-      setup({ tierValue: TierNames.TEAM })
+      setup({ isTeamPlan: true })
       render(<GeneralTab />, { wrapper })
 
       const tokensComponent = screen.getByText(/Tokens Component/)
@@ -131,7 +121,7 @@ describe('GeneralTab', () => {
     })
 
     it('render danger zone component', () => {
-      setup({ tierValue: TierNames.TEAM })
+      setup({ isTeamPlan: true })
       render(<GeneralTab />, { wrapper })
 
       const tokensComponent = screen.getByText(/DangerZone Component/)
@@ -139,10 +129,10 @@ describe('GeneralTab', () => {
     })
   })
 
-  describe('when rendered with team tier', () => {
+  describe('when rendered with team plan', () => {
     describe('when the repository is private', () => {
       beforeEach(() => {
-        setup({ tierValue: TierNames.TEAM, isPrivate: true })
+        setup({ isTeamPlan: true, isPrivate: true })
       })
 
       it('render tokens team component', async () => {
@@ -162,7 +152,7 @@ describe('GeneralTab', () => {
 
     describe('when the repository is public', () => {
       beforeEach(() => {
-        setup({ tierValue: TierNames.TEAM, isPrivate: false })
+        setup({ isTeamPlan: true, isPrivate: false })
       })
 
       it('render tokens component', () => {

--- a/src/pages/RepoPage/CoverageTab/ComponentsTab/ComponentsTab.test.tsx
+++ b/src/pages/RepoPage/CoverageTab/ComponentsTab/ComponentsTab.test.tsx
@@ -6,8 +6,6 @@ import { setupServer } from 'msw/node'
 import React from 'react'
 import { MemoryRouter, Route } from 'react-router-dom'
 
-import { TierNames, TTierNames } from 'services/tier'
-
 import ComponentsTab from './ComponentsTab'
 
 vi.mock('./BackfillBanners/TriggerSyncBanner/TriggerSyncBanner.tsx', () => ({
@@ -161,25 +159,20 @@ describe('Components Tab', () => {
   function setup({
     data = {},
     flags = [nextPageFlagData, initialFlagData],
-    tierValue = TierNames.PRO,
+    isTeamPlan = false,
     isPrivate = false,
     isCurrentUserPartOfOrg = true,
   }: {
     data?: object
     flags?: any[]
-    tierValue?: TTierNames
+    isTeamPlan?: boolean
     isPrivate?: boolean
     isCurrentUserPartOfOrg?: boolean
   }) {
     server.use(
-      graphql.query('OwnerTier', () => {
-        if (tierValue === TierNames.TEAM) {
-          return HttpResponse.json({
-            data: { owner: { plan: { tierName: TierNames.TEAM } } },
-          })
-        }
+      graphql.query('OwnerPlan', () => {
         return HttpResponse.json({
-          data: { owner: { plan: { tierName: TierNames.PRO } } },
+          data: { owner: { plan: { isTeamPlan } } },
         })
       }),
       graphql.query('GetRepoSettingsTeam', () => {
@@ -216,7 +209,7 @@ describe('Components Tab', () => {
     describe('the repo is public', () => {
       it('renders the components tab', async () => {
         setup({
-          tierValue: TierNames.TEAM,
+          isTeamPlan: true,
           isPrivate: false,
           data: backfillDataCompleted,
         })
@@ -229,7 +222,7 @@ describe('Components Tab', () => {
 
     describe('the repo is private', () => {
       it('redirects to the coverage tab', async () => {
-        setup({ tierValue: TierNames.TEAM, isPrivate: true })
+        setup({ isTeamPlan: true, isPrivate: true })
         render(<ComponentsTab />, { wrapper })
 
         await waitFor(() =>

--- a/src/pages/RepoPage/CoverageTab/ComponentsTab/ComponentsTab.test.tsx
+++ b/src/pages/RepoPage/CoverageTab/ComponentsTab/ComponentsTab.test.tsx
@@ -170,7 +170,7 @@ describe('Components Tab', () => {
     isCurrentUserPartOfOrg?: boolean
   }) {
     server.use(
-      graphql.query('OwnerPlan', () => {
+      graphql.query('IsTeamPlan', () => {
         return HttpResponse.json({
           data: { owner: { plan: { isTeamPlan } } },
         })

--- a/src/pages/RepoPage/CoverageTab/ComponentsTab/ComponentsTab.tsx
+++ b/src/pages/RepoPage/CoverageTab/ComponentsTab/ComponentsTab.tsx
@@ -3,7 +3,7 @@ import { Redirect, useParams } from 'react-router-dom'
 import { SentryRoute } from 'sentry'
 
 import { useRepoSettingsTeam } from 'services/repo'
-import { TierNames, useTier } from 'services/tier'
+import { useIsTeamPlan } from 'services/useIsTeamPlan'
 
 import BackfillBanners from './BackfillBanners/BackfillBanners'
 import { useRepoBackfillingStatus } from './BackfillBanners/useRepoBackfillingStatus'
@@ -38,7 +38,7 @@ interface URLParams {
 
 function ComponentsTab() {
   const { provider, owner, repo } = useParams<URLParams>()
-  const { data: tierData } = useTier({ owner, provider })
+  const { data: isTeamPlan } = useIsTeamPlan({ owner, provider })
   const { data: repoSettings } = useRepoSettingsTeam()
 
   const {
@@ -48,7 +48,7 @@ function ComponentsTab() {
     isTimescaleEnabled,
   } = useRepoBackfillingStatus()
 
-  if (tierData === TierNames.TEAM && repoSettings?.repository?.private) {
+  if (isTeamPlan && repoSettings?.repository?.private) {
     return <Redirect to={`/${provider}/${owner}/${repo}`} />
   }
 

--- a/src/pages/RepoPage/CoverageTab/CoverageTab.test.tsx
+++ b/src/pages/RepoPage/CoverageTab/CoverageTab.test.tsx
@@ -92,7 +92,7 @@ interface SetupArgs {
 describe('CoverageTab', () => {
   function setup({ isTeamPlan = false }: SetupArgs) {
     server.use(
-      graphql.query('OwnerPlan', () => {
+      graphql.query('IsTeamPlan', () => {
         return HttpResponse.json({ data: { owner: { plan: { isTeamPlan } } } })
       }),
       graphql.query('GetRepoSettingsTeam', () => {

--- a/src/pages/RepoPage/CoverageTab/CoverageTab.test.tsx
+++ b/src/pages/RepoPage/CoverageTab/CoverageTab.test.tsx
@@ -6,8 +6,6 @@ import { setupServer } from 'msw/node'
 import { Suspense } from 'react'
 import { MemoryRouter, Route, useLocation } from 'react-router-dom'
 
-import { TierNames, TTierNames } from 'services/tier'
-
 import CoverageTab from './CoverageTab'
 
 const mockRepoSettingsTeam = {
@@ -88,14 +86,14 @@ afterAll(() => {
 })
 
 interface SetupArgs {
-  tierName?: TTierNames
+  isTeamPlan?: boolean
 }
 
 describe('CoverageTab', () => {
-  function setup({ tierName = TierNames.PRO }: SetupArgs) {
+  function setup({ isTeamPlan = false }: SetupArgs) {
     server.use(
-      graphql.query('OwnerTier', () => {
-        return HttpResponse.json({ data: { owner: { plan: { tierName } } } })
+      graphql.query('OwnerPlan', () => {
+        return HttpResponse.json({ data: { owner: { plan: { isTeamPlan } } } })
       }),
       graphql.query('GetRepoSettingsTeam', () => {
         return HttpResponse.json({ data: mockRepoSettingsTeam })
@@ -119,7 +117,7 @@ describe('CoverageTab', () => {
   })
 
   it('hides navigator when on team plan and private repo', async () => {
-    setup({ tierName: TierNames.TEAM })
+    setup({ isTeamPlan: true })
     render(<CoverageTab />, { wrapper: wrapper() })
 
     const overview = await screen.findByText('OverviewTab')

--- a/src/pages/RepoPage/CoverageTab/CoverageTab.tsx
+++ b/src/pages/RepoPage/CoverageTab/CoverageTab.tsx
@@ -4,7 +4,7 @@ import { Switch, useParams } from 'react-router-dom'
 import { SentryRoute } from 'sentry'
 
 import { useRepoSettingsTeam } from 'services/repo'
-import { TierNames, useTier } from 'services/tier'
+import { useIsTeamPlan } from 'services/useIsTeamPlan'
 import LoadingLogo from 'ui/LoadingLogo'
 
 import { CoverageTabNavigator } from './CoverageTabNavigator'
@@ -28,14 +28,13 @@ interface URLParams {
 
 function CoverageTab() {
   const { provider, owner } = useParams<URLParams>()
-  const { data: tierData } = useTier({
+  const { data: isTeamPlan } = useIsTeamPlan({
     owner,
     provider,
   })
   const { data: repoSettings } = useRepoSettingsTeam()
 
-  const hideNavigator =
-    tierData === TierNames.TEAM && repoSettings?.repository?.private
+  const hideNavigator = isTeamPlan && repoSettings?.repository?.private
 
   return (
     <div className="flex flex-col gap-2 divide-y">

--- a/src/pages/RepoPage/CoverageTab/FlagsTab/FlagsTab.jsx
+++ b/src/pages/RepoPage/CoverageTab/FlagsTab/FlagsTab.jsx
@@ -3,7 +3,7 @@ import { Redirect, useParams } from 'react-router-dom'
 import { SentryRoute } from 'sentry'
 
 import { useRepoFlagsSelect, useRepoSettingsTeam } from 'services/repo'
-import { TierNames, useTier } from 'services/tier'
+import { useIsTeamPlan } from 'services/useIsTeamPlan'
 import FlagsNotConfigured from 'shared/FlagsNotConfigured'
 
 import blurredTable from './assets/blurredTable.png'
@@ -30,7 +30,7 @@ const showFlagsData = ({ flagsData }) => {
 function FlagsTab() {
   const { data: flagsData } = useRepoFlagsSelect()
   const { provider, owner, repo } = useParams()
-  const { data: tierData } = useTier({ owner, provider })
+  const { data: isTeamPlan } = useIsTeamPlan({ owner, provider })
   const { data: repoSettings } = useRepoSettingsTeam()
 
   const {
@@ -40,7 +40,7 @@ function FlagsTab() {
     isTimescaleEnabled,
   } = useRepoBackfillingStatus()
 
-  if (tierData === TierNames.TEAM && repoSettings?.repository?.private) {
+  if (isTeamPlan && repoSettings?.repository?.private) {
     return <Redirect to={`/${provider}/${owner}/${repo}`} />
   }
 

--- a/src/pages/RepoPage/CoverageTab/FlagsTab/FlagsTab.test.jsx
+++ b/src/pages/RepoPage/CoverageTab/FlagsTab/FlagsTab.test.jsx
@@ -5,8 +5,6 @@ import { graphql, HttpResponse } from 'msw'
 import { setupServer } from 'msw/node'
 import { MemoryRouter, Route } from 'react-router-dom'
 
-import { TierNames } from 'services/tier'
-
 import FlagsTab from './FlagsTab'
 
 const mocks = vi.hoisted(() => ({
@@ -105,7 +103,7 @@ describe('Flags Tab', () => {
   function setup({
     data = {},
     flags = flagsData,
-    tierValue = TierNames.PRO,
+    isTeamPlan = false,
     isPrivate = false,
     isCurrentUserPartOfOrg = true,
   }) {
@@ -113,14 +111,9 @@ describe('Flags Tab', () => {
     mocks.useRepoBackfilled.mockReturnValue(data)
 
     server.use(
-      graphql.query('OwnerTier', () => {
-        if (tierValue === TierNames.TEAM) {
-          return HttpResponse.json({
-            data: { owner: { plan: { tierName: TierNames.TEAM } } },
-          })
-        }
+      graphql.query('OwnerPlan', () => {
         return HttpResponse.json({
-          data: { owner: { plan: { tierName: TierNames.PRO } } },
+          data: { owner: { plan: { isTeamPlan } } },
         })
       }),
       graphql.query('GetRepoSettingsTeam', () => {
@@ -131,11 +124,11 @@ describe('Flags Tab', () => {
     )
   }
 
-  describe('when user has a team tier', () => {
+  describe('when user has a team plan', () => {
     describe('the repo is public', () => {
       it('renders the flags tab', async () => {
         setup({
-          tierValue: TierNames.TEAM,
+          isTeamPlan: true,
           isPrivate: false,
           data: {
             data: {
@@ -154,7 +147,7 @@ describe('Flags Tab', () => {
 
     describe('the repo is private', () => {
       it('redirects to the coverage tab', async () => {
-        setup({ tierValue: TierNames.TEAM, isPrivate: true })
+        setup({ isTeamPlan: true, isPrivate: true })
         render(<FlagsTab />, { wrapper })
 
         await waitFor(() =>

--- a/src/pages/RepoPage/CoverageTab/FlagsTab/FlagsTab.test.jsx
+++ b/src/pages/RepoPage/CoverageTab/FlagsTab/FlagsTab.test.jsx
@@ -111,7 +111,7 @@ describe('Flags Tab', () => {
     mocks.useRepoBackfilled.mockReturnValue(data)
 
     server.use(
-      graphql.query('OwnerPlan', () => {
+      graphql.query('IsTeamPlan', () => {
         return HttpResponse.json({
           data: { owner: { plan: { isTeamPlan } } },
         })

--- a/src/pages/RepoPage/CoverageTab/OverviewTab/OverviewTab.test.tsx
+++ b/src/pages/RepoPage/CoverageTab/OverviewTab/OverviewTab.test.tsx
@@ -4,8 +4,6 @@ import { graphql, http, HttpResponse } from 'msw'
 import { setupServer } from 'msw/node'
 import { MemoryRouter, Route } from 'react-router-dom'
 
-import { TierNames, TTierNames } from 'services/tier'
-
 import CoverageOverviewTab from './OverviewTab'
 
 declare global {
@@ -329,7 +327,7 @@ afterAll(() => {
 interface SetupArgs {
   isFirstPullRequest?: boolean
   isPrivate?: boolean
-  tierValue?: TTierNames
+  isTeamPlan?: boolean
   fileCount?: number
 }
 
@@ -337,7 +335,7 @@ describe('Coverage overview tab', () => {
   function setup({
     isFirstPullRequest = false,
     isPrivate = false,
-    tierValue = TierNames.PRO,
+    isTeamPlan = false,
     fileCount = 10,
   }: SetupArgs) {
     server.use(
@@ -374,9 +372,9 @@ describe('Coverage overview tab', () => {
       graphql.query('BackfillFlagMemberships', () => {
         return HttpResponse.json({ data: mockBackfillFlag })
       }),
-      graphql.query('OwnerTier', () => {
+      graphql.query('OwnerPlan', () => {
         return HttpResponse.json({
-          data: { owner: { plan: { tierName: tierValue } } },
+          data: { owner: { plan: { isTeamPlan } } },
         })
       }),
       graphql.query('GetRepoSettingsTeam', () => {
@@ -459,7 +457,7 @@ describe('Coverage overview tab', () => {
 
   describe('when the repo is private and org is on team plan', () => {
     it('renders team summary', async () => {
-      setup({ isPrivate: true, tierValue: TierNames.TEAM })
+      setup({ isPrivate: true, isTeamPlan: true })
 
       render(<CoverageOverviewTab />, {
         wrapper: wrapper(['/gh/test-org/repoName']),
@@ -470,7 +468,7 @@ describe('Coverage overview tab', () => {
     })
 
     it('does not render coverage chart', async () => {
-      setup({ isPrivate: true, tierValue: TierNames.TEAM })
+      setup({ isPrivate: true, isTeamPlan: true })
 
       render(<CoverageOverviewTab />, {
         wrapper: wrapper(['/gh/test-org/repoName']),

--- a/src/pages/RepoPage/CoverageTab/OverviewTab/OverviewTab.test.tsx
+++ b/src/pages/RepoPage/CoverageTab/OverviewTab/OverviewTab.test.tsx
@@ -372,7 +372,7 @@ describe('Coverage overview tab', () => {
       graphql.query('BackfillFlagMemberships', () => {
         return HttpResponse.json({ data: mockBackfillFlag })
       }),
-      graphql.query('OwnerPlan', () => {
+      graphql.query('IsTeamPlan', () => {
         return HttpResponse.json({
           data: { owner: { plan: { isTeamPlan } } },
         })

--- a/src/pages/RepoPage/CoverageTab/OverviewTab/OverviewTab.tsx
+++ b/src/pages/RepoPage/CoverageTab/OverviewTab/OverviewTab.tsx
@@ -5,7 +5,7 @@ import { SentryRoute } from 'sentry'
 
 import SilentNetworkErrorWrapper from 'layouts/shared/SilentNetworkErrorWrapper'
 import { useRepo } from 'services/repo'
-import { TierNames, useTier } from 'services/tier'
+import { useIsTeamPlan } from 'services/useIsTeamPlan'
 import { cn } from 'shared/utils/cn'
 import Spinner from 'ui/Spinner'
 import { ToggleElement } from 'ui/ToggleElement'
@@ -43,7 +43,7 @@ function CoverageOverviewTab() {
     repo,
   })
 
-  const { data: tierName } = useTier({ provider, owner })
+  const { data: isTeamPlan } = useIsTeamPlan({ provider, owner })
 
   const { data } = useCoverageTabData({
     provider,
@@ -61,8 +61,7 @@ function CoverageOverviewTab() {
     displaySunburst = true
   }
 
-  const showTeamSummary =
-    tierName === TierNames.TEAM && repoData?.repository?.private
+  const showTeamSummary = isTeamPlan && repoData?.repository?.private
 
   return (
     <div className="mx-4 flex flex-col gap-4 divide-y border-solid border-ds-gray-secondary pt-4 sm:mx-0">

--- a/src/pages/RepoPage/CoverageTab/OverviewTab/subroute/FileExplorer/FlagMultiSelect.jsx
+++ b/src/pages/RepoPage/CoverageTab/OverviewTab/subroute/FileExplorer/FlagMultiSelect.jsx
@@ -10,7 +10,7 @@ import {
   useRepoFlagsSelect,
   useRepoSettingsTeam,
 } from 'services/repo'
-import { TierNames, useTier } from 'services/tier'
+import { useIsTeamPlan } from 'services/useIsTeamPlan'
 import Icon from 'ui/Icon'
 import MultiSelect from 'ui/MultiSelect'
 
@@ -26,7 +26,7 @@ function FlagMultiSelect() {
   const [selectedFlags, setSelectedFlags] = useState(params?.flags)
   const [flagSearch, setFlagSearch] = useState(null)
 
-  const { data: tierName } = useTier({ provider, owner })
+  const { data: isTeamPlan } = useIsTeamPlan({ provider, owner })
   const { data: repoData } = useRepoSettingsTeam()
   const { data: repoBackfilledData } = useRepoBackfilled()
 
@@ -34,8 +34,7 @@ function FlagMultiSelect() {
   const flagsMeasurementsActive = !!repoBackfilledData?.flagsMeasurementsActive
   const noFlagsPresent = eq(repoBackfilledData?.flagsCount, 0)
 
-  const hideFlagMultiSelect =
-    tierName === TierNames.TEAM && repoData?.repository?.private
+  const hideFlagMultiSelect = isTeamPlan && repoData?.repository?.private
 
   const {
     data: flagsData,

--- a/src/pages/RepoPage/CoverageTab/OverviewTab/subroute/FileExplorer/FlagMultiSelect.test.jsx
+++ b/src/pages/RepoPage/CoverageTab/OverviewTab/subroute/FileExplorer/FlagMultiSelect.test.jsx
@@ -213,7 +213,7 @@ describe('FlagMultiSelect', () => {
       graphql.query('BackfillFlagMemberships', () => {
         return HttpResponse.json({ data: backfillData })
       }),
-      graphql.query('OwnerPlan', () => {
+      graphql.query('IsTeamPlan', () => {
         return HttpResponse.json({
           data: { owner: { plan: { isTeamPlan } } },
         })

--- a/src/pages/RepoPage/CoverageTab/OverviewTab/subroute/FileExplorer/FlagMultiSelect.test.jsx
+++ b/src/pages/RepoPage/CoverageTab/OverviewTab/subroute/FileExplorer/FlagMultiSelect.test.jsx
@@ -5,8 +5,6 @@ import { graphql, HttpResponse } from 'msw'
 import { setupServer } from 'msw/node'
 import { MemoryRouter, Route } from 'react-router-dom'
 
-import { TierNames } from 'services/tier'
-
 import FlagMultiSelect from './FlagMultiSelect'
 
 const mocks = vi.hoisted(() => ({
@@ -187,13 +185,13 @@ describe('FlagMultiSelect', () => {
       isIntersecting = false,
       noNextPage = false,
       backfillData = mockBackfillHasFlagsAndActive,
-      tierValue = TierNames.PRO,
+      isTeamPlan = false,
       isPrivate = false,
     } = {
       isIntersecting: false,
       noNextPage: false,
       mockBackfillHasFlagsAndActive: mockBackfillHasFlagsAndActive,
-      tierValue: TierNames.PRO,
+      isTeamPlan: false,
       isPrivate: false,
     }
   ) {
@@ -215,9 +213,9 @@ describe('FlagMultiSelect', () => {
       graphql.query('BackfillFlagMemberships', () => {
         return HttpResponse.json({ data: backfillData })
       }),
-      graphql.query('OwnerTier', () => {
+      graphql.query('OwnerPlan', () => {
         return HttpResponse.json({
-          data: { owner: { plan: { tierName: tierValue } } },
+          data: { owner: { plan: { isTeamPlan } } },
         })
       }),
       graphql.query('GetRepoSettingsTeam', () => {
@@ -346,7 +344,7 @@ describe('FlagMultiSelect', () => {
     describe('repo is public', () => {
       it('renders multi select', async () => {
         setup({
-          tierValue: TierNames.TEAM,
+          isTeamPlan: true,
           isPrivate: false,
         })
         render(<FlagMultiSelect />, { wrapper })
@@ -358,7 +356,7 @@ describe('FlagMultiSelect', () => {
 
     describe('repo is private', () => {
       it('does not show multi select', async () => {
-        setup({ tierValue: TierNames.TEAM, isPrivate: true })
+        setup({ isTeamPlan: true, isPrivate: true })
         const { container } = render(<FlagMultiSelect />, { wrapper })
 
         await waitFor(() => queryClient.isFetching)

--- a/src/pages/RepoPage/CoverageTab/OverviewTab/subroute/Fileviewer/Fileviewer.jsx
+++ b/src/pages/RepoPage/CoverageTab/OverviewTab/subroute/Fileviewer/Fileviewer.jsx
@@ -1,7 +1,7 @@
 import { useParams } from 'react-router-dom'
 
 import { useRepoSettingsTeam } from 'services/repo'
-import { TierNames, useTier } from 'services/tier'
+import { useIsTeamPlan } from 'services/useIsTeamPlan'
 import RawFileViewer from 'shared/RawFileViewer'
 import { useTreePaths } from 'shared/treePaths'
 import { STICKY_PADDING_SIZES } from 'shared/utils/fileviewer'
@@ -12,11 +12,9 @@ function FileView() {
   const { provider, owner, ref: commit } = useParams()
   const { data: repoData } = useRepoSettingsTeam()
 
-  const { data: tierName } = useTier({ provider, owner })
+  const { data: isTeamPlan } = useIsTeamPlan({ provider, owner })
 
-  const showFlagSelector = !(
-    tierName === TierNames.TEAM && repoData?.repository?.private
-  )
+  const showFlagSelector = !(isTeamPlan && repoData?.repository?.private)
 
   return (
     <>

--- a/src/pages/RepoPage/CoverageTab/OverviewTab/subroute/Fileviewer/Fileviewer.test.jsx
+++ b/src/pages/RepoPage/CoverageTab/OverviewTab/subroute/Fileviewer/Fileviewer.test.jsx
@@ -213,7 +213,7 @@ describe('FileView', () => {
       graphql.query('FlagsSelect', () => {
         return HttpResponse.json({ data: mockFlagResponse })
       }),
-      graphql.query('OwnerPlan', () => {
+      graphql.query('IsTeamPlan', () => {
         return HttpResponse.json({
           data: { owner: { plan: { isTeamPlan } } },
         })

--- a/src/pages/RepoPage/CoverageTab/OverviewTab/subroute/Fileviewer/Fileviewer.test.jsx
+++ b/src/pages/RepoPage/CoverageTab/OverviewTab/subroute/Fileviewer/Fileviewer.test.jsx
@@ -4,8 +4,6 @@ import { graphql, HttpResponse } from 'msw'
 import { setupServer } from 'msw/node'
 import { MemoryRouter, Route } from 'react-router-dom'
 
-import { TierNames } from 'services/tier'
-
 import FileView from './Fileviewer'
 
 window.requestAnimationFrame = (cb) => {
@@ -192,8 +190,8 @@ afterAll(() => {
 
 describe('FileView', () => {
   function setup(
-    { tierName = TierNames.PRO, isPrivate = false } = {
-      tierName: TierNames.PRO,
+    { isTeamPlan = false, isPrivate = false } = {
+      isTeamPlan: false,
       isPrivate: false,
     }
   ) {
@@ -215,9 +213,9 @@ describe('FileView', () => {
       graphql.query('FlagsSelect', () => {
         return HttpResponse.json({ data: mockFlagResponse })
       }),
-      graphql.query('OwnerTier', () => {
+      graphql.query('OwnerPlan', () => {
         return HttpResponse.json({
-          data: { owner: { plan: { tierName: tierName } } },
+          data: { owner: { plan: { isTeamPlan } } },
         })
       }),
       graphql.query('GetRepoSettingsTeam', () => {
@@ -310,7 +308,7 @@ describe('FileView', () => {
       describe('on a team plan', () => {
         describe('repo is public', () => {
           it('renders the flag multi select', async () => {
-            setup({ tierName: TierNames.TEAM, isPrivate: false })
+            setup({ isTeamPlan: true, isPrivate: false })
 
             render(<FileView />, { wrapper: wrapper() })
 
@@ -321,7 +319,7 @@ describe('FileView', () => {
 
         describe('repo is private', () => {
           it('does not render the flag multi select', async () => {
-            setup({ tierName: TierNames.TEAM, isPrivate: true })
+            setup({ isTeamPlan: true, isPrivate: true })
             render(<FileView />, { wrapper: wrapper() })
 
             await waitFor(() => queryClient.isFetching)

--- a/src/pages/RepoPage/RepoPage.test.tsx
+++ b/src/pages/RepoPage/RepoPage.test.tsx
@@ -7,7 +7,6 @@ import { Suspense } from 'react'
 import { MemoryRouter, Route, useLocation } from 'react-router-dom'
 
 import NetworkErrorBoundary from 'layouts/shared/NetworkErrorBoundary'
-import { TierNames } from 'services/tier'
 
 import { RepoBreadcrumbProvider } from './context'
 import RepoPage from './RepoPage'
@@ -198,7 +197,7 @@ interface SetupArgs {
   isRepoPrivate?: boolean
   isRepoActivated?: boolean
   isRepoActive?: boolean
-  tierValue?: string
+  isTeamPlan?: boolean
   isCurrentUserActivated?: boolean
   coverageEnabled?: boolean
   bundleAnalysisEnabled?: boolean
@@ -215,7 +214,7 @@ describe('RepoPage', () => {
       isRepoPrivate = false,
       isRepoActivated = true,
       isRepoActive = true,
-      tierValue = TierNames.PRO,
+      isTeamPlan = false,
       isCurrentUserActivated = true,
       coverageEnabled = true,
       bundleAnalysisEnabled = true,
@@ -228,7 +227,7 @@ describe('RepoPage', () => {
       isRepoPrivate: false,
       isRepoActivated: true,
       isRepoActive: true,
-      tierValue: TierNames.PRO,
+      isTeamPlan: false,
       isCurrentUserActivated: true,
       coverageEnabled: true,
       bundleAnalysisEnabled: true,
@@ -261,14 +260,9 @@ describe('RepoPage', () => {
 
         return HttpResponse.json({ data: { owner: {} } })
       }),
-      graphql.query('OwnerTier', () => {
-        if (tierValue === TierNames.TEAM) {
-          return HttpResponse.json({
-            data: { owner: { plan: { tierName: TierNames.TEAM } } },
-          })
-        }
+      graphql.query('OwnerPlan', () => {
         return HttpResponse.json({
-          data: { owner: { plan: { tierName: TierNames.PRO } } },
+          data: { owner: { plan: { isTeamPlan } } },
         })
       }),
       graphql.query('GetRepoOverview', () => {

--- a/src/pages/RepoPage/RepoPage.test.tsx
+++ b/src/pages/RepoPage/RepoPage.test.tsx
@@ -260,7 +260,7 @@ describe('RepoPage', () => {
 
         return HttpResponse.json({ data: { owner: {} } })
       }),
-      graphql.query('OwnerPlan', () => {
+      graphql.query('IsTeamPlan', () => {
         return HttpResponse.json({
           data: { owner: { plan: { isTeamPlan } } },
         })

--- a/src/pages/RepoPage/RepoPageTabs.test.tsx
+++ b/src/pages/RepoPage/RepoPageTabs.test.tsx
@@ -11,8 +11,6 @@ import { setupServer } from 'msw/node'
 import { Suspense } from 'react'
 import { MemoryRouter, Route } from 'react-router-dom'
 
-import { TierNames, TTierNames } from 'services/tier'
-
 import RepoPageTabs, { useRepoTabs } from './RepoPageTabs'
 
 const mockRepoOverview = ({
@@ -121,7 +119,7 @@ interface SetupArgs {
   isRepoPrivate?: boolean
   coverageEnabled?: boolean
   bundleAnalysisEnabled?: boolean
-  tierName?: TTierNames
+  isTeamPlan?: boolean
   isCurrentUserPartOfOrg?: boolean
   testAnalyticsEnabled?: boolean
 }
@@ -132,7 +130,7 @@ describe('RepoPageTabs', () => {
     bundleAnalysisEnabled,
     coverageEnabled,
     isRepoPrivate,
-    tierName = TierNames.PRO,
+    isTeamPlan = false,
     isCurrentUserPartOfOrg = true,
     testAnalyticsEnabled = false,
   }: SetupArgs) {
@@ -149,8 +147,8 @@ describe('RepoPageTabs', () => {
         })
       }),
 
-      graphql.query('OwnerTier', () => {
-        return HttpResponse.json({ data: { owner: { plan: { tierName } } } })
+      graphql.query('OwnerPlan', () => {
+        return HttpResponse.json({ data: { owner: { plan: { isTeamPlan } } } })
       }),
       graphql.query('GetRepo', () => {
         return HttpResponse.json({ data: mockRepo({ isCurrentUserPartOfOrg }) })
@@ -440,7 +438,7 @@ describe('useRepoTabs', () => {
     coverageEnabled,
     testAnalyticsEnabled = false,
     isRepoPrivate,
-    tierName = TierNames.PRO,
+    isTeamPlan = false,
     isCurrentUserPartOfOrg = true,
   }: SetupArgs) {
     server.use(
@@ -455,8 +453,8 @@ describe('useRepoTabs', () => {
           }),
         })
       }),
-      graphql.query('OwnerTier', () => {
-        return HttpResponse.json({ data: { owner: { plan: { tierName } } } })
+      graphql.query('OwnerPlan', () => {
+        return HttpResponse.json({ data: { owner: { plan: { isTeamPlan } } } })
       }),
       graphql.query('GetRepo', () => {
         return HttpResponse.json({ data: mockRepo({ isCurrentUserPartOfOrg }) })

--- a/src/pages/RepoPage/RepoPageTabs.test.tsx
+++ b/src/pages/RepoPage/RepoPageTabs.test.tsx
@@ -147,7 +147,7 @@ describe('RepoPageTabs', () => {
         })
       }),
 
-      graphql.query('OwnerPlan', () => {
+      graphql.query('IsTeamPlan', () => {
         return HttpResponse.json({ data: { owner: { plan: { isTeamPlan } } } })
       }),
       graphql.query('GetRepo', () => {
@@ -453,7 +453,7 @@ describe('useRepoTabs', () => {
           }),
         })
       }),
-      graphql.query('OwnerPlan', () => {
+      graphql.query('IsTeamPlan', () => {
         return HttpResponse.json({ data: { owner: { plan: { isTeamPlan } } } })
       }),
       graphql.query('GetRepo', () => {

--- a/src/services/tier/index.ts
+++ b/src/services/tier/index.ts
@@ -1,1 +1,0 @@
-export * from './useTier'

--- a/src/services/useIsTeamPlan/index.ts
+++ b/src/services/useIsTeamPlan/index.ts
@@ -1,0 +1,1 @@
+export * from './useIsTeamPlan'

--- a/src/services/useIsTeamPlan/useIsTeamPlan.test.tsx
+++ b/src/services/useIsTeamPlan/useIsTeamPlan.test.tsx
@@ -5,7 +5,7 @@ import { setupServer } from 'msw/node'
 
 import { useIsTeamPlan } from './useIsTeamPlan'
 
-const mockOwnerPlan = {
+const mockIsTeamPlan = {
   owner: {
     plan: {
       isTeamPlan: true,
@@ -52,13 +52,13 @@ describe('useIsTeamPlan', () => {
     isNullOwner = false,
   }: SetupArgs) {
     server.use(
-      graphql.query('OwnerPlan', () => {
+      graphql.query('IsTeamPlan', () => {
         if (isUnsuccessfulParseError) {
           return HttpResponse.json({ data: mockUnsuccessfulParseError })
         } else if (isNullOwner) {
           return HttpResponse.json({ data: mockNullOwner })
         } else {
-          return HttpResponse.json({ data: mockOwnerPlan })
+          return HttpResponse.json({ data: mockIsTeamPlan })
         }
       })
     )

--- a/src/services/useIsTeamPlan/useIsTeamPlan.test.tsx
+++ b/src/services/useIsTeamPlan/useIsTeamPlan.test.tsx
@@ -3,12 +3,12 @@ import { renderHook, waitFor } from '@testing-library/react'
 import { graphql, HttpResponse } from 'msw'
 import { setupServer } from 'msw/node'
 
-import { useTier } from './useTier'
+import { useIsTeamPlan } from './useIsTeamPlan'
 
-const mockOwnerTier = {
+const mockOwnerPlan = {
   owner: {
     plan: {
-      tierName: 'pro',
+      isTeamPlan: true,
     },
   },
 }
@@ -46,32 +46,32 @@ interface SetupArgs {
   isUnsuccessfulParseError?: boolean
 }
 
-describe('useTier', () => {
+describe('useIsTeamPlan', () => {
   function setup({
     isUnsuccessfulParseError = false,
     isNullOwner = false,
   }: SetupArgs) {
     server.use(
-      graphql.query('OwnerTier', () => {
+      graphql.query('OwnerPlan', () => {
         if (isUnsuccessfulParseError) {
           return HttpResponse.json({ data: mockUnsuccessfulParseError })
         } else if (isNullOwner) {
           return HttpResponse.json({ data: mockNullOwner })
         } else {
-          return HttpResponse.json({ data: mockOwnerTier })
+          return HttpResponse.json({ data: mockOwnerPlan })
         }
       })
     )
   }
 
-  describe('when useTier is called', () => {
+  describe('when useIsTeamPlan is called', () => {
     describe('api returns valid response', () => {
-      describe('tier field is resolved', () => {
-        it('returns the owners tier', async () => {
+      describe('isTeamPlan field is resolved', () => {
+        it('returns the isTeamPlan value', async () => {
           setup({})
           const { result } = renderHook(
             () =>
-              useTier({
+              useIsTeamPlan({
                 provider: 'gh',
                 owner: 'codecov',
               }),
@@ -79,7 +79,7 @@ describe('useTier', () => {
           )
 
           await waitFor(() => result.current.isSuccess)
-          await waitFor(() => expect(result.current.data).toEqual('pro'))
+          await waitFor(() => expect(result.current.data).toEqual(true))
         })
       })
 
@@ -89,7 +89,7 @@ describe('useTier', () => {
 
           const { result } = renderHook(
             () =>
-              useTier({
+              useIsTeamPlan({
                 provider: 'gh',
                 owner: 'codecov',
               }),
@@ -114,7 +114,7 @@ describe('useTier', () => {
         setup({ isUnsuccessfulParseError: true })
         const { result } = renderHook(
           () =>
-            useTier({
+            useIsTeamPlan({
               provider: 'gh',
               owner: 'codecov',
             }),

--- a/src/services/useIsTeamPlan/useIsTeamPlan.ts
+++ b/src/services/useIsTeamPlan/useIsTeamPlan.ts
@@ -23,7 +23,7 @@ export interface UseIsTeamPlanArgs {
 }
 
 const query = `
-  query OwnerPlan($owner: String!) {
+  query IsTeamPlan($owner: String!) {
     owner(username:$owner){
       plan {
         isTeamPlan
@@ -34,7 +34,7 @@ const query = `
 
 export const useIsTeamPlan = ({ provider, owner }: UseIsTeamPlanArgs) =>
   useQuery({
-    queryKey: ['OwnerPlan', provider, owner, query],
+    queryKey: ['IsTeamPlan', provider, owner, query],
     queryFn: ({ signal }) =>
       Api.graphql({
         provider,
@@ -56,12 +56,3 @@ export const useIsTeamPlan = ({ provider, owner }: UseIsTeamPlanArgs) =>
         return parsedRes.data?.owner?.plan?.isTeamPlan ?? null
       }),
   })
-
-export const TierNames = {
-  BASIC: 'basic',
-  TEAM: 'team',
-  PRO: 'pro',
-  ENTERPRISE: 'enterprise',
-} as const
-
-export type TierNamesType = (typeof TierNames)[keyof typeof TierNames]

--- a/src/services/useIsTeamPlan/useIsTeamPlan.ts
+++ b/src/services/useIsTeamPlan/useIsTeamPlan.ts
@@ -3,22 +3,13 @@ import { z } from 'zod'
 
 import Api from 'shared/api'
 
-export const TierNames = {
-  BASIC: 'basic',
-  TEAM: 'team',
-  PRO: 'pro',
-  ENTERPRISE: 'enterprise',
-} as const
-
-export type TTierNames = (typeof TierNames)[keyof typeof TierNames]
-
-export const TierSchema = z
+export const PlanSchema = z
   .object({
     owner: z
       .object({
         plan: z
           .object({
-            tierName: z.nativeEnum(TierNames),
+            isTeamPlan: z.boolean(),
           })
           .nullable(),
       })
@@ -26,24 +17,24 @@ export const TierSchema = z
   })
   .nullable()
 
-export interface UseTierArgs {
+export interface UseIsTeamPlanArgs {
   provider: string
   owner: string
 }
 
 const query = `
-  query OwnerTier($owner: String!) {
+  query OwnerPlan($owner: String!) {
     owner(username:$owner){
       plan {
-        tierName
+        isTeamPlan
       }
     }
   }
 `
 
-export const useTier = ({ provider, owner }: UseTierArgs) =>
+export const useIsTeamPlan = ({ provider, owner }: UseIsTeamPlanArgs) =>
   useQuery({
-    queryKey: ['OwnerTier', provider, owner, query],
+    queryKey: ['OwnerPlan', provider, owner, query],
     queryFn: ({ signal }) =>
       Api.graphql({
         provider,
@@ -53,7 +44,7 @@ export const useTier = ({ provider, owner }: UseTierArgs) =>
           owner,
         },
       }).then((res) => {
-        const parsedRes = TierSchema.safeParse(res?.data)
+        const parsedRes = PlanSchema.safeParse(res?.data)
 
         if (!parsedRes.success) {
           return Promise.reject({
@@ -62,6 +53,15 @@ export const useTier = ({ provider, owner }: UseTierArgs) =>
           })
         }
 
-        return parsedRes.data?.owner?.plan?.tierName ?? null
+        return parsedRes.data?.owner?.plan?.isTeamPlan ?? null
       }),
   })
+
+export const TierNames = {
+  BASIC: 'basic',
+  TEAM: 'team',
+  PRO: 'pro',
+  ENTERPRISE: 'enterprise',
+} as const
+
+export type TierNamesType = (typeof TierNames)[keyof typeof TierNames]

--- a/src/shared/GlobalTopBanners/TeamPlanFeedbackBanner/TeamPlanFeedbackBanner.test.tsx
+++ b/src/shared/GlobalTopBanners/TeamPlanFeedbackBanner/TeamPlanFeedbackBanner.test.tsx
@@ -47,7 +47,7 @@ describe('TeamPlanFeedbackBanner', () => {
     const mockGetItem = vi.spyOn(window.localStorage.__proto__, 'getItem')
 
     server.use(
-      graphql.query('OwnerPlan', () => {
+      graphql.query('IsTeamPlan', () => {
         return HttpResponse.json({
           data: {
             owner: {

--- a/src/shared/GlobalTopBanners/TeamPlanFeedbackBanner/TeamPlanFeedbackBanner.test.tsx
+++ b/src/shared/GlobalTopBanners/TeamPlanFeedbackBanner/TeamPlanFeedbackBanner.test.tsx
@@ -6,25 +6,7 @@ import { setupServer } from 'msw/node'
 import React from 'react'
 import { MemoryRouter, Route } from 'react-router-dom'
 
-import { TierNames } from 'services/tier'
-
 import TeamPlanFeedbackBanner from './TeamPlanFeedbackBanner'
-
-const mockTeamTier = {
-  owner: {
-    plan: {
-      tierName: TierNames.TEAM,
-    },
-  },
-}
-
-const mockProTier = {
-  owner: {
-    plan: {
-      tierName: TierNames.PRO,
-    },
-  },
-}
 
 console.error = () => {}
 
@@ -59,17 +41,22 @@ const wrapper =
   )
 
 describe('TeamPlanFeedbackBanner', () => {
-  function setup(isPro = false) {
+  function setup({ isTeamPlan = true } = {}) {
     const user = userEvent.setup()
     const mockSetItem = vi.spyOn(window.localStorage.__proto__, 'setItem')
     const mockGetItem = vi.spyOn(window.localStorage.__proto__, 'getItem')
 
     server.use(
-      graphql.query('OwnerTier', () => {
-        if (isPro) {
-          return HttpResponse.json({ data: mockProTier })
-        }
-        return HttpResponse.json({ data: mockTeamTier })
+      graphql.query('OwnerPlan', () => {
+        return HttpResponse.json({
+          data: {
+            owner: {
+              plan: {
+                isTeamPlan,
+              },
+            },
+          },
+        })
       })
     )
 
@@ -139,7 +126,7 @@ describe('TeamPlanFeedbackBanner', () => {
 
   describe('user is not on team plan', () => {
     it('does not render banner', async () => {
-      setup(true)
+      setup({ isTeamPlan: false })
       const { container } = render(<TeamPlanFeedbackBanner />, {
         wrapper: wrapper('/gh/codecov'),
       })

--- a/src/shared/GlobalTopBanners/TeamPlanFeedbackBanner/TeamPlanFeedbackBanner.tsx
+++ b/src/shared/GlobalTopBanners/TeamPlanFeedbackBanner/TeamPlanFeedbackBanner.tsx
@@ -1,6 +1,6 @@
 import { useParams } from 'react-router-dom'
 
-import { TierNames, useTier } from 'services/tier'
+import { useIsTeamPlan } from 'services/useIsTeamPlan'
 import A from 'ui/A'
 import TopBanner from 'ui/TopBanner'
 
@@ -13,8 +13,7 @@ interface URLParams {
 
 const TeamPlanFeedbackBanner = () => {
   const { provider, owner } = useParams<URLParams>()
-  const { data: tierData } = useTier({ provider, owner })
-  const isTeamPlan = tierData === TierNames.TEAM
+  const { data: isTeamPlan } = useIsTeamPlan({ provider, owner })
 
   if (!isTeamPlan) {
     return null

--- a/src/shared/ListRepo/ListRepo.jsx
+++ b/src/shared/ListRepo/ListRepo.jsx
@@ -5,7 +5,7 @@ import { useParams } from 'react-router-dom'
 
 import { useLocationParams } from 'services/navigation'
 import { orderingOptions } from 'services/repos/orderingOptions'
-import { TierNames, useTier } from 'services/tier'
+import { useIsTeamPlan } from 'services/useIsTeamPlan'
 import { useUser } from 'services/user'
 import { ActiveContext } from 'shared/context'
 import { Alert } from 'ui/Alert'
@@ -31,14 +31,12 @@ export const repoDisplayOptions = Object.freeze({
 function ListRepo({ canRefetch }) {
   const { provider, owner } = useParams()
   const { params, updateParams } = useLocationParams(defaultQueryParams)
-  const { data: tierData } = useTier({ provider, owner })
+  const { data: isTeamPlan } = useIsTeamPlan({ provider, owner })
   const { data: currentUser } = useUser({
     options: {
       suspense: false,
     },
   })
-
-  const showTeamRepos = tierData === TierNames.TEAM
 
   const repoDisplay = useContext(ActiveContext)
 
@@ -87,7 +85,7 @@ function ListRepo({ canRefetch }) {
       ) : null}
 
       <Suspense fallback={loadingState}>
-        {showTeamRepos ? (
+        {isTeamPlan ? (
           <ReposTableTeam searchValue={params.search} />
         ) : (
           <ReposTable

--- a/src/shared/ListRepo/ListRepo.test.jsx
+++ b/src/shared/ListRepo/ListRepo.test.jsx
@@ -5,7 +5,6 @@ import { graphql, HttpResponse } from 'msw'
 import { setupServer } from 'msw/node'
 import { MemoryRouter, Route } from 'react-router-dom'
 
-import { TierNames } from 'services/tier'
 import { ActiveContext } from 'shared/context'
 
 import ListRepo from './ListRepo'
@@ -88,15 +87,15 @@ const mockUser = {
 
 describe('ListRepo', () => {
   function setup(
-    { tierValue = TierNames.PRO } = { tierValue: TierNames.PRO },
+    { isTeamPlan = false } = { isTeamPlan: false },
     me = mockUser
   ) {
     const user = userEvent.setup()
 
     server.use(
-      graphql.query('OwnerTier', () => {
+      graphql.query('OwnerPlan', () => {
         return HttpResponse.json({
-          data: { owner: { plan: { tierName: tierValue } } },
+          data: { owner: { plan: { isTeamPlan } } },
         })
       }),
       graphql.query('CurrentUser', () => {
@@ -226,9 +225,9 @@ describe('ListRepo', () => {
     })
   })
 
-  describe('when rendered for team tier', () => {
+  describe('when rendered for team plan', () => {
     it('renders the team table', async () => {
-      setup({ tierValue: TierNames.TEAM })
+      setup({ isTeamPlan: true })
       render(<ListRepo canRefetch />, {
         wrapper: wrapper(),
       })

--- a/src/shared/ListRepo/ListRepo.test.jsx
+++ b/src/shared/ListRepo/ListRepo.test.jsx
@@ -93,7 +93,7 @@ describe('ListRepo', () => {
     const user = userEvent.setup()
 
     server.use(
-      graphql.query('OwnerPlan', () => {
+      graphql.query('IsTeamPlan', () => {
         return HttpResponse.json({
           data: { owner: { plan: { isTeamPlan } } },
         })

--- a/src/shared/ListRepo/ReposTable/ReposTable.test.tsx
+++ b/src/shared/ListRepo/ReposTable/ReposTable.test.tsx
@@ -270,7 +270,7 @@ describe('ReposTable', () => {
           },
         })
       }),
-      graphql.query('OwnerPlan', () => {
+      graphql.query('IsTeamPlan', () => {
         return HttpResponse.json({
           data: { owner: { plan: { isTeamPlan } } },
         })

--- a/src/shared/ListRepo/ReposTable/ReposTable.test.tsx
+++ b/src/shared/ListRepo/ReposTable/ReposTable.test.tsx
@@ -16,7 +16,6 @@ import { setupServer } from 'msw/node'
 import { mockIsIntersecting } from 'react-intersection-observer/test-utils'
 import { MemoryRouter, Route } from 'react-router-dom'
 
-import { TierNames } from 'services/tier'
 import { ActiveContext } from 'shared/context'
 
 import ReposTable from './ReposTable'
@@ -193,14 +192,14 @@ interface SetupArgs {
   edges?: any[]
   isCurrentUserPartOfOrg?: boolean
   privateAccess?: boolean
-  tierValue?: string
+  isTeamPlan?: boolean
 }
 
 describe('ReposTable', () => {
   function setup({
     edges = [],
     isCurrentUserPartOfOrg = true,
-    tierValue = TierNames.PRO,
+    isTeamPlan = false,
   }: SetupArgs) {
     const reposForOwnerMock = vi.fn()
     const myReposMock = vi.fn()
@@ -271,9 +270,9 @@ describe('ReposTable', () => {
           },
         })
       }),
-      graphql.query('OwnerTier', () => {
+      graphql.query('OwnerPlan', () => {
         return HttpResponse.json({
-          data: { owner: { plan: { tierName: tierValue } } },
+          data: { owner: { plan: { isTeamPlan } } },
         })
       }),
       graphql.query('RepoConfig', () => {
@@ -588,10 +587,10 @@ describe('ReposTable', () => {
     })
   })
 
-  describe('when user is in team tier', () => {
+  describe('when user is in team plan', () => {
     beforeEach(() => {
       setup({
-        tierValue: TierNames.TEAM,
+        isTeamPlan: true,
         edges: mockRepositories(),
       })
     })

--- a/src/shared/ListRepo/ReposTable/ReposTable.tsx
+++ b/src/shared/ListRepo/ReposTable/ReposTable.tsx
@@ -18,7 +18,7 @@ import {
   OrderingDirection,
   ReposQueryOpts,
 } from 'services/repos/ReposQueryOpts'
-import { TierNames, useTier } from 'services/tier'
+import { useIsTeamPlan } from 'services/useIsTeamPlan'
 import { useOwner, useUser } from 'services/user'
 import { ActiveContext } from 'shared/context'
 import { DEMO_REPO, formatDemoRepos, isNotNull } from 'shared/utils/demo'
@@ -117,11 +117,10 @@ const ReposTable = ({
   })
   const isCurrentUserPartOfOrg = ownerData?.isCurrentUserPartOfOrg
 
-  const { data: tierName } = useTier({
+  const { data: isTeamPlan } = useIsTeamPlan({
     provider,
     owner,
   })
-  const shouldDisplayPublicReposOnly = tierName === TierNames.TEAM ? true : null
 
   const repoDisplay = useContext(ActiveContext)
   const activated =
@@ -146,7 +145,7 @@ const ReposTable = ({
       sortItem: getOrderingDirection(sorting),
       term: searchValue,
       repoNames: filterValues,
-      isPublic: shouldDisplayPublicReposOnly,
+      isPublic: isTeamPlan,
     })
   )
 

--- a/src/shared/utils/billing.ts
+++ b/src/shared/utils/billing.ts
@@ -149,3 +149,10 @@ export function lastTwoDigits(value: number | string) {
   }
   return null
 }
+
+export const TierNames = {
+  BASIC: 'basic',
+  TEAM: 'team',
+  PRO: 'pro',
+  ENTERPRISE: 'enterprise',
+} as const

--- a/src/shared/utils/billing.ts
+++ b/src/shared/utils/billing.ts
@@ -24,6 +24,13 @@ export const Plans = {
 
 export type PlanName = (typeof Plans)[keyof typeof Plans]
 
+export const TierNames = {
+  BASIC: 'basic',
+  TEAM: 'team',
+  PRO: 'pro',
+  ENTERPRISE: 'enterprise',
+} as const
+
 export const BillingRate = {
   MONTHLY: 'monthly',
   ANNUALLY: 'annually',
@@ -149,10 +156,3 @@ export function lastTwoDigits(value: number | string) {
   }
   return null
 }
-
-export const TierNames = {
-  BASIC: 'basic',
-  TEAM: 'team',
-  PRO: 'pro',
-  ENTERPRISE: 'enterprise',
-} as const


### PR DESCRIPTION
# Description
There's no need to fetch the tier name anymore; we should unify the queries to use isTeamPlan, as it's consistently used throughout the codebase.

# Notable Changes
- Refactored useTiers -> useIsTeamPlan
- Updated components and tests to align with the new hook structure.

closes: [#3240](https://github.com/codecov/engineering-team/issues/3240)

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.