### PR TITLE
fix: Only show GH config banner when no welcome banner

### DIFF
--- a/src/shared/ListRepo/ListRepo.jsx
+++ b/src/shared/ListRepo/ListRepo.jsx
@@ -60,7 +60,8 @@ function ListRepo({ canRefetch, hasGhApp }) {
 
   return (
     <>
-      {!hasGhApp && <GithubConfigBanner />}
+      {/* we only want one of these two banners to show at a time */}
+      {!hasGhApp && !showDemoAlert && <GithubConfigBanner />}
       <OrgControlTable
         searchValue={params.search}
         repoDisplay={repoDisplay}

--- a/src/shared/ListRepo/ListRepo.test.tsx
+++ b/src/shared/ListRepo/ListRepo.test.tsx
@@ -303,7 +303,7 @@ describe('ListRepo', () => {
   })
 
   describe('user does not have gh app installed', () => {
-    it('displays github app config banner', async () => {
+    it('displays github app config banner if showDemoAlert is false', async () => {
       setup({})
       render(<ListRepo canRefetch hasGhApp={false} />, {
         wrapper: wrapper({
@@ -312,9 +312,21 @@ describe('ListRepo', () => {
         }),
       })
 
+      const banner = await screen.findByText("Codecov's GitHub app")
+      return expect(banner).toBeInTheDocument()
+    })
+    it('does not display github app config banner if showDemoAlert is true', async () => {
+      setup({})
+      render(<ListRepo canRefetch hasGhApp={false} />, {
+        wrapper: wrapper({
+          url: '/gh/janedoe?source=onboarding',
+          path: '/:provider/:owner',
+        }),
+      })
+
       await waitFor(() => {
-        const banner = screen.getByText("Codecov's GitHub app")
-        return expect(banner).toBeInTheDocument()
+        const banner = screen.queryByText("Codecov's GitHub app")
+        expect(banner).not.toBeInTheDocument()
       })
     })
   })


### PR DESCRIPTION
# Description

Followup PR to the Non-PAT Appless experience to prevent both the blue Welcome banner and blue GH App Install banner don't show at the same time as it overwhelms the user. The GH banner should only come up when the other is not showing.

# Code Example

# Notable Changes

# Screenshots

Problem: 
![Screenshot 2025-01-24 at 15 06 06](https://github.com/user-attachments/assets/4202d555-0089-4583-a4a5-4634f97cd4de)

New:
<img width="1719" alt="Screenshot 2025-01-24 at 1 49 16 PM" src="https://github.com/user-attachments/assets/e4294d82-ae00-4694-a08d-3bb1e7d29310" />
<img width="1722" alt="Screenshot 2025-01-24 at 1 49 32 PM" src="https://github.com/user-attachments/assets/2d703c27-7a1a-4d76-93a4-48ce1a43d4c2" />


# Link to Sample Entry

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.