### PR TITLE
ref: Migrate useReposCoverageMeasurements to TSQ V5

### DIFF
--- a/src/pages/AnalyticsPage/Chart/Chart.test.tsx
+++ b/src/pages/AnalyticsPage/Chart/Chart.test.tsx
@@ -1,4 +1,8 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import {
+  QueryClientProvider as QueryClientProviderV5,
+  QueryClient as QueryClientV5,
+} from '@tanstack/react-queryV5'
 import { render, screen, within } from '@testing-library/react'
 import { graphql, HttpResponse } from 'msw'
 import { setupServer } from 'msw/node'
@@ -44,13 +48,18 @@ const mockDataPoints = {
 const queryClient = new QueryClient({
   defaultOptions: { queries: { retry: false } },
 })
+const queryClientV5 = new QueryClientV5({
+  defaultOptions: { queries: { retry: false } },
+})
 
 const wrapper: React.FC<React.PropsWithChildren> = ({ children }) => (
-  <QueryClientProvider client={queryClient}>
-    <MemoryRouter initialEntries={['/bb/critical-role/bells-hells']}>
-      <Route path="/:provider/:owner/:repo">{children}</Route>
-    </MemoryRouter>
-  </QueryClientProvider>
+  <QueryClientProviderV5 client={queryClientV5}>
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={['/bb/critical-role/bells-hells']}>
+        <Route path="/:provider/:owner/:repo">{children}</Route>
+      </MemoryRouter>
+    </QueryClientProvider>
+  </QueryClientProviderV5>
 )
 
 const server = setupServer()
@@ -84,6 +93,7 @@ beforeEach(() => {
 
 afterEach(() => {
   queryClient.clear()
+  queryClientV5.clear()
   server.resetHandlers()
 })
 

--- a/src/pages/AnalyticsPage/Chart/Chart.tsx
+++ b/src/pages/AnalyticsPage/Chart/Chart.tsx
@@ -27,20 +27,19 @@ interface ChartProps {
 function Chart({ startDate, endDate, repositories }: ChartProps) {
   const {
     data: coverage,
-    isPreviousData,
-    isLoading,
+    isPlaceholderData,
+    isPending,
     isError,
   } = useCoverage({
     startDate,
     endDate,
     repositories,
-    options: {
-      suspense: false,
-      keepPreviousData: true,
+    opts: {
+      keepPrevious: true,
     },
   })
 
-  if (!isPreviousData && isLoading) {
+  if (!isPlaceholderData && isPending) {
     return (
       <div className="flex h-64 items-center justify-center">
         <LoadingLogo />
@@ -56,7 +55,7 @@ function Chart({ startDate, endDate, repositories }: ChartProps) {
     )
   }
 
-  if (coverage.length < 1) {
+  if (!isPending && coverage.length < 1) {
     return (
       <div className="flex max-h-[260px] min-h-[200px] w-full items-center justify-center">
         <p>Not enough coverage data to display chart.</p>

--- a/src/pages/AnalyticsPage/Chart/useCoverage.test.tsx
+++ b/src/pages/AnalyticsPage/Chart/useCoverage.test.tsx
@@ -1,4 +1,8 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import {
+  QueryClientProvider as QueryClientProviderV5,
+  QueryClient as QueryClientV5,
+} from '@tanstack/react-queryV5'
 import { renderHook, waitFor } from '@testing-library/react'
 import { graphql, HttpResponse } from 'msw'
 import { setupServer } from 'msw/node'
@@ -38,12 +42,18 @@ const mockPublicRepoMeasurements = {
 const queryClient = new QueryClient({
   defaultOptions: { queries: { retry: false } },
 })
+const queryClientV5 = new QueryClientV5({
+  defaultOptions: { queries: { retry: false } },
+})
+
 const wrapper: React.FC<React.PropsWithChildren> = ({ children }) => (
-  <QueryClientProvider client={queryClient}>
-    <MemoryRouter initialEntries={['/gh/codecov/cool-repo']}>
-      <Route path="/:provider/:owner/:repo">{children}</Route>
-    </MemoryRouter>
-  </QueryClientProvider>
+  <QueryClientProviderV5 client={queryClientV5}>
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={['/gh/codecov/cool-repo']}>
+        <Route path="/:provider/:owner/:repo">{children}</Route>
+      </MemoryRouter>
+    </QueryClientProvider>
+  </QueryClientProviderV5>
 )
 
 const server = setupServer()
@@ -53,6 +63,7 @@ beforeAll(() => {
 
 afterEach(() => {
   queryClient.clear()
+  queryClientV5.clear()
   server.resetHandlers()
   vi.clearAllMocks()
 })


### PR DESCRIPTION
# Description

This PR migrates the `useReposCoverageMeasurements` over to the query options version `ReposCoverageMeasurementsQueryOpts`. 

Ticket: codecov/engineering-team#3165

# Notable Changes

- Migrates `useReposCoverageMeasurements` to `ReposCoverageMeasurementsQueryOpts`
- Update usage in `useCoverage`
- Update usage in `Chart.tsx`
- Update tests