### PR TITLE
fix: Check to see if user exists before setting default org

### DIFF
--- a/src/layouts/BaseLayout/hooks/useUserAccessGate.js
+++ b/src/layouts/BaseLayout/hooks/useUserAccessGate.js
@@ -59,14 +59,11 @@ const useUserAccessGate = () => {
   })
 
   useEffect(() => {
-    if (!userData?.owner?.defaultOrgUsername) {
+    // only update the default org if the user exists
+    if (userData && !userData?.owner?.defaultOrgUsername) {
       updateDefaultOrg({ username: userData?.user?.username })
     }
-  }, [
-    userData?.user?.username,
-    userData?.owner?.defaultOrgUsername,
-    updateDefaultOrg,
-  ])
+  }, [userData, updateDefaultOrg])
 
   useOnboardingRedirect({
     username: userData?.user?.username,


### PR DESCRIPTION
# Description

This PR fixes a small logic issue, where if the user doesn't exist it tries to update the default org for the user, causing an empty failure toast to pop up. This PR fixes this issue, by checking to see if the user data exists in the first place.

# Notable Changes

- Check to see if user exists

# Screenshots

Before:

https://github.com/user-attachments/assets/ef3a7e5d-6b54-4493-9a58-f8e34b3e9e74

After:

https://github.com/user-attachments/assets/59152997-43b9-4d91-aad2-74d2999700c0
