### PR TITLE
Reword the "Erase Repo" action

### DIFF
--- a/src/pages/RepoPage/ConfigTab/tabs/GeneralTab/DangerZone/DangerZone.jsx
+++ b/src/pages/RepoPage/ConfigTab/tabs/GeneralTab/DangerZone/DangerZone.jsx
@@ -7,7 +7,7 @@ function DangerZone() {
   return (
     <SettingsDescriptor
       title="Danger Zone"
-      description="Erase repsitory or pause upload ability"
+      description="Erase repository or pause upload ability"
       content={
         <>
           <EraseRepo />

--- a/src/pages/RepoPage/ConfigTab/tabs/GeneralTab/DangerZone/DangerZone.jsx
+++ b/src/pages/RepoPage/ConfigTab/tabs/GeneralTab/DangerZone/DangerZone.jsx
@@ -1,16 +1,16 @@
 import SettingsDescriptor from 'ui/SettingsDescriptor'
 
-import EraseRepoContent from './EraseRepoContent'
+import EraseRepo from './EraseRepo'
 import RepoState from './RepoState'
 
 function DangerZone() {
   return (
     <SettingsDescriptor
       title="Danger Zone"
-      description="Erase repo coverage data and pause upload ability"
+      description="Erase repsitory or pause upload ability"
       content={
         <>
-          <EraseRepoContent />
+          <EraseRepo />
           <RepoState />
         </>
       }

--- a/src/pages/RepoPage/ConfigTab/tabs/GeneralTab/DangerZone/EraseRepo/EraseRepo.jsx
+++ b/src/pages/RepoPage/ConfigTab/tabs/GeneralTab/DangerZone/EraseRepo/EraseRepo.jsx
@@ -1,10 +1,10 @@
 import PropTypes from 'prop-types'
 import { useState } from 'react'
 
-import { useEraseRepoContent } from 'services/repo'
+import { useEraseRepo } from 'services/repo'
 import Button from 'ui/Button'
 
-import EraseRepoContentModal from './EraseRepoContentModal'
+import EraseRepoModal from './EraseRepoModal'
 
 function EraseRepoButton({ isLoading, setShowModal }) {
   if (isLoading) {
@@ -21,7 +21,7 @@ function EraseRepoButton({ isLoading, setShowModal }) {
       hook="show-modal"
       onClick={() => setShowModal(true)}
     >
-      Erase Content
+      Erase Repository
     </Button>
   )
 }
@@ -31,26 +31,26 @@ EraseRepoButton.propTypes = {
   isLoading: PropTypes.bool.isRequired,
 }
 
-function EraseRepoContent() {
+function EraseRepo() {
   const [showModal, setShowModal] = useState(false)
-  const { mutate: eraseRepoContent, isLoading } = useEraseRepoContent()
+  const { mutate: eraseRepo, isLoading } = useEraseRepo()
 
   return (
     <div className="flex flex-col sm:flex-row">
       <div className="flex flex-1 flex-col gap-1">
-        <h2 className="font-semibold">Erase repo coverage content</h2>
+        <h2 className="font-semibold">Erase repository</h2>
         <p className="max-w-md">
-          This will remove all coverage reporting from the repo. For larger
-          repositories, this process may not be able to complete automatically.
-          In that case, please reach out to support for help.
+          This will erase the repository, including all of its contents. The
+          repository itself will be re-created when resync-ing the organization
+          contents.
         </p>
       </div>
       <div>
         <EraseRepoButton isLoading={isLoading} setShowModal={setShowModal} />
-        <EraseRepoContentModal
+        <EraseRepoModal
           showModal={showModal}
           closeModal={() => setShowModal(false)}
-          eraseRepoContent={eraseRepoContent}
+          eraseRepo={eraseRepo}
           isLoading={isLoading}
         />
       </div>
@@ -58,4 +58,4 @@ function EraseRepoContent() {
   )
 }
 
-export default EraseRepoContent
+export default EraseRepo

--- a/src/pages/RepoPage/ConfigTab/tabs/GeneralTab/DangerZone/EraseRepo/EraseRepo.test.jsx
+++ b/src/pages/RepoPage/ConfigTab/tabs/GeneralTab/DangerZone/EraseRepo/EraseRepo.test.jsx
@@ -6,7 +6,7 @@ import { delay, graphql, HttpResponse } from 'msw'
 import { setupServer } from 'msw/node'
 import { MemoryRouter, Route } from 'react-router-dom'
 
-import EraseRepoContent from './EraseRepoContent'
+import EraseRepo from './EraseRepo'
 
 const mocks = vi.hoisted(() => ({
   useAddNotification: vi.fn(),
@@ -70,7 +70,7 @@ const mockResponse = {
   },
 }
 
-describe('EraseRepoContent', () => {
+describe('EraseRepository', () => {
   function setup(
     { failedMutation = false, isLoading = false, unauthorized = false } = {
       failedMutation: false,
@@ -103,45 +103,45 @@ describe('EraseRepoContent', () => {
     return { user, mutate, addNotification }
   }
 
-  describe('renders EraseRepoContent component', () => {
+  describe('renders EraseRepo component', () => {
     beforeEach(() => setup())
 
     it('renders title', async () => {
-      render(<EraseRepoContent />, { wrapper })
+      render(<EraseRepo />, { wrapper })
 
-      const title = await screen.findByText(/Erase repo coverage content/)
+      const title = await screen.findByText(/Erase repository/)
       expect(title).toBeInTheDocument()
     })
 
     it('renders body', async () => {
-      render(<EraseRepoContent />, { wrapper })
+      render(<EraseRepo />, { wrapper })
 
       const firstBlock = await screen.findByText(
-        /This will remove all coverage reporting from the repo./
+        /This will erase the repository, including all of its contents./
       )
       expect(firstBlock).toBeInTheDocument()
     })
 
     it('renders erase button', async () => {
-      render(<EraseRepoContent />, { wrapper })
+      render(<EraseRepo />, { wrapper })
 
       const eraseButton = await screen.findByRole('button', {
-        name: /Erase Content/,
+        name: /Erase Repository/,
       })
       expect(eraseButton).toBeInTheDocument()
     })
 
     it('renders processing copy when isLoading is true', async () => {
       const { user } = setup({ isLoading: true })
-      render(<EraseRepoContent />, { wrapper })
+      render(<EraseRepo />, { wrapper })
 
       const eraseButton = await screen.findByRole('button', {
-        name: /Erase Content/,
+        name: /Erase Repository/,
       })
       await user.click(eraseButton)
 
       const modalCancelButton = await screen.findByRole('button', {
-        name: /Erase Content/,
+        name: /Erase Repository/,
       })
       await user.click(modalCancelButton)
 
@@ -152,56 +152,56 @@ describe('EraseRepoContent', () => {
     })
   })
 
-  describe('when the user clicks on erase content button', () => {
-    describe('displays Erase Content Modal', () => {
+  describe('when the user clicks on erase repository button', () => {
+    describe('displays Erase Repository Modal', () => {
       beforeEach(() => setup())
 
-      it('displays erase content button', async () => {
+      it('displays erase repository button', async () => {
         const { user } = setup()
-        render(<EraseRepoContent />, { wrapper })
+        render(<EraseRepo />, { wrapper })
 
         const eraseButton = await screen.findByRole('button', {
-          name: /Erase Content/,
+          name: /Erase Repository/,
         })
         user.click(eraseButton)
 
         const modalEraseButton = await screen.findByRole('button', {
-          name: /Erase Content/,
+          name: /Erase Repository/,
         })
         expect(modalEraseButton).toBeInTheDocument()
       })
 
       it('displays modal body', async () => {
         const { user } = setup()
-        render(<EraseRepoContent />, { wrapper })
+        render(<EraseRepo />, { wrapper })
 
         const eraseButton = await screen.findByRole('button', {
-          name: /Erase Content/,
+          name: /Erase Repository/,
         })
         user.click(eraseButton)
 
         const p1 = await screen.findByText(
-          /Are you sure you want to erase the repo coverage content?/
+          /Are you sure you want to erase the repository?/
         )
         expect(p1).toBeInTheDocument()
 
         const p2 = await screen.findByText(
-          /This will erase repo coverage content should erase all coverage data contained in the repo. This action is irreversible and if you proceed, you will permanently erase any historical code coverage in Codecov for this repository./
+          /This will erase the repository, including all of its contents. This action is irreversible/
         )
         expect(p2).toBeInTheDocument()
       })
 
       it('displays modal buttons', async () => {
         const { user } = setup()
-        render(<EraseRepoContent />, { wrapper })
+        render(<EraseRepo />, { wrapper })
 
         const eraseButton = await screen.findByRole('button', {
-          name: /Erase Content/,
+          name: /Erase Repository/,
         })
         user.click(eraseButton)
 
         const modalEraseButton = await screen.findByRole('button', {
-          name: /Erase Content/,
+          name: /Erase Repository/,
         })
         expect(modalEraseButton).toBeInTheDocument()
 
@@ -215,10 +215,10 @@ describe('EraseRepoContent', () => {
     describe('when user clicks on Cancel button', () => {
       it('does not call the mutation', async () => {
         const { user, mutate } = setup()
-        render(<EraseRepoContent />, { wrapper })
+        render(<EraseRepo />, { wrapper })
 
         const eraseButton = await screen.findByRole('button', {
-          name: /Erase Content/,
+          name: /Erase Repository/,
         })
         await user.click(eraseButton)
 
@@ -232,18 +232,18 @@ describe('EraseRepoContent', () => {
     })
   })
 
-  describe('when user clicks on Erase Content button', () => {
+  describe('when user clicks on Erase Repository button', () => {
     it('calls the mutation', async () => {
       const { user, mutate } = setup()
-      render(<EraseRepoContent />, { wrapper })
+      render(<EraseRepo />, { wrapper })
 
       const eraseButton = await screen.findByRole('button', {
-        name: /Erase Content/,
+        name: /Erase Repository/,
       })
       await user.click(eraseButton)
 
       const modalEraseButton = await screen.findByRole('button', {
-        name: /Erase Content/,
+        name: /Erase Repository/,
       })
       await user.click(modalEraseButton)
 
@@ -254,15 +254,15 @@ describe('EraseRepoContent', () => {
   describe('when mutation is successful', () => {
     it('adds a success notification', async () => {
       const { user, mutate, addNotification } = setup()
-      render(<EraseRepoContent />, { wrapper })
+      render(<EraseRepo />, { wrapper })
 
       const eraseButton = await screen.findByRole('button', {
-        name: /Erase Content/,
+        name: /Erase Repository/,
       })
       await user.click(eraseButton)
 
       const modalEraseButton = await screen.findByRole('button', {
-        name: /Erase Content/,
+        name: /Erase Repository/,
       })
       await user.click(modalEraseButton)
 
@@ -270,7 +270,7 @@ describe('EraseRepoContent', () => {
       await waitFor(() =>
         expect(addNotification).toHaveBeenCalledWith({
           type: 'success',
-          text: 'Repo coverage content erased successfully',
+          text: 'Repository erased successfully',
         })
       )
     })
@@ -279,15 +279,15 @@ describe('EraseRepoContent', () => {
   describe('when mutation is not successful', () => {
     it('adds an error notification', async () => {
       const { user, mutate, addNotification } = setup({ failedMutation: true })
-      render(<EraseRepoContent />, { wrapper })
+      render(<EraseRepo />, { wrapper })
 
       const eraseButton = await screen.findByRole('button', {
-        name: /Erase Content/,
+        name: /Erase Repository/,
       })
       await user.click(eraseButton)
 
       const modalEraseButton = await screen.findByRole('button', {
-        name: /Erase Content/,
+        name: /Erase Repository/,
       })
       await user.click(modalEraseButton)
 
@@ -295,7 +295,7 @@ describe('EraseRepoContent', () => {
       await waitFor(() =>
         expect(addNotification).toHaveBeenCalledWith({
           type: 'error',
-          text: "We were unable to erase this repo's content",
+          text: 'We were unable to erase this repository',
         })
       )
     })
@@ -304,15 +304,15 @@ describe('EraseRepoContent', () => {
   describe('when user is unauthorized', () => {
     it('adds an error notification', async () => {
       const { user, mutate, addNotification } = setup({ unauthorized: true })
-      render(<EraseRepoContent />, { wrapper })
+      render(<EraseRepo />, { wrapper })
 
       const eraseButton = await screen.findByRole('button', {
-        name: /Erase Content/,
+        name: /Erase Repository/,
       })
       await user.click(eraseButton)
 
       const modalEraseButton = await screen.findByRole('button', {
-        name: /Erase Content/,
+        name: /Erase Repository/,
       })
       await user.click(modalEraseButton)
 
@@ -320,7 +320,7 @@ describe('EraseRepoContent', () => {
       await waitFor(() =>
         expect(addNotification).toHaveBeenCalledWith({
           type: 'error',
-          text: "We were unable to erase this repo's content",
+          text: 'We were unable to erase this repository',
         })
       )
     })

--- a/src/pages/RepoPage/ConfigTab/tabs/GeneralTab/DangerZone/EraseRepo/EraseRepoModal.jsx
+++ b/src/pages/RepoPage/ConfigTab/tabs/GeneralTab/DangerZone/EraseRepo/EraseRepoModal.jsx
@@ -3,23 +3,19 @@ import PropTypes from 'prop-types'
 import Button from 'ui/Button'
 import Modal from 'ui/Modal'
 
-const EraseRepoContentModal = ({
-  closeModal,
-  eraseRepoContent,
-  isLoading,
-  showModal,
-}) => {
+const EraseRepoModal = ({ closeModal, eraseRepo, isLoading, showModal }) => {
   return (
     <Modal
       isOpen={showModal}
       onClose={closeModal}
-      title="Are you sure you want to erase the repo coverage content?"
+      title="Are you sure you want to erase the repository?"
       body={
         <p>
-          This will erase repo coverage content should erase all coverage data
-          contained in the repo. This action is irreversible and if you proceed,
-          you will permanently erase any historical code coverage in Codecov for
-          this repository.
+          This will erase the repository, including all of its contents. This
+          action is irreversible and if you proceed, you will permanently erase
+          any historical code coverage in Codecov for this repository. The
+          repository itself will be re-created when resync-ing the organization
+          contents.
         </p>
       }
       footer={
@@ -35,11 +31,11 @@ const EraseRepoContentModal = ({
               hook="erase-repo-content"
               variant="danger"
               onClick={async () => {
-                await eraseRepoContent()
+                await eraseRepo()
                 closeModal()
               }}
             >
-              Erase Content
+              Erase Repository
             </Button>
           </div>
         </div>
@@ -48,11 +44,11 @@ const EraseRepoContentModal = ({
   )
 }
 
-EraseRepoContentModal.propTypes = {
+EraseRepoModal.propTypes = {
   showModal: PropTypes.bool.isRequired,
   closeModal: PropTypes.func.isRequired,
-  eraseRepoContent: PropTypes.func.isRequired,
+  eraseRepo: PropTypes.func.isRequired,
   isLoading: PropTypes.bool.isRequired,
 }
 
-export default EraseRepoContentModal
+export default EraseRepoModal

--- a/src/pages/RepoPage/ConfigTab/tabs/GeneralTab/DangerZone/EraseRepo/index.js
+++ b/src/pages/RepoPage/ConfigTab/tabs/GeneralTab/DangerZone/EraseRepo/index.js
@@ -1,0 +1,1 @@
+export { default } from './EraseRepo'

--- a/src/pages/RepoPage/ConfigTab/tabs/GeneralTab/DangerZone/EraseRepoContent/index.js
+++ b/src/pages/RepoPage/ConfigTab/tabs/GeneralTab/DangerZone/EraseRepoContent/index.js
@@ -1,1 +1,0 @@
-export { default } from './EraseRepoContent'

--- a/src/services/repo/useEraseRepoContent.test.tsx
+++ b/src/services/repo/useEraseRepoContent.test.tsx
@@ -5,7 +5,7 @@ import { setupServer } from 'msw/node'
 import React from 'react'
 import { MemoryRouter, Route } from 'react-router-dom'
 
-import { useEraseRepoContent } from './useEraseRepoContent'
+import { useEraseRepo } from './useEraseRepoContent'
 
 const queryClient = new QueryClient({
   defaultOptions: { queries: { retry: false } },
@@ -52,7 +52,7 @@ describe('useEraseRepoContent', () => {
     describe('When success', () => {
       it('returns isSuccess true', async () => {
         setup()
-        const { result } = renderHook(() => useEraseRepoContent(), {
+        const { result } = renderHook(() => useEraseRepo(), {
           wrapper: wrapper(),
         })
 

--- a/src/services/repo/useEraseRepoContent.tsx
+++ b/src/services/repo/useEraseRepoContent.tsx
@@ -28,7 +28,7 @@ interface URLParams {
   repo: string
 }
 
-export const useEraseRepoContent = () => {
+export const useEraseRepo = () => {
   const { provider, owner, repo } = useParams<URLParams>()
   const queryClient = useQueryClient()
   const addToast = useAddNotification()
@@ -49,12 +49,12 @@ export const useEraseRepoContent = () => {
       if (error) {
         addToast({
           type: 'error',
-          text: "We were unable to erase this repo's content",
+          text: 'We were unable to erase this repository',
         })
       } else {
         addToast({
           type: 'success',
-          text: 'Repo coverage content erased successfully',
+          text: 'Repository erased successfully',
         })
       }
       queryClient.invalidateQueries(['GetRepo'])
@@ -63,7 +63,7 @@ export const useEraseRepoContent = () => {
     onError: () => {
       addToast({
         type: 'error',
-        text: "We were unable to erase this repo's content",
+        text: 'We were unable to erase this repository',
       })
     },
     retry: false,


### PR DESCRIPTION
Instead of erasing just the "repo coverage content", the repository as a whole will be deleted using the new `FlushRepo` task. This adjusts the frontend to reflect that.