### PR TITLE
fix: Try using history instead of window.loc.href

### DIFF
--- a/src/pages/TermsOfService/TermsOfService.tsx
+++ b/src/pages/TermsOfService/TermsOfService.tsx
@@ -1,6 +1,7 @@
 import { zodResolver } from '@hookform/resolvers/zod'
 import { useEffect, useLayoutEffect } from 'react'
 import { SubmitHandler, useForm } from 'react-hook-form'
+import { useHistory, useLocation } from 'react-router-dom'
 import { z } from 'zod'
 
 import config from 'config'
@@ -132,6 +133,9 @@ export default function TermsOfService() {
     }
   }, [currentUser, isDirty, reset])
 
+  const location = useLocation()
+  const history = useHistory()
+
   const { mutate, isLoading: isMutationLoading } = useSaveTermsAgreement({
     onSuccess: ({ data }) => {
       if (data?.saveTermsAgreement?.error) {
@@ -140,9 +144,12 @@ export default function TermsOfService() {
         return
       }
 
-      const url = new URL(window.location.href)
-      url.searchParams.set('source', ONBOARDING_SOURCE)
-      window.location.href = url.toString()
+      const params = new URLSearchParams(location.search)
+      params.set('source', ONBOARDING_SOURCE)
+      history.push(`${location.pathname}?${params.toString()}`)
+      // const url = new URL(window.location.href)
+      // url.searchParams.set('source', ONBOARDING_SOURCE)
+      // window.location.href = url.toString()
     },
     onError: (error) => setError('apiError', error),
   })


### PR DESCRIPTION
# Description

Testing using `history.push()` instead of `window.location.href = ...`

# Code Example

# Notable Changes

# Screenshots

# Link to Sample Entry

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.