### PR TITLE
ref: Update Amplitude page view sanitization

### DIFF
--- a/src/services/events/amplitude/amplitude.test.tsx
+++ b/src/services/events/amplitude/amplitude.test.tsx
@@ -73,13 +73,16 @@ describe('pageViewTrackingSanitization', () => {
         event_properties: {
           '[Amplitude] Page Counter': 1,
           '[Amplitude] Page Domain': 'app.codecov.io',
+          '[Amplitude] Page Title': 'Codecov',
           '[Amplitude] Page Path': '/sensitive/info',
           '[Amplitude] Page Location': 'https://app.codecov.io/sensitive/info',
+          '[Amplitude] Page URL': 'https://app.codecov.io/sensitive/info',
         },
       } as Event)
       expect(event?.event_properties).toMatchObject({
         '[Amplitude] Page Counter': 1,
         '[Amplitude] Page Domain': 'app.codecov.io',
+        '[Amplitude] Page Title': 'Codecov',
         path: undefined,
       })
     }

--- a/src/services/events/amplitude/amplitude.ts
+++ b/src/services/events/amplitude/amplitude.ts
@@ -14,14 +14,14 @@ export const pageViewTrackingSanitization = (): EnrichmentPlugin => {
     type: 'enrichment',
     setup: async () => undefined,
     execute: async (event) => {
+      /* eslint-disable camelcase */
       if (event.event_type === '[Amplitude] Page Viewed') {
-        /* eslint-disable camelcase */
-        event.event_properties = {
-          '[Amplitude] Page Counter':
-            event.event_properties?.['[Amplitude] Page Counter'],
-          '[Amplitude] Page Domain':
-            event.event_properties?.['[Amplitude] Page Domain'],
-          path: eventTracker().context.path,
+        if (event.event_properties) {
+          delete event.event_properties?.['[Amplitude] Page Location']
+          delete event.event_properties?.['[Amplitude] Page Path']
+          delete event.event_properties?.['[Amplitude] Page URL']
+          delete event.event_properties?.['referrer']
+          event.event_properties.path = eventTracker().context.path
         }
       }
 

--- a/src/services/events/amplitude/amplitude.ts
+++ b/src/services/events/amplitude/amplitude.ts
@@ -17,11 +17,13 @@ export const pageViewTrackingSanitization = (): EnrichmentPlugin => {
       /* eslint-disable camelcase */
       if (event.event_type === '[Amplitude] Page Viewed') {
         if (event.event_properties) {
-          delete event.event_properties?.['[Amplitude] Page Location']
-          delete event.event_properties?.['[Amplitude] Page Path']
-          delete event.event_properties?.['[Amplitude] Page URL']
-          delete event.event_properties?.['referrer']
-          event.event_properties.path = eventTracker().context.path
+          // Remove any information containing names and/or ids.
+          delete event.event_properties['[Amplitude] Page Location'] // location.href
+          delete event.event_properties['[Amplitude] Page Path'] // Full path of current page
+          delete event.event_properties['[Amplitude] Page URL'] // Full URL of current page
+          delete event.event_properties.referrer // Full URL of previous page
+
+          event.event_properties.path = eventTracker().context.path // Add the React path match
         }
       }
 


### PR DESCRIPTION
I was looking at the available properties again and it seems we are missing out on a bunch by doing things in the way I had initially set it up. Now, instead of stating the keys we do want, we'll just delete the keys we don't want. This means we get whatever else amplitude sends, including some useful attribution stuff (utm_params, referrer domain, etc).
