### PR TITLE
fix: Handle ach case

### DIFF
--- a/src/pages/PlanPage/subRoutes/CurrentOrgPlan/CurrentOrgPlan.tsx
+++ b/src/pages/PlanPage/subRoutes/CurrentOrgPlan/CurrentOrgPlan.tsx
@@ -75,7 +75,9 @@ function CurrentOrgPlan() {
         />
       ) : null}
       <InfoMessageStripeCallback
-        hasUnverifiedPaymentMethods={hasUnverifiedPaymentMethods}
+        awaitingInitialPaymentMethodVerification={
+          awaitingInitialPaymentMethodVerification
+        }
       />
       {isDelinquent ? <DelinquentAlert /> : null}
       {data?.plan ? (

--- a/src/pages/PlanPage/subRoutes/CurrentOrgPlan/InfoMessageStripeCallback/InfoMessageStripeCallback.test.tsx
+++ b/src/pages/PlanPage/subRoutes/CurrentOrgPlan/InfoMessageStripeCallback/InfoMessageStripeCallback.test.tsx
@@ -13,7 +13,9 @@ const wrapper =
 describe('InfoMessageStripeCallback', () => {
   describe('when rendering without success or cancel in the url', () => {
     const { container } = render(
-      <InfoMessageStripeCallback hasUnverifiedPaymentMethods={false} />,
+      <InfoMessageStripeCallback
+        awaitingInitialPaymentMethodVerification={false}
+      />,
       {
         wrapper: wrapper('/account/gh/codecov'),
       }
@@ -27,7 +29,9 @@ describe('InfoMessageStripeCallback', () => {
   describe('when rendering with success in the url', () => {
     it('renders a success message', async () => {
       render(
-        <InfoMessageStripeCallback hasUnverifiedPaymentMethods={false} />,
+        <InfoMessageStripeCallback
+          awaitingInitialPaymentMethodVerification={false}
+        />,
         {
           wrapper: wrapper('/account/gh/codecov?success'),
         }
@@ -39,10 +43,12 @@ describe('InfoMessageStripeCallback', () => {
     })
   })
 
-  describe('when hasUnverifiedPaymentMethods is true', () => {
+  describe('when awaitingInitialPaymentMethodVerification is true', () => {
     it('does not enders a success message even at ?success', async () => {
       const { container } = render(
-        <InfoMessageStripeCallback hasUnverifiedPaymentMethods={true} />,
+        <InfoMessageStripeCallback
+          awaitingInitialPaymentMethodVerification={true}
+        />,
         {
           wrapper: wrapper('/account/gh/codecov?success'),
         }

--- a/src/pages/PlanPage/subRoutes/CurrentOrgPlan/InfoMessageStripeCallback/InfoMessageStripeCallback.tsx
+++ b/src/pages/PlanPage/subRoutes/CurrentOrgPlan/InfoMessageStripeCallback/InfoMessageStripeCallback.tsx
@@ -6,15 +6,15 @@ import Message from 'old_ui/Message'
 // Stripe redirects to this page with ?success or ?cancel in the URL
 // this component takes care of rendering a message if it is successful
 function InfoMessageStripeCallback({
-  hasUnverifiedPaymentMethods,
+  awaitingInitialPaymentMethodVerification,
 }: {
-  hasUnverifiedPaymentMethods: boolean
+  awaitingInitialPaymentMethodVerification: boolean
 }) {
   const urlParams = qs.parse(useLocation().search, {
     ignoreQueryPrefix: true,
   })
 
-  if ('success' in urlParams && !hasUnverifiedPaymentMethods)
+  if ('success' in urlParams && !awaitingInitialPaymentMethodVerification)
     return (
       <div className="col-start-1 col-end-13 mb-4">
         <Message variant="success">

--- a/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/UpgradeForm.tsx
+++ b/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/UpgradeForm.tsx
@@ -94,13 +94,17 @@ function UpgradeForm({ selectedPlan, setSelectedPlan }: UpgradeFormProps) {
   const newPlan = watch('newPlan')
   const seats = watch('seats')
 
+  const awaitingInitialPaymentMethodVerification =
+    !!unverifiedPaymentMethods?.length &&
+    !accountDetails?.subscriptionDetail?.defaultPaymentMethod
+
   useEffect(() => {
     // This is necessary because the validity of seats depends on the value of newPlan
     trigger('seats')
   }, [newPlan, trigger])
 
   const onSubmit = handleSubmit((data) => {
-    if (unverifiedPaymentMethods?.length) {
+    if (awaitingInitialPaymentMethodVerification) {
       setFormData(data)
       setShowModal(true)
     } else {


### PR DESCRIPTION
Fixes scenario where user sets up an initial checkout session with an instant payment method (like credit card), then they go to put in a new delayed notification payment method (e.g., ACH microdeposits). Then during these 2 days of waiting, they go to upgrade their Codecov account from Team to Pro. This should NOT show the modal that says it will cancel their existing incomplete upgrade. The modal should only show if this is the initial checkout session. This PR fixes that logic.