### PR TITLE
chore: Remove use of barrel files in services/branches

### DIFF
--- a/src/pages/RepoPage/BundlesTab/BundleContent/BundleSelection/BranchSelector.tsx
+++ b/src/pages/RepoPage/BundlesTab/BundleContent/BundleSelection/BranchSelector.tsx
@@ -1,7 +1,8 @@
 import { useState } from 'react'
 import { useHistory, useParams } from 'react-router-dom'
 
-import { Branch, useBranch, useBranches } from 'services/branches'
+import { useBranch } from 'services/branches/useBranch'
+import { Branch, useBranches } from 'services/branches/useBranches'
 import { useNavLinks } from 'services/navigation'
 import { useRepoOverview } from 'services/repo'
 import A from 'ui/A'

--- a/src/pages/RepoPage/CommitsTab/CommitsTab.jsx
+++ b/src/pages/RepoPage/CommitsTab/CommitsTab.jsx
@@ -1,7 +1,7 @@
 import { Suspense, useEffect, useRef, useState } from 'react'
 import { useHistory, useParams } from 'react-router-dom'
 
-import { useBranchHasCommits } from 'services/branches'
+import { useBranchHasCommits } from 'services/branches/useBranchHasCommits'
 import {
   ALL_BRANCHES,
   useLocationParams,

--- a/src/pages/RepoPage/CommitsTab/hooks/useCommitsTabBranchSelector.ts
+++ b/src/pages/RepoPage/CommitsTab/hooks/useCommitsTabBranchSelector.ts
@@ -1,8 +1,8 @@
 import { useState } from 'react'
 import { useParams } from 'react-router-dom'
 
-import { useBranches } from 'services/branches'
 import { useBranch, query as useBranchQuery } from 'services/branches/useBranch'
+import { useBranches } from 'services/branches/useBranches'
 
 interface URLParams {
   repo: string

--- a/src/pages/RepoPage/ConfigTab/tabs/BadgesAndGraphsTab/Badges/Badges.tsx
+++ b/src/pages/RepoPage/ConfigTab/tabs/BadgesAndGraphsTab/Badges/Badges.tsx
@@ -3,7 +3,7 @@ import { useParams } from 'react-router-dom'
 
 import config from 'config'
 
-import { Branch, useBranches } from 'services/branches'
+import { Branch, useBranches } from 'services/branches/useBranches'
 import A from 'ui/A'
 import Select from 'ui/Select'
 import SettingsDescriptor from 'ui/SettingsDescriptor'

--- a/src/pages/RepoPage/ConfigTab/tabs/GeneralTab/DefaultBranch/DefaultBranch.jsx
+++ b/src/pages/RepoPage/ConfigTab/tabs/GeneralTab/DefaultBranch/DefaultBranch.jsx
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types'
 import { useState } from 'react'
 import { useParams } from 'react-router-dom'
 
-import { useBranches } from 'services/branches'
+import { useBranches } from 'services/branches/useBranches'
 import { useUpdateRepo } from 'services/repo'
 import { useAddNotification } from 'services/toastNotification'
 import Icon from 'ui/Icon'

--- a/src/pages/RepoPage/CoverageTab/ComponentsTab/Header/BranchSelector/BranchSelector.tsx
+++ b/src/pages/RepoPage/CoverageTab/ComponentsTab/Header/BranchSelector/BranchSelector.tsx
@@ -1,7 +1,8 @@
 import { useState } from 'react'
 import { useHistory, useParams } from 'react-router-dom'
 
-import { Branch, useBranch, useBranches } from 'services/branches'
+import { useBranch } from 'services/branches/useBranch'
+import { Branch, useBranches } from 'services/branches/useBranches'
 import { useNavLinks } from 'services/navigation'
 import { useRepoOverview } from 'services/repo'
 import A from 'ui/A'

--- a/src/pages/RepoPage/CoverageTab/OverviewTab/Summary/CoverageTrend/CoverageTrend.tsx
+++ b/src/pages/RepoPage/CoverageTab/OverviewTab/Summary/CoverageTrend/CoverageTrend.tsx
@@ -1,7 +1,7 @@
 import { keepPreviousData } from '@tanstack/react-queryV5'
 import { useParams } from 'react-router-dom'
 
-import { useBranches } from 'services/branches'
+import { useBranches } from 'services/branches/useBranches'
 import { useRepoOverview } from 'services/repo'
 import Spinner from 'ui/Spinner'
 import { SummaryField } from 'ui/Summary'

--- a/src/pages/RepoPage/CoverageTab/OverviewTab/hooks/useBranchSelector.ts
+++ b/src/pages/RepoPage/CoverageTab/OverviewTab/hooks/useBranchSelector.ts
@@ -1,7 +1,6 @@
 import { useParams } from 'react-router-dom'
 
-import { useBranch } from 'services/branches/useBranch'
-import { Branch } from 'services/branches/useBranches'
+import { Branch, useBranch } from 'services/branches/useBranch'
 
 const getDecodedBranch = (branch?: string) =>
   branch ? decodeURIComponent(branch) : branch

--- a/src/pages/RepoPage/CoverageTab/OverviewTab/hooks/useBranchSelector.ts
+++ b/src/pages/RepoPage/CoverageTab/OverviewTab/hooks/useBranchSelector.ts
@@ -1,6 +1,7 @@
 import { useParams } from 'react-router-dom'
 
-import { Branch, useBranch } from 'services/branches'
+import { useBranch } from 'services/branches/useBranch'
+import { Branch } from 'services/branches/useBranches'
 
 const getDecodedBranch = (branch?: string) =>
   branch ? decodeURIComponent(branch) : branch

--- a/src/pages/RepoPage/CoverageTab/OverviewTab/subroute/ComponentsMultiSelect/ComponentsMultiSelect.tsx
+++ b/src/pages/RepoPage/CoverageTab/OverviewTab/subroute/ComponentsMultiSelect/ComponentsMultiSelect.tsx
@@ -2,7 +2,7 @@ import isUndefined from 'lodash/isUndefined'
 import { useMemo, useState } from 'react'
 import { useParams } from 'react-router-dom'
 
-import { useBranchComponents } from 'services/branches'
+import { useBranchComponents } from 'services/branches/useBranchComponents'
 import { useLocationParams } from 'services/navigation'
 import Icon from 'ui/Icon'
 import MultiSelect from 'ui/MultiSelect'

--- a/src/pages/RepoPage/CoverageTab/OverviewTab/subroute/CoverageChart/CoverageChart.tsx
+++ b/src/pages/RepoPage/CoverageTab/OverviewTab/subroute/CoverageChart/CoverageChart.tsx
@@ -3,7 +3,7 @@ import { format } from 'date-fns'
 import { useParams } from 'react-router-dom'
 import { Area, AreaChart, CartesianGrid, XAxis, YAxis } from 'recharts'
 
-import { useBranches } from 'services/branches'
+import { useBranches } from 'services/branches/useBranches'
 import { useRepoOverview } from 'services/repo'
 import {
   ChartConfig,

--- a/src/pages/RepoPage/CoverageTab/OverviewTab/summaryHooks/useSummary.ts
+++ b/src/pages/RepoPage/CoverageTab/OverviewTab/summaryHooks/useSummary.ts
@@ -1,7 +1,7 @@
 import { useState } from 'react'
 import { useParams } from 'react-router-dom'
 
-import { useBranches } from 'services/branches'
+import { useBranches } from 'services/branches/useBranches'
 import { useRepoCoverage, useRepoOverview } from 'services/repo'
 
 import { useBranchSelector } from '../hooks'

--- a/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/SelectorSection/BranchSelector/BranchSelector.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/SelectorSection/BranchSelector/BranchSelector.tsx
@@ -1,7 +1,8 @@
 import { useMemo, useState } from 'react'
 import { useHistory, useParams } from 'react-router-dom'
 
-import { Branch, useBranch, useBranches } from 'services/branches'
+import { useBranch } from 'services/branches/useBranch'
+import { Branch, useBranches } from 'services/branches/useBranches'
 import { useNavLinks } from 'services/navigation'
 import { useRepoOverview } from 'services/repo'
 import Icon from 'ui/Icon'

--- a/src/services/branches/index.ts
+++ b/src/services/branches/index.ts
@@ -1,4 +1,0 @@
-export * from './useBranch'
-export * from './useBranchComponents'
-export * from './useBranches'
-export * from './useBranchHasCommits'

--- a/src/services/branches/useBranch.tsx
+++ b/src/services/branches/useBranch.tsx
@@ -20,7 +20,7 @@ export const BranchSchema = z
   })
   .nullable()
 
-type BranchData = z.infer<typeof BranchSchema>
+export type Branch = z.infer<typeof BranchSchema>
 
 const GetBranchSchema = z.object({
   owner: z
@@ -44,7 +44,7 @@ export interface UseBranchArgs {
   owner: string
   repo: string
   branch: string
-  opts?: UseQueryOptions<{ branch: BranchData }>
+  opts?: UseQueryOptions<{ branch: Branch }>
 }
 
 export const query = `


### PR DESCRIPTION
# Description

This PR removes the barrel index file from the `services/branches` directory, and updates the respective imports across the app.

Ticket: codecov/engineering-team#3352

# Notable Changes

- Remove `index.ts` from `services/branches`
- Update `services/branches` imports