### PR TITLE
fix: Hide tokenless banner for signed out user

### DIFF
--- a/src/shared/GlobalTopBanners/TokenlessBanner/TokenlessBanner.test.tsx
+++ b/src/shared/GlobalTopBanners/TokenlessBanner/TokenlessBanner.test.tsx
@@ -133,7 +133,9 @@ describe('TokenlessBanner', () => {
 
   it('renders nothing when tokenlessSection flag is false', () => {
     setup({ tokenlessSection: false, currentUser: mockSignedInUser })
-    const { container } = render(<TokenlessBanner />, { wrapper: wrapper(['/gh/codecov']) })
+    const { container } = render(<TokenlessBanner />, {
+      wrapper: wrapper(['/gh/codecov']),
+    })
     expect(container).toBeEmptyDOMElement()
   })
 

--- a/src/shared/GlobalTopBanners/TokenlessBanner/TokenlessBanner.tsx
+++ b/src/shared/GlobalTopBanners/TokenlessBanner/TokenlessBanner.tsx
@@ -26,7 +26,14 @@ const TokenlessBanner: React.FC = () => {
   // @ts-expect-error useLocationParams needs to be typed
   const cameFromOnboarding = params['source'] === ONBOARDING_SOURCE
 
-  if (!tokenlessSection || !owner || !data || !currentUser?.user || cameFromOnboarding) return null
+  if (
+    !tokenlessSection ||
+    !owner ||
+    !data ||
+    !currentUser?.user ||
+    cameFromOnboarding
+  )
+    return null
 
   return data?.uploadTokenRequired ? (
     <TokenRequiredBanner />

--- a/src/shared/GlobalTopBanners/TokenlessBanner/TokenlessBanner.tsx
+++ b/src/shared/GlobalTopBanners/TokenlessBanner/TokenlessBanner.tsx
@@ -4,6 +4,7 @@ import { useParams } from 'react-router-dom'
 import { ONBOARDING_SOURCE } from 'pages/TermsOfService/constants'
 import { useLocationParams } from 'services/navigation'
 import { useUploadTokenRequired } from 'services/uploadTokenRequired'
+import { useUser } from 'services/user'
 import { useFlags } from 'shared/featureFlags'
 
 const TokenRequiredBanner = lazy(() => import('./TokenRequiredBanner'))
@@ -20,11 +21,12 @@ const TokenlessBanner: React.FC = () => {
   })
   const { provider, owner } = useParams<UseParams>()
   const { data } = useUploadTokenRequired({ provider, owner, enabled: !!owner })
+  const { data: currentUser } = useUser()
   const { params } = useLocationParams()
   // @ts-expect-error useLocationParams needs to be typed
   const cameFromOnboarding = params['source'] === ONBOARDING_SOURCE
 
-  if (!tokenlessSection || !owner || !data || cameFromOnboarding) return null
+  if (!tokenlessSection || !owner || !data || !currentUser?.user || cameFromOnboarding) return null
 
   return data?.uploadTokenRequired ? (
     <TokenRequiredBanner />


### PR DESCRIPTION
# Description

Closes https://github.com/codecov/engineering-team/issues/3009

Only show banner if user is logged in.

# Screenshots
Logged in:
<img width="1727" alt="Screenshot 2025-01-27 at 3 35 38 PM" src="https://github.com/user-attachments/assets/7beb066e-f09a-46e0-9e18-a5e3c5db57d1" />
Logged out:
<img width="1728" alt="Screenshot 2025-01-27 at 3 35 48 PM" src="https://github.com/user-attachments/assets/2d15b6d1-95eb-4ce9-bd25-a11d45204e98" />

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.