### PR TITLE
feat: Hide BA trend chart if Timescale is disabled

### DIFF
--- a/src/pages/RepoPage/BundlesTab/BundleContent/BundleContent.test.tsx
+++ b/src/pages/RepoPage/BundlesTab/BundleContent/BundleContent.test.tsx
@@ -18,13 +18,13 @@ vi.mock('./BundleSelection', () => ({
   default: () => <div>BundleSelection</div>,
 }))
 
-const mockRepoOverview = {
+const mockRepoOverview = (hasDefaultBranch: boolean) => ({
   owner: {
     isCurrentUserActivated: true,
     repository: {
       __typename: 'Repository',
       private: false,
-      defaultBranch: 'main',
+      defaultBranch: hasDefaultBranch ? 'main' : null,
       oldestCommitAt: '2022-10-10T11:59:59',
       coverageEnabled: true,
       bundleAnalysisEnabled: true,
@@ -32,7 +32,7 @@ const mockRepoOverview = {
       testAnalyticsEnabled: true,
     },
   },
-}
+})
 
 const mockBranchBundles = (isTimescaleEnabled: boolean) => ({
   config: { isTimescaleEnabled },
@@ -274,6 +274,7 @@ interface SetupArgs {
   isBundleError?: boolean
   isEmptyBundleSelection?: boolean
   isTimescaleEnabled?: boolean
+  hasDefaultBranch?: boolean
 }
 
 describe('BundleContent', () => {
@@ -281,6 +282,7 @@ describe('BundleContent', () => {
     isBundleError = false,
     isEmptyBundleSelection = false,
     isTimescaleEnabled = true,
+    hasDefaultBranch = true,
   }: SetupArgs) {
     server.use(
       graphql.query('BranchBundleSummaryData', () => {
@@ -294,7 +296,7 @@ describe('BundleContent', () => {
         })
       }),
       graphql.query('GetRepoOverview', () => {
-        return HttpResponse.json({ data: mockRepoOverview })
+        return HttpResponse.json({ data: mockRepoOverview(hasDefaultBranch) })
       }),
       graphql.query('BundleAssets', () => {
         if (isBundleError) {
@@ -446,7 +448,7 @@ describe('BundleContent', () => {
 
       describe('when bundle and branch are not set', () => {
         it('renders no branch selected banner and empty table', async () => {
-          setup({})
+          setup({ hasDefaultBranch: false })
           render(<BundleContent />, {
             wrapper: wrapper('/gh/codecov/test-repo/bundles'),
           })
@@ -491,7 +493,7 @@ describe('BundleContent', () => {
     describe('when the bundle type is not BundleAnalysisReport', () => {
       describe('there is no branch data and no branch set', () => {
         it('renders the info banner', async () => {
-          setup({ isEmptyBundleSelection: true })
+          setup({ isEmptyBundleSelection: true, hasDefaultBranch: false })
           render(<BundleContent />, {
             wrapper: wrapper('/gh/codecov/test-repo/bundles'),
           })

--- a/src/pages/RepoPage/BundlesTab/BundleContent/BundleContent.tsx
+++ b/src/pages/RepoPage/BundlesTab/BundleContent/BundleContent.tsx
@@ -48,7 +48,7 @@ const BundleContent: React.FC = () => {
     owner,
   })
 
-  const branch = branchParam ?? repoOverview?.defaultBranch
+  const branch = branchParam ?? repoOverview?.defaultBranch ?? null
 
   const { data } = useSuspenseQueryV5(
     BranchBundleSummaryQueryOpts({
@@ -92,13 +92,13 @@ const BundleContent: React.FC = () => {
                 '/:provider/:owner/:repo/bundles/',
               ]}
             >
-              <InfoBanner branch={branchParam} bundle={bundle} />
+              <InfoBanner branch={branch} bundle={bundle} />
               <AssetEmptyTable />
             </SentryRoute>
           </Switch>
-        ) : bundleType === undefined && !branchParam ? (
+        ) : bundleType === undefined && !branch ? (
           <>
-            <InfoBanner branch={branchParam} bundle={bundle} />
+            <InfoBanner branch={branch} bundle={bundle} />
             <AssetEmptyTable />
           </>
         ) : (

--- a/src/pages/RepoPage/BundlesTab/BundleContent/InfoBanner/InfoBanner.test.tsx
+++ b/src/pages/RepoPage/BundlesTab/BundleContent/InfoBanner/InfoBanner.test.tsx
@@ -29,7 +29,7 @@ describe('InfoBanner', () => {
 
   describe('branch and bundle are not defined', () => {
     it('renders NoSelectedBranchContent', () => {
-      render(<InfoBanner />)
+      render(<InfoBanner branch={null} />)
 
       const header = screen.getByText('No Branch Selected')
       expect(header).toBeInTheDocument()

--- a/src/pages/RepoPage/BundlesTab/BundleContent/InfoBanner/InfoBanner.tsx
+++ b/src/pages/RepoPage/BundlesTab/BundleContent/InfoBanner/InfoBanner.tsx
@@ -23,7 +23,7 @@ const NoSelectedBundleContent: React.FC = () => {
 }
 
 interface InfoBannerProps {
-  branch?: string
+  branch: string | null
   bundle?: string
 }
 


### PR DESCRIPTION
# Description

This PR updates the bundles tab to conditionally render the trend chart if timescale is not enabled on the backend as the chart is powered from data that comes from timescale.

Closes: codecov/engineering-team#3215

# Notable Changes

- Migrate `BranchBundleSummaryQueryOpts` fully to query options API and remove `useBranchBundleSummary`
- Update `BundleContent` to conditionally 

# Screenshots

Timescale enabled:

![Screenshot 2025-02-04 at 08 50 47](https://github.com/user-attachments/assets/f15f247d-a356-4e0d-91fd-fbe7cabc0ec0)

Timescale disabled:

![Screenshot 2025-02-04 at 08 51 01](https://github.com/user-attachments/assets/01021aa6-af7f-4046-b4db-bd0ddc6e4b54)