### PR TITLE
chore: Fix grammar in failed tests error banner

### DIFF
--- a/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/FailedTestsErrorBanner/FailedTestsErrorBanner.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/FailedTestsErrorBanner/FailedTestsErrorBanner.tsx
@@ -26,7 +26,7 @@ const FileNotFoundBanner = () => (
     </BannerHeading>
     <BannerContent>
       <p>
-        No result to display due to Test Analytics couldn&apos;t locate a JUnit
+        No result to display because Test Analytics couldn&apos;t locate a JUnit
         XML file. Please rename the file to include{' '}
         <CodeSnippet>junit</CodeSnippet>, ensure CLI file search is enabled, or
         use the <CodeSnippet>file</CodeSnippet> or{' '}


### PR DESCRIPTION
Fixes grammar mistake pointed out by Rohan in the failed tests error banner.
