### PR TITLE
ref: Migrate useOktaConfig to TSQ V5

### DIFF
--- a/src/pages/AccountSettings/tabs/OktaAccess/OktaAccess.test.tsx
+++ b/src/pages/AccountSettings/tabs/OktaAccess/OktaAccess.test.tsx
@@ -1,4 +1,8 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import {
+  QueryClientProvider as QueryClientProviderV5,
+  QueryClient as QueryClientV5,
+} from '@tanstack/react-queryV5'
 import { render, screen } from '@testing-library/react'
 import { graphql, HttpResponse } from 'msw'
 import { setupServer } from 'msw/node'
@@ -10,15 +14,20 @@ import OktaAccess from './OktaAccess'
 const queryClient = new QueryClient({
   defaultOptions: { queries: { suspense: true, retry: false } },
 })
+const queryClientV5 = new QueryClientV5({
+  defaultOptions: { queries: { retry: false } },
+})
 
 const wrapper: React.FC<React.PropsWithChildren> = ({ children }) => (
-  <QueryClientProvider client={queryClient}>
-    <MemoryRouter initialEntries={['/account/gh/codecov/okta-access/']}>
-      <Route path="/account/:provider/:owner/okta-access/">
-        <Suspense fallback={null}>{children}</Suspense>
-      </Route>
-    </MemoryRouter>
-  </QueryClientProvider>
+  <QueryClientProviderV5 client={queryClientV5}>
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={['/account/gh/codecov/okta-access/']}>
+        <Route path="/account/:provider/:owner/okta-access/">
+          <Suspense fallback={null}>{children}</Suspense>
+        </Route>
+      </MemoryRouter>
+    </QueryClientProvider>
+  </QueryClientProviderV5>
 )
 
 const server = setupServer()

