### PR TITLE
feat: Add Sentry feature flag integration with LD

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -30,17 +30,17 @@ if (
 
 ReactModal.setAppElement('#root')
 
-// use with pattern to not block app loading.
-const FeatureFlagApp = withFeatureFlagProvider(App)
-
-const ProfiledApp = Sentry.withProfiler(FeatureFlagApp)
-
 const history = createBrowserHistory()
 
 const TOO_MANY_REQUESTS_ERROR_CODE = 429
 
 initEventTracker()
 setupSentry({ history })
+
+// use with pattern to not block app loading.
+const FeatureFlagApp = withFeatureFlagProvider(App)
+
+const ProfiledApp = Sentry.withProfiler(FeatureFlagApp)
 
 // setting to 2 minutes, this value will ensure that components that are mounted
 // after suspense do not trigger a new query to be fetched. By default, the

--- a/src/sentry.ts
+++ b/src/sentry.ts
@@ -153,6 +153,9 @@ export const setupSentry = ({
         filterKeys: ['gazebo'],
         behaviour: 'apply-tag-if-contains-third-party-frames',
       }),
+
+      // Adds LaunchDarkly integration for feature flag tracking/errors
+      Sentry.launchDarklyIntegration(),
     ],
     tracePropagationTargets,
     tracesSampleRate: config?.SENTRY_TRACING_SAMPLE_RATE,

--- a/src/shared/featureFlags/featureFlag.ts
+++ b/src/shared/featureFlags/featureFlag.ts
@@ -1,4 +1,5 @@
 /* eslint-disable no-restricted-imports */
+import * as Sentry from '@sentry/react'
 import {
   useLDClient,
   useFlags as useLDFlags,
@@ -15,6 +16,10 @@ export const withFeatureFlagProvider = (Component: React.ComponentType) => {
       clientSideID: config.LAUNCHDARKLY,
       options: {
         bootstrap: 'localStorage',
+        inspectors: [
+          // Add in Sentry error handling for LaunchDarkly flags
+          Sentry.buildLaunchDarklyFlagUsedHandler(),
+        ],
       },
     })(Component)
   }


### PR DESCRIPTION
# Description

Followed the [docs](https://docs.sentry.io/platforms/javascript/configuration/integrations/launchdarkly/) to get the Sentry LD setup all configured. As well i have gone through and setup the webhook integration in LD itself to send updates to Sentry when we change our feature flags.

# Notable Changes

- Reorder App startup sequence so Sentry is initialized before LD
- Add LD integration to Sentry integrations
- Add Sentry inspector to LD inspectors