### PR TITLE
fix: Only show GH app config banner if admin

### DIFF
--- a/src/pages/OwnerPage/OwnerPage.jsx
+++ b/src/pages/OwnerPage/OwnerPage.jsx
@@ -90,12 +90,12 @@ function OwnerPage() {
       </Suspense>
       <div>
         {showOnboardingContainer ? <OnboardingOrg /> : null}
-        {ownerData?.isCurrentUserPartOfOrg && (
+        {ownerData?.isCurrentUserPartOfOrg ? (
           <Tabs owner={ownerData} provider={provider} />
-        )}
+        ) : null}
         <ActiveContext.Provider value={params?.repoDisplay}>
           <ListRepo
-            canRefetch={ownerData?.isCurrentUserPartOfOrg}
+            canRefetch={!!ownerData?.isCurrentUserPartOfOrg}
             hasGhApp={hasGhApp}
           />
         </ActiveContext.Provider>

--- a/src/shared/ListRepo/ListRepo.test.tsx
+++ b/src/shared/ListRepo/ListRepo.test.tsx
@@ -127,7 +127,10 @@ const wrapper =
 
 describe('ListRepo', () => {
   function setup(
-    { isTeamPlan = false }: { isTeamPlan?: boolean },
+    {
+      isTeamPlan = false,
+      isAdmin = true,
+    }: { isTeamPlan?: boolean; isAdmin?: boolean },
     me = mockUser
   ) {
     const user = userEvent.setup()
@@ -140,6 +143,11 @@ describe('ListRepo', () => {
       }),
       graphql.query('CurrentUser', () => {
         return HttpResponse.json({ data: me })
+      }),
+      graphql.query('DetailOwner', () => {
+        return HttpResponse.json({
+          data: { owner: { username: 'janedoe', isAdmin } },
+        })
       })
     )
 
@@ -327,6 +335,28 @@ describe('ListRepo', () => {
       await waitFor(() => {
         const banner = screen.queryByText("Codecov's GitHub app")
         expect(banner).not.toBeInTheDocument()
+      })
+    })
+    it('does not display github app config banner if isAdmin is false', async () => {
+      setup({ isAdmin: false })
+      render(<ListRepo canRefetch hasGhApp={false} />, {
+        wrapper: wrapper({
+          url: '/gh/janedoe',
+          path: '/:provider/:owner',
+        }),
+      })
+      const banner = screen.queryByText("Codecov's GitHub app")
+      expect(banner).not.toBeInTheDocument()
+    })
+  })
+  describe('user has gh app installed', () => {
+    it('does not display github app config banner if hasGhApp is true', async () => {
+      setup({})
+      render(<ListRepo canRefetch hasGhApp={true} />, {
+        wrapper: wrapper({
+          url: '/gh/janedoe',
+          path: '/:provider/:owner',
+        }),
       })
     })
   })

--- a/src/ui/Icon/svg/outline/index.jsx
+++ b/src/ui/Icon/svg/outline/index.jsx
@@ -185,7 +185,7 @@ import search from './search.svg?react'
 // import shoppingCart from './shopping-cart.svg?react'
 // import sortAscending from './sort-ascending.svg?react'
 // import sortDescending from './sort-descending.svg?react'
-// import sparkles from './sparkles.svg?react'
+import sparkles from './sparkles.svg?react'
 import speakerphone from './speakerphone.svg?react'
 // import star from './star.svg?react'
 // import statusOffline from './status-offline.svg?react'
@@ -266,6 +266,7 @@ export {
   questionMarkCircle,
   refresh,
   search,
+  sparkles,
   speakerphone,
   sun,
   trash,


### PR DESCRIPTION
# Description

Closes https://github.com/codecov/engineering-team/issues/3287

Background info copied from ^ for context:
In the new non-PAT appless experience, we made a shift of rendering the GH Config Banner from `<HeaderBanners>` to `<ListRepo>` which moved it outside of scope of the `SilentNetworkErrorWrapper`. The `account-details` API (used for getting data about if org has GH app installed) call 404s inside of that ErrorBoundary wrapper so anything `isGHApp` related would just error and be caught by the boundary. Now that we've moved `<GithubConfigBanner>` out, it needs more boolean checks to make sure we only show it for admins on their org that does not have the GH app already installed. We also don't want to show this at the same time as the "Welcome" banner when someone just onboards. 

# Notable Changes

Check that the user viewing the org page is an admin to get the GH Config Banner. Rest of the changes are just minor refactors and TS conversion made while I was there.

# Screenshots

# Link to Sample Entry

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.