--- a/src/pages/AccountSettings/tabs/OktaAccess/OktaAccess.test.tsx
+++ b/src/pages/AccountSettings/tabs/OktaAccess/OktaAccess.test.tsx
@@ -37,6 +37,7 @@ beforeAll(() => {
 
 afterEach(() => {
   queryClient.clear()
+  queryClientV5.clear()
   server.resetHandlers()
 })
 

--- a/src/pages/AccountSettings/tabs/OktaAccess/OktaConfigForm/OktaConfigForm.test.tsx
+++ b/src/pages/AccountSettings/tabs/OktaAccess/OktaConfigForm/OktaConfigForm.test.tsx
@@ -12,13 +12,13 @@ import { MemoryRouter, Route } from 'react-router-dom'
 
 import { OktaConfigForm } from './OktaConfigForm'
 
-const oktaConfigMock = {
-  enabled: true,
-  enforced: true,
+const oktaConfigMock = (isEnabled: boolean, isEnforced: boolean) => ({
+  enabled: isEnabled,
+  enforced: isEnforced,
   url: 'https://okta.com',
   clientId: 'clientId',
   clientSecret: 'clientSecret',
-}
+})
 
 const queryClient = new QueryClient({
   defaultOptions: { queries: { retry: false } },
@@ -46,6 +46,7 @@ beforeAll(() => {
 
 afterEach(() => {
   queryClient.clear()
+  queryClientV5.clear()
   server.resetHandlers()
 })
 
@@ -53,8 +54,18 @@ afterAll(() => {
   server.close()
 })
 
+interface SetupArgs {
+  isEnabled?: boolean
+  isEnforced?: boolean
+}
+
 describe('OktaConfigForm', () => {
-  function setup() {
+  function setup(
+    { isEnabled = true, isEnforced = true }: SetupArgs = {
+      isEnabled: true,
+      isEnforced: true,
+    }
+  ) {
     const user = userEvent.setup()
     const mutate = vi.fn()
 
@@ -65,7 +76,7 @@ describe('OktaConfigForm', () => {
             owner: {
               isUserOktaAuthenticated: true,
               account: {
-                oktaConfig: oktaConfigMock,
+                oktaConfig: oktaConfigMock(isEnabled, isEnforced),
               },
             },
           },
@@ -189,7 +200,7 @@ describe('OktaConfigForm', () => {
   })
 
   it('should toggle Okta Sync Enabled on', async () => {
-    const { user } = setup()
+    const { user } = setup({ isEnabled: false, isEnforced: false })
     render(<OktaConfigForm />, { wrapper })
 
     const oktaSyncEnabledToggle = await screen.findByRole('button', {
@@ -199,11 +210,13 @@ describe('OktaConfigForm', () => {
     expect(oktaSyncEnabledToggle).toHaveClass('bg-toggle-inactive')
 
     await user.click(oktaSyncEnabledToggle)
-    expect(oktaSyncEnabledToggle).toHaveClass('bg-toggle-active')
+    await waitFor(() =>
+      expect(oktaSyncEnabledToggle).toHaveClass('bg-toggle-active')
+    )
   })
 
   it('should toggle Okta Login Enforce on', async () => {
-    const { user } = setup()
+    const { user } = setup({ isEnabled: false, isEnforced: false })
     render(<OktaConfigForm />, { wrapper })
 
     const oktaLoginEnforceToggle = await screen.findByRole('button', {
@@ -213,11 +226,13 @@ describe('OktaConfigForm', () => {
     expect(oktaLoginEnforceToggle).toHaveClass('bg-toggle-inactive')
 
     await user.click(oktaLoginEnforceToggle)
-    expect(oktaLoginEnforceToggle).toHaveClass('bg-toggle-active')
+    await waitFor(() =>
+      expect(oktaLoginEnforceToggle).toHaveClass('bg-toggle-active')
+    )
   })
 
   it('toggles enabled on when enforced is on', async () => {
-    const { user } = setup()
+    const { user } = setup({ isEnabled: false, isEnforced: false })
     render(<OktaConfigForm />, { wrapper })
 
     const oktaLoginEnforceToggle = await screen.findByRole('button', {
@@ -235,7 +250,7 @@ describe('OktaConfigForm', () => {
   })
 
   it('disables enforce toggle when enabled is off', async () => {
-    const { user } = setup()
+    const { user } = setup({ isEnabled: false, isEnforced: false })
     render(<OktaConfigForm />, { wrapper })
 
     const oktaSyncEnabledToggle = await screen.findByRole('button', {
@@ -308,9 +323,7 @@ describe('OktaConfigForm', () => {
       const oktaSyncEnabledToggle = await screen.findByRole('button', {
         name: /Okta Sync Enabled/,
       })
-      await waitFor(() => {
-        expect(oktaSyncEnabledToggle).toHaveClass('bg-toggle-active')
-      })
+      expect(oktaSyncEnabledToggle).toHaveClass('bg-toggle-active')
     })
 
     it('renders default values for Okta Login Enforce toggle', async () => {

--- a/src/pages/AccountSettings/tabs/OktaAccess/OktaConfigForm/OktaConfigForm.test.tsx
+++ b/src/pages/AccountSettings/tabs/OktaAccess/OktaConfigForm/OktaConfigForm.test.tsx
@@ -270,7 +270,7 @@ describe('OktaConfigForm', () => {
     expect(saveButton).toBeDisabled()
   })
 
-  describe.only('form should render default values for Okta Config', () => {
+  describe('form should render default values for Okta Config', () => {
     it('renders default values for client id', async () => {
       setup()
       render(<OktaConfigForm />, { wrapper })

--- a/src/pages/AccountSettings/tabs/OktaAccess/hooks/index.ts
+++ b/src/pages/AccountSettings/tabs/OktaAccess/hooks/index.ts
@@ -1,2 +1,1 @@
-export { useOktaConfig } from './useOktaConfig'
 export { useUpdateOktaConfig } from './useUpdateOktaConfig'

--- a/src/pages/AccountSettings/tabs/OktaAccess/hooks/useUpdateOktaConfig.test.tsx
+++ b/src/pages/AccountSettings/tabs/OktaAccess/hooks/useUpdateOktaConfig.test.tsx
@@ -1,4 +1,8 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import {
+  QueryClientProvider as QueryClientProviderV5,
+  QueryClient as QueryClientV5,
+} from '@tanstack/react-queryV5'
 import { render, renderHook, screen, waitFor } from '@testing-library/react'
 import { graphql, HttpResponse } from 'msw'
 import { setupServer } from 'msw/node'
@@ -18,15 +22,20 @@ const mockedToastNotification = useAddNotification as Mock
 const queryClient = new QueryClient({
   defaultOptions: { queries: { retry: false } },
 })
+const queryClientV5 = new QueryClientV5({
+  defaultOptions: { queries: { retry: false } },
+})
 
 const wrapper =
   (initialEntries = '/gh/codecov'): React.FC<React.PropsWithChildren> =>
   ({ children }) => (
-    <QueryClientProvider client={queryClient}>
-      <MemoryRouter initialEntries={[initialEntries]}>
-        <Route path="/:provider/:owner">{children}</Route>
-      </MemoryRouter>
-    </QueryClientProvider>
+    <QueryClientProviderV5 client={queryClientV5}>
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter initialEntries={[initialEntries]}>
+          <Route path="/:provider/:owner">{children}</Route>
+        </MemoryRouter>
+      </QueryClientProvider>
+    </QueryClientProviderV5>
   )
 
 const provider = 'gh'

--- a/src/pages/AccountSettings/tabs/OktaAccess/hooks/useUpdateOktaConfig.test.tsx
+++ b/src/pages/AccountSettings/tabs/OktaAccess/hooks/useUpdateOktaConfig.test.tsx
@@ -58,6 +58,7 @@ beforeAll(() => {
 
 afterEach(() => {
   queryClient.clear()
+  queryClientV5.clear()
   server.resetHandlers()
 })
 

--- a/src/pages/AccountSettings/tabs/OktaAccess/hooks/useUpdateOktaConfig.tsx
+++ b/src/pages/AccountSettings/tabs/OktaAccess/hooks/useUpdateOktaConfig.tsx
@@ -1,10 +1,13 @@
-import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { useMutation } from '@tanstack/react-query'
+import { useQueryClient as useQueryClientV5 } from '@tanstack/react-queryV5'
 import z from 'zod'
 
 import { useAddNotification } from 'services/toastNotification'
 import Api from 'shared/api'
 import { NetworkErrorObject } from 'shared/api/helpers'
 import A from 'ui/A'
+
+import { OktaConfigQueryOpts } from '../queries/OktaConfigQueryOpts'
 
 const TOAST_DURATION = 10000
 
@@ -78,7 +81,7 @@ type MutationFnParams = {
 
 export const useUpdateOktaConfig = ({ provider, owner }: URLParams) => {
   const addToast = useAddNotification()
-  const queryClient = useQueryClient()
+  const queryClientV5 = useQueryClientV5()
 
   return useMutation({
     mutationFn: ({
@@ -143,7 +146,9 @@ export const useUpdateOktaConfig = ({ provider, owner }: URLParams) => {
       })
     },
     onSettled: () => {
-      queryClient.invalidateQueries(['GetOktaConfig'])
+      queryClientV5.invalidateQueries(
+        OktaConfigQueryOpts({ provider, username: owner })
+      )
     },
     retry: false,
   })

--- a/src/pages/AccountSettings/tabs/OktaAccess/queries/OktaConfigQueryOpts.test.tsx
+++ b/src/pages/AccountSettings/tabs/OktaAccess/queries/OktaConfigQueryOpts.test.tsx
@@ -108,11 +108,13 @@ describe('useOktaConfig', () => {
         )
 
         await waitFor(() =>
-          expect(result.current.error).toStrictEqual({
-            status: 404,
-            data: {},
-            dev: 'useOktaConfig - 404 failed to parse',
-          })
+          expect(result.current.error).toEqual(
+            expect.objectContaining({
+              status: 404,
+              data: {},
+              dev: 'OktaConfigQueryOpts - 404 failed to parse',
+            })
+          )
         )
       })
     })

--- a/src/pages/AccountSettings/tabs/OktaAccess/queries/OktaConfigQueryOpts.test.tsx
+++ b/src/pages/AccountSettings/tabs/OktaAccess/queries/OktaConfigQueryOpts.test.tsx
@@ -1,9 +1,13 @@
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import {
+  QueryClientProvider as QueryClientProviderV5,
+  QueryClient as QueryClientV5,
+  useQuery as useQueryV5,
+} from '@tanstack/react-queryV5'
 import { renderHook, waitFor } from '@testing-library/react'
 import { graphql, HttpResponse } from 'msw'
 import { setupServer } from 'msw/node'
 
-import { useOktaConfig } from './useOktaConfig'
+import { OktaConfigQueryOpts } from './OktaConfigQueryOpts'
 
 const oktaConfigMock = {
   enabled: true,
@@ -13,13 +17,15 @@ const oktaConfigMock = {
   clientSecret: 'clientSecret',
 }
 
-const queryClient = new QueryClient({
+const queryClientV5 = new QueryClientV5({
   defaultOptions: { queries: { retry: false } },
 })
 const server = setupServer()
 
 const wrapper: React.FC<React.PropsWithChildren> = ({ children }) => (
-  <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  <QueryClientProviderV5 client={queryClientV5}>
+    {children}
+  </QueryClientProviderV5>
 )
 
 beforeAll(() => {
@@ -27,7 +33,7 @@ beforeAll(() => {
 })
 
 afterEach(() => {
-  queryClient.clear()
+  queryClientV5.clear()
   server.resetHandlers()
 })
 
@@ -58,10 +64,12 @@ describe('useOktaConfig', () => {
 
         const { result } = renderHook(
           () =>
-            useOktaConfig({
-              provider: 'gh',
-              username: 'codecov',
-            }),
+            useQueryV5(
+              OktaConfigQueryOpts({
+                provider: 'gh',
+                username: 'codecov',
+              })
+            ),
           { wrapper }
         )
 
@@ -90,10 +98,12 @@ describe('useOktaConfig', () => {
 
         const { result } = renderHook(
           () =>
-            useOktaConfig({
-              provider: 'gh',
-              username: 'codecov',
-            }),
+            useQueryV5(
+              OktaConfigQueryOpts({
+                provider: 'gh',
+                username: 'codecov',
+              })
+            ),
           { wrapper }
         )
 

--- a/src/pages/AccountSettings/tabs/OktaAccess/queries/OktaConfigQueryOpts.tsx
+++ b/src/pages/AccountSettings/tabs/OktaAccess/queries/OktaConfigQueryOpts.tsx
@@ -1,4 +1,4 @@
-import { useQuery, type UseQueryOptions } from '@tanstack/react-query'
+import { queryOptions as queryOptionsV5 } from '@tanstack/react-queryV5'
 import { z } from 'zod'
 
 import Api from 'shared/api'
@@ -26,30 +26,32 @@ const OktaConfigRequestSchema = z.object({
 })
 
 const oktaConfigQuery = `
-  query GetOktaConfig($username: String!) {
-    owner(username: $username) {
-      isUserOktaAuthenticated
-      account {
-        oktaConfig {
-          enabled
-          enforced
-          url
-          clientId
-          clientSecret
-        }
+query GetOktaConfig($username: String!) {
+  owner(username: $username) {
+    isUserOktaAuthenticated
+    account {
+      oktaConfig {
+        enabled
+        enforced
+        url
+        clientId
+        clientSecret
       }
     }
   }
+}
 `
 
-interface UseOktaConfigArgs {
+interface OktaConfigQueryArgs {
   provider: string
   username: string
-  opts?: UseQueryOptions<z.infer<typeof OktaConfigRequestSchema>>
 }
 
-export function useOktaConfig({ provider, username, opts }: UseOktaConfigArgs) {
-  return useQuery({
+export function OktaConfigQueryOpts({
+  provider,
+  username,
+}: OktaConfigQueryArgs) {
+  return queryOptionsV5({
     queryKey: ['GetOktaConfig', provider, username, oktaConfigQuery],
     queryFn: ({ signal }) => {
       return Api.graphql({
@@ -73,6 +75,5 @@ export function useOktaConfig({ provider, username, opts }: UseOktaConfigArgs) {
         return parsedRes.data
       })
     },
-    ...(!!opts && opts),
   })
 }

--- a/src/pages/AccountSettings/tabs/OktaAccess/queries/OktaConfigQueryOpts.tsx
+++ b/src/pages/AccountSettings/tabs/OktaAccess/queries/OktaConfigQueryOpts.tsx
@@ -2,7 +2,7 @@ import { queryOptions as queryOptionsV5 } from '@tanstack/react-queryV5'
 import { z } from 'zod'
 
 import Api from 'shared/api'
-import { NetworkErrorObject } from 'shared/api/helpers'
+import { rejectNetworkError } from 'shared/api/helpers'
 
 export const OktaConfigSchema = z.object({
   enabled: z.boolean(),
@@ -65,11 +65,12 @@ export function OktaConfigQueryOpts({
         const parsedRes = OktaConfigRequestSchema.safeParse(res?.data)
 
         if (!parsedRes.success) {
-          return Promise.reject({
+          return rejectNetworkError({
             status: 404,
             data: {},
-            dev: 'useOktaConfig - 404 failed to parse',
-          } satisfies NetworkErrorObject)
+            dev: 'OktaConfigQueryOpts - 404 failed to parse',
+            error: parsedRes.error,
+          })
         }
 
         return parsedRes.data

--- a/src/shared/GlobalTopBanners/OktaBanners/OktaBanners.test.tsx
+++ b/src/shared/GlobalTopBanners/OktaBanners/OktaBanners.test.tsx
@@ -1,5 +1,9 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { render, screen } from '@testing-library/react'
+import {
+  QueryClientProvider as QueryClientProviderV5,
+  QueryClient as QueryClientV5,
+} from '@tanstack/react-queryV5'
+import { render, screen, waitFor } from '@testing-library/react'
 import { graphql, HttpResponse } from 'msw'
 import { setupServer } from 'msw/node'
 import { Suspense } from 'react'
@@ -15,29 +19,40 @@ vi.mock('../OktaErrorBanners', () => ({
   default: () => 'OktaErrorBanners',
 }))
 
-const wrapper =
-  (initialEntries = ['/gh/owner']): React.FC<React.PropsWithChildren> =>
-  ({ children }) => (
-    <QueryClientProvider client={queryClient}>
-      <MemoryRouter initialEntries={initialEntries}>
-        <Route path="/:provider/:owner">
-          <Suspense fallback={<p>Loading</p>}>{children}</Suspense>
-        </Route>
-      </MemoryRouter>
-    </QueryClientProvider>
-  )
-
 const queryClient = new QueryClient({
   defaultOptions: { queries: { retry: false } },
 })
+const queryClientV5 = new QueryClientV5({
+  defaultOptions: { queries: { retry: false } },
+})
+const wrapper =
+  (initialEntries = ['/gh/owner']): React.FC<React.PropsWithChildren> =>
+  ({ children }) => (
+    <QueryClientProviderV5 client={queryClientV5}>
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter initialEntries={initialEntries}>
+          <Route path="/:provider/:owner">
+            <Suspense fallback={<p>Loading</p>}>{children}</Suspense>
+          </Route>
+        </MemoryRouter>
+      </QueryClientProvider>
+    </QueryClientProviderV5>
+  )
 
 const server = setupServer()
-beforeAll(() => server.listen())
-beforeEach(() => {
-  server.resetHandlers()
-  queryClient.clear()
+beforeAll(() => {
+  server.listen()
 })
-afterAll(() => server.close())
+
+beforeEach(() => {
+  queryClient.clear()
+  queryClientV5.clear()
+  server.resetHandlers()
+})
+
+afterAll(() => {
+  server.close()
+})
 
 describe('OktaBanners', () => {
   function setup(data = {}) {
@@ -50,14 +65,12 @@ describe('OktaBanners', () => {
 
   describe('when owner is not provided', () => {
     it('should render null', async () => {
-      setup({
-        owner: null,
-      })
+      setup({ owner: null })
       const { container } = render(<OktaBanners />, {
         wrapper: wrapper(['/gh']),
       })
 
-      expect(container).toBeEmptyDOMElement()
+      await waitFor(() => expect(container).toBeEmptyDOMElement())
     })
   })
 
@@ -80,7 +93,7 @@ describe('OktaBanners', () => {
         })
 
         const { container } = render(<OktaBanners />, { wrapper: wrapper() })
-        expect(container).toBeEmptyDOMElement()
+        await waitFor(() => expect(container).toBeEmptyDOMElement())
       })
     })
 
@@ -102,7 +115,7 @@ describe('OktaBanners', () => {
         })
 
         const { container } = render(<OktaBanners />, { wrapper: wrapper() })
-        expect(container).toBeEmptyDOMElement()
+        await waitFor(() => expect(container).toBeEmptyDOMElement())
       })
     })
 
@@ -124,7 +137,7 @@ describe('OktaBanners', () => {
         })
 
         const { container } = render(<OktaBanners />, { wrapper: wrapper() })
-        expect(container).toBeEmptyDOMElement()
+        await waitFor(() => expect(container).toBeEmptyDOMElement())
       })
     })
 

--- a/src/shared/GlobalTopBanners/OktaBanners/OktaBanners.tsx
+++ b/src/shared/GlobalTopBanners/OktaBanners/OktaBanners.tsx
@@ -1,7 +1,8 @@
+import { useSuspenseQuery as useSuspenseQueryV5 } from '@tanstack/react-queryV5'
 import { lazy } from 'react'
 import { useParams } from 'react-router'
 
-import { useOktaConfig } from 'pages/AccountSettings/tabs/OktaAccess/hooks'
+import { OktaConfigQueryOpts } from 'pages/AccountSettings/tabs/OktaAccess/queries/OktaConfigQueryOpts'
 
 interface URLParams {
   provider: string
@@ -15,16 +16,18 @@ const OktaErrorBanners = lazy(() => import('../OktaErrorBanners'))
 function OktaBanners() {
   const { provider, owner } = useParams<URLParams>()
 
-  const { data } = useOktaConfig({
-    provider,
-    username: owner || '',
-    opts: { enabled: !!owner },
-  })
+  const { data } = useSuspenseQueryV5(
+    OktaConfigQueryOpts({
+      provider,
+      username: owner || '',
+    })
+  )
 
   const oktaConfig = data?.owner?.account?.oktaConfig
 
-  if (!owner || !oktaConfig?.enabled || data?.owner?.isUserOktaAuthenticated)
+  if (!owner || !oktaConfig?.enabled || data?.owner?.isUserOktaAuthenticated) {
     return null
+  }
 
   return (
     <div className="flex flex-col gap-2">
@@ -34,4 +37,13 @@ function OktaBanners() {
   )
 }
 
-export default OktaBanners
+function OktaBannersWrapper() {
+  const { owner } = useParams<URLParams>()
+  if (!owner) {
+    return null
+  }
+
+  return <OktaBanners />
+}
+
+export default OktaBannersWrapper


### PR DESCRIPTION
# Description

This PR migrates the `useOktaConfig` to TSQ V5 `queryOptions` API version `OktaConfigQueryOpts`, as well as it's usage in a couple of components and tests.

Ticket: codecov/engineering-team#2963

# Notable Changes

- Migrates `useOktaConfig` to `OktaConfigQueryOpts`
- Update `useUpdateOktaConfig` to use TSQ V5 and `OktaConfigQueryOpts` to clear the cache
- Update usage in `OktaConfigForm`, and `OktaBanners`
- Update tests, including `OktaAccess`