### PR TITLE
fix: Infer name if not in billing details

### DIFF
--- a/src/pages/PlanPage/subRoutes/CurrentOrgPlan/BillingDetails/BillingDetails.tsx
+++ b/src/pages/PlanPage/subRoutes/CurrentOrgPlan/BillingDetails/BillingDetails.tsx
@@ -30,7 +30,7 @@ function BillingDetails() {
       <EmailAddress />
       <PaymentCard
         // @ts-expect-error - TODO fix this once we update PaymentCard to TS
-        subscriptionDetail={subscriptionDetail}
+        accountDetails={accountDetails}
         provider={provider}
         owner={owner}
       />

--- a/src/pages/PlanPage/subRoutes/CurrentOrgPlan/BillingDetails/PaymentCard/PaymentCard.jsx
+++ b/src/pages/PlanPage/subRoutes/CurrentOrgPlan/BillingDetails/PaymentCard/PaymentCard.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types'
 import { useState } from 'react'
 
-import { subscriptionDetailType } from 'services/account'
+import { accountDetailsPropType } from 'services/account'
 import { formatTimestampToCalendarDate } from 'shared/utils/billing'
 import A from 'ui/A'
 import Button from 'ui/Button'
@@ -10,8 +10,9 @@ import Icon from 'ui/Icon'
 import BankInformation from './BankInformation'
 import CardInformation from './CardInformation'
 import PaymentMethodForm from './PaymentMethodForm'
-function PaymentCard({ subscriptionDetail, provider, owner }) {
+function PaymentCard({ accountDetails, provider, owner }) {
   const [isFormOpen, setIsFormOpen] = useState(false)
+  const subscriptionDetail = accountDetails?.subscriptionDetail
   const card = subscriptionDetail?.defaultPaymentMethod?.card
   const usBankAccount = subscriptionDetail?.defaultPaymentMethod?.usBankAccount
 
@@ -41,7 +42,7 @@ function PaymentCard({ subscriptionDetail, provider, owner }) {
           provider={provider}
           owner={owner}
           closeForm={() => setIsFormOpen(false)}
-          subscriptionDetail={subscriptionDetail}
+          accountDetails={accountDetails}
         />
       ) : card ? (
         <CardInformation card={card} subscriptionDetail={subscriptionDetail} />
@@ -72,7 +73,7 @@ function PaymentCard({ subscriptionDetail, provider, owner }) {
 }
 
 PaymentCard.propTypes = {
-  subscriptionDetail: subscriptionDetailType,
+  accountDetails: accountDetailsPropType,
   provider: PropTypes.string.isRequired,
   owner: PropTypes.string.isRequired,
 }

--- a/src/pages/PlanPage/subRoutes/CurrentOrgPlan/BillingDetails/PaymentCard/PaymentCard.test.jsx
+++ b/src/pages/PlanPage/subRoutes/CurrentOrgPlan/BillingDetails/PaymentCard/PaymentCard.test.jsx
@@ -55,6 +55,10 @@ const subscriptionDetail = {
   cancelAtPeriodEnd: false,
 }
 
+const accountDetails = {
+  subscriptionDetail,
+}
+
 const usBankSubscriptionDetail = {
   defaultPaymentMethod: {
     usBankAccount: {
@@ -100,12 +104,12 @@ describe('PaymentCard', () => {
     return { user }
   }
 
-  describe(`when the user doesn't have any subscriptionDetail`, () => {
+  describe(`when the user doesn't have any accountDetails`, () => {
     // NOTE: This test is misleading because we hide this component from a higher level in
-    // BillingDetails.tsx if there is no subscriptionDetail
+    // BillingDetails.tsx if there is no accountDetails
     it('renders the set payment method message', () => {
       render(
-        <PaymentCard subscriptionDetail={null} provider="gh" owner="codecov" />
+        <PaymentCard accountDetails={null} provider="gh" owner="codecov" />
       )
 
       expect(
@@ -120,9 +124,12 @@ describe('PaymentCard', () => {
     it('renders an error message', () => {
       render(
         <PaymentCard
-          subscriptionDetail={{
-            ...subscriptionDetail,
-            defaultPaymentMethod: null,
+          accountDetails={{
+            ...accountDetails,
+            subscriptionDetail: {
+              ...accountDetails.subscriptionDetail,
+              defaultPaymentMethod: null,
+            },
           }}
           provider="gh"
           owner="codecov"
@@ -142,9 +149,12 @@ describe('PaymentCard', () => {
         const { user } = setup()
         render(
           <PaymentCard
-            subscriptionDetail={{
-              ...subscriptionDetail,
-              defaultPaymentMethod: null,
+            accountDetails={{
+              ...accountDetails,
+              subscriptionDetail: {
+                ...accountDetails.subscriptionDetail,
+                defaultPaymentMethod: null,
+              },
             }}
             provider="gh"
             owner="codecov"
@@ -165,9 +175,12 @@ describe('PaymentCard', () => {
         const { user } = setup()
         render(
           <PaymentCard
-            subscriptionDetail={{
-              ...subscriptionDetail,
-              defaultPaymentMethod: null,
+            accountDetails={{
+              ...accountDetails,
+              subscriptionDetail: {
+                ...accountDetails.subscriptionDetail,
+                defaultPaymentMethod: null,
+              },
             }}
             provider="gh"
             owner="codecov"
@@ -190,7 +203,7 @@ describe('PaymentCard', () => {
     it('renders the card', () => {
       render(
         <PaymentCard
-          subscriptionDetail={subscriptionDetail}
+          accountDetails={accountDetails}
           provider="gh"
           owner="codecov"
         />,
@@ -204,7 +217,7 @@ describe('PaymentCard', () => {
     it('renders the next billing', () => {
       render(
         <PaymentCard
-          subscriptionDetail={subscriptionDetail}
+          accountDetails={accountDetails}
           provider="gh"
           owner="codecov"
         />,
@@ -217,9 +230,15 @@ describe('PaymentCard', () => {
 
   describe('when the user has a US bank account', () => {
     it('renders the bank account details', () => {
+      const testAccountDetails = {
+        ...accountDetails,
+        subscriptionDetail: {
+          ...usBankSubscriptionDetail,
+        },
+      }
       render(
         <PaymentCard
-          subscriptionDetail={usBankSubscriptionDetail}
+          accountDetails={testAccountDetails}
           provider="gh"
           owner="codecov"
         />,
@@ -235,9 +254,12 @@ describe('PaymentCard', () => {
     it(`doesn't render the next billing`, () => {
       render(
         <PaymentCard
-          subscriptionDetail={{
-            ...subscriptionDetail,
-            cancelAtPeriodEnd: true,
+          accountDetails={{
+            ...accountDetails,
+            subscriptionDetail: {
+              ...accountDetails.subscriptionDetail,
+              cancelAtPeriodEnd: true,
+            },
           }}
           provider="gh"
           owner="codecov"
@@ -260,7 +282,7 @@ describe('PaymentCard', () => {
 
       render(
         <PaymentCard
-          subscriptionDetail={subscriptionDetail}
+          accountDetails={accountDetails}
           provider="gh"
           owner="codecov"
         />,
@@ -280,7 +302,7 @@ describe('PaymentCard', () => {
       })
       render(
         <PaymentCard
-          subscriptionDetail={subscriptionDetail}
+          accountDetails={accountDetails}
           provider="gh"
           owner="codecov"
         />,
@@ -305,7 +327,7 @@ describe('PaymentCard', () => {
 
         render(
           <PaymentCard
-            subscriptionDetail={subscriptionDetail}
+            accountDetails={accountDetails}
             provider="gh"
             owner="codecov"
           />,
@@ -327,7 +349,7 @@ describe('PaymentCard', () => {
         })
         render(
           <PaymentCard
-            subscriptionDetail={subscriptionDetail}
+            accountDetails={accountDetails}
             provider="gh"
             owner="codecov"
           />,
@@ -354,7 +376,7 @@ describe('PaymentCard', () => {
       })
       render(
         <PaymentCard
-          subscriptionDetail={subscriptionDetail}
+          accountDetails={accountDetails}
           provider="gh"
           owner="codecov"
         />,
@@ -376,7 +398,7 @@ describe('PaymentCard', () => {
       })
       render(
         <PaymentCard
-          subscriptionDetail={subscriptionDetail}
+          accountDetails={accountDetails}
           provider="gh"
           owner="codecov"
         />,

--- a/src/pages/PlanPage/subRoutes/CurrentOrgPlan/BillingDetails/PaymentCard/PaymentCard.test.jsx
+++ b/src/pages/PlanPage/subRoutes/CurrentOrgPlan/BillingDetails/PaymentCard/PaymentCard.test.jsx
@@ -105,8 +105,6 @@ describe('PaymentCard', () => {
   }
 
   describe(`when the user doesn't have any accountDetails`, () => {
-    // NOTE: This test is misleading because we hide this component from a higher level in
-    // BillingDetails.tsx if there is no accountDetails
     it('renders the set payment method message', () => {
       render(
         <PaymentCard accountDetails={null} provider="gh" owner="codecov" />

--- a/src/pages/PlanPage/subRoutes/CurrentOrgPlan/BillingDetails/PaymentCard/PaymentMethodForm.test.tsx
+++ b/src/pages/PlanPage/subRoutes/CurrentOrgPlan/BillingDetails/PaymentCard/PaymentMethodForm.test.tsx
@@ -90,7 +90,7 @@ describe('PaymentMethodForm', () => {
 
       render(
         <PaymentMethodForm
-          subscriptionDetail={subscriptionDetail}
+          accountDetails={subscriptionDetail}
           provider="gh"
           owner="codecov"
           closeForm={() => {}}
@@ -111,7 +111,7 @@ describe('PaymentMethodForm', () => {
       })
       render(
         <PaymentMethodForm
-          subscriptionDetail={subscriptionDetail}
+          accountDetails={subscriptionDetail}
           provider="gh"
           owner="codecov"
           closeForm={() => {}}
@@ -133,7 +133,7 @@ describe('PaymentMethodForm', () => {
         })
         render(
           <PaymentMethodForm
-            subscriptionDetail={subscriptionDetail}
+            accountDetails={subscriptionDetail}
             provider="gh"
             owner="codecov"
             closeForm={() => {}}
@@ -155,7 +155,7 @@ describe('PaymentMethodForm', () => {
         })
         render(
           <PaymentMethodForm
-            subscriptionDetail={subscriptionDetail}
+            accountDetails={subscriptionDetail}
             provider="gh"
             owner="codecov"
             closeForm={closeForm}
@@ -181,7 +181,7 @@ describe('PaymentMethodForm', () => {
       })
       render(
         <PaymentMethodForm
-          subscriptionDetail={subscriptionDetail}
+          accountDetails={subscriptionDetail}
           provider="gh"
           owner="codecov"
           closeForm={() => {}}
@@ -203,7 +203,7 @@ describe('PaymentMethodForm', () => {
       })
       render(
         <PaymentMethodForm
-          subscriptionDetail={subscriptionDetail}
+          accountDetails={subscriptionDetail}
           provider="gh"
           owner="codecov"
           closeForm={() => {}}

--- a/src/pages/PlanPage/subRoutes/CurrentOrgPlan/BillingDetails/PaymentCard/PaymentMethodForm.test.tsx
+++ b/src/pages/PlanPage/subRoutes/CurrentOrgPlan/BillingDetails/PaymentCard/PaymentMethodForm.test.tsx
@@ -295,26 +295,5 @@ describe('PaymentMethodForm', () => {
 
       expect(name).toBe('Account Name')
     })
-
-    it('uses email when all other name fields are missing', () => {
-      const accountDetailsWithoutBillingName = {
-        name: undefined,
-        email: 'customer@email.com',
-        subscriptionDetail: {
-          defaultPaymentMethod: {
-            billingDetails: {
-              name: undefined,
-            },
-          },
-          latestInvoice: {
-            customerName: undefined,
-          },
-        },
-      } as unknown as z.infer<typeof AccountDetailsSchema>
-
-      const name = getName(accountDetailsWithoutBillingName)
-
-      expect(name).toBe('customer@email.com')
-    })
   })
 })

--- a/src/pages/PlanPage/subRoutes/CurrentOrgPlan/BillingDetails/PaymentCard/PaymentMethodForm.tsx
+++ b/src/pages/PlanPage/subRoutes/CurrentOrgPlan/BillingDetails/PaymentCard/PaymentMethodForm.tsx
@@ -146,7 +146,6 @@ export const getName = (
       ?.name ||
     accountDetails?.subscriptionDetail?.latestInvoice?.customerName ||
     accountDetails?.name ||
-    getEmail(accountDetails) ||
     undefined
   )
 }

--- a/src/pages/PlanPage/subRoutes/CurrentOrgPlan/BillingDetails/PaymentCard/PaymentMethodForm.tsx
+++ b/src/pages/PlanPage/subRoutes/CurrentOrgPlan/BillingDetails/PaymentCard/PaymentMethodForm.tsx
@@ -27,19 +27,8 @@ const PaymentMethodForm = ({
   const billingDetails =
     subscriptionDetail?.defaultPaymentMethod?.billingDetails
 
-  const email =
-    billingDetails?.email ||
-    subscriptionDetail?.customer?.email ||
-    subscriptionDetail?.latestInvoice?.customerEmail ||
-    accountDetails?.email ||
-    undefined
-
-  const name =
-    billingDetails?.name ||
-    subscriptionDetail?.latestInvoice?.customerName ||
-    accountDetails?.name ||
-    email ||
-    undefined
+  const email = getEmail(accountDetails)
+  const name = getName(accountDetails)
 
   const {
     mutate: updatePaymentMethod,
@@ -134,6 +123,32 @@ export const stripeAddress = (
     postal_code: address.postalCode || null,
     country: address.country || null,
   }
+}
+
+export const getEmail = (
+  accountDetails: z.infer<typeof AccountDetailsSchema>
+) => {
+  return (
+    accountDetails?.subscriptionDetail?.defaultPaymentMethod?.billingDetails
+      ?.email ||
+    accountDetails?.subscriptionDetail?.latestInvoice?.customerEmail ||
+    accountDetails?.subscriptionDetail?.customer?.email ||
+    accountDetails?.email ||
+    undefined
+  )
+}
+
+export const getName = (
+  accountDetails: z.infer<typeof AccountDetailsSchema>
+) => {
+  return (
+    accountDetails?.subscriptionDetail?.defaultPaymentMethod?.billingDetails
+      ?.name ||
+    accountDetails?.subscriptionDetail?.latestInvoice?.customerName ||
+    accountDetails?.name ||
+    getEmail(accountDetails) ||
+    undefined
+  )
 }
 
 export default PaymentMethodForm

--- a/src/pages/PlanPage/subRoutes/CurrentOrgPlan/BillingDetails/PaymentCard/PaymentMethodForm.tsx
+++ b/src/pages/PlanPage/subRoutes/CurrentOrgPlan/BillingDetails/PaymentCard/PaymentMethodForm.tsx
@@ -3,10 +3,7 @@ import { StripePaymentElement } from '@stripe/stripe-js'
 import cs from 'classnames'
 import { z } from 'zod'
 
-import {
-  BillingDetailsSchema,
-  SubscriptionDetailSchema,
-} from 'services/account'
+import { AccountDetailsSchema, BillingDetailsSchema } from 'services/account'
 import { useUpdatePaymentMethod } from 'services/account/useUpdatePaymentMethod'
 import { Provider } from 'shared/api/helpers'
 import Button from 'ui/Button'
@@ -15,19 +12,34 @@ interface PaymentMethodFormProps {
   closeForm: () => void
   provider: Provider
   owner: string
-  subscriptionDetail: z.infer<typeof SubscriptionDetailSchema>
+  accountDetails: z.infer<typeof AccountDetailsSchema>
 }
 
 const PaymentMethodForm = ({
   closeForm,
   provider,
   owner,
-  subscriptionDetail,
+  accountDetails,
 }: PaymentMethodFormProps) => {
   const elements = useElements()
+  const subscriptionDetail = accountDetails?.subscriptionDetail
 
   const billingDetails =
     subscriptionDetail?.defaultPaymentMethod?.billingDetails
+
+  const email =
+    billingDetails?.email ||
+    subscriptionDetail?.customer?.email ||
+    subscriptionDetail?.latestInvoice?.customerEmail ||
+    accountDetails?.email ||
+    undefined
+
+  const name =
+    billingDetails?.name ||
+    subscriptionDetail?.latestInvoice?.customerName ||
+    accountDetails?.name ||
+    email ||
+    undefined
 
   const {
     mutate: updatePaymentMethod,
@@ -37,8 +49,8 @@ const PaymentMethodForm = ({
   } = useUpdatePaymentMethod({
     provider,
     owner,
-    name: billingDetails?.name || undefined,
-    email: billingDetails?.email || undefined,
+    name,
+    email,
     address: stripeAddress(billingDetails) || undefined,
   })
 


### PR DESCRIPTION
It appears some customers can have messy data missing billing details email or name, which makes them encounter an error on the Payment Element (this UI element requires this that was formerly optional with the Card Element). 
Instead infer these values from other places on the Stripe customer such as the name/email on the latest invoice, or that attached to the customer, or that attached to the accountDetails.

Fixes https://codecov.sentry.io/issues/6237642048/?alert_rule_id=15115849&alert_type=issue&notification_uuid=50a22e19-57b2-4b3e-81c9-c85911f30570&project=5514400&referrer=issue_alert-slack