### PR TITLE
chore: Remove barrel files from services part 2

### DIFF
--- a/src/layouts/BaseLayout/BaseLayout.test.tsx
+++ b/src/layouts/BaseLayout/BaseLayout.test.tsx
@@ -12,7 +12,7 @@ import { type Mock } from 'vitest'
 import config from 'config'
 
 import { useImage } from 'services/image'
-import { useImpersonate } from 'services/impersonate'
+import { useImpersonate } from 'services/impersonate/useImpersonate'
 import { useInternalUser, useUser } from 'services/user'
 import { Plans } from 'shared/utils/billing'
 
@@ -21,7 +21,7 @@ import BaseLayout from './BaseLayout'
 vi.mock('services/image')
 const mockedUseImage = useImage as Mock
 
-vi.mock('services/impersonate')
+vi.mock('services/impersonate/useImpersonate')
 const mockedUseImpersonate = useImpersonate as Mock
 
 vi.mock('shared/GlobalTopBanners', () => ({

--- a/src/layouts/BaseLayout/BaseLayout.tsx
+++ b/src/layouts/BaseLayout/BaseLayout.tsx
@@ -13,7 +13,7 @@ import { OnboardingContainerProvider } from 'pages/OwnerPage/OnboardingContainer
 import { RepoBreadcrumbProvider } from 'pages/RepoPage/context'
 import TermsOfService from 'pages/TermsOfService'
 import { useEventContext } from 'services/events/hooks'
-import { useImpersonate } from 'services/impersonate'
+import { useImpersonate } from 'services/impersonate/useImpersonate'
 import { useTracking } from 'services/tracking'
 import GlobalBanners from 'shared/GlobalBanners'
 import GlobalTopBanners from 'shared/GlobalTopBanners'

--- a/src/layouts/EnterpriseLoginLayout/Header/Header.tsx
+++ b/src/layouts/EnterpriseLoginLayout/Header/Header.tsx
@@ -1,7 +1,7 @@
 import cs from 'classnames'
 
 import { CodecovIcon } from 'assets/svg/codecov'
-import { useImpersonate } from 'services/impersonate'
+import { useImpersonate } from 'services/impersonate/useImpersonate'
 import A from 'ui/A'
 
 function Header() {

--- a/src/layouts/Header/Header.test.tsx
+++ b/src/layouts/Header/Header.test.tsx
@@ -7,7 +7,7 @@ import { type Mock, vi } from 'vitest'
 
 import config from 'config'
 
-import { useImpersonate } from 'services/impersonate'
+import { useImpersonate } from 'services/impersonate/useImpersonate'
 import { User } from 'services/user'
 import { Plans } from 'shared/utils/billing'
 
@@ -32,7 +32,7 @@ vi.mock('src/layouts/Header/components/ThemeToggle', () => ({
   default: () => 'Theme Toggle',
 }))
 
-vi.mock('services/impersonate')
+vi.mock('services/impersonate/useImpersonate')
 const mockedUseImpersonate = useImpersonate as Mock
 
 const mockUser = {

--- a/src/layouts/Header/Header.tsx
+++ b/src/layouts/Header/Header.tsx
@@ -3,7 +3,7 @@ import { useRouteMatch } from 'react-router-dom'
 
 import config from 'config'
 
-import { useImpersonate } from 'services/impersonate'
+import { useImpersonate } from 'services/impersonate/useImpersonate'
 import { useUser } from 'services/user'
 
 import AdminLink from './components/AdminLink'

--- a/src/pages/AccountSettings/tabs/OrgUploadToken/OrgUploadToken.tsx
+++ b/src/pages/AccountSettings/tabs/OrgUploadToken/OrgUploadToken.tsx
@@ -1,6 +1,6 @@
 import { useParams } from 'react-router-dom'
 
-import { useOrgUploadToken } from 'services/orgUploadToken'
+import { useOrgUploadToken } from 'services/orgUploadToken/useOrgUploadToken'
 import { useFlags } from 'shared/featureFlags'
 import A from 'ui/A'
 import Banner from 'ui/Banner'

--- a/src/pages/AccountSettings/tabs/OrgUploadToken/useGenerateOrgUploadToken.ts
+++ b/src/pages/AccountSettings/tabs/OrgUploadToken/useGenerateOrgUploadToken.ts
@@ -1,4 +1,4 @@
-import { useRegenerateOrgUploadToken } from 'services/orgUploadToken'
+import { useRegenerateOrgUploadToken } from 'services/orgUploadToken/useRegenerateOrgUploadToken'
 import { useAddNotification } from 'services/toastNotification'
 
 export default function useGenerateOrgUploadToken() {

--- a/src/pages/RepoPage/BundlesTab/BundleOnboarding/NuxtOnboarding/NuxtOnboarding.tsx
+++ b/src/pages/RepoPage/BundlesTab/BundleOnboarding/NuxtOnboarding/NuxtOnboarding.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { useParams } from 'react-router-dom'
 
-import { useOrgUploadToken } from 'services/orgUploadToken'
+import { useOrgUploadToken } from 'services/orgUploadToken/useOrgUploadToken'
 import { useRepo } from 'services/repo'
 import A from 'ui/A'
 import { Card } from 'ui/Card'

--- a/src/pages/RepoPage/BundlesTab/BundleOnboarding/RemixOnboarding/RemixOnboarding.tsx
+++ b/src/pages/RepoPage/BundlesTab/BundleOnboarding/RemixOnboarding/RemixOnboarding.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { useParams } from 'react-router-dom'
 
-import { useOrgUploadToken } from 'services/orgUploadToken'
+import { useOrgUploadToken } from 'services/orgUploadToken/useOrgUploadToken'
 import { useRepo } from 'services/repo'
 import A from 'ui/A'
 import { Card } from 'ui/Card'

--- a/src/pages/RepoPage/BundlesTab/BundleOnboarding/RollupOnboarding/RollupOnboarding.tsx
+++ b/src/pages/RepoPage/BundlesTab/BundleOnboarding/RollupOnboarding/RollupOnboarding.tsx
@@ -1,6 +1,6 @@
 import { useParams } from 'react-router-dom'
 
-import { useOrgUploadToken } from 'services/orgUploadToken'
+import { useOrgUploadToken } from 'services/orgUploadToken/useOrgUploadToken'
 import { useRepo } from 'services/repo'
 import A from 'ui/A'
 import { Card } from 'ui/Card'

--- a/src/pages/RepoPage/BundlesTab/BundleOnboarding/SolidStartOnboarding/SolidStartOnboarding.tsx
+++ b/src/pages/RepoPage/BundlesTab/BundleOnboarding/SolidStartOnboarding/SolidStartOnboarding.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { useParams } from 'react-router-dom'
 
-import { useOrgUploadToken } from 'services/orgUploadToken'
+import { useOrgUploadToken } from 'services/orgUploadToken/useOrgUploadToken'
 import { useRepo } from 'services/repo'
 import A from 'ui/A'
 import { Card } from 'ui/Card'

--- a/src/pages/RepoPage/BundlesTab/BundleOnboarding/SvelteKitOnboarding/SvelteKitOnboarding.tsx
+++ b/src/pages/RepoPage/BundlesTab/BundleOnboarding/SvelteKitOnboarding/SvelteKitOnboarding.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { useParams } from 'react-router-dom'
 
-import { useOrgUploadToken } from 'services/orgUploadToken'
+import { useOrgUploadToken } from 'services/orgUploadToken/useOrgUploadToken'
 import { useRepo } from 'services/repo'
 import A from 'ui/A'
 import { Card } from 'ui/Card'

--- a/src/pages/RepoPage/BundlesTab/BundleOnboarding/ViteOnboarding/ViteOnboarding.tsx
+++ b/src/pages/RepoPage/BundlesTab/BundleOnboarding/ViteOnboarding/ViteOnboarding.tsx
@@ -1,6 +1,6 @@
 import { useParams } from 'react-router-dom'
 
-import { useOrgUploadToken } from 'services/orgUploadToken'
+import { useOrgUploadToken } from 'services/orgUploadToken/useOrgUploadToken'
 import { useRepo } from 'services/repo'
 import A from 'ui/A'
 import { Card } from 'ui/Card'

--- a/src/pages/RepoPage/BundlesTab/BundleOnboarding/WebpackOnboarding/WebpackOnboarding.tsx
+++ b/src/pages/RepoPage/BundlesTab/BundleOnboarding/WebpackOnboarding/WebpackOnboarding.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { useParams } from 'react-router-dom'
 
-import { useOrgUploadToken } from 'services/orgUploadToken'
+import { useOrgUploadToken } from 'services/orgUploadToken/useOrgUploadToken'
 import { useRepo } from 'services/repo'
 import A from 'ui/A'
 import { Card } from 'ui/Card'

--- a/src/pages/RepoPage/CoverageOnboarding/CircleCI/CircleCI.tsx
+++ b/src/pages/RepoPage/CoverageOnboarding/CircleCI/CircleCI.tsx
@@ -6,7 +6,7 @@ import {
   EVENT_METRICS,
   useStoreCodecovEventMetric,
 } from 'services/codecovEventMetrics'
-import { useOrgUploadToken } from 'services/orgUploadToken'
+import { useOrgUploadToken } from 'services/orgUploadToken/useOrgUploadToken'
 import { useRepo } from 'services/repo'
 import { Provider } from 'shared/api/helpers'
 import { providerToInternalProvider } from 'shared/utils/provider'

--- a/src/pages/RepoPage/CoverageOnboarding/GitHubActions/GitHubActions.tsx
+++ b/src/pages/RepoPage/CoverageOnboarding/GitHubActions/GitHubActions.tsx
@@ -1,7 +1,7 @@
 import { useRef, useState } from 'react'
 import { useParams } from 'react-router-dom'
 
-import { useOrgUploadToken } from 'services/orgUploadToken'
+import { useOrgUploadToken } from 'services/orgUploadToken/useOrgUploadToken'
 import { useRepo } from 'services/repo'
 import { useUploadTokenRequired } from 'services/uploadTokenRequired'
 import { Provider } from 'shared/api/helpers'

--- a/src/pages/RepoPage/CoverageOnboarding/GitHubActions/TokenStep.test.tsx
+++ b/src/pages/RepoPage/CoverageOnboarding/GitHubActions/TokenStep.test.tsx
@@ -9,7 +9,7 @@ import { ThemeContextProvider } from 'shared/ThemeContext'
 import TokenStepSection from './TokenStep'
 
 vi.mock('services/uploadTokenRequired')
-vi.mock('services/orgUploadToken')
+vi.mock('services/orgUploadToken/useOrgUploadToken')
 vi.mock('services/repo')
 vi.mock('shared/featureFlags')
 vi.mock('services/user')
@@ -30,8 +30,10 @@ vi.mock('services/uploadTokenRequired', async () => {
   }
 })
 
-vi.mock('services/orgUploadToken', async () => {
-  const original = await vi.importActual('services/orgUploadToken')
+vi.mock('services/orgUploadToken/useOrgUploadToken', async () => {
+  const original = await vi.importActual(
+    'services/orgUploadToken/useOrgUploadToken'
+  )
   return {
     ...original,
     useOrgUploadToken: mocks.useOrgUploadToken,

--- a/src/pages/RepoPage/CoverageOnboarding/GitHubActions/TokenStep.tsx
+++ b/src/pages/RepoPage/CoverageOnboarding/GitHubActions/TokenStep.tsx
@@ -11,7 +11,7 @@ import {
   StoreEventMetricMutationArgs,
   useStoreCodecovEventMetric,
 } from 'services/codecovEventMetrics'
-import { useOrgUploadToken } from 'services/orgUploadToken'
+import { useOrgUploadToken } from 'services/orgUploadToken/useOrgUploadToken'
 import { useRepo } from 'services/repo'
 import { useUploadTokenRequired } from 'services/uploadTokenRequired'
 import { useIsCurrentUserAnAdmin } from 'services/user'

--- a/src/pages/RepoPage/CoverageOnboarding/GitHubActions/WorkflowYMLStep.tsx
+++ b/src/pages/RepoPage/CoverageOnboarding/GitHubActions/WorkflowYMLStep.tsx
@@ -4,7 +4,7 @@ import {
   EVENT_METRICS,
   useStoreCodecovEventMetric,
 } from 'services/codecovEventMetrics'
-import { useOrgUploadToken } from 'services/orgUploadToken'
+import { useOrgUploadToken } from 'services/orgUploadToken/useOrgUploadToken'
 import { Provider } from 'shared/api/helpers'
 import A from 'ui/A'
 import { Card } from 'ui/Card'

--- a/src/pages/RepoPage/CoverageOnboarding/OtherCI/OtherCI.tsx
+++ b/src/pages/RepoPage/CoverageOnboarding/OtherCI/OtherCI.tsx
@@ -3,7 +3,7 @@ import { useParams } from 'react-router-dom'
 
 import config from 'config'
 
-import { useOrgUploadToken } from 'services/orgUploadToken'
+import { useOrgUploadToken } from 'services/orgUploadToken/useOrgUploadToken'
 import { useRepo } from 'services/repo'
 import A from 'ui/A'
 import { Card } from 'ui/Card'

--- a/src/pages/RepoPage/CoverageTab/ComponentsTab/subroute/ComponentsTable/DeleteComponentModal/DeleteComponentModal.tsx
+++ b/src/pages/RepoPage/CoverageTab/ComponentsTab/subroute/ComponentsTable/DeleteComponentModal/DeleteComponentModal.tsx
@@ -1,4 +1,4 @@
-import { useDeleteComponentMeasurements } from 'services/deleteComponentMeasurements'
+import { useDeleteComponentMeasurements } from 'services/deleteComponentMeasurements/useDeleteComponentMeasurements'
 import Button from 'ui/Button'
 import Modal from 'ui/Modal'
 

--- a/src/pages/RepoPage/CoverageTab/FlagsTab/subroute/FlagsTable/DeleteFlagModal/DeleteFlagModal.tsx
+++ b/src/pages/RepoPage/CoverageTab/FlagsTab/subroute/FlagsTable/DeleteFlagModal/DeleteFlagModal.tsx
@@ -1,4 +1,4 @@
-import { useDeleteFlag } from 'services/deleteFlag'
+import { useDeleteFlag } from 'services/deleteFlag/useDeleteFlag'
 import Button from 'ui/Button'
 import Modal from 'ui/Modal'
 

--- a/src/services/commit/useCommit.tsx
+++ b/src/services/commit/useCommit.tsx
@@ -12,7 +12,7 @@ import {
   MissingHeadCommitSchema,
   MissingHeadReportSchema,
 } from 'services/comparison/schemas'
-import { UnknownFlagsSchema } from 'services/impactedFiles/schemas'
+import { UnknownFlagsSchema } from 'services/impactedFiles/schemas/UnknownFlags'
 import {
   RepoNotFoundErrorSchema,
   RepoOwnerNotActivatedErrorSchema,

--- a/src/services/deleteComponentMeasurements/index.ts
+++ b/src/services/deleteComponentMeasurements/index.ts
@@ -1,1 +1,0 @@
-export * from './useDeleteComponentMeasurements'

--- a/src/services/deleteFlag/index.js
+++ b/src/services/deleteFlag/index.js
@@ -1,1 +1,0 @@
-export * from './useDeleteFlag'

--- a/src/services/file/index.ts
+++ b/src/services/file/index.ts
@@ -1,1 +1,0 @@
-export * from './useCommitBasedCoverageForFileViewer'

--- a/src/services/impactedFiles/schemas/index.ts
+++ b/src/services/impactedFiles/schemas/index.ts
@@ -1,1 +1,0 @@
-export * from './UnknownFlags'

--- a/src/services/impersonate/index.js
+++ b/src/services/impersonate/index.js
@@ -1,1 +1,0 @@
-export * from './useImpersonate'

--- a/src/services/orgUploadToken/index.js
+++ b/src/services/orgUploadToken/index.js
@@ -1,2 +1,0 @@
-export * from './useOrgUploadToken'
-export * from './useRegenerateOrgUploadToken'

--- a/src/services/pathContents/branch/dir/usePrefetchBranchDirEntry.tsx
+++ b/src/services/pathContents/branch/dir/usePrefetchBranchDirEntry.tsx
@@ -2,7 +2,7 @@ import { useQueryClient } from '@tanstack/react-query'
 import { useParams } from 'react-router-dom'
 import { z } from 'zod'
 
-import { UnknownFlagsSchema } from 'services/impactedFiles/schemas'
+import { UnknownFlagsSchema } from 'services/impactedFiles/schemas/UnknownFlags'
 import {
   RepoNotFoundErrorSchema,
   RepoOwnerNotActivatedErrorSchema,

--- a/src/services/pathContents/branch/dir/useRepoBranchContents.tsx
+++ b/src/services/pathContents/branch/dir/useRepoBranchContents.tsx
@@ -2,7 +2,7 @@ import * as Sentry from '@sentry/react'
 import { useInfiniteQuery } from '@tanstack/react-query'
 import { z } from 'zod'
 
-import { UnknownFlagsSchema } from 'services/impactedFiles/schemas'
+import { UnknownFlagsSchema } from 'services/impactedFiles/schemas/UnknownFlags'
 import {
   RepoNotFoundErrorSchema,
   RepoOwnerNotActivatedErrorSchema,

--- a/src/services/pathContents/commit/dir/constants.ts
+++ b/src/services/pathContents/commit/dir/constants.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod'
 
 import { MissingHeadReportSchema } from 'services/comparison'
-import { UnknownFlagsSchema } from 'services/impactedFiles/schemas'
+import { UnknownFlagsSchema } from 'services/impactedFiles/schemas/UnknownFlags'
 import {
   MissingCoverageSchema,
   PathContentsResultSchema,

--- a/src/services/pathContents/pull/dir/constants.ts
+++ b/src/services/pathContents/pull/dir/constants.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod'
 
 import { MissingHeadReportSchema } from 'services/comparison'
-import { UnknownFlagsSchema } from 'services/impactedFiles/schemas'
+import { UnknownFlagsSchema } from 'services/impactedFiles/schemas/UnknownFlags'
 
 const MissingCoverageSchema = z.object({
   __typename: z.literal('MissingCoverage'),

--- a/src/shared/RawFileViewer/RawFileViewer.tsx
+++ b/src/shared/RawFileViewer/RawFileViewer.tsx
@@ -5,7 +5,7 @@ import qs from 'qs'
 import { useLocation, useParams } from 'react-router-dom'
 
 import NotFound from 'pages/NotFound'
-import { useCommitBasedCoverageForFileViewer } from 'services/file'
+import { useCommitBasedCoverageForFileViewer } from 'services/file/useCommitBasedCoverageForFileViewer'
 import { useOwner } from 'services/user'
 import { unsupportedExtensionsMapper } from 'shared/utils/unsupportedExtensionsMapper'
 import { getFilenameFromFilePath } from 'shared/utils/url'


### PR DESCRIPTION
# Description

This PR removes the barrel files from the following directories: `services/deleteComponentMeasurements`, `services/deleteFlag`, `services/file`, `services/impactedFiles`, `services/impersonate`, `services/orgUploadToken`, as well as updating imports across the app reflecting those changes.

Ticket: codecov/engineering-team#3352

# Notable Changes

- Remove barrel files from `services/deleteComponentMeasurements`, `services/deleteFlag`, `services/file`, `services/impactedFiles`, `services/impersonate`, `services/orgUploadToken`
- Update imports throughout app