### PR TITLE
Pass the `owner` along to the `eraseRepository` mutation

### DIFF
--- a/src/services/repo/useEraseRepoContent.tsx
+++ b/src/services/repo/useEraseRepoContent.tsx
@@ -5,8 +5,8 @@ import { useAddNotification } from 'services/toastNotification'
 import Api from 'shared/api'
 
 const query = `
-  mutation EraseRepository($repoName: String!) {
-    eraseRepository(input: { repoName: $repoName }) {
+  mutation EraseRepository($owner: String!, $repoName: String!) {
+    eraseRepository(input: { owner: $owner, repoName: $repoName }) {
       error {
         ... on UnauthorizedError {
           message


### PR DESCRIPTION
Interestingly enough, the `owner` was already being passed an one of the mutation `variables`, but that was not being used to pass along to the `eraseRepository` mutation within the graphql query.

This is being done now, and the mutation is being triggered with that input field.

---

Depends on https://github.com/codecov/codecov-api/pull/1156 which adds this new input field.