### PR TITLE
ref: Remove over application of lazy

### DIFF
--- a/src/layouts/BaseLayout/BaseLayout.tsx
+++ b/src/layouts/BaseLayout/BaseLayout.tsx
@@ -1,5 +1,5 @@
 import { useQuery as useQueryV5 } from '@tanstack/react-queryV5'
-import { lazy, Suspense } from 'react'
+import { Suspense } from 'react'
 import { Redirect, useParams } from 'react-router-dom'
 
 import Footer from 'layouts/Footer'
@@ -11,6 +11,7 @@ import SilentNetworkErrorWrapper from 'layouts/shared/SilentNetworkErrorWrapper'
 import ToastNotifications from 'layouts/ToastNotifications'
 import { OnboardingContainerProvider } from 'pages/OwnerPage/OnboardingContainerContext/context'
 import { RepoBreadcrumbProvider } from 'pages/RepoPage/context'
+import TermsOfService from 'pages/TermsOfService'
 import { useEventContext } from 'services/events/hooks'
 import { useImpersonate } from 'services/impersonate'
 import { useTracking } from 'services/tracking'
@@ -20,8 +21,6 @@ import LoadingLogo from 'ui/LoadingLogo'
 
 import { NavigatorDataQueryOpts } from './hooks/NavigatorDataQueryOpts'
 import { useUserAccessGate } from './hooks/useUserAccessGate'
-
-const TermsOfService = lazy(() => import('pages/TermsOfService'))
 
 const FullPageLoader = () => (
   <div className="mt-16 flex flex-1 items-center justify-center">

--- a/src/pages/AccountSettings/tabs/OrgUploadToken/OrgUploadToken.tsx
+++ b/src/pages/AccountSettings/tabs/OrgUploadToken/OrgUploadToken.tsx
@@ -1,4 +1,3 @@
-import { lazy } from 'react'
 import { useParams } from 'react-router-dom'
 
 import { useOrgUploadToken } from 'services/orgUploadToken'
@@ -8,8 +7,7 @@ import Banner from 'ui/Banner'
 
 import GenerateOrgUploadToken from './GenerateOrgUploadToken'
 import RegenerateOrgUploadToken from './RegenerateOrgUploadToken'
-
-const TokenlessSection = lazy(() => import('./TokenlessSection'))
+import TokenlessSection from './TokenlessSection'
 
 interface URLParams {
   provider: string

--- a/src/pages/AdminSettings/AdminAccess/AdminAccess.tsx
+++ b/src/pages/AdminSettings/AdminAccess/AdminAccess.tsx
@@ -1,9 +1,9 @@
-import { lazy, Suspense } from 'react'
+import { Suspense } from 'react'
 
 import A from 'ui/A'
 import Spinner from 'ui/Spinner'
 
-const AdminAccessTable = lazy(() => import('./AdminAccessTable'))
+import AdminAccessTable from './AdminAccessTable'
 
 const Loader = () => (
   <div className="flex justify-center py-8">

--- a/src/pages/AdminSettings/AdminMembers/ActivationInfo/ActivationInfo.tsx
+++ b/src/pages/AdminSettings/AdminMembers/ActivationInfo/ActivationInfo.tsx
@@ -1,11 +1,9 @@
-import { lazy, Suspense } from 'react'
+import { Suspense } from 'react'
 
 import Spinner from 'ui/Spinner'
 
-const ActivationCount = lazy(() => import('./ActivationCount/ActivationCount'))
-const AutoActivateMembers = lazy(
-  () => import('./AutoActivateMembers/AutoActivateMembers')
-)
+import ActivationCount from './ActivationCount/ActivationCount'
+import AutoActivateMembers from './AutoActivateMembers/AutoActivateMembers'
 
 const Loader = () => (
   <div className="flex items-center justify-center py-16">

--- a/src/pages/AdminSettings/AdminMembers/AdminMembers.jsx
+++ b/src/pages/AdminSettings/AdminMembers/AdminMembers.jsx
@@ -1,14 +1,15 @@
-import { lazy, Suspense } from 'react'
+import { Suspense } from 'react'
 
 import Spinner from 'ui/Spinner'
+
+import ActivationInfo from './ActivationInfo'
+import MemberList from './MemberList'
+
 const Loader = () => (
   <div className="flex items-center justify-center py-16">
     <Spinner />
   </div>
 )
-
-const ActivationInfo = lazy(() => import('./ActivationInfo'))
-const MemberList = lazy(() => import('./MemberList'))
 
 function AdminMembers() {
   return (

--- a/src/pages/AdminSettings/AdminMembers/MemberList/MemberList.jsx
+++ b/src/pages/AdminSettings/AdminMembers/MemberList/MemberList.jsx
@@ -1,11 +1,11 @@
-import { lazy, Suspense } from 'react'
+import { Suspense } from 'react'
 
 import { useLocationParams } from 'services/navigation'
 import SearchField from 'ui/SearchField'
 import Select from 'ui/Select'
 import Spinner from 'ui/Spinner'
 
-const MemberTable = lazy(() => import('./MemberTable'))
+import MemberTable from './MemberTable'
 
 const ActivationStates = Object.freeze({
   ALL_USERS: { value: 'All Users' },

--- a/src/pages/AdminSettings/AdminSettings.jsx
+++ b/src/pages/AdminSettings/AdminSettings.jsx
@@ -1,5 +1,5 @@
 import { useSuspenseQuery as useSuspenseQueryV5 } from '@tanstack/react-queryV5'
-import { lazy, Suspense } from 'react'
+import { Suspense } from 'react'
 import { Redirect, Switch, useParams } from 'react-router-dom'
 
 import { SentryRoute } from 'sentry'
@@ -9,10 +9,9 @@ import { SelfHostedCurrentUserQueryOpts } from 'services/selfHosted/SelfHostedCu
 import LoadingLogo from 'ui/LoadingLogo'
 import Spinner from 'ui/Spinner'
 
+import AdminAccess from './AdminAccess'
+import AdminMembers from './AdminMembers'
 import AdminSettingsSidebar from './AdminSettingsSidebar'
-
-const AdminAccess = lazy(() => import('./AdminAccess'))
-const AdminMembers = lazy(() => import('./AdminMembers'))
 
 const Loader = (
   <div className="mt-16 flex flex-1 items-center justify-center">

--- a/src/pages/CommitDetailPage/CommitBundleAnalysis/CommitBundleAnalysis.tsx
+++ b/src/pages/CommitDetailPage/CommitBundleAnalysis/CommitBundleAnalysis.tsx
@@ -1,5 +1,5 @@
 import { useSuspenseQuery as useSuspenseQueryV5 } from '@tanstack/react-queryV5'
-import { lazy, Suspense } from 'react'
+import { Suspense } from 'react'
 import { useParams } from 'react-router-dom'
 
 import { CachedBundleContentBanner } from 'shared/CachedBundleContentBanner/CachedBundleContentBanner'
@@ -8,6 +8,7 @@ import { ReportUploadType } from 'shared/utils/comparison'
 import Spinner from 'ui/Spinner'
 
 import BundleMessage from './BundleMessage'
+import CommitBundleAnalysisTable from './CommitBundleAnalysisTable'
 import EmptyTable from './EmptyTable'
 import FirstPullBanner from './FirstPullBanner'
 
@@ -15,10 +16,6 @@ import {
   CommitPageDataQueryOpts,
   TBundleAnalysisComparisonResult,
 } from '../queries/CommitPageDataQueryOpts'
-
-const CommitBundleAnalysisTable = lazy(
-  () => import('./CommitBundleAnalysisTable')
-)
 
 interface URLParams {
   provider: string

--- a/src/pages/CommitDetailPage/CommitCoverage/CommitCoverage.jsx
+++ b/src/pages/CommitDetailPage/CommitCoverage/CommitCoverage.jsx
@@ -1,6 +1,6 @@
 import { useSuspenseQuery as useSuspenseQueryV5 } from '@tanstack/react-queryV5'
 import isEmpty from 'lodash/isEmpty'
-import { lazy, Suspense } from 'react'
+import { Suspense } from 'react'
 import { Redirect, Switch, useParams } from 'react-router-dom'
 
 import { SentryRoute } from 'sentry'
@@ -17,24 +17,19 @@ import { extractUploads } from 'shared/utils/extractUploads'
 import Spinner from 'ui/Spinner'
 
 import BotErrorBanner from './BotErrorBanner'
+import CommitCoverageSummary from './CommitCoverageSummary'
 import CommitCoverageSummarySkeleton from './CommitCoverageSummary/CommitCoverageSummarySkeleton'
 import CommitCoverageTabs from './CommitCoverageTabs'
 import ErroredUploads from './ErroredUploads'
 import FirstPullBanner from './FirstPullBanner'
+import CommitDetailFileExplorer from './routes/CommitDetailFileExplorer'
+import CommitDetailFileViewer from './routes/CommitDetailFileViewer'
+import FilesChangedTab from './routes/FilesChangedTab'
+import IndirectChangesTab from './routes/IndirectChangesTab'
+import UploadsCard from './UploadsCard'
 import YamlErrorBanner from './YamlErrorBanner'
 
 import { CommitPageDataQueryOpts } from '../queries/CommitPageDataQueryOpts'
-
-const CommitDetailFileExplorer = lazy(
-  () => import('./routes/CommitDetailFileExplorer')
-)
-const CommitDetailFileViewer = lazy(
-  () => import('./routes/CommitDetailFileViewer')
-)
-const FilesChangedTab = lazy(() => import('./routes/FilesChangedTab'))
-const IndirectChangesTab = lazy(() => import('./routes/IndirectChangesTab'))
-const UploadsCard = lazy(() => import('./UploadsCard'))
-const CommitCoverageSummary = lazy(() => import('./CommitCoverageSummary'))
 
 const Loader = () => (
   <div className="flex flex-1 justify-center">

--- a/src/pages/CommitDetailPage/CommitCoverage/YamlModal/YamlModal.jsx
+++ b/src/pages/CommitDetailPage/CommitCoverage/YamlModal/YamlModal.jsx
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types'
-import { lazy, Suspense } from 'react'
+import { Suspense } from 'react'
 
 import YamlErrorBanner from 'pages/CommitDetailPage/CommitCoverage/YamlErrorBanner'
 import { useCommitErrors } from 'services/commitErrors'
@@ -7,7 +7,7 @@ import A from 'ui/A'
 import Modal from 'ui/Modal'
 import Spinner from 'ui/Spinner'
 
-const YAMLViewer = lazy(() => import('./YAMLViewer'))
+import YAMLViewer from './YAMLViewer'
 
 function YamlModal({ showYAMLModal, setShowYAMLModal }) {
   const { data } = useCommitErrors()

--- a/src/pages/CommitDetailPage/CommitCoverage/routes/FilesChangedTab/FilesChangedTab.tsx
+++ b/src/pages/CommitDetailPage/CommitCoverage/routes/FilesChangedTab/FilesChangedTab.tsx
@@ -1,4 +1,4 @@
-import { lazy, Suspense } from 'react'
+import { Suspense } from 'react'
 import { useParams } from 'react-router-dom'
 
 import ToggleHeader from 'pages/CommitDetailPage/Header/ToggleHeader/ToggleHeader'
@@ -6,8 +6,8 @@ import { useRepoSettingsTeam } from 'services/repo'
 import { useIsTeamPlan } from 'services/useIsTeamPlan'
 import Spinner from 'ui/Spinner'
 
-const FilesChangedTable = lazy(() => import('./FilesChangedTable'))
-const FilesChangedTableTeam = lazy(() => import('./FilesChangedTableTeam'))
+import FilesChangedTable from './FilesChangedTable'
+import FilesChangedTableTeam from './FilesChangedTableTeam'
 
 const Loader = () => (
   <div className="flex flex-1 justify-center p-4">

--- a/src/pages/CommitDetailPage/CommitCoverage/routes/FilesChangedTab/FilesChangedTable/FilesChangedTable.tsx
+++ b/src/pages/CommitDetailPage/CommitCoverage/routes/FilesChangedTab/FilesChangedTable/FilesChangedTable.tsx
@@ -14,7 +14,7 @@ import isArray from 'lodash/isArray'
 import isEmpty from 'lodash/isEmpty'
 import isNumber from 'lodash/isNumber'
 import qs from 'qs'
-import { Fragment, lazy, Suspense, useMemo, useState } from 'react'
+import { Fragment, Suspense, useMemo, useState } from 'react'
 import { useLocation, useParams } from 'react-router-dom'
 
 import { ImpactedFileType, useCommit } from 'services/commit'
@@ -23,7 +23,7 @@ import Icon from 'ui/Icon'
 import Spinner from 'ui/Spinner'
 import TotalsNumber from 'ui/TotalsNumber'
 
-const CommitFileDiff = lazy(() => import('../shared/CommitFileDiff'))
+import CommitFileDiff from '../shared/CommitFileDiff'
 
 const columnHelper = createColumnHelper<ImpactedFileType>()
 

--- a/src/pages/CommitDetailPage/CommitCoverage/routes/FilesChangedTab/FilesChangedTableTeam/FilesChangedTableTeam.tsx
+++ b/src/pages/CommitDetailPage/CommitCoverage/routes/FilesChangedTab/FilesChangedTableTeam/FilesChangedTableTeam.tsx
@@ -11,7 +11,7 @@ import {
 } from '@tanstack/react-table'
 import cs from 'classnames'
 import isEmpty from 'lodash/isEmpty'
-import { Fragment, lazy, Suspense, useMemo, useState } from 'react'
+import { Fragment, Suspense, useMemo, useState } from 'react'
 import { useParams } from 'react-router-dom'
 
 import {
@@ -24,7 +24,7 @@ import A from 'ui/A'
 import Icon from 'ui/Icon'
 import Spinner from 'ui/Spinner'
 
-const CommitFileDiff = lazy(() => import('../shared/CommitFileDiff'))
+import CommitFileDiff from '../shared/CommitFileDiff'
 
 const columnHelper = createColumnHelper<ImpactedFile>()
 

--- a/src/pages/CommitDetailPage/CommitCoverage/routes/IndirectChangesTab/IndirectChangesTab.jsx
+++ b/src/pages/CommitDetailPage/CommitCoverage/routes/IndirectChangesTab/IndirectChangesTab.jsx
@@ -1,8 +1,8 @@
-import { lazy, Suspense } from 'react'
+import { Suspense } from 'react'
 
 import Spinner from 'ui/Spinner'
 
-const IndirectChangesTable = lazy(() => import('./IndirectChangesTable'))
+import IndirectChangesTable from './IndirectChangesTable'
 
 const Loader = () => (
   <div className="m-4 flex flex-1 justify-center">

--- a/src/pages/CommitDetailPage/CommitCoverage/routes/IndirectChangesTab/IndirectChangesTable/IndirectChangesTable.tsx
+++ b/src/pages/CommitDetailPage/CommitCoverage/routes/IndirectChangesTab/IndirectChangesTable/IndirectChangesTable.tsx
@@ -12,7 +12,7 @@ import isArray from 'lodash/isArray'
 import isEmpty from 'lodash/isEmpty'
 import isNumber from 'lodash/isNumber'
 import qs from 'qs'
-import { Fragment, lazy, Suspense, useMemo, useState } from 'react'
+import { Fragment, Suspense, useMemo, useState } from 'react'
 import { useLocation, useParams } from 'react-router-dom'
 
 import ToggleHeader from 'pages/CommitDetailPage/Header/ToggleHeader/ToggleHeader'
@@ -21,7 +21,7 @@ import Icon from 'ui/Icon'
 import Spinner from 'ui/Spinner'
 import TotalsNumber from 'ui/TotalsNumber'
 
-const CommitFileDiff = lazy(() => import('./CommitFileDiff'))
+import CommitFileDiff from './CommitFileDiff'
 
 const columnHelper = createColumnHelper<ImpactedFileType>()
 

--- a/src/pages/CommitDetailPage/CommitDetailPage.tsx
+++ b/src/pages/CommitDetailPage/CommitDetailPage.tsx
@@ -3,7 +3,7 @@ import {
   useSuspenseQuery as useSuspenseQueryV5,
 } from '@tanstack/react-queryV5'
 import qs from 'qs'
-import { lazy, Suspense, useLayoutEffect } from 'react'
+import { Suspense, useLayoutEffect } from 'react'
 import { useLocation, useParams } from 'react-router-dom'
 
 import NotFound from 'pages/NotFound'
@@ -12,14 +12,13 @@ import Icon from 'ui/Icon'
 import Spinner from 'ui/Spinner'
 import SummaryDropdown from 'ui/SummaryDropdown'
 
+import CommitBundleAnalysis from './CommitBundleAnalysis'
+import CommitCoverage from './CommitCoverage'
 import CommitBundleDropdown from './Dropdowns/CommitBundleDropdown'
 import CommitCoverageDropdown from './Dropdowns/CommitCoverageDropdown'
 import Header from './Header'
 import { CommitPageDataQueryOpts } from './queries/CommitPageDataQueryOpts'
 import { IgnoredIdsQueryOptions } from './queries/IgnoredIdsQueryOptions'
-
-const CommitCoverage = lazy(() => import('./CommitCoverage'))
-const CommitBundleAnalysis = lazy(() => import('./CommitBundleAnalysis'))
 
 const DISPLAY_MODE = {
   COVERAGE: 'coverage',

--- a/src/pages/MembersPage/MembersList/MembersList.jsx
+++ b/src/pages/MembersPage/MembersList/MembersList.jsx
@@ -1,4 +1,4 @@
-import { lazy, Suspense, useState } from 'react'
+import { Suspense, useState } from 'react'
 import { useParams } from 'react-router-dom'
 
 import { usePlanData } from 'services/account'
@@ -9,9 +9,8 @@ import Select from 'ui/Select'
 import Spinner from 'ui/Spinner'
 
 import { ActivatedItems, AdminItems } from './enums'
+import MembersTable from './MembersTable'
 import UpgradeModal from './UpgradeModal/UpgradeModal'
-
-const MembersTable = lazy(() => import('./MembersTable'))
 
 const UserManagementClasses = {
   root: 'space-y-4 col-span-2 mb-20 grow mt-4', // Select pushes page length out. For now padding

--- a/src/pages/OwnerPage/Tabs/Tabs.tsx
+++ b/src/pages/OwnerPage/Tabs/Tabs.tsx
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types'
-import { lazy, Suspense } from 'react'
+import { Suspense } from 'react'
 
 import config from 'config'
 
@@ -7,7 +7,7 @@ import { useFlags } from 'shared/featureFlags'
 import Badge from 'ui/Badge'
 import TabNavigation from 'ui/TabNavigation'
 
-const TrialReminder = lazy(() => import('./TrialReminder'))
+import TrialReminder from './TrialReminder'
 
 function Tabs() {
   const { codecovAiFeaturesTab } = useFlags({

--- a/src/pages/PlanPage/subRoutes/CancelPlanPage/CancelPlanPage.tsx
+++ b/src/pages/PlanPage/subRoutes/CancelPlanPage/CancelPlanPage.tsx
@@ -1,4 +1,4 @@
-import { lazy, Suspense } from 'react'
+import { Suspense } from 'react'
 import { Redirect, Switch, useParams } from 'react-router-dom'
 
 import { SentryRoute } from 'sentry'
@@ -13,10 +13,9 @@ import { Provider } from 'shared/api/helpers'
 import { BillingRate, shouldDisplayTeamCard } from 'shared/utils/billing'
 import Spinner from 'ui/Spinner'
 
+import DowngradePlan from './subRoutes/DowngradePlan'
 import SpecialOffer from './subRoutes/SpecialOffer'
 import TeamPlanSpecialOffer from './subRoutes/TeamPlanSpecialOffer'
-
-const DowngradePlan = lazy(() => import('./subRoutes/DowngradePlan'))
 
 const Loader = () => (
   <div className="flex flex-1 justify-center">

--- a/src/pages/PullRequestPage/PullBundleAnalysis/PullBundleAnalysis.test.tsx
+++ b/src/pages/PullRequestPage/PullBundleAnalysis/PullBundleAnalysis.test.tsx
@@ -3,12 +3,7 @@ import {
   QueryClientProvider as QueryClientProviderV5,
   QueryClient as QueryClientV5,
 } from '@tanstack/react-queryV5'
-import {
-  render,
-  screen,
-  waitFor,
-  waitForElementToBeRemoved,
-} from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
 import { graphql, HttpResponse } from 'msw'
 import { setupServer } from 'msw/node'
 import { Suspense } from 'react'
@@ -189,9 +184,6 @@ describe('PullBundleAnalysis', () => {
       it('does not render bundle summary', async () => {
         setup({ coverageEnabled: true, bundleAnalysisEnabled: true })
         render(<PullBundleAnalysis />, { wrapper })
-
-        const loader = await screen.findByText('Loading')
-        await waitForElementToBeRemoved(loader)
 
         const message = screen.queryByText(/Bundle report:/)
         expect(message).not.toBeInTheDocument()

--- a/src/pages/PullRequestPage/PullBundleAnalysis/PullBundleAnalysis.tsx
+++ b/src/pages/PullRequestPage/PullBundleAnalysis/PullBundleAnalysis.tsx
@@ -1,5 +1,5 @@
 import { useSuspenseQuery as useSuspenseQueryV5 } from '@tanstack/react-queryV5'
-import { lazy, Suspense } from 'react'
+import { Suspense } from 'react'
 import { useParams } from 'react-router-dom'
 
 import { CachedBundleContentBanner } from 'shared/CachedBundleContentBanner/CachedBundleContentBanner'
@@ -10,16 +10,13 @@ import Spinner from 'ui/Spinner'
 import BundleMessage from './BundleMessage'
 import EmptyTable from './EmptyTable'
 import FirstPullBanner from './FirstPullBanner'
+import PullBundleComparisonTable from './PullBundleComparisonTable'
+import PullBundleHeadTable from './PullBundleHeadTable'
 
 import {
   PullPageDataQueryOpts,
   TBundleAnalysisComparisonResult,
 } from '../queries/PullPageDataQueryOpts'
-
-const PullBundleComparisonTable = lazy(
-  () => import('./PullBundleComparisonTable')
-)
-const PullBundleHeadTable = lazy(() => import('./PullBundleHeadTable'))
 
 interface URLParams {
   provider: string

--- a/src/pages/PullRequestPage/PullCoverage/PullCoverage.tsx
+++ b/src/pages/PullRequestPage/PullCoverage/PullCoverage.tsx
@@ -1,5 +1,5 @@
 import { useSuspenseQuery as useSuspenseQueryV5 } from '@tanstack/react-queryV5'
-import { lazy, Suspense } from 'react'
+import { Suspense } from 'react'
 import { Redirect, Switch, useParams } from 'react-router-dom'
 
 import { SentryRoute } from 'sentry'
@@ -12,21 +12,19 @@ import GitHubRateLimitExceededBanner from 'shared/GlobalBanners/GitHubRateLimitE
 import { ComparisonReturnType, ReportUploadType } from 'shared/utils/comparison'
 import Spinner from 'ui/Spinner'
 
+import FirstPullBanner from './FirstPullBanner'
 import PullCoverageTabs from './PullCoverageTabs'
+import CommitsTab from './routes/CommitsTab'
+import ComponentsTab from './routes/ComponentsTab'
+import FileExplorer from './routes/FileExplorer'
+import FilesChangedTab from './routes/FilesChangedTab'
+import FileViewer from './routes/FileViewer'
+import FlagsTab from './routes/FlagsTab'
+import IndirectChangesTab from './routes/IndirectChangesTab'
+import CompareSummary from './Summary'
 import CompareSummarySkeleton from './Summary/CompareSummary/CompareSummarySkeleton'
 
 import { PullPageDataQueryOpts } from '../queries/PullPageDataQueryOpts'
-
-const CompareSummary = lazy(() => import('./Summary'))
-const FirstPullBanner = lazy(() => import('./FirstPullBanner'))
-
-const CommitsTab = lazy(() => import('./routes/CommitsTab'))
-const ComponentsTab = lazy(() => import('./routes/ComponentsTab'))
-const FlagsTab = lazy(() => import('./routes/FlagsTab'))
-const FilesChangedTab = lazy(() => import('./routes/FilesChangedTab'))
-const FileExplorer = lazy(() => import('./routes/FileExplorer'))
-const FileViewer = lazy(() => import('./routes/FileViewer'))
-const IndirectChangesTab = lazy(() => import('./routes/IndirectChangesTab'))
 
 const Loader = () => (
   <div className="flex items-center justify-center py-16">

--- a/src/pages/PullRequestPage/PullCoverage/routes/CommitsTab/CommitsTab.tsx
+++ b/src/pages/PullRequestPage/PullCoverage/routes/CommitsTab/CommitsTab.tsx
@@ -1,8 +1,8 @@
-import { lazy, Suspense } from 'react'
+import { Suspense } from 'react'
 
 import Spinner from 'ui/Spinner'
 
-const CommitsTable = lazy(() => import('./CommitsTable'))
+import CommitsTable from './CommitsTable'
 
 const Loader = () => (
   <div className="flex items-center justify-center py-16">

--- a/src/pages/PullRequestPage/PullCoverage/routes/FilesChangedTab/FilesChanged/FilesChangedTable/FilesChangedTable.tsx
+++ b/src/pages/PullRequestPage/PullCoverage/routes/FilesChangedTab/FilesChanged/FilesChangedTable/FilesChangedTable.tsx
@@ -13,7 +13,7 @@ import cs from 'classnames'
 import isEmpty from 'lodash/isEmpty'
 import isNumber from 'lodash/isNumber'
 import qs from 'qs'
-import { Fragment, lazy, Suspense, useEffect, useMemo, useState } from 'react'
+import { Fragment, Suspense, useEffect, useMemo, useState } from 'react'
 import { useLocation, useParams } from 'react-router-dom'
 
 import {
@@ -26,7 +26,7 @@ import Icon from 'ui/Icon'
 import Spinner from 'ui/Spinner'
 import TotalsNumber from 'ui/TotalsNumber'
 
-const PullFileDiff = lazy(() => import('../PullFileDiff'))
+import PullFileDiff from '../PullFileDiff'
 
 const columnHelper = createColumnHelper<ImpactedFile>()
 

--- a/src/pages/PullRequestPage/PullCoverage/routes/FilesChangedTab/FilesChanged/TableTeam/TableTeam.tsx
+++ b/src/pages/PullRequestPage/PullCoverage/routes/FilesChangedTab/FilesChanged/TableTeam/TableTeam.tsx
@@ -12,7 +12,7 @@ import {
 import cs from 'classnames'
 import isEmpty from 'lodash/isEmpty'
 import qs from 'qs'
-import { Fragment, lazy, Suspense, useEffect, useMemo, useState } from 'react'
+import { Fragment, Suspense, useEffect, useMemo, useState } from 'react'
 import { useLocation, useParams } from 'react-router-dom'
 
 import {
@@ -25,7 +25,7 @@ import A from 'ui/A'
 import Icon from 'ui/Icon'
 import Spinner from 'ui/Spinner'
 
-const PullFileDiff = lazy(() => import('../PullFileDiff'))
+import PullFileDiff from '../PullFileDiff'
 
 const columnHelper = createColumnHelper<ImpactedFile>()
 

--- a/src/pages/PullRequestPage/PullCoverage/routes/FilesChangedTab/FilesChangedTab.tsx
+++ b/src/pages/PullRequestPage/PullCoverage/routes/FilesChangedTab/FilesChangedTab.tsx
@@ -1,4 +1,4 @@
-import { lazy, Suspense } from 'react'
+import { Suspense } from 'react'
 import { useParams } from 'react-router-dom'
 
 import ToggleHeader from 'pages/PullRequestPage/Header/ToggleHeader/ToggleHeader'
@@ -6,8 +6,8 @@ import { useRepoSettingsTeam } from 'services/repo'
 import { useIsTeamPlan } from 'services/useIsTeamPlan'
 import Spinner from 'ui/Spinner'
 
-const FilesChangedTable = lazy(() => import('./FilesChanged'))
-const TeamFilesChangedTable = lazy(() => import('./FilesChanged/TableTeam'))
+import FilesChangedTable from './FilesChanged'
+import TeamFilesChangedTable from './FilesChanged/TableTeam'
 
 const Loader = () => (
   <div className="flex items-center justify-center py-16">

--- a/src/pages/PullRequestPage/PullRequestPage.tsx
+++ b/src/pages/PullRequestPage/PullRequestPage.tsx
@@ -1,6 +1,6 @@
 import { useSuspenseQuery as useSuspenseQueryV5 } from '@tanstack/react-queryV5'
 import qs from 'qs'
-import { lazy, Suspense, useLayoutEffect } from 'react'
+import { Suspense, useLayoutEffect } from 'react'
 import { useLocation, useParams } from 'react-router-dom'
 
 import NotFound from 'pages/NotFound'
@@ -14,10 +14,9 @@ import SummaryDropdown from 'ui/SummaryDropdown'
 import PullBundleDropdown from './Dropdowns/PullBundleDropdown'
 import PullCoverageDropdown from './Dropdowns/PullCoverageDropdown'
 import Header from './Header'
+import PullBundleAnalysis from './PullBundleAnalysis'
+import PullCoverage from './PullCoverage'
 import { PullPageDataQueryOpts } from './queries/PullPageDataQueryOpts'
-
-const PullCoverage = lazy(() => import('./PullCoverage'))
-const PullBundleAnalysis = lazy(() => import('./PullBundleAnalysis'))
 
 interface usePRPageBreadCrumbsArgs {
   owner: string

--- a/src/pages/RepoPage/BundlesTab/BundleContent/BundleContent.tsx
+++ b/src/pages/RepoPage/BundlesTab/BundleContent/BundleContent.tsx
@@ -1,5 +1,5 @@
 import { useSuspenseQuery as useSuspenseQueryV5 } from '@tanstack/react-queryV5'
-import { lazy, Suspense } from 'react'
+import { Suspense } from 'react'
 import { Switch, useParams } from 'react-router-dom'
 
 import { SentryRoute } from 'sentry'
@@ -14,10 +14,9 @@ import { EmptyTable as AssetEmptyTable } from './AssetsTable/EmptyTable'
 import { BundleChart } from './BundleChart'
 import { BundleDetails, NoDetails } from './BundleDetails'
 import BundleSelection from './BundleSelection'
+import ErrorBanner from './ErrorBanner'
 import InfoBanner from './InfoBanner'
 import { TrendDropdown } from './TrendDropdown'
-
-const ErrorBanner = lazy(() => import('./ErrorBanner'))
 
 interface URLParams {
   provider: string

--- a/src/pages/RepoPage/BundlesTab/BundleContent/BundleSelection/BundleSelection.tsx
+++ b/src/pages/RepoPage/BundlesTab/BundleContent/BundleSelection/BundleSelection.tsx
@@ -1,12 +1,12 @@
-import { lazy, useCallback, useRef, useState } from 'react'
+import { useCallback, useRef, useState } from 'react'
 
 import { ConfigureCachedBundleModal } from 'pages/RepoPage/shared/ConfigureCachedBundleModal/ConfigureCachedBundleModal'
 import Icon from 'ui/Icon'
 
 import BranchSelector from './BranchSelector'
+import BundleSelector from './BundleSelector'
 import { LoadSelector } from './LoadSelector'
 import { TypeSelector } from './TypeSelector'
-const BundleSelector = lazy(() => import('./BundleSelector'))
 
 const BundleSelection: React.FC = () => {
   const bundleSelectRef = useRef<{ resetSelected: () => void }>(null)

--- a/src/pages/RepoPage/BundlesTab/BundlesTab.tsx
+++ b/src/pages/RepoPage/BundlesTab/BundlesTab.tsx
@@ -1,10 +1,10 @@
-import { lazy, Suspense } from 'react'
+import { Suspense } from 'react'
 import { Redirect, Switch, useParams } from 'react-router-dom'
 
 import { useRepoOverview } from 'services/repo'
 import Spinner from 'ui/Spinner'
 
-const BundleContent = lazy(() => import('./BundleContent'))
+import BundleContent from './BundleContent'
 
 interface URLParams {
   provider: string

--- a/src/pages/RepoPage/CommitsTab/CommitsTab.jsx
+++ b/src/pages/RepoPage/CommitsTab/CommitsTab.jsx
@@ -1,4 +1,4 @@
-import { lazy, Suspense, useEffect, useRef, useState } from 'react'
+import { Suspense, useEffect, useRef, useState } from 'react'
 import { useHistory, useParams } from 'react-router-dom'
 
 import { useBranchHasCommits } from 'services/branches'
@@ -14,10 +14,9 @@ import SearchField from 'ui/SearchField'
 import Select from 'ui/Select'
 import Spinner from 'ui/Spinner'
 
+import CommitsTable from './CommitsTable'
 import { filterItems, statusEnum } from './enums'
 import { useCommitsTabBranchSelector } from './hooks'
-
-const CommitsTable = lazy(() => import('./CommitsTable'))
 
 const Loader = () => (
   <div className="flex flex-1 justify-center">

--- a/src/pages/RepoPage/ConfigTab/ConfigTab.tsx
+++ b/src/pages/RepoPage/ConfigTab/ConfigTab.tsx
@@ -1,4 +1,4 @@
-import { lazy, Suspense } from 'react'
+import { Suspense } from 'react'
 import { Switch, useParams } from 'react-router-dom'
 
 import { SentryRoute } from 'sentry'
@@ -8,12 +8,12 @@ import { useOwner } from 'services/user'
 import LoadingLogo from 'ui/LoadingLogo'
 import Sidemenu from 'ui/Sidemenu'
 
+import BadgesAndGraphsTab from './tabs/BadgesAndGraphsTab'
 import ConfigurationManager from './tabs/ConfigurationManager'
+import GeneralTab from './tabs/GeneralTab'
+import YamlTab from './tabs/YamlTab'
 
-const NotFound = lazy(() => import('../../NotFound'))
-const GeneralTab = lazy(() => import('./tabs/GeneralTab'))
-const YamlTab = lazy(() => import('./tabs/YamlTab'))
-const BadgesAndGraphsTab = lazy(() => import('./tabs/BadgesAndGraphsTab'))
+import NotFound from '../../NotFound'
 
 const tabLoading = (
   <div className="flex size-full items-center justify-center">

--- a/src/pages/RepoPage/CoverageOnboarding/NewRepoTab.tsx
+++ b/src/pages/RepoPage/CoverageOnboarding/NewRepoTab.tsx
@@ -1,4 +1,4 @@
-import { lazy, Suspense, useEffect } from 'react'
+import { Suspense, useEffect } from 'react'
 import { Switch, useHistory, useLocation, useParams } from 'react-router-dom'
 
 import { SentryRoute } from 'sentry'
@@ -21,8 +21,7 @@ import Spinner from 'ui/Spinner'
 import ActivationBanner from './ActivationBanner'
 import CircleCI from './CircleCI'
 import GitHubActions from './GitHubActions'
-
-const OtherCI = lazy(() => import('./OtherCI'))
+import OtherCI from './OtherCI'
 
 const Loader = () => (
   <div className="mt-16 flex flex-1 items-center justify-center">

--- a/src/pages/RepoPage/CoverageTab/CoverageTab.tsx
+++ b/src/pages/RepoPage/CoverageTab/CoverageTab.tsx
@@ -1,4 +1,4 @@
-import { lazy, Suspense } from 'react'
+import { Suspense } from 'react'
 import { Switch, useParams } from 'react-router-dom'
 
 import { SentryRoute } from 'sentry'
@@ -7,11 +7,10 @@ import { useRepoSettingsTeam } from 'services/repo'
 import { useIsTeamPlan } from 'services/useIsTeamPlan'
 import LoadingLogo from 'ui/LoadingLogo'
 
+import ComponentsTab from './ComponentsTab'
 import { CoverageTabNavigator } from './CoverageTabNavigator'
+import FlagsTab from './FlagsTab'
 import OverviewTab from './OverviewTab'
-
-const FlagsTab = lazy(() => import('./FlagsTab'))
-const ComponentsTab = lazy(() => import('./ComponentsTab'))
 
 const path = '/:provider/:owner/:repo'
 

--- a/src/pages/RepoPage/CoverageTab/OverviewTab/OverviewTab.tsx
+++ b/src/pages/RepoPage/CoverageTab/OverviewTab/OverviewTab.tsx
@@ -1,5 +1,5 @@
 import { useSuspenseQuery as useSuspenseQueryV5 } from '@tanstack/react-queryV5'
-import { lazy, Suspense } from 'react'
+import { Suspense } from 'react'
 import { Switch, useParams } from 'react-router-dom'
 
 import config from 'config'
@@ -15,13 +15,12 @@ import { ToggleElement } from 'ui/ToggleElement'
 
 import FirstPullRequestBanner from './FirstPullRequestBanner'
 import { CoverageTabDataQueryOpts } from './queries/CoverageTabDataQueryOpts'
+import CoverageChart from './subroute/CoverageChart'
+import FileExplorer from './subroute/FileExplorer'
+import FileViewer from './subroute/Fileviewer'
+import Sunburst from './subroute/Sunburst'
 import Summary from './Summary'
 import SummaryTeamPlan from './SummaryTeamPlan'
-
-const FileViewer = lazy(() => import('./subroute/Fileviewer'))
-const FileExplorer = lazy(() => import('./subroute/FileExplorer'))
-const CoverageChart = lazy(() => import('./subroute/CoverageChart'))
-const Sunburst = lazy(() => import('./subroute/Sunburst'))
 
 const MAX_FILE_COUNT = 200_000
 

--- a/src/pages/RepoPage/PullsTab/PullsTab.tsx
+++ b/src/pages/RepoPage/PullsTab/PullsTab.tsx
@@ -1,4 +1,4 @@
-import { lazy, Suspense, useCallback, useLayoutEffect, useState } from 'react'
+import { Suspense, useCallback, useLayoutEffect, useState } from 'react'
 
 import { useLocationParams } from 'services/navigation'
 import MultiSelect from 'ui/MultiSelect'
@@ -13,10 +13,9 @@ import {
   stateEnum,
   stateNames,
 } from './enums'
+import PullsTable from './PullsTable'
 
 import { useCrumbs } from '../context'
-
-const PullsTable = lazy(() => import('./PullsTable'))
 
 const Loader = () => (
   <div className="flex flex-1 justify-center">

--- a/src/shared/GlobalTopBanners/GlobalTopBanners.tsx
+++ b/src/shared/GlobalTopBanners/GlobalTopBanners.tsx
@@ -1,13 +1,11 @@
-import { lazy } from 'react'
-
 import SilentNetworkErrorWrapper from 'layouts/shared/SilentNetworkErrorWrapper'
 
-const BundleFeedbackBanner = lazy(() => import('./BundleFeedbackBanner'))
-const TrialBanner = lazy(() => import('./TrialBanner'))
-const TeamPlanFeedbackBanner = lazy(() => import('./TeamPlanFeedbackBanner'))
-const ProPlanFeedbackBanner = lazy(() => import('./ProPlanFeedbackBanner'))
-const OktaBanners = lazy(() => import('./OktaBanners'))
-const TokenlessBanner = lazy(() => import('./TokenlessBanner'))
+import BundleFeedbackBanner from './BundleFeedbackBanner'
+import OktaBanners from './OktaBanners'
+import ProPlanFeedbackBanner from './ProPlanFeedbackBanner'
+import TeamPlanFeedbackBanner from './TeamPlanFeedbackBanner'
+import TokenlessBanner from './TokenlessBanner'
+import TrialBanner from './TrialBanner'
 
 const GlobalTopBanners: React.FC = () => {
   return (

--- a/src/shared/GlobalTopBanners/OktaBanners/OktaBanners.tsx
+++ b/src/shared/GlobalTopBanners/OktaBanners/OktaBanners.tsx
@@ -1,17 +1,16 @@
 import { useSuspenseQuery as useSuspenseQueryV5 } from '@tanstack/react-queryV5'
-import { lazy } from 'react'
 import { useParams } from 'react-router'
 
 import { OktaConfigQueryOpts } from 'pages/AccountSettings/tabs/OktaAccess/queries/OktaConfigQueryOpts'
+
+import OktaEnabledBanner from '../OktaEnabledBanner'
+import OktaEnforcedBanner from '../OktaEnforcedBanner'
+import OktaErrorBanners from '../OktaErrorBanners'
 
 interface URLParams {
   provider: string
   owner?: string
 }
-
-const OktaEnabledBanner = lazy(() => import('../OktaEnabledBanner'))
-const OktaEnforcedBanner = lazy(() => import('../OktaEnforcedBanner'))
-const OktaErrorBanners = lazy(() => import('../OktaErrorBanners'))
 
 function OktaBanners() {
   const { provider, owner } = useParams<URLParams>()

--- a/src/shared/GlobalTopBanners/TokenlessBanner/TokenlessBanner.tsx
+++ b/src/shared/GlobalTopBanners/TokenlessBanner/TokenlessBanner.tsx
@@ -1,4 +1,3 @@
-import React, { lazy } from 'react'
 import { useParams } from 'react-router-dom'
 
 import { ONBOARDING_SOURCE } from 'pages/TermsOfService/constants'
@@ -7,8 +6,8 @@ import { useUploadTokenRequired } from 'services/uploadTokenRequired'
 import { useUser } from 'services/user'
 import { useFlags } from 'shared/featureFlags'
 
-const TokenRequiredBanner = lazy(() => import('./TokenRequiredBanner'))
-const TokenNotRequiredBanner = lazy(() => import('./TokenNotRequiredBanner'))
+import TokenNotRequiredBanner from './TokenNotRequiredBanner'
+import TokenRequiredBanner from './TokenRequiredBanner'
 
 type UseParams = {
   provider: string


### PR DESCRIPTION
# Description

This PR removes usage of `lazy` across Gazebo (minus some allowed areas). The goal of this is to reduce the amount of waterfalls users encounter when trying to load the app. With this change, users should also feel like the app is snappier as we're making less requests for JS as it should already be present on their machine.

You can read more about this in this [notion doc](https://www.notion.so/sentry/Lazy-Loading-1998b10e4b5d80f39ca4f76156620ef7).

Closes: codecov/engineering-team#3351

# Notable Changes

- Remove `lazy` from many (many) components
  - Reduces the amount of assets from `492 -> 257`