### PR TITLE
chore: Remove use of barrel files in services/commit

### DIFF
--- a/src/pages/CommitDetailPage/CommitCoverage/CommitCoverage.jsx
+++ b/src/pages/CommitDetailPage/CommitCoverage/CommitCoverage.jsx
@@ -5,7 +5,7 @@ import { Redirect, Switch, useParams } from 'react-router-dom'
 
 import { SentryRoute } from 'sentry'
 
-import { useCommit } from 'services/commit'
+import { useCommit } from 'services/commit/useCommit'
 import { useCommitErrors } from 'services/commitErrors'
 import { useRepoOverview, useRepoRateLimitStatus } from 'services/repo'
 import { useIsTeamPlan } from 'services/useIsTeamPlan'

--- a/src/pages/CommitDetailPage/CommitCoverage/CommitCoverageSummary/hooks/useCommitForSummary.js
+++ b/src/pages/CommitDetailPage/CommitCoverage/CommitCoverageSummary/hooks/useCommitForSummary.js
@@ -2,7 +2,7 @@ import isNumber from 'lodash/isNumber'
 import { useMemo } from 'react'
 import { useParams } from 'react-router-dom'
 
-import { useCommit } from 'services/commit'
+import { useCommit } from 'services/commit/useCommit'
 
 export function getCommitDataForSummary({
   compareWithParent,

--- a/src/pages/CommitDetailPage/CommitCoverage/UploadsCard/useUploads/useUploads.ts
+++ b/src/pages/CommitDetailPage/CommitCoverage/UploadsCard/useUploads/useUploads.ts
@@ -1,6 +1,6 @@
 import { useParams } from 'react-router-dom'
 
-import { useCommit } from 'services/commit'
+import { useCommit } from 'services/commit/useCommit'
 import { useRepoOverview } from 'services/repo'
 import { useIsTeamPlan } from 'services/useIsTeamPlan'
 import { extractUploads } from 'shared/utils/extractUploads'

--- a/src/pages/CommitDetailPage/CommitCoverage/YamlModal/YAMLViewer.jsx
+++ b/src/pages/CommitDetailPage/CommitCoverage/YamlModal/YAMLViewer.jsx
@@ -2,7 +2,7 @@ import cs from 'classnames'
 import Highlight, { defaultProps } from 'prism-react-renderer'
 import { useParams } from 'react-router-dom'
 
-import { useCommitYaml } from 'services/commit'
+import { useCommitYaml } from 'services/commit/useCommitYaml'
 import 'shared/utils/prism/prismTheme.css'
 
 import './YAMLViewer.css'

--- a/src/pages/CommitDetailPage/CommitCoverage/YamlModal/YAMLViewer.test.jsx
+++ b/src/pages/CommitDetailPage/CommitCoverage/YamlModal/YAMLViewer.test.jsx
@@ -7,8 +7,8 @@ const mocks = vi.hoisted(() => ({
   useCommitYaml: vi.fn(),
 }))
 
-vi.mock('services/commit', async () => {
-  const actual = await vi.importActual('services/commit')
+vi.mock('services/commit/useCommitYaml', async () => {
+  const actual = await vi.importActual('services/commit/useCommitYaml')
   return {
     ...actual,
     useCommitYaml: mocks.useCommitYaml,

--- a/src/pages/CommitDetailPage/CommitCoverage/routes/ComponentsSelector/ComponentsSelector.tsx
+++ b/src/pages/CommitDetailPage/CommitCoverage/routes/ComponentsSelector/ComponentsSelector.tsx
@@ -1,7 +1,7 @@
 import isUndefined from 'lodash/isUndefined'
 import { useMemo, useState } from 'react'
 
-import { useCommitComponents } from 'services/commit'
+import { useCommitComponents } from 'services/commit/useCommitComponents'
 import { useLocationParams } from 'services/navigation'
 import Icon from 'ui/Icon'
 import MultiSelect from 'ui/MultiSelect'

--- a/src/pages/CommitDetailPage/CommitCoverage/routes/FilesChangedTab/FilesChangedTable/FilesChangedTable.test.tsx
+++ b/src/pages/CommitDetailPage/CommitCoverage/routes/FilesChangedTab/FilesChangedTable/FilesChangedTable.test.tsx
@@ -7,7 +7,7 @@ import qs from 'qs'
 import { Suspense } from 'react'
 import { MemoryRouter, Route } from 'react-router-dom'
 
-import { ImpactedFileType } from 'services/commit'
+import { ImpactedFileType } from 'services/commit/useCommit'
 
 import FilesChangedTable from './FilesChangedTable'
 

--- a/src/pages/CommitDetailPage/CommitCoverage/routes/FilesChangedTab/FilesChangedTable/FilesChangedTable.tsx
+++ b/src/pages/CommitDetailPage/CommitCoverage/routes/FilesChangedTab/FilesChangedTable/FilesChangedTable.tsx
@@ -17,7 +17,7 @@ import qs from 'qs'
 import { Fragment, Suspense, useMemo, useState } from 'react'
 import { useLocation, useParams } from 'react-router-dom'
 
-import { ImpactedFileType, useCommit } from 'services/commit'
+import { ImpactedFileType, useCommit } from 'services/commit/useCommit'
 import { OrderingDirection, OrderingParameter } from 'services/pull/usePull'
 import Icon from 'ui/Icon'
 import Spinner from 'ui/Spinner'

--- a/src/pages/CommitDetailPage/CommitCoverage/routes/IndirectChangesTab/IndirectChangesTable/CommitFileDiff/CommitFileDiff.test.tsx
+++ b/src/pages/CommitDetailPage/CommitCoverage/routes/IndirectChangesTab/IndirectChangesTable/CommitFileDiff/CommitFileDiff.test.tsx
@@ -11,7 +11,7 @@ import { MemoryRouter, Route } from 'react-router-dom'
 import { type MockInstance } from 'vitest'
 
 import { IgnoredIdsQueryOptions } from 'pages/CommitDetailPage/queries/IgnoredIdsQueryOptions'
-import { ImpactedFileType } from 'services/commit'
+import { ImpactedFileType } from 'services/commit/useCommit'
 
 import CommitFileDiff from './CommitFileDiff'
 

--- a/src/services/commit/index.ts
+++ b/src/services/commit/index.ts
@@ -1,6 +1,0 @@
-export * from './useCommitYaml'
-export * from './useCompareTotals'
-export * from './useCommit'
-export * from './useCommitTeam'
-export * from './useCompareTotalsTeam'
-export * from './useCommitComponents'

--- a/src/services/commit/useCommit.test.tsx
+++ b/src/services/commit/useCommit.test.tsx
@@ -5,7 +5,7 @@ import { setupServer } from 'msw/node'
 import { MemoryRouter, Route } from 'react-router-dom'
 import { type MockInstance } from 'vitest'
 
-import { useCommit } from './index'
+import { useCommit } from './useCommit'
 
 const compareDoneData = {
   owner: {

--- a/src/services/commit/useCommitYaml.test.tsx
+++ b/src/services/commit/useCommitYaml.test.tsx
@@ -4,7 +4,7 @@ import { graphql, HttpResponse } from 'msw'
 import { setupServer } from 'msw/node'
 import { MemoryRouter, Route } from 'react-router-dom'
 
-import { useCommitYaml } from './index'
+import { useCommitYaml } from './useCommitYaml'
 
 const mockCommitYaml = (yaml: string) => ({
   owner: {

--- a/src/shared/utils/extractUploads.ts
+++ b/src/shared/utils/extractUploads.ts
@@ -5,7 +5,7 @@ import {
   UploadErrorCodeEnumSchema,
   UploadStateEnumSchema,
   UploadTypeEnumSchema,
-} from 'services/commit'
+} from 'services/commit/useCommit'
 import {
   UploadErrorStates,
   UploadStateEnum,


### PR DESCRIPTION
# Description

This PR removes the `index.ts` file from the `services/commit` directory, and updates the various imports throughout the app to their updated import paths.

Ticket: codecov/engineering-team#3352

# Notable Changes

- Remove `index.ts` from `services/commit`
- Update imports across the app