### PR TITLE
fix: Extra x's when replacing / hiding tokens

### DIFF
--- a/src/pages/AccountSettings/tabs/OrgUploadToken/OrgUploadToken.test.tsx
+++ b/src/pages/AccountSettings/tabs/OrgUploadToken/OrgUploadToken.test.tsx
@@ -270,7 +270,7 @@ describe('OrgUploadToken', () => {
       })
       await user.click(saveBtn)
 
-      const token = await screen.findByText('CODECOV_TOKEN=xxxxxx')
+      const token = await screen.findByText('CODECOV_TOKEN=xxxxx')
       expect(token).toBeInTheDocument()
     })
   })
@@ -296,7 +296,7 @@ describe('OrgUploadToken', () => {
 
       render(<OrgUploadToken />, { wrapper })
 
-      const token = await screen.findByText('CODECOV_TOKEN=xxxxxx')
+      const token = await screen.findByText('CODECOV_TOKEN=xxxxx')
       expect(token).toBeInTheDocument()
     })
 
@@ -315,7 +315,7 @@ describe('OrgUploadToken', () => {
       expect(hide).toBeInTheDocument()
       await user.click(hide)
 
-      const token2 = await screen.findByText('CODECOV_TOKEN=xxxxxx')
+      const token2 = await screen.findByText('CODECOV_TOKEN=xxxxx')
       expect(token2).toBeInTheDocument()
     })
   })

--- a/src/pages/AccountSettings/tabs/OrgUploadToken/RegenerateOrgUploadToken.tsx
+++ b/src/pages/AccountSettings/tabs/OrgUploadToken/RegenerateOrgUploadToken.tsx
@@ -17,7 +17,7 @@ const TokenFormatEnum = Object.freeze({
 const UploadToken = ({ token, format }: { token: string; format: string }) => {
   const [hideClipboard, setHideClipboard] = useState(true)
   const encodedToken = hideClipboard
-    ? format + token.replace(/[^w-]|/g, 'x')
+    ? format + token.replace(/[^w-]/g, 'x')
     : undefined
 
   return (


### PR DESCRIPTION
# Description

This PR aims to fix some weird behavior when hiding org upload tokens where an extra character was being added to the end of each pattern due to the "|" operator being present and comparing the last character in each sequence, an empty "" and converting that character to an "x" as well.

We just remove the "|" and we're good

Closes https://github.com/codecov/internal-issues/issues/174

# Screenshots

**BEFORE**

https://github.com/user-attachments/assets/f6ea57a6-056b-4ff3-bb0e-5d9ae8874043



**AFTER**

https://github.com/user-attachments/assets/e70a7da3-e87b-45ff-ad12-2ab3845180f7





# Link to Sample Entry

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.