### PR TITLE
feat: Allow build time configuration of sunburst

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -12,6 +12,7 @@ const defaultConfig = {
   SENTRY_ERROR_SAMPLE_RATE: 1.0,
   GH_APP: DEFAULT_GH_APP,
   GH_APP_AI: 'codecov-ai',
+  SUNBURST_ENABLED: true,
 }
 
 export function removeReactAppPrefix(obj) {
@@ -31,6 +32,10 @@ export function removeReactAppPrefix(obj) {
 
   if ('HIDE_ACCESS_TAB' in keys) {
     keys['HIDE_ACCESS_TAB'] = keys['HIDE_ACCESS_TAB'].toLowerCase() === 'true'
+  }
+
+  if ('SUNBURST_ENABLED' in keys) {
+    keys['SUNBURST_ENABLED'] = keys['SUNBURST_ENABLED'].toLowerCase() === 'true'
   }
 
   if ('SENTRY_TRACING_SAMPLE_RATE' in keys) {

--- a/src/config.test.js
+++ b/src/config.test.js
@@ -3,18 +3,14 @@ import { removeReactAppPrefix } from 'config'
 describe('config', () => {
   describe('removeReactAppPrefix', () => {
     it('removes REACT_APP prefix', () => {
-      const obj = {
-        REACT_APP_TEST_ENV: 'test env',
-      }
+      const obj = { REACT_APP_TEST_ENV: 'test env' }
 
       expect(removeReactAppPrefix(obj)).toEqual({ TEST_ENV: 'test env' })
     })
 
     describe('sets IS_SELF_HOSTED to boolean', () => {
       it('sets to true', () => {
-        const obj = {
-          ENV: 'enterprise',
-        }
+        const obj = { ENV: 'enterprise' }
 
         expect(removeReactAppPrefix(obj)).toEqual({
           ENV: 'enterprise',
@@ -23,9 +19,7 @@ describe('config', () => {
       })
 
       it('sets to false', () => {
-        const obj = {
-          ENV: 'production',
-        }
+        const obj = { ENV: 'production' }
 
         expect(removeReactAppPrefix(obj)).toEqual({
           ENV: 'production',
@@ -65,6 +59,14 @@ describe('config', () => {
         const obj = {}
 
         expect(removeReactAppPrefix(obj)).toEqual({})
+      })
+    })
+
+    describe('sets SUNBURST_ENABLED to boolean', () => {
+      it('sets to true', () => {
+        const obj = { SUNBURST_ENABLED: 'true' }
+
+        expect(removeReactAppPrefix(obj)).toEqual({ SUNBURST_ENABLED: true })
       })
     })
 

--- a/src/pages/RepoPage/CoverageTab/OverviewTab/OverviewTab.tsx
+++ b/src/pages/RepoPage/CoverageTab/OverviewTab/OverviewTab.tsx
@@ -2,6 +2,8 @@ import { useSuspenseQuery as useSuspenseQueryV5 } from '@tanstack/react-queryV5'
 import { lazy, Suspense } from 'react'
 import { Switch, useParams } from 'react-router-dom'
 
+import config from 'config'
+
 import { SentryRoute } from 'sentry'
 
 import SilentNetworkErrorWrapper from 'layouts/shared/SilentNetworkErrorWrapper'
@@ -71,7 +73,8 @@ function CoverageOverviewTab() {
     typeof fileCount === 'number' && fileCount <= MAX_FILE_COUNT
 
   let displaySunburst = false
-  if (withinFileCount) {
+  // only enable sunburst when both cases are met
+  if (withinFileCount && config.SUNBURST_ENABLED) {
     displaySunburst = true
   }
 


### PR DESCRIPTION
# Description

This PR adds in a new configuration var `SUNBURST_ENABLED` for build time to override the display of the sunburst chart.

# Notable Changes

- Add in new config var `SUNBURST_ENABLED`
- Update `OverviewTab` to take into account of new build time variable