### PR TITLE
fix: Update picker button colors for ACH on dark mode

### DIFF
--- a/src/stripe.ts
+++ b/src/stripe.ts
@@ -33,13 +33,12 @@ export const StripeAppearance = (isDarkMode: boolean) => {
           color: isDarkMode ? 'rgb(210,212,215)' : 'rgb(14,27,41)', // Same values as --color-app-text-primary.
         },
         '.PickerItem': {
-          backgroundColor: isDarkMode ? 'rgb(22,24,29)' : 'rgb(255,255,255)', // Same values as --color-app-container.
+          backgroundColor: isDarkMode ? 'rgb(145 152 168)' : 'rgb(255,255,255)', // Custom dark mode color for bank name buttons
           borderColor: isDarkMode ? 'rgb(47,51,60)' : 'rgb(216,220,226)', // Same values as --color-ds-gray-tertiary.
-          color: isDarkMode ? 'rgb(210,212,215)' : 'rgb(14,27,41)', // Same values as --color-app-text-primary.
         },
         '.PickerItem:hover': {
-          backgroundColor: isDarkMode ? 'rgb(22,24,29)' : 'rgb(255,255,255)', // Same values as --color-app-container.
-          borderColor: isDarkMode ? 'rgb(210,212,215)' : 'rgb(14,27,41)', // Same values as --color-app-text-primary.          color: isDarkMode ? 'rgb(210,212,215)' : 'rgb(14,27,41)', // Same values as --color-app-text-primary.
+          backgroundColor: isDarkMode ? 'rgb(145 152 168)' : 'rgb(255,255,255)', // Custom dark mode color for bank name buttons
+          borderColor: isDarkMode ? 'rgb(210,212,215)' : 'rgb(14,27,41)', // Same values as --color-app-text-primary.
         },
         '.PickerItem--selected': {
           backgroundColor: isDarkMode ? 'rgb(22,24,29)' : 'rgb(255,255,255)', // Same values as --color-app-container.


### PR DESCRIPTION
# Description

ACH bank picker buttons were hard to read due to the background color of them previously. This PR updates that color to a lighter gray to make it easier to view. Also updates the text color to be darker as well, which I think is only the case on test mode, but just to be safe.

Closes https://github.com/codecov/engineering-team/issues/3338

# Screenshots

**OLD**
![Screenshot 2025-02-06 at 6 43 20 PM](https://github.com/user-attachments/assets/d0c84b35-9ed4-4722-9452-b5b0d341e480)

**NEW - Dark Mode**
<img width="583" alt="Screenshot 2025-02-07 at 9 49 39 AM" src="https://github.com/user-attachments/assets/d942adfa-7da0-4e61-aaf8-c920582bfbcb" />

**Regression - Light Mode**

<img width="1129" alt="Screenshot 2025-02-07 at 9 56 58 AM" src="https://github.com/user-attachments/assets/08b15948-9a29-4080-926d-ff2cbcfe4bdb" />


# Link to Sample Entry

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.