### PR TITLE
ref: Migrate useSessions to TSQ V5

### DIFF
--- a/src/pages/AccountSettings/tabs/Access/Access.test.tsx
+++ b/src/pages/AccountSettings/tabs/Access/Access.test.tsx
@@ -1,4 +1,8 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import {
+  QueryClientProvider as QueryClientProviderV5,
+  QueryClient as QueryClientV5,
+} from '@tanstack/react-queryV5'
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { subDays } from 'date-fns'
@@ -80,31 +84,32 @@ const mockSessionInfo = {
 }
 
 const queryClient = new QueryClient({
-  defaultOptions: {
-    queries: {
-      suspense: true,
-    },
-  },
+  defaultOptions: { queries: { retry: false, suspense: true } },
+})
+const queryClientV5 = new QueryClientV5({
+  defaultOptions: { queries: { retry: false } },
 })
 
 let testLocation: ReturnType<typeof useLocation>
 const wrapper: (initialEntries?: string) => React.FC<React.PropsWithChildren> =
   (initialEntries = '/account/gh/janedoe/access') =>
   ({ children }) => (
-    <QueryClientProvider client={queryClient}>
-      <MemoryRouter initialEntries={[initialEntries]}>
-        <Suspense fallback={<p>loading</p>}>
-          <Route path="/account/:provider/:owner/access">{children}</Route>
-          <Route
-            path="*"
-            render={({ location }) => {
-              testLocation = location
-              return null
-            }}
-          />
-        </Suspense>
-      </MemoryRouter>
-    </QueryClientProvider>
+    <QueryClientProviderV5 client={queryClientV5}>
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter initialEntries={[initialEntries]}>
+          <Suspense fallback={<p>loading</p>}>
+            <Route path="/account/:provider/:owner/access">{children}</Route>
+            <Route
+              path="*"
+              render={({ location }) => {
+                testLocation = location
+                return null
+              }}
+            />
+          </Suspense>
+        </MemoryRouter>
+      </QueryClientProvider>
+    </QueryClientProviderV5>
   )
 
 const server = setupServer()
@@ -114,6 +119,7 @@ beforeAll(() => {
 
 afterEach(() => {
   queryClient.clear()
+  queryClientV5.clear()
   server.resetHandlers()
 })
 

--- a/src/pages/AccountSettings/tabs/Access/Access.tsx
+++ b/src/pages/AccountSettings/tabs/Access/Access.tsx
@@ -1,7 +1,8 @@
+import { useSuspenseQuery as useSuspenseQueryV5 } from '@tanstack/react-queryV5'
 import { useState } from 'react'
 import { Redirect, useParams } from 'react-router-dom'
 
-import { useSessions } from 'services/access'
+import { SessionsQueryOpts } from 'services/access/SessionsQueryOpts'
 import { useUser } from 'services/user'
 import Button from 'ui/Button'
 
@@ -18,9 +19,9 @@ function Access() {
   const { provider, owner } = useParams<URLParams>()
   const [showModal, setShowModal] = useState(false)
 
-  const { data: sessionData } = useSessions({
-    provider,
-  })
+  const { data: sessionData } = useSuspenseQueryV5(
+    SessionsQueryOpts({ provider })
+  )
 
   const { data: currentUser } = useUser()
 

--- a/src/services/access/SessionsQueryOpts.ts
+++ b/src/services/access/SessionsQueryOpts.ts
@@ -1,4 +1,4 @@
-import { useQuery } from '@tanstack/react-query'
+import { queryOptions as queryOptionsV5 } from '@tanstack/react-queryV5'
 import { z } from 'zod'
 
 import Api from 'shared/api'
@@ -47,42 +47,40 @@ const RequestSchema = z.object({
     .nullable(),
 })
 
-interface UseSessionsArgs {
-  provider: string
-}
-
-export function useSessions({ provider }: UseSessionsArgs) {
-  const query = `
-    query MySessions {
-      me {
-        sessions {
-          edges {
-            node{
-              sessionid
-              name
-              ip
-              lastseen
-              useragent
-              type
-              lastFour
-            }
-          }
-        }
-        tokens {
-          edges {
-            node {
-              type
-              name
-              lastFour
-              id
-            }
-          }
+const query = `query MySessions {
+  me {
+    sessions {
+      edges {
+        node{
+          sessionid
+          name
+          ip
+          lastseen
+          useragent
+          type
+          lastFour
         }
       }
     }
-  `
+    tokens {
+      edges {
+        node {
+          type
+          name
+          lastFour
+          id
+        }
+      }
+    }
+  }
+}`
 
-  return useQuery({
+interface SessionsQueryArgs {
+  provider: string
+}
+
+export function SessionsQueryOpts({ provider }: SessionsQueryArgs) {
+  return queryOptionsV5({
     queryKey: ['sessions', provider, query],
     queryFn: ({ signal }) =>
       Api.graphql({

--- a/src/services/access/index.ts
+++ b/src/services/access/index.ts
@@ -1,4 +1,3 @@
-export * from './useSessions'
 export * from './useDeleteSession'
 export * from './useRevokeUserToken'
 export * from './useGenerateUserToken'


### PR DESCRIPTION
# Description

This PR migrates the `useSessions` to the TSQ V5 `queryOptions` API version `SessionsQueryOpts`, as well as updating the related usage and tests.

Closes codecov/engineering-team#3167

# Notable Changes

- Migrate `useSessions` to `SessionsQueryOpts`
- Update usage in `Access`
- Update tests