### PR TITLE
feat: Only show auto-activate toggle for admins when on enterprise cloud plan

### DIFF
--- a/src/pages/MembersPage/MembersActivation/MembersActivation.jsx
+++ b/src/pages/MembersPage/MembersActivation/MembersActivation.jsx
@@ -18,13 +18,18 @@ function MemberActivation() {
     owner,
   })
 
-  const planAutoActivate = accountDetails?.planAutoActivate
+  const planAutoActivateIsDefined = !isUndefined(
+    accountDetails?.planAutoActivate
+  )
+  const isNotTrialing =
+    !planData?.plan?.isTrialPlan &&
+    planData?.plan?.trialStatus !== TrialStatuses.ONGOING
+  const isNotAnEnterpriseDeveloper = !(
+    planData?.plan?.isEnterprisePlan && !ownerData.isAdmin
+  ) // only show for admins on enterprise cloud plans
 
   const showAutoActivate =
-    !isUndefined(planAutoActivate) &&
-    !planData?.plan?.isTrialPlan &&
-    planData?.plan?.trialStatus !== TrialStatuses.ONGOING &&
-    !(planData?.plan?.isEnterprisePlan && !ownerData.isAdmin) // only show for admins on enterprise cloud plans
+    planAutoActivateIsDefined && isNotTrialing && isNotAnEnterpriseDeveloper
 
   return (
     <div className="border-2 border-ds-gray-primary">
@@ -33,7 +38,7 @@ function MemberActivation() {
         <>
           {/* TODO: have this be created dynamically w/ a better parent component */}
           <hr className="mx-4" />
-          <AutoActivate planAutoActivate={planAutoActivate} />
+          <AutoActivate planAutoActivate={accountDetails?.planAutoActivate} />
         </>
       )}
     </div>

--- a/src/pages/MembersPage/MembersActivation/MembersActivation.jsx
+++ b/src/pages/MembersPage/MembersActivation/MembersActivation.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 import { useParams } from 'react-router-dom'
 
 import { TrialStatuses, useAccountDetails, usePlanData } from 'services/account'
+import { useOwner } from 'services/user'
 
 import Activation from './Activation'
 import AutoActivate from './AutoActivate'
@@ -10,6 +11,7 @@ import AutoActivate from './AutoActivate'
 function MemberActivation() {
   const { owner, provider } = useParams()
   const { data: accountDetails } = useAccountDetails({ owner, provider })
+  const { data: ownerData } = useOwner({ username: owner })
 
   const { data: planData } = usePlanData({
     provider,
@@ -21,7 +23,8 @@ function MemberActivation() {
   const showAutoActivate =
     !isUndefined(planAutoActivate) &&
     !planData?.plan?.isTrialPlan &&
-    planData?.plan?.trialStatus !== TrialStatuses.ONGOING
+    planData?.plan?.trialStatus !== TrialStatuses.ONGOING &&
+    !(planData?.plan?.isEnterprisePlan && !ownerData.isAdmin) // only show for admins on enterprise cloud plans
 
   return (
     <div className="border-2 border-ds-gray-primary">

--- a/src/pages/MembersPage/MembersActivation/MembersActivation.test.jsx
+++ b/src/pages/MembersPage/MembersActivation/MembersActivation.test.jsx
@@ -238,6 +238,48 @@ describe('Members Activation', () => {
           })
         })
       })
+
+      describe('user is not in an enterprise org', () => {
+        describe('and they are not an admin', () => {
+          it('renders auto activate component', async () => {
+            setup(
+              { ...mockedAccountDetails, planAutoActivate: true },
+              TrialStatuses.NOT_STARTED,
+              Plans.USERS_PR_INAPPM,
+              false,
+              false
+            )
+
+            render(<MembersActivation />, { wrapper })
+
+            await waitFor(() => queryClient.isFetching)
+            await waitFor(() => !queryClient.isFetching)
+
+            const AutoActivate = await screen.findByText(/AutoActivate/)
+            expect(AutoActivate).toBeInTheDocument()
+          })
+        })
+
+        describe.only('and they are an admin', () => {
+          it('renders auto activate component', async () => {
+            setup(
+              { ...mockedAccountDetails, planAutoActivate: true },
+              TrialStatuses.NOT_STARTED,
+              Plans.USERS_PR_INAPPM,
+              false,
+              true
+            )
+
+            render(<MembersActivation />, { wrapper })
+
+            await waitFor(() => queryClient.isFetching)
+            await waitFor(() => !queryClient.isFetching)
+
+            const AutoActivate = await screen.findByText(/AutoActivate/)
+            expect(AutoActivate).toBeInTheDocument()
+          })
+        })
+      })
     })
   })
 })

--- a/src/pages/MembersPage/MembersActivation/MembersActivation.test.jsx
+++ b/src/pages/MembersPage/MembersActivation/MembersActivation.test.jsx
@@ -260,7 +260,7 @@ describe('Members Activation', () => {
           })
         })
 
-        describe.only('and they are an admin', () => {
+        describe('and they are an admin', () => {
           it('renders auto activate component', async () => {
             setup(
               { ...mockedAccountDetails, planAutoActivate: true },

--- a/src/pages/MembersPage/MembersActivation/MembersActivation.test.jsx
+++ b/src/pages/MembersPage/MembersActivation/MembersActivation.test.jsx
@@ -218,7 +218,7 @@ describe('Members Activation', () => {
           })
         })
 
-        describe.only('and they are an admin', () => {
+        describe('and they are an admin', () => {
           it('renders auto activate component', async () => {
             setup(
               { ...mockedAccountDetails, planAutoActivate: true },

--- a/src/pages/MembersPage/MembersActivation/MembersActivation.test.jsx
+++ b/src/pages/MembersPage/MembersActivation/MembersActivation.test.jsx
@@ -78,11 +78,26 @@ describe('Members Activation', () => {
   function setup(
     accountDetails = mockedAccountDetails,
     trialStatus = TrialStatuses.NOT_STARTED,
-    planValue = mockedAccountDetails.plan.value
+    planValue = mockedAccountDetails.plan.value,
+    isEnterprisePlan = false,
+    isAdmin = true
   ) {
     server.use(
       http.get('/internal/:provider/:owner/account-details/', () => {
         return HttpResponse.json(accountDetails)
+      }),
+      graphql.query('DetailOwner', () => {
+        return HttpResponse.json({
+          data: {
+            owner: {
+              ownerid: 123,
+              username: 'codecov',
+              avatarUrl: null,
+              isCurrentUserPartOfOrg: true,
+              isAdmin,
+            },
+          },
+        })
       }),
       graphql.query('GetPlanData', () => {
         return HttpResponse.json({
@@ -93,6 +108,7 @@ describe('Members Activation', () => {
                 ...mockPlanData,
                 trialStatus,
                 value: planValue,
+                isEnterprisePlan,
               },
             },
           },
@@ -178,6 +194,48 @@ describe('Members Activation', () => {
 
           const AutoActivate = screen.queryByText(/AutoActivate/)
           expect(AutoActivate).not.toBeInTheDocument()
+        })
+      })
+
+      describe('user is in an enterprise org', () => {
+        describe('and they are not an admin', () => {
+          it('does not render auto activate component', async () => {
+            setup(
+              { ...mockedAccountDetails, planAutoActivate: true },
+              TrialStatuses.NOT_STARTED,
+              Plans.USERS_ENTERPRISEY,
+              true,
+              false
+            )
+
+            render(<MembersActivation />, { wrapper })
+
+            await waitFor(() => queryClient.isFetching)
+            await waitFor(() => !queryClient.isFetching)
+
+            const AutoActivate = screen.queryByText(/AutoActivate/)
+            expect(AutoActivate).not.toBeInTheDocument()
+          })
+        })
+
+        describe.only('and they are an admin', () => {
+          it('renders auto activate component', async () => {
+            setup(
+              { ...mockedAccountDetails, planAutoActivate: true },
+              TrialStatuses.NOT_STARTED,
+              Plans.USERS_ENTERPRISEY,
+              true,
+              true
+            )
+
+            render(<MembersActivation />, { wrapper })
+
+            await waitFor(() => queryClient.isFetching)
+            await waitFor(() => !queryClient.isFetching)
+
+            const AutoActivate = await screen.findByText(/AutoActivate/)
+            expect(AutoActivate).toBeInTheDocument()
+          })
         })
       })
     })


### PR DESCRIPTION
Title. Adds another data fetch hook call, but I think this is guaranteed to be a local cache hit as this same hook is used in a parent component.

Closes https://github.com/codecov/engineering-team/issues/3201
