### PR TITLE
Is repo public bug

### DIFF
--- a/src/pages/AnalyticsPage/Chart/useCoverage.ts
+++ b/src/pages/AnalyticsPage/Chart/useCoverage.ts
@@ -39,7 +39,7 @@ export const useCoverage = ({
     repos: queryVars?.repositories,
     before: queryVars?.endDate,
     after: queryVars?.startDate,
-    isPublic: isTeamPlan ?? false,
+    isPublic: isTeamPlan === true ? true : undefined,
     opts: {
       staleTime: 30000,
       keepPreviousData: false,

--- a/src/pages/AnalyticsPage/ChartSelectors/ChartSelectors.jsx
+++ b/src/pages/AnalyticsPage/ChartSelectors/ChartSelectors.jsx
@@ -68,7 +68,7 @@ function RepoSelector({
       activated: active,
       term: search,
       first: Infinity,
-      isPublic: isTeamPlan,
+      isPublic: isTeamPlan === true ? true : null,
     })
   )
 

--- a/src/shared/ListRepo/ReposTable/ReposTable.tsx
+++ b/src/shared/ListRepo/ReposTable/ReposTable.tsx
@@ -145,7 +145,7 @@ const ReposTable = ({
       sortItem: getOrderingDirection(sorting),
       term: searchValue,
       repoNames: filterValues,
-      isPublic: isTeamPlan,
+      isPublic: isTeamPlan === true ? true : null,
     })
   )
 


### PR DESCRIPTION
# Description 
We replaced the check for tier names with isTeamPlan, resulting in a false default for isPublic for signed in users 

# Code Example

# Notable Changes

# Screenshots

# Link to Sample Entry

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.