### PR TITLE
chore: Remove use of barrel files in services

### DIFF
--- a/src/pages/CommitDetailPage/CommitCoverage/CommitCoverage.jsx
+++ b/src/pages/CommitDetailPage/CommitCoverage/CommitCoverage.jsx
@@ -6,7 +6,7 @@ import { Redirect, Switch, useParams } from 'react-router-dom'
 import { SentryRoute } from 'sentry'
 
 import { useCommit } from 'services/commit/useCommit'
-import { useCommitErrors } from 'services/commitErrors'
+import { useCommitErrors } from 'services/commitErrors/useCommitErrors'
 import { useRepoOverview, useRepoRateLimitStatus } from 'services/repo'
 import { useIsTeamPlan } from 'services/useIsTeamPlan'
 import { useOwner } from 'services/user'

--- a/src/pages/CommitDetailPage/CommitCoverage/UploadsCard/UploadsCard.test.tsx
+++ b/src/pages/CommitDetailPage/CommitCoverage/UploadsCard/UploadsCard.test.tsx
@@ -25,7 +25,7 @@ const mocks = vi.hoisted(() => ({
 }))
 
 vi.mock('./useUploads', async () => mocks)
-vi.mock('services/commitErrors', async () => mocks)
+vi.mock('services/commitErrors/useCommitErrors', async () => mocks)
 
 const server = setupServer()
 const queryClient = new QueryClient({

--- a/src/pages/CommitDetailPage/CommitCoverage/UploadsCard/UploadsCard.tsx
+++ b/src/pages/CommitDetailPage/CommitCoverage/UploadsCard/UploadsCard.tsx
@@ -3,7 +3,7 @@ import flatMap from 'lodash/flatMap'
 import { Fragment, useState } from 'react'
 
 import { IgnoredIdsQueryOptions } from 'pages/CommitDetailPage/queries/IgnoredIdsQueryOptions'
-import { useCommitErrors } from 'services/commitErrors'
+import { useCommitErrors } from 'services/commitErrors/useCommitErrors'
 import { cn } from 'shared/utils/cn'
 import { NONE } from 'shared/utils/extractUploads'
 import A from 'ui/A'

--- a/src/pages/CommitDetailPage/CommitCoverage/YamlModal/YamlModal.jsx
+++ b/src/pages/CommitDetailPage/CommitCoverage/YamlModal/YamlModal.jsx
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types'
 import { Suspense } from 'react'
 
 import YamlErrorBanner from 'pages/CommitDetailPage/CommitCoverage/YamlErrorBanner'
-import { useCommitErrors } from 'services/commitErrors'
+import { useCommitErrors } from 'services/commitErrors/useCommitErrors'
 import A from 'ui/A'
 import Modal from 'ui/Modal'
 import Spinner from 'ui/Spinner'

--- a/src/pages/CommitDetailPage/CommitCoverage/routes/FilesChangedTab/shared/CommitFileDiff/CommitFileDiff.test.tsx
+++ b/src/pages/CommitDetailPage/CommitCoverage/routes/FilesChangedTab/shared/CommitFileDiff/CommitFileDiff.test.tsx
@@ -10,7 +10,7 @@ import { Suspense } from 'react'
 import { MemoryRouter, Route } from 'react-router-dom'
 import { type MockInstance } from 'vitest'
 
-import { ImpactedFileType } from 'services/comparison'
+import { ImpactedFileType } from 'services/comparison/useComparisonForCommitAndParent'
 
 import CommitFileDiff from './CommitFileDiff'
 

--- a/src/pages/CommitDetailPage/Header/HeaderTeam/queries/CommitHeaderDataTeamQueryOpts.tsx
+++ b/src/pages/CommitDetailPage/Header/HeaderTeam/queries/CommitHeaderDataTeamQueryOpts.tsx
@@ -1,14 +1,12 @@
 import { queryOptions as queryOptionsV5 } from '@tanstack/react-queryV5'
 import { z } from 'zod'
 
-import {
-  FirstPullRequestSchema,
-  MissingBaseCommitSchema,
-  MissingBaseReportSchema,
-  MissingComparisonSchema,
-  MissingHeadCommitSchema,
-  MissingHeadReportSchema,
-} from 'services/comparison/schemas'
+import { FirstPullRequestSchema } from 'services/comparison/schemas/FirstPullRequest'
+import { MissingBaseCommitSchema } from 'services/comparison/schemas/MissingBaseCommit'
+import { MissingBaseReportSchema } from 'services/comparison/schemas/MissingBaseReport'
+import { MissingComparisonSchema } from 'services/comparison/schemas/MissingComparison'
+import { MissingHeadCommitSchema } from 'services/comparison/schemas/MissingHeadCommit'
+import { MissingHeadReportSchema } from 'services/comparison/schemas/MissingHeadReport'
 import {
   RepoNotFoundErrorSchema,
   RepoOwnerNotActivatedErrorSchema,

--- a/src/pages/CommitDetailPage/queries/CommitPageDataQueryOpts.tsx
+++ b/src/pages/CommitDetailPage/queries/CommitPageDataQueryOpts.tsx
@@ -1,14 +1,12 @@
 import { queryOptions as queryOptionsV5 } from '@tanstack/react-queryV5'
 import { z } from 'zod'
 
-import {
-  FirstPullRequestSchema,
-  MissingBaseCommitSchema,
-  MissingBaseReportSchema,
-  MissingComparisonSchema,
-  MissingHeadCommitSchema,
-  MissingHeadReportSchema,
-} from 'services/comparison'
+import { FirstPullRequestSchema } from 'services/comparison/schemas/FirstPullRequest'
+import { MissingBaseCommitSchema } from 'services/comparison/schemas/MissingBaseCommit'
+import { MissingBaseReportSchema } from 'services/comparison/schemas/MissingBaseReport'
+import { MissingComparisonSchema } from 'services/comparison/schemas/MissingComparison'
+import { MissingHeadCommitSchema } from 'services/comparison/schemas/MissingHeadCommit'
+import { MissingHeadReportSchema } from 'services/comparison/schemas/MissingHeadReport'
 import {
   RepoNotFoundErrorSchema,
   RepoOwnerNotActivatedErrorSchema,

--- a/src/pages/PullRequestPage/Header/HeaderTeam/queries/PullHeadDataTeamQueryOpts.tsx
+++ b/src/pages/PullRequestPage/Header/HeaderTeam/queries/PullHeadDataTeamQueryOpts.tsx
@@ -1,14 +1,12 @@
 import { queryOptions as queryOptionsV5 } from '@tanstack/react-queryV5'
 import { z } from 'zod'
 
-import {
-  FirstPullRequestSchema,
-  MissingBaseCommitSchema,
-  MissingBaseReportSchema,
-  MissingComparisonSchema,
-  MissingHeadCommitSchema,
-  MissingHeadReportSchema,
-} from 'services/comparison/schemas'
+import { FirstPullRequestSchema } from 'services/comparison/schemas/FirstPullRequest'
+import { MissingBaseCommitSchema } from 'services/comparison/schemas/MissingBaseCommit'
+import { MissingBaseReportSchema } from 'services/comparison/schemas/MissingBaseReport'
+import { MissingComparisonSchema } from 'services/comparison/schemas/MissingComparison'
+import { MissingHeadCommitSchema } from 'services/comparison/schemas/MissingHeadCommit'
+import { MissingHeadReportSchema } from 'services/comparison/schemas/MissingHeadReport'
 import {
   RepoNotFoundErrorSchema,
   RepoOwnerNotActivatedErrorSchema,

--- a/src/pages/PullRequestPage/PullCoverage/routes/ComponentsTab/queries/ComponentComparisonQueryOpts.tsx
+++ b/src/pages/PullRequestPage/PullCoverage/routes/ComponentsTab/queries/ComponentComparisonQueryOpts.tsx
@@ -2,14 +2,12 @@ import { queryOptions as queryOptionsV5 } from '@tanstack/react-queryV5'
 import { type ParsedQs } from 'qs'
 import { z } from 'zod'
 
-import {
-  FirstPullRequestSchema,
-  MissingBaseCommitSchema,
-  MissingBaseReportSchema,
-  MissingComparisonSchema,
-  MissingHeadCommitSchema,
-  MissingHeadReportSchema,
-} from 'services/comparison'
+import { FirstPullRequestSchema } from 'services/comparison/schemas/FirstPullRequest'
+import { MissingBaseCommitSchema } from 'services/comparison/schemas/MissingBaseCommit'
+import { MissingBaseReportSchema } from 'services/comparison/schemas/MissingBaseReport'
+import { MissingComparisonSchema } from 'services/comparison/schemas/MissingComparison'
+import { MissingHeadCommitSchema } from 'services/comparison/schemas/MissingHeadCommit'
+import { MissingHeadReportSchema } from 'services/comparison/schemas/MissingHeadReport'
 import {
   RepoNotFoundErrorSchema,
   RepoOwnerNotActivatedErrorSchema,

--- a/src/pages/PullRequestPage/queries/PullPageDataQueryOpts.tsx
+++ b/src/pages/PullRequestPage/queries/PullPageDataQueryOpts.tsx
@@ -1,14 +1,12 @@
 import { queryOptions as queryOptionsV5 } from '@tanstack/react-queryV5'
 import { z } from 'zod'
 
-import {
-  FirstPullRequestSchema,
-  MissingBaseCommitSchema,
-  MissingBaseReportSchema,
-  MissingComparisonSchema,
-  MissingHeadCommitSchema,
-  MissingHeadReportSchema,
-} from 'services/comparison'
+import { FirstPullRequestSchema } from 'services/comparison/schemas/FirstPullRequest'
+import { MissingBaseCommitSchema } from 'services/comparison/schemas/MissingBaseCommit'
+import { MissingBaseReportSchema } from 'services/comparison/schemas/MissingBaseReport'
+import { MissingComparisonSchema } from 'services/comparison/schemas/MissingComparison'
+import { MissingHeadCommitSchema } from 'services/comparison/schemas/MissingHeadCommit'
+import { MissingHeadReportSchema } from 'services/comparison/schemas/MissingHeadReport'
 import {
   RepoNotFoundErrorSchema,
   RepoOwnerNotActivatedErrorSchema,

--- a/src/pages/RepoPage/BundlesTab/BundleOnboarding/BundleOnboarding.tsx
+++ b/src/pages/RepoPage/BundlesTab/BundleOnboarding/BundleOnboarding.tsx
@@ -7,7 +7,7 @@ import NotFound from 'pages/NotFound'
 import {
   EVENT_METRICS,
   useStoreCodecovEventMetric,
-} from 'services/codecovEventMetrics'
+} from 'services/codecovEventMetrics/useStoreCodecovEventMetric'
 import { useNavLinks } from 'services/navigation'
 import { useRepo } from 'services/repo'
 import { Provider } from 'shared/api/helpers'

--- a/src/pages/RepoPage/CoverageOnboarding/CircleCI/CircleCI.tsx
+++ b/src/pages/RepoPage/CoverageOnboarding/CircleCI/CircleCI.tsx
@@ -5,7 +5,7 @@ import envVarScreenshot from 'assets/onboarding/env_variable_screenshot.png'
 import {
   EVENT_METRICS,
   useStoreCodecovEventMetric,
-} from 'services/codecovEventMetrics'
+} from 'services/codecovEventMetrics/useStoreCodecovEventMetric'
 import { useOrgUploadToken } from 'services/orgUploadToken/useOrgUploadToken'
 import { useRepo } from 'services/repo'
 import { Provider } from 'shared/api/helpers'

--- a/src/pages/RepoPage/CoverageOnboarding/GitHubActions/TokenStep.tsx
+++ b/src/pages/RepoPage/CoverageOnboarding/GitHubActions/TokenStep.tsx
@@ -10,7 +10,7 @@ import {
   EVENT_METRICS,
   StoreEventMetricMutationArgs,
   useStoreCodecovEventMetric,
-} from 'services/codecovEventMetrics'
+} from 'services/codecovEventMetrics/useStoreCodecovEventMetric'
 import { useOrgUploadToken } from 'services/orgUploadToken/useOrgUploadToken'
 import { useRepo } from 'services/repo'
 import { useUploadTokenRequired } from 'services/uploadTokenRequired'

--- a/src/pages/RepoPage/CoverageOnboarding/GitHubActions/WorkflowYMLStep.tsx
+++ b/src/pages/RepoPage/CoverageOnboarding/GitHubActions/WorkflowYMLStep.tsx
@@ -3,7 +3,7 @@ import { useParams } from 'react-router-dom'
 import {
   EVENT_METRICS,
   useStoreCodecovEventMetric,
-} from 'services/codecovEventMetrics'
+} from 'services/codecovEventMetrics/useStoreCodecovEventMetric'
 import { useOrgUploadToken } from 'services/orgUploadToken/useOrgUploadToken'
 import { Provider } from 'shared/api/helpers'
 import A from 'ui/A'

--- a/src/pages/RepoPage/CoverageOnboarding/NewRepoTab.tsx
+++ b/src/pages/RepoPage/CoverageOnboarding/NewRepoTab.tsx
@@ -7,7 +7,7 @@ import NotFound from 'pages/NotFound'
 import {
   EVENT_METRICS,
   useStoreCodecovEventMetric,
-} from 'services/codecovEventMetrics'
+} from 'services/codecovEventMetrics/useStoreCodecovEventMetric'
 import { useNavLinks } from 'services/navigation'
 import { useRepo } from 'services/repo'
 import { Provider } from 'shared/api/helpers'

--- a/src/pages/RepoPage/CoverageOnboarding/OutputCoverageStep/OutputCoverageStep.tsx
+++ b/src/pages/RepoPage/CoverageOnboarding/OutputCoverageStep/OutputCoverageStep.tsx
@@ -1,7 +1,7 @@
 import {
   EVENT_METRICS,
   useStoreCodecovEventMetric,
-} from 'services/codecovEventMetrics'
+} from 'services/codecovEventMetrics/useStoreCodecovEventMetric'
 import A from 'ui/A'
 import { Card } from 'ui/Card'
 import { CodeSnippet } from 'ui/CodeSnippet'

--- a/src/services/bundleAnalysis/BranchBundleSummaryQueryOpts.tsx
+++ b/src/services/bundleAnalysis/BranchBundleSummaryQueryOpts.tsx
@@ -1,7 +1,7 @@
 import { queryOptions as queryOptionsV5 } from '@tanstack/react-queryV5'
 import { z } from 'zod'
 
-import { MissingHeadReportSchema } from 'services/comparison'
+import { MissingHeadReportSchema } from 'services/comparison/schemas/MissingHeadReport'
 import {
   RepoNotFoundErrorSchema,
   RepoOwnerNotActivatedErrorSchema,

--- a/src/services/bundleAnalysis/BranchBundlesNamesQueryOpts.tsx
+++ b/src/services/bundleAnalysis/BranchBundlesNamesQueryOpts.tsx
@@ -1,7 +1,7 @@
 import { queryOptions as queryOptionsV5 } from '@tanstack/react-queryV5'
 import { z } from 'zod'
 
-import { MissingHeadReportSchema } from 'services/comparison'
+import { MissingHeadReportSchema } from 'services/comparison/schemas/MissingHeadReport'
 import {
   RepoNotFoundErrorSchema,
   RepoOwnerNotActivatedErrorSchema,

--- a/src/services/bundleAnalysis/BundleAssetsQueryOpts.tsx
+++ b/src/services/bundleAnalysis/BundleAssetsQueryOpts.tsx
@@ -3,7 +3,7 @@ import { z } from 'zod'
 
 import { OrderingDirection } from 'types'
 
-import { MissingHeadReportSchema } from 'services/comparison'
+import { MissingHeadReportSchema } from 'services/comparison/schemas/MissingHeadReport'
 import {
   RepoNotFoundErrorSchema,
   RepoOwnerNotActivatedErrorSchema,

--- a/src/services/bundleAnalysis/BundleTrendDataQueryOpts.tsx
+++ b/src/services/bundleAnalysis/BundleTrendDataQueryOpts.tsx
@@ -2,7 +2,7 @@ import { queryOptions as queryOptionsV5 } from '@tanstack/react-queryV5'
 import { z } from 'zod'
 
 // import { BUNDLE_LOAD_TYPE_ITEMS } from 'pages/RepoPage/BundlesTab/BundleContent/constants'
-import { MissingHeadReportSchema } from 'services/comparison'
+import { MissingHeadReportSchema } from 'services/comparison/schemas/MissingHeadReport'
 import {
   RepoNotFoundErrorSchema,
   RepoOwnerNotActivatedErrorSchema,

--- a/src/services/bundleAnalysis/CachedBundlesQueryOpts.tsx
+++ b/src/services/bundleAnalysis/CachedBundlesQueryOpts.tsx
@@ -1,7 +1,7 @@
 import { queryOptions as queryOptionsV5 } from '@tanstack/react-queryV5'
 import { z } from 'zod'
 
-import { MissingHeadReportSchema } from 'services/comparison'
+import { MissingHeadReportSchema } from 'services/comparison/schemas/MissingHeadReport'
 import {
   RepoNotFoundErrorSchema,
   RepoOwnerNotActivatedErrorSchema,

--- a/src/services/bundleAnalysis/useBundleAssetModules.tsx
+++ b/src/services/bundleAnalysis/useBundleAssetModules.tsx
@@ -4,7 +4,7 @@ import {
 } from '@tanstack/react-queryV5'
 import { z } from 'zod'
 
-import { MissingHeadReportSchema } from 'services/comparison'
+import { MissingHeadReportSchema } from 'services/comparison/schemas/MissingHeadReport'
 import {
   RepoNotFoundErrorSchema,
   RepoOwnerNotActivatedErrorSchema,

--- a/src/services/bundleAnalysis/useBundleSummary.tsx
+++ b/src/services/bundleAnalysis/useBundleSummary.tsx
@@ -4,7 +4,7 @@ import {
 } from '@tanstack/react-queryV5'
 import { z } from 'zod'
 
-import { MissingHeadReportSchema } from 'services/comparison'
+import { MissingHeadReportSchema } from 'services/comparison/schemas/MissingHeadReport'
 import {
   RepoNotFoundErrorSchema,
   RepoOwnerNotActivatedErrorSchema,

--- a/src/services/codecovEventMetrics/index.ts
+++ b/src/services/codecovEventMetrics/index.ts
@@ -1,1 +1,0 @@
-export * from './useStoreCodecovEventMetric'

--- a/src/services/commit/useCommit.tsx
+++ b/src/services/commit/useCommit.tsx
@@ -4,14 +4,12 @@ import { z } from 'zod'
 
 import { OrderingDirection } from 'types'
 
-import {
-  FirstPullRequestSchema,
-  MissingBaseCommitSchema,
-  MissingBaseReportSchema,
-  MissingComparisonSchema,
-  MissingHeadCommitSchema,
-  MissingHeadReportSchema,
-} from 'services/comparison/schemas'
+import { FirstPullRequestSchema } from 'services/comparison/schemas/FirstPullRequest'
+import { MissingBaseCommitSchema } from 'services/comparison/schemas/MissingBaseCommit'
+import { MissingBaseReportSchema } from 'services/comparison/schemas/MissingBaseReport'
+import { MissingComparisonSchema } from 'services/comparison/schemas/MissingComparison'
+import { MissingHeadCommitSchema } from 'services/comparison/schemas/MissingHeadCommit'
+import { MissingHeadReportSchema } from 'services/comparison/schemas/MissingHeadReport'
 import { UnknownFlagsSchema } from 'services/impactedFiles/schemas/UnknownFlags'
 import {
   RepoNotFoundErrorSchema,

--- a/src/services/commit/useCommitBADropdownSummary.tsx
+++ b/src/services/commit/useCommitBADropdownSummary.tsx
@@ -1,13 +1,11 @@
 import { useQuery } from '@tanstack/react-query'
 import { z } from 'zod'
 
-import {
-  FirstPullRequestSchema,
-  MissingBaseCommitSchema,
-  MissingBaseReportSchema,
-  MissingHeadCommitSchema,
-  MissingHeadReportSchema,
-} from 'services/comparison/schemas'
+import { FirstPullRequestSchema } from 'services/comparison/schemas/FirstPullRequest'
+import { MissingBaseCommitSchema } from 'services/comparison/schemas/MissingBaseCommit'
+import { MissingBaseReportSchema } from 'services/comparison/schemas/MissingBaseReport'
+import { MissingHeadCommitSchema } from 'services/comparison/schemas/MissingHeadCommit'
+import { MissingHeadReportSchema } from 'services/comparison/schemas/MissingHeadReport'
 import {
   RepoNotFoundErrorSchema,
   RepoOwnerNotActivatedErrorSchema,

--- a/src/services/commit/useCommitBundleList.tsx
+++ b/src/services/commit/useCommitBundleList.tsx
@@ -1,13 +1,11 @@
 import { useQuery } from '@tanstack/react-query'
 import { z } from 'zod'
 
-import {
-  FirstPullRequestSchema,
-  MissingBaseCommitSchema,
-  MissingBaseReportSchema,
-  MissingHeadCommitSchema,
-  MissingHeadReportSchema,
-} from 'services/comparison/schemas'
+import { FirstPullRequestSchema } from 'services/comparison/schemas/FirstPullRequest'
+import { MissingBaseCommitSchema } from 'services/comparison/schemas/MissingBaseCommit'
+import { MissingBaseReportSchema } from 'services/comparison/schemas/MissingBaseReport'
+import { MissingHeadCommitSchema } from 'services/comparison/schemas/MissingHeadCommit'
+import { MissingHeadReportSchema } from 'services/comparison/schemas/MissingHeadReport'
 import {
   RepoNotFoundErrorSchema,
   RepoOwnerNotActivatedErrorSchema,

--- a/src/services/commit/useCommitCoverageDropdownSummary.tsx
+++ b/src/services/commit/useCommitCoverageDropdownSummary.tsx
@@ -1,14 +1,12 @@
 import { useQuery } from '@tanstack/react-query'
 import { z } from 'zod'
 
-import {
-  FirstPullRequestSchema,
-  MissingBaseCommitSchema,
-  MissingBaseReportSchema,
-  MissingComparisonSchema,
-  MissingHeadCommitSchema,
-  MissingHeadReportSchema,
-} from 'services/comparison/schemas'
+import { FirstPullRequestSchema } from 'services/comparison/schemas/FirstPullRequest'
+import { MissingBaseCommitSchema } from 'services/comparison/schemas/MissingBaseCommit'
+import { MissingBaseReportSchema } from 'services/comparison/schemas/MissingBaseReport'
+import { MissingComparisonSchema } from 'services/comparison/schemas/MissingComparison'
+import { MissingHeadCommitSchema } from 'services/comparison/schemas/MissingHeadCommit'
+import { MissingHeadReportSchema } from 'services/comparison/schemas/MissingHeadReport'
 import {
   RepoNotFoundErrorSchema,
   RepoOwnerNotActivatedErrorSchema,

--- a/src/services/commit/useCommitTeam.tsx
+++ b/src/services/commit/useCommitTeam.tsx
@@ -1,14 +1,12 @@
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { z } from 'zod'
 
-import {
-  FirstPullRequestSchema,
-  MissingBaseCommitSchema,
-  MissingBaseReportSchema,
-  MissingComparisonSchema,
-  MissingHeadCommitSchema,
-  MissingHeadReportSchema,
-} from 'services/comparison/schemas'
+import { FirstPullRequestSchema } from 'services/comparison/schemas/FirstPullRequest'
+import { MissingBaseCommitSchema } from 'services/comparison/schemas/MissingBaseCommit'
+import { MissingBaseReportSchema } from 'services/comparison/schemas/MissingBaseReport'
+import { MissingComparisonSchema } from 'services/comparison/schemas/MissingComparison'
+import { MissingHeadCommitSchema } from 'services/comparison/schemas/MissingHeadCommit'
+import { MissingHeadReportSchema } from 'services/comparison/schemas/MissingHeadReport'
 import {
   RepoNotFoundErrorSchema,
   RepoOwnerNotActivatedErrorSchema,

--- a/src/services/commit/useCompareTotals.tsx
+++ b/src/services/commit/useCompareTotals.tsx
@@ -1,14 +1,12 @@
 import { useQuery, type UseQueryOptions } from '@tanstack/react-query'
 import { z } from 'zod'
 
-import {
-  FirstPullRequestSchema,
-  MissingBaseCommitSchema,
-  MissingBaseReportSchema,
-  MissingComparisonSchema,
-  MissingHeadCommitSchema,
-  MissingHeadReportSchema,
-} from 'services/comparison/schemas'
+import { FirstPullRequestSchema } from 'services/comparison/schemas/FirstPullRequest'
+import { MissingBaseCommitSchema } from 'services/comparison/schemas/MissingBaseCommit'
+import { MissingBaseReportSchema } from 'services/comparison/schemas/MissingBaseReport'
+import { MissingComparisonSchema } from 'services/comparison/schemas/MissingComparison'
+import { MissingHeadCommitSchema } from 'services/comparison/schemas/MissingHeadCommit'
+import { MissingHeadReportSchema } from 'services/comparison/schemas/MissingHeadReport'
 import {
   RepoNotFoundErrorSchema,
   RepoOwnerNotActivatedErrorSchema,

--- a/src/services/commit/useCompareTotalsTeam.tsx
+++ b/src/services/commit/useCompareTotalsTeam.tsx
@@ -1,14 +1,12 @@
 import { useQuery, type UseQueryOptions } from '@tanstack/react-query'
 import { z } from 'zod'
 
-import {
-  FirstPullRequestSchema,
-  MissingBaseCommitSchema,
-  MissingBaseReportSchema,
-  MissingComparisonSchema,
-  MissingHeadCommitSchema,
-  MissingHeadReportSchema,
-} from 'services/comparison/schemas'
+import { FirstPullRequestSchema } from 'services/comparison/schemas/FirstPullRequest'
+import { MissingBaseCommitSchema } from 'services/comparison/schemas/MissingBaseCommit'
+import { MissingBaseReportSchema } from 'services/comparison/schemas/MissingBaseReport'
+import { MissingComparisonSchema } from 'services/comparison/schemas/MissingComparison'
+import { MissingHeadCommitSchema } from 'services/comparison/schemas/MissingHeadCommit'
+import { MissingHeadReportSchema } from 'services/comparison/schemas/MissingHeadReport'
 import {
   RepoNotFoundErrorSchema,
   RepoOwnerNotActivatedErrorSchema,

--- a/src/services/commitErrors/index.ts
+++ b/src/services/commitErrors/index.ts
@@ -1,1 +1,0 @@
-export * from './useCommitErrors'

--- a/src/services/commits/index.ts
+++ b/src/services/commits/index.ts
@@ -1,1 +1,0 @@
-export * from './useCommits'

--- a/src/services/commits/useCommits.tsx
+++ b/src/services/commits/useCommits.tsx
@@ -5,14 +5,12 @@ import {
 import isNumber from 'lodash/isNumber'
 import { z } from 'zod'
 
-import {
-  FirstPullRequestSchema,
-  MissingBaseCommitSchema,
-  MissingBaseReportSchema,
-  MissingComparisonSchema,
-  MissingHeadCommitSchema,
-  MissingHeadReportSchema,
-} from 'services/comparison'
+import { FirstPullRequestSchema } from 'services/comparison/schemas/FirstPullRequest'
+import { MissingBaseCommitSchema } from 'services/comparison/schemas/MissingBaseCommit'
+import { MissingBaseReportSchema } from 'services/comparison/schemas/MissingBaseReport'
+import { MissingComparisonSchema } from 'services/comparison/schemas/MissingComparison'
+import { MissingHeadCommitSchema } from 'services/comparison/schemas/MissingHeadCommit'
+import { MissingHeadReportSchema } from 'services/comparison/schemas/MissingHeadReport'
 import {
   RepoNotFoundErrorSchema,
   RepoOwnerNotActivatedErrorSchema,

--- a/src/services/comparison/index.ts
+++ b/src/services/comparison/index.ts
@@ -1,2 +1,0 @@
-export * from './useComparisonForCommitAndParent'
-export * from './schemas'

--- a/src/services/comparison/schemas/index.ts
+++ b/src/services/comparison/schemas/index.ts
@@ -1,6 +1,0 @@
-export * from './FirstPullRequest'
-export * from './MissingBaseCommit'
-export * from './MissingBaseReport'
-export * from './MissingComparison'
-export * from './MissingHeadCommit'
-export * from './MissingHeadReport'

--- a/src/services/comparison/useComparisonForCommitAndParent/useComparisonForCommitAndParent.tsx
+++ b/src/services/comparison/useComparisonForCommitAndParent/useComparisonForCommitAndParent.tsx
@@ -11,14 +11,12 @@ import A from 'ui/A'
 
 import { query } from './query'
 
-import {
-  FirstPullRequestSchema,
-  MissingBaseCommitSchema,
-  MissingBaseReportSchema,
-  MissingComparisonSchema,
-  MissingHeadCommitSchema,
-  MissingHeadReportSchema,
-} from '../schemas'
+import { FirstPullRequestSchema } from '../schemas/FirstPullRequest'
+import { MissingBaseCommitSchema } from '../schemas/MissingBaseCommit'
+import { MissingBaseReportSchema } from '../schemas/MissingBaseReport'
+import { MissingComparisonSchema } from '../schemas/MissingComparison'
+import { MissingHeadCommitSchema } from '../schemas/MissingHeadCommit'
+import { MissingHeadReportSchema } from '../schemas/MissingHeadReport'
 
 const CoverageObjSchema = z.object({
   coverage: z.number().nullish(),

--- a/src/services/pathContents/commit/dir/constants.ts
+++ b/src/services/pathContents/commit/dir/constants.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod'
 
-import { MissingHeadReportSchema } from 'services/comparison'
+import { MissingHeadReportSchema } from 'services/comparison/schemas/MissingHeadReport'
 import { UnknownFlagsSchema } from 'services/impactedFiles/schemas/UnknownFlags'
 import {
   MissingCoverageSchema,

--- a/src/services/pathContents/pull/dir/constants.ts
+++ b/src/services/pathContents/pull/dir/constants.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod'
 
-import { MissingHeadReportSchema } from 'services/comparison'
+import { MissingHeadReportSchema } from 'services/comparison/schemas/MissingHeadReport'
 import { UnknownFlagsSchema } from 'services/impactedFiles/schemas/UnknownFlags'
 
 const MissingCoverageSchema = z.object({

--- a/src/services/pull/usePrefetchSingleFileComp.tsx
+++ b/src/services/pull/usePrefetchSingleFileComp.tsx
@@ -1,14 +1,12 @@
 import { useQueryClient } from '@tanstack/react-query'
 import { z } from 'zod'
 
-import {
-  FirstPullRequestSchema,
-  MissingBaseCommitSchema,
-  MissingBaseReportSchema,
-  MissingComparisonSchema,
-  MissingHeadCommitSchema,
-  MissingHeadReportSchema,
-} from 'services/comparison'
+import { FirstPullRequestSchema } from 'services/comparison/schemas/FirstPullRequest'
+import { MissingBaseCommitSchema } from 'services/comparison/schemas/MissingBaseCommit'
+import { MissingBaseReportSchema } from 'services/comparison/schemas/MissingBaseReport'
+import { MissingComparisonSchema } from 'services/comparison/schemas/MissingComparison'
+import { MissingHeadCommitSchema } from 'services/comparison/schemas/MissingHeadCommit'
+import { MissingHeadReportSchema } from 'services/comparison/schemas/MissingHeadReport'
 import {
   RepoNotFoundErrorSchema,
   RepoOwnerNotActivatedErrorSchema,

--- a/src/services/pull/usePull.tsx
+++ b/src/services/pull/usePull.tsx
@@ -1,14 +1,12 @@
 import { useQuery } from '@tanstack/react-query'
 import { z } from 'zod'
 
-import {
-  FirstPullRequestSchema,
-  MissingBaseCommitSchema,
-  MissingBaseReportSchema,
-  MissingComparisonSchema,
-  MissingHeadCommitSchema,
-  MissingHeadReportSchema,
-} from 'services/comparison/schemas'
+import { FirstPullRequestSchema } from 'services/comparison/schemas/FirstPullRequest'
+import { MissingBaseCommitSchema } from 'services/comparison/schemas/MissingBaseCommit'
+import { MissingBaseReportSchema } from 'services/comparison/schemas/MissingBaseReport'
+import { MissingComparisonSchema } from 'services/comparison/schemas/MissingComparison'
+import { MissingHeadCommitSchema } from 'services/comparison/schemas/MissingHeadCommit'
+import { MissingHeadReportSchema } from 'services/comparison/schemas/MissingHeadReport'
 import {
   RepoNotFoundErrorSchema,
   RepoOwnerNotActivatedErrorSchema,

--- a/src/services/pull/usePullBADropdownSummary.tsx
+++ b/src/services/pull/usePullBADropdownSummary.tsx
@@ -1,13 +1,11 @@
 import { useQuery } from '@tanstack/react-query'
 import { z } from 'zod'
 
-import {
-  FirstPullRequestSchema,
-  MissingBaseCommitSchema,
-  MissingBaseReportSchema,
-  MissingHeadCommitSchema,
-  MissingHeadReportSchema,
-} from 'services/comparison/schemas'
+import { FirstPullRequestSchema } from 'services/comparison/schemas/FirstPullRequest'
+import { MissingBaseCommitSchema } from 'services/comparison/schemas/MissingBaseCommit'
+import { MissingBaseReportSchema } from 'services/comparison/schemas/MissingBaseReport'
+import { MissingHeadCommitSchema } from 'services/comparison/schemas/MissingHeadCommit'
+import { MissingHeadReportSchema } from 'services/comparison/schemas/MissingHeadReport'
 import {
   RepoNotFoundErrorSchema,
   RepoOwnerNotActivatedErrorSchema,

--- a/src/services/pull/usePullBundleComparisonList.tsx
+++ b/src/services/pull/usePullBundleComparisonList.tsx
@@ -1,13 +1,11 @@
 import { useQuery } from '@tanstack/react-query'
 import { z } from 'zod'
 
-import {
-  FirstPullRequestSchema,
-  MissingBaseCommitSchema,
-  MissingBaseReportSchema,
-  MissingHeadCommitSchema,
-  MissingHeadReportSchema,
-} from 'services/comparison/schemas'
+import { FirstPullRequestSchema } from 'services/comparison/schemas/FirstPullRequest'
+import { MissingBaseCommitSchema } from 'services/comparison/schemas/MissingBaseCommit'
+import { MissingBaseReportSchema } from 'services/comparison/schemas/MissingBaseReport'
+import { MissingHeadCommitSchema } from 'services/comparison/schemas/MissingHeadCommit'
+import { MissingHeadReportSchema } from 'services/comparison/schemas/MissingHeadReport'
 import {
   RepoNotFoundErrorSchema,
   RepoOwnerNotActivatedErrorSchema,

--- a/src/services/pull/usePullCompareTotalsTeam.tsx
+++ b/src/services/pull/usePullCompareTotalsTeam.tsx
@@ -1,14 +1,12 @@
 import { useQuery, type UseQueryOptions } from '@tanstack/react-query'
 import { z } from 'zod'
 
-import {
-  FirstPullRequestSchema,
-  MissingBaseCommitSchema,
-  MissingBaseReportSchema,
-  MissingComparisonSchema,
-  MissingHeadCommitSchema,
-  MissingHeadReportSchema,
-} from 'services/comparison/schemas'
+import { FirstPullRequestSchema } from 'services/comparison/schemas/FirstPullRequest'
+import { MissingBaseCommitSchema } from 'services/comparison/schemas/MissingBaseCommit'
+import { MissingBaseReportSchema } from 'services/comparison/schemas/MissingBaseReport'
+import { MissingComparisonSchema } from 'services/comparison/schemas/MissingComparison'
+import { MissingHeadCommitSchema } from 'services/comparison/schemas/MissingHeadCommit'
+import { MissingHeadReportSchema } from 'services/comparison/schemas/MissingHeadReport'
 import {
   RepoNotFoundErrorSchema,
   RepoOwnerNotActivatedErrorSchema,

--- a/src/services/pull/usePullComponents.tsx
+++ b/src/services/pull/usePullComponents.tsx
@@ -2,14 +2,12 @@ import { useQuery } from '@tanstack/react-query'
 import { useParams } from 'react-router-dom'
 import { z } from 'zod'
 
-import {
-  FirstPullRequestSchema,
-  MissingBaseCommitSchema,
-  MissingBaseReportSchema,
-  MissingComparisonSchema,
-  MissingHeadCommitSchema,
-  MissingHeadReportSchema,
-} from 'services/comparison'
+import { FirstPullRequestSchema } from 'services/comparison/schemas/FirstPullRequest'
+import { MissingBaseCommitSchema } from 'services/comparison/schemas/MissingBaseCommit'
+import { MissingBaseReportSchema } from 'services/comparison/schemas/MissingBaseReport'
+import { MissingComparisonSchema } from 'services/comparison/schemas/MissingComparison'
+import { MissingHeadCommitSchema } from 'services/comparison/schemas/MissingHeadCommit'
+import { MissingHeadReportSchema } from 'services/comparison/schemas/MissingHeadReport'
 import {
   RepoNotFoundErrorSchema,
   RepoOwnerNotActivatedErrorSchema,

--- a/src/services/pull/usePullCoverageDropdownSummary.tsx
+++ b/src/services/pull/usePullCoverageDropdownSummary.tsx
@@ -1,14 +1,12 @@
 import { useQuery } from '@tanstack/react-query'
 import { z } from 'zod'
 
-import {
-  FirstPullRequestSchema,
-  MissingBaseCommitSchema,
-  MissingBaseReportSchema,
-  MissingComparisonSchema,
-  MissingHeadCommitSchema,
-  MissingHeadReportSchema,
-} from 'services/comparison/schemas'
+import { FirstPullRequestSchema } from 'services/comparison/schemas/FirstPullRequest'
+import { MissingBaseCommitSchema } from 'services/comparison/schemas/MissingBaseCommit'
+import { MissingBaseReportSchema } from 'services/comparison/schemas/MissingBaseReport'
+import { MissingComparisonSchema } from 'services/comparison/schemas/MissingComparison'
+import { MissingHeadCommitSchema } from 'services/comparison/schemas/MissingHeadCommit'
+import { MissingHeadReportSchema } from 'services/comparison/schemas/MissingHeadReport'
 import {
   RepoNotFoundErrorSchema,
   RepoOwnerNotActivatedErrorSchema,

--- a/src/services/pull/usePullTeam.tsx
+++ b/src/services/pull/usePullTeam.tsx
@@ -1,14 +1,12 @@
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { z } from 'zod'
 
-import {
-  FirstPullRequestSchema,
-  MissingBaseCommitSchema,
-  MissingBaseReportSchema,
-  MissingComparisonSchema,
-  MissingHeadCommitSchema,
-  MissingHeadReportSchema,
-} from 'services/comparison/schemas'
+import { FirstPullRequestSchema } from 'services/comparison/schemas/FirstPullRequest'
+import { MissingBaseCommitSchema } from 'services/comparison/schemas/MissingBaseCommit'
+import { MissingBaseReportSchema } from 'services/comparison/schemas/MissingBaseReport'
+import { MissingComparisonSchema } from 'services/comparison/schemas/MissingComparison'
+import { MissingHeadCommitSchema } from 'services/comparison/schemas/MissingHeadCommit'
+import { MissingHeadReportSchema } from 'services/comparison/schemas/MissingHeadReport'
 import {
   RepoNotFoundErrorSchema,
   RepoOwnerNotActivatedErrorSchema,

--- a/src/services/pull/useSingularImpactedFileComparison.tsx
+++ b/src/services/pull/useSingularImpactedFileComparison.tsx
@@ -1,14 +1,12 @@
 import { useQuery } from '@tanstack/react-query'
 import z from 'zod'
 
-import {
-  FirstPullRequestSchema,
-  MissingBaseCommitSchema,
-  MissingBaseReportSchema,
-  MissingComparisonSchema,
-  MissingHeadCommitSchema,
-  MissingHeadReportSchema,
-} from 'services/comparison'
+import { FirstPullRequestSchema } from 'services/comparison/schemas/FirstPullRequest'
+import { MissingBaseCommitSchema } from 'services/comparison/schemas/MissingBaseCommit'
+import { MissingBaseReportSchema } from 'services/comparison/schemas/MissingBaseReport'
+import { MissingComparisonSchema } from 'services/comparison/schemas/MissingComparison'
+import { MissingHeadCommitSchema } from 'services/comparison/schemas/MissingHeadCommit'
+import { MissingHeadReportSchema } from 'services/comparison/schemas/MissingHeadReport'
 import {
   RepoNotFoundErrorSchema,
   RepoOwnerNotActivatedErrorSchema,

--- a/src/services/pulls/usePulls.tsx
+++ b/src/services/pulls/usePulls.tsx
@@ -6,14 +6,12 @@ import { z } from 'zod'
 
 import { OrderingDirection } from 'types'
 
-import {
-  FirstPullRequestSchema,
-  MissingBaseCommitSchema,
-  MissingBaseReportSchema,
-  MissingComparisonSchema,
-  MissingHeadCommitSchema,
-  MissingHeadReportSchema,
-} from 'services/comparison'
+import { FirstPullRequestSchema } from 'services/comparison/schemas/FirstPullRequest'
+import { MissingBaseCommitSchema } from 'services/comparison/schemas/MissingBaseCommit'
+import { MissingBaseReportSchema } from 'services/comparison/schemas/MissingBaseReport'
+import { MissingComparisonSchema } from 'services/comparison/schemas/MissingComparison'
+import { MissingHeadCommitSchema } from 'services/comparison/schemas/MissingHeadCommit'
+import { MissingHeadReportSchema } from 'services/comparison/schemas/MissingHeadReport'
 import {
   RepoNotFoundErrorSchema,
   RepoOwnerNotActivatedErrorSchema,

--- a/src/services/repo/useRepoFlagsSelect.tsx
+++ b/src/services/repo/useRepoFlagsSelect.tsx
@@ -2,14 +2,12 @@ import { useInfiniteQuery } from '@tanstack/react-query'
 import { useParams } from 'react-router-dom'
 import { z } from 'zod'
 
-import {
-  FirstPullRequestSchema,
-  MissingBaseCommitSchema,
-  MissingBaseReportSchema,
-  MissingComparisonSchema,
-  MissingHeadCommitSchema,
-  MissingHeadReportSchema,
-} from 'services/comparison/schemas'
+import { FirstPullRequestSchema } from 'services/comparison/schemas/FirstPullRequest'
+import { MissingBaseCommitSchema } from 'services/comparison/schemas/MissingBaseCommit'
+import { MissingBaseReportSchema } from 'services/comparison/schemas/MissingBaseReport'
+import { MissingComparisonSchema } from 'services/comparison/schemas/MissingComparison'
+import { MissingHeadCommitSchema } from 'services/comparison/schemas/MissingHeadCommit'
+import { MissingHeadReportSchema } from 'services/comparison/schemas/MissingHeadReport'
 import {
   RepoNotFoundErrorSchema,
   RepoOwnerNotActivatedErrorSchema,


### PR DESCRIPTION
# Description

This PR removes the barrel files from the following directories: `services/codecovEventMetrics`, `services/commitErrors`, `services/commits`, `services/comparison`, as well as updating imports across the app reflecting those changes.

Ticket: codecov/engineering-team#3352

# Notable Changes

- Remove barrel files from `services/codecovEventMetrics`, `services/commitErrors`, `services/commits`, `services/comparison`
- Update imports across Gazebo