### PR TITLE
feat: Add users-developer to plans enum

### DIFF
--- a/src/shared/utils/billing.ts
+++ b/src/shared/utils/billing.ts
@@ -20,6 +20,7 @@ export const Plans = {
   USERS_TEAMY: 'users-teamy',
   USERS_ENTERPRISEM: 'users-enterprisem',
   USERS_ENTERPRISEY: 'users-enterprisey',
+  USERS_DEVELOPER: 'users-developer',
 } as const
 
 export type PlanName = (typeof Plans)[keyof typeof Plans]


### PR DESCRIPTION
# Description
Needed so it doesn't fail when we default users to usere-developer in db


<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.