### PR TITLE
ref: Migrate useGenerateUserToken to TSQ V5

### DIFF
--- a/src/pages/AccountSettings/tabs/Access/CreateTokenModal.jsx
+++ b/src/pages/AccountSettings/tabs/Access/CreateTokenModal.jsx
@@ -2,29 +2,25 @@ import PropTypes from 'prop-types'
 import { useState } from 'react'
 import { useForm } from 'react-hook-form'
 
-import { useGenerateUserToken } from 'services/access'
+import { useGenerateUserToken } from 'services/access/useGenerateUserToken'
 import Button from 'ui/Button'
 import { CopyClipboard } from 'ui/CopyClipboard'
 import Modal from 'ui/Modal'
 import TextInput from 'ui/TextInput/TextInput'
 
 function CreateTokenModal({ closeModal, provider }) {
+  const [token, setToken] = useState(null)
   const { register, handleSubmit, watch } = useForm({
-    defaultValues: {
-      name: '',
-    },
+    defaultValues: { name: '' },
   })
   const nameValue = watch('name', '')
-
-  const [token, setToken] = useState(null)
-
   const { mutate, isLoading } = useGenerateUserToken({ provider })
 
   const submit = ({ name }) => {
     mutate(
       { name },
       {
-        onSuccess: ({ data }) => {
+        onSuccess: (data) => {
           setToken(data?.createUserToken?.fullToken)
         },
       }

--- a/src/services/access/index.ts
+++ b/src/services/access/index.ts
@@ -1,1 +1,0 @@
-export * from './useGenerateUserToken'

--- a/src/services/access/useGenerateUserToken.test.tsx
+++ b/src/services/access/useGenerateUserToken.test.tsx
@@ -8,7 +8,7 @@ import { setupServer } from 'msw/node'
 import { PropsWithChildren } from 'react'
 import { MemoryRouter, Route } from 'react-router-dom'
 
-import { useGenerateUserToken } from './index'
+import { useGenerateUserToken } from './useGenerateUserToken'
 
 const queryClientV5 = new QueryClientV5({
   defaultOptions: { queries: { retry: false } },

--- a/src/services/access/useGenerateUserToken.test.tsx
+++ b/src/services/access/useGenerateUserToken.test.tsx
@@ -1,4 +1,7 @@
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import {
+  QueryClientProvider as QueryClientProviderV5,
+  QueryClient as QueryClientV5,
+} from '@tanstack/react-queryV5'
 import { renderHook, waitFor } from '@testing-library/react'
 import { graphql, HttpResponse } from 'msw'
 import { setupServer } from 'msw/node'
@@ -7,15 +10,15 @@ import { MemoryRouter, Route } from 'react-router-dom'
 
 import { useGenerateUserToken } from './index'
 
-const queryClient = new QueryClient({
+const queryClientV5 = new QueryClientV5({
   defaultOptions: { queries: { retry: false } },
 })
 const wrapper: React.FC<PropsWithChildren> = ({ children }) => (
-  <MemoryRouter initialEntries={['/gh']}>
-    <Route path="/:provider">
-      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
-    </Route>
-  </MemoryRouter>
+  <QueryClientProviderV5 client={queryClientV5}>
+    <MemoryRouter initialEntries={['/gh']}>
+      <Route path="/:provider">{children}</Route>
+    </MemoryRouter>
+  </QueryClientProviderV5>
 )
 
 const provider = 'gh'
@@ -27,7 +30,7 @@ beforeAll(() => {
 
 beforeEach(() => {
   server.resetHandlers()
-  queryClient.clear()
+  queryClientV5.clear()
 })
 
 afterAll(() => {

--- a/src/services/access/useGenerateUserToken.ts
+++ b/src/services/access/useGenerateUserToken.ts
@@ -1,14 +1,19 @@
-import { useMutation, useQueryClient } from '@tanstack/react-query'
+import {
+  useMutation as useMutationV5,
+  useQueryClient as useQueryClientV5,
+} from '@tanstack/react-queryV5'
 import { z } from 'zod'
 
 import Api from 'shared/api'
-import { NetworkErrorObject, rejectNetworkError } from 'shared/api/helpers'
+import { rejectNetworkError } from 'shared/api/helpers'
 
 import { USER_TOKEN_TYPE } from './constants'
+import { SessionsQueryOpts } from './SessionsQueryOpts'
 
 const UseGenerateTokenResponseSchema = z.object({
   createUserToken: z
     .object({
+      fullToken: z.string().nullable(),
       error: z
         .discriminatedUnion('__typename', [
           z.object({
@@ -21,45 +26,47 @@ const UseGenerateTokenResponseSchema = z.object({
           }),
         ])
         .nullable(),
-      fullToken: z.string().nullable(),
     })
     .nullable(),
 })
 
+const query = `mutation CreateUserToken($input: CreateUserTokenInput!) {
+  createUserToken(input: $input) {
+    fullToken
+    error {
+      __typename
+    }
+  }
+}`
+
 export function useGenerateUserToken({ provider }: { provider: string }) {
-  const queryClient = useQueryClient()
-  return useMutation({
+  const queryClientV5 = useQueryClientV5()
+  return useMutationV5({
     mutationFn: ({ name }: { name: string }) => {
-      const query = `
-        mutation CreateUserToken($input: CreateUserTokenInput!) {
-          createUserToken(input: $input) {
-            error {
-              __typename
-            }
-            fullToken
-          }
-        }
-      `
       const variables = { input: { name, tokenType: USER_TOKEN_TYPE.API } }
       return Api.graphqlMutation({
         provider,
         query,
         variables,
         mutationPath: 'createUserToken',
+      }).then((res) => {
+        const parsedData = UseGenerateTokenResponseSchema.safeParse(res?.data)
+        if (!parsedData.success) {
+          return rejectNetworkError({
+            status: 404,
+            data: {},
+            dev: 'useGenerateUserToken - 404 failed to parse',
+          })
+        }
+
+        return parsedData.data
       })
     },
-    useErrorBoundary: true,
-    onSuccess: ({ data }) => {
-      queryClient.invalidateQueries(['sessions'])
-
-      const parsedData = UseGenerateTokenResponseSchema.safeParse(data)
-      if (!parsedData.success) {
-        return rejectNetworkError({
-          status: 404,
-          data: {},
-          dev: 'useGenerateUserToken - 404 failed to parse',
-        } satisfies NetworkErrorObject)
-      }
+    throwOnError: true,
+    onSuccess: () => {
+      queryClientV5.invalidateQueries({
+        queryKey: SessionsQueryOpts({ provider }).queryKey,
+      })
     },
   })
 }


### PR DESCRIPTION
# Description

This PR migrates the `useGenerateUserToken` over to TSQ V5, and updates it's usage throughout the app.

Ticket: codecov/engineering-team#3167

# Notable Changes

- Migrate `useGenerateUserToken` over to TSQ V5
- Update usage in `CreateTokenModal`
- Update tests