### PR TITLE
fix: Add modal max width on wide screens

### DIFF
--- a/src/ui/Modal/Modal.tsx
+++ b/src/ui/Modal/Modal.tsx
@@ -4,8 +4,8 @@ import ReactModal from 'react-modal'
 import BaseModal from './BaseModal'
 
 const modalSizes = Object.freeze({
-  medium: 'w-11/12 md:w-3/4 xl:w-1/2',
-  small: 'w-3/4 md:w-2/4 xl:w-2/4 2xl:w-1/4',
+  medium: 'w-11/12 md:w-3/4 xl:w-1/2 4xl:w-[1000px]',
+  small: 'w-3/4 md:w-2/4 xl:w-2/4 2xl:w-1/4 3xl:w-[448px]',
 })
 
 export interface ModalProps {

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -178,6 +178,8 @@ const config = {
         },
       },
       screens: {
+        '3xl': '1792px',
+        '4xl': '2048px',
         print: { raw: 'print' },
       },
       backgroundImage: {


### PR DESCRIPTION
# Description

Adding an optional classname prop for the size of a modal to allow possible extra styles such as max width. Currently, on large screens, the designated width is 50% which can be much wider than needed, especially if the modal also has vertical scrolling as our BaseModal element right now has a max height of `m-h-96' designated.
# Code Example

# Notable Changes

# Screenshots

Existing situation that is super wide where a single text line doesn't even reach the halfway point of the modal:
![Screenshot 2025-01-21 at 1 15 31 PM](https://github.com/user-attachments/assets/de818a56-f7da-4aa1-ba2c-6ea65723533b)

# Link to Sample Entry

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.