### PR TITLE
ref: Update useSetUploadTokenRequired to TSQ V5

### DIFF
--- a/src/pages/AccountSettings/tabs/OrgUploadToken/TokenlessSection/TokenlessSection.test.tsx
+++ b/src/pages/AccountSettings/tabs/OrgUploadToken/TokenlessSection/TokenlessSection.test.tsx
@@ -1,4 +1,8 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import {
+  QueryClientProvider as QueryClientProviderV5,
+  QueryClient as QueryClientV5,
+} from '@tanstack/react-queryV5'
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { graphql, HttpResponse } from 'msw'
@@ -31,30 +35,37 @@ vi.mock('shared/featureFlags', async () => {
 const queryClient = new QueryClient({
   defaultOptions: { queries: { retry: false } },
 })
+const queryClientV5 = new QueryClientV5({
+  defaultOptions: { queries: { retry: false } },
+})
+
+const wrapper: React.FC<React.PropsWithChildren> = ({ children }) => (
+  <QueryClientProviderV5 client={queryClientV5}>
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={['/account/gh/codecov/org-upload-token']}>
+        <Route path="/account/:provider/:owner/org-upload-token">
+          {children}
+        </Route>
+      </MemoryRouter>
+    </QueryClientProvider>
+  </QueryClientProviderV5>
+)
 
 const server = setupServer()
-
 beforeAll(() => {
   console.error = () => {}
   server.listen()
 })
 
-beforeEach(() => {
-  server.resetHandlers()
+afterEach(() => {
   queryClient.clear()
+  queryClientV5.clear()
+  server.resetHandlers()
 })
 
-afterAll(() => server.close())
-
-const wrapper: React.FC<React.PropsWithChildren> = ({ children }) => (
-  <QueryClientProvider client={queryClient}>
-    <MemoryRouter initialEntries={['/account/gh/codecov/org-upload-token']}>
-      <Route path="/account/:provider/:owner/org-upload-token">
-        {children}
-      </Route>
-    </MemoryRouter>
-  </QueryClientProvider>
-)
+afterAll(() => {
+  server.close()
+})
 
 describe('TokenlessSection', () => {
   function setup({

--- a/src/pages/AccountSettings/tabs/OrgUploadToken/TokenlessSection/TokenlessSection.tsx
+++ b/src/pages/AccountSettings/tabs/OrgUploadToken/TokenlessSection/TokenlessSection.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react'
 import { useParams } from 'react-router-dom'
 
 import { useUploadTokenRequired } from 'services/uploadTokenRequired'
+import { Provider } from 'shared/api/helpers'
 import A from 'ui/A'
 import { Card } from 'ui/Card'
 import { RadioTileGroup } from 'ui/RadioTileGroup'
@@ -15,7 +16,7 @@ const AUTHENTICATION_OPTIONS = {
 } as const
 
 interface UseParams {
-  provider: string
+  provider: Provider
   owner: string
 }
 
@@ -25,8 +26,8 @@ const TokenlessSection: React.FC = () => {
     data: uploadTokenRequiredData,
     isLoading: isUploadTokenRequiredLoading,
   } = useUploadTokenRequired({ provider, owner })
-  const { mutate, isLoading: isSetUploadTokenRequiredLoading } =
-    useSetUploadTokenRequired()
+  const { mutate, isPending: isSetUploadTokenRequiredPending } =
+    useSetUploadTokenRequired({ provider, owner })
 
   const [showModal, setShowModal] = useState<boolean>(false)
   const [tokenRequired, setTokenRequiredState] = useState<boolean>(true)
@@ -108,7 +109,7 @@ const TokenlessSection: React.FC = () => {
               setTokenRequiredState(value)
               mutate(true)
             }}
-            isLoading={isSetUploadTokenRequiredLoading}
+            isLoading={isSetUploadTokenRequiredPending}
           />
         )}
       </Card.Content>

--- a/src/pages/AccountSettings/tabs/OrgUploadToken/TokenlessSection/useSetUploadTokenRequired.tsx
+++ b/src/pages/AccountSettings/tabs/OrgUploadToken/TokenlessSection/useSetUploadTokenRequired.tsx
@@ -97,6 +97,9 @@ export const useSetUploadTokenRequired = ({
           text: 'Upload token requirement updated successfully',
           disappearAfter: TOAST_DURATION,
         })
+
+        // only want to invalidate the query if the mutation was successful
+        // otherwise we're just going to re-fetch the same data
         queryClient.invalidateQueries(['GetUploadTokenRequired'])
       }
     },


### PR DESCRIPTION
# Description

This PR migrates the `useSetUploadTokenRequired` over to TSQ V5, as well updating its usage in the `TokenlessSection` to match V5 expectations.

Ticket: codecov/engineering-team#2963

# Notable Changes

- Migrate `useSetUploadTokenRequired` to TSQ V5
- Update usage in `TokenlessSection`
  - Including a switch from `isLoading` to `isPending` see [TSQ V5 migration docs](https://tanstack.com/query/latest/docs/framework/react/guides/migrating-to-v5#status-loading-has-been-changed-to-status-pending-and-isloading-has-been-changed-to-ispending-and-isinitialloading-has-now-been-renamed-to-isloading) for more info.
- Update tests