### PR TITLE
chore: Remove use of barrel files in services/pull

### DIFF
--- a/src/pages/PullRequestPage/PullCoverage/Summary/CompareSummary/usePullForCompareSummary.js
+++ b/src/pages/PullRequestPage/PullCoverage/Summary/CompareSummary/usePullForCompareSummary.js
@@ -2,7 +2,7 @@ import isNumber from 'lodash/isNumber'
 import { useMemo } from 'react'
 import { useParams } from 'react-router-dom'
 
-import { usePull } from 'services/pull'
+import { usePull } from 'services/pull/usePull'
 import { mapEdges } from 'shared/utils/graphql'
 
 export function getPullDataForCompareSummary({

--- a/src/pages/PullRequestPage/PullCoverage/Summary/CompareSummary/usePullForCompareSummary.test.js
+++ b/src/pages/PullRequestPage/PullCoverage/Summary/CompareSummary/usePullForCompareSummary.test.js
@@ -17,8 +17,8 @@ vi.mock('react-router-dom', async () => {
     useParams: mocks.useParams,
   }
 })
-vi.mock('services/pull', async () => {
-  const actual = await vi.importActual('services/pull')
+vi.mock('services/pull/usePull', async () => {
+  const actual = await vi.importActual('services/pull/usePull')
   return {
     ...actual,
     usePull: mocks.usePull,

--- a/src/pages/PullRequestPage/PullCoverage/routes/ComponentsSelector/ComponentsSelector.tsx
+++ b/src/pages/PullRequestPage/PullCoverage/routes/ComponentsSelector/ComponentsSelector.tsx
@@ -2,7 +2,7 @@ import isUndefined from 'lodash/isUndefined'
 import { useMemo, useState } from 'react'
 
 import { useLocationParams } from 'services/navigation/useLocationParams'
-import { usePullComponents } from 'services/pull'
+import { usePullComponents } from 'services/pull/usePullComponents'
 import Icon from 'ui/Icon'
 import MultiSelect from 'ui/MultiSelect'
 

--- a/src/pages/PullRequestPage/PullCoverage/routes/FilesChangedTab/FilesChanged/FilesChangedTable/FilesChangedTable.test.tsx
+++ b/src/pages/PullRequestPage/PullCoverage/routes/FilesChangedTab/FilesChanged/FilesChangedTable/FilesChangedTable.test.tsx
@@ -5,8 +5,11 @@ import { graphql, HttpResponse } from 'msw'
 import { setupServer } from 'msw/node'
 import { MemoryRouter, Route } from 'react-router-dom'
 
-import { PullComparison } from 'services/pull'
-import { OrderingDirection, OrderingParameter } from 'services/pull/usePull'
+import {
+  OrderingDirection,
+  OrderingParameter,
+  PullComparison,
+} from 'services/pull/usePull'
 import { UploadTypeEnum } from 'shared/utils/commit'
 
 import FilesChangedTable, { getFilter } from './FilesChangedTable'

--- a/src/pages/PullRequestPage/PullCoverage/routes/FilesChangedTab/FilesChanged/NameColumn/NameColumn.jsx
+++ b/src/pages/PullRequestPage/PullCoverage/routes/FilesChangedTab/FilesChanged/NameColumn/NameColumn.jsx
@@ -2,7 +2,7 @@ import cs from 'classnames'
 import PropTypes from 'prop-types'
 import { useParams } from 'react-router-dom'
 
-import { usePrefetchSingleFileComp } from 'services/pull'
+import { usePrefetchSingleFileComp } from 'services/pull/usePrefetchSingleFileComp'
 import Icon from 'ui/Icon'
 
 export default function NameColumn({ row, getValue }) {

--- a/src/pages/PullRequestPage/PullCoverage/routes/FilesChangedTab/FilesChanged/hooks/useImpactedFilesTable.js
+++ b/src/pages/PullRequestPage/PullCoverage/routes/FilesChangedTab/FilesChanged/hooks/useImpactedFilesTable.js
@@ -4,7 +4,7 @@ import qs from 'qs'
 import { useCallback, useState } from 'react'
 import { useLocation, useParams } from 'react-router-dom'
 
-import { usePull } from 'services/pull'
+import { usePull } from 'services/pull/usePull'
 import { ImpactedFilesReturnType } from 'shared/utils/impactedFiles'
 
 const orderingDirection = Object.freeze({

--- a/src/pages/PullRequestPage/PullCoverage/routes/FlagsTab/FlagsTab.test.tsx
+++ b/src/pages/PullRequestPage/PullCoverage/routes/FlagsTab/FlagsTab.test.tsx
@@ -4,7 +4,7 @@ import { graphql, HttpResponse } from 'msw'
 import { setupServer } from 'msw/node'
 import { MemoryRouter, Route } from 'react-router-dom'
 
-import { PullComparison } from 'services/pull'
+import { PullComparison } from 'services/pull/usePull'
 import { UploadTypeEnum } from 'shared/utils/commit'
 
 import FlagsTab from './FlagsTab'

--- a/src/pages/PullRequestPage/PullCoverage/routes/FlagsTab/FlagsTab.tsx
+++ b/src/pages/PullRequestPage/PullCoverage/routes/FlagsTab/FlagsTab.tsx
@@ -9,7 +9,7 @@ import isEmpty from 'lodash/isEmpty'
 import { useMemo } from 'react'
 import { useParams } from 'react-router-dom'
 
-import { FlagsComparison, usePull } from 'services/pull'
+import { FlagsComparison, usePull } from 'services/pull/usePull'
 import FlagsNotConfigured from 'shared/FlagsNotConfigured'
 import Spinner from 'ui/Spinner'
 import TotalsNumber from 'ui/TotalsNumber'

--- a/src/pages/PullRequestPage/PullCoverage/routes/IndirectChangesTab/IndirectChangedFiles/IndirectChangedFiles.test.tsx
+++ b/src/pages/PullRequestPage/PullCoverage/routes/IndirectChangesTab/IndirectChangedFiles/IndirectChangedFiles.test.tsx
@@ -5,7 +5,7 @@ import { graphql, HttpResponse } from 'msw'
 import { setupServer } from 'msw/node'
 import { MemoryRouter, Route } from 'react-router-dom'
 
-import { PullComparison } from 'services/pull'
+import { PullComparison } from 'services/pull/usePull'
 import { UploadTypeEnum } from 'shared/utils/commit'
 
 import IndirectChangedFiles from './IndirectChangedFiles'

--- a/src/pages/PullRequestPage/PullCoverage/routes/IndirectChangesTab/IndirectChangedFiles/NameColumn/NameColumn.jsx
+++ b/src/pages/PullRequestPage/PullCoverage/routes/IndirectChangesTab/IndirectChangedFiles/NameColumn/NameColumn.jsx
@@ -2,7 +2,7 @@ import cs from 'classnames'
 import PropTypes from 'prop-types'
 import { useParams } from 'react-router-dom'
 
-import { usePrefetchSingleFileComp } from 'services/pull'
+import { usePrefetchSingleFileComp } from 'services/pull/usePrefetchSingleFileComp'
 import Icon from 'ui/Icon'
 
 export default function NameColumn({ row, getValue }) {

--- a/src/pages/PullRequestPage/PullCoverage/routes/IndirectChangesTab/IndirectChangedFiles/hooks/useIndirectChangedFilesTable.ts
+++ b/src/pages/PullRequestPage/PullCoverage/routes/IndirectChangesTab/IndirectChangedFiles/hooks/useIndirectChangedFilesTable.ts
@@ -5,7 +5,7 @@ import qs, { ParsedQs } from 'qs'
 import { useMemo, useState } from 'react'
 import { useLocation, useParams } from 'react-router-dom'
 
-import { PullSchemaType, usePull } from 'services/pull'
+import { PullSchemaType, usePull } from 'services/pull/usePull'
 
 const orderingDirection = Object.freeze({
   desc: 'DESC',

--- a/src/pages/PullRequestPage/PullCoverage/routes/IndirectChangesTab/PullFileDiff/PullFileDiff.tsx
+++ b/src/pages/PullRequestPage/PullCoverage/routes/IndirectChangesTab/PullFileDiff/PullFileDiff.tsx
@@ -5,7 +5,7 @@ import { useNavLinks } from 'services/navigation/useNavLinks'
 import {
   PullImpactedFile,
   useSingularImpactedFileComparison,
-} from 'services/pull'
+} from 'services/pull/useSingularImpactedFileComparison'
 import { useRepoOverview } from 'services/repo'
 import A from 'ui/A'
 import CodeRendererInfoRow from 'ui/CodeRenderer/CodeRendererInfoRow'

--- a/src/services/pull/index.ts
+++ b/src/services/pull/index.ts
@@ -1,4 +1,0 @@
-export * from './usePrefetchSingleFileComp'
-export * from './usePull'
-export * from './useSingularImpactedFileComparison'
-export * from './usePullComponents'


### PR DESCRIPTION
# Description

This PR removes the barrel file from `services/pull`, while updating the imports throughout the app.

Ticket: codecov/engineering-team#3352

# Notable Changes

- Remove `index.ts` from `services/pull`
- Update imports throughout app.