### PR TITLE
feat: Update current usage of rejectNetworkError

### DIFF
--- a/src/layouts/BaseLayout/hooks/NavigatorDataQueryOpts.test.tsx
+++ b/src/layouts/BaseLayout/hooks/NavigatorDataQueryOpts.test.tsx
@@ -193,8 +193,8 @@ describe('NavigatorDataQueryOpts', () => {
       await waitFor(() =>
         expect(result.current.error).toEqual(
           expect.objectContaining({
-            status: 404,
-            dev: 'NavigatorDataQueryOpts - 404 Failed to parse data',
+            status: 400,
+            dev: 'NavigatorDataQueryOpts - Parsing Error',
           })
         )
       )

--- a/src/layouts/BaseLayout/hooks/NavigatorDataQueryOpts.ts
+++ b/src/layouts/BaseLayout/hooks/NavigatorDataQueryOpts.ts
@@ -6,7 +6,7 @@ import {
   RepoOwnerNotActivatedErrorSchema,
 } from 'services/repo'
 import Api from 'shared/api'
-import { rejectNetworkError } from 'shared/api/helpers'
+import { rejectNetworkError } from 'shared/api/rejectNetworkError'
 
 const RepositorySchema = z.object({
   __typename: z.literal('Repository'),
@@ -71,10 +71,11 @@ export const NavigatorDataQueryOpts = ({
 
         if (!parsedData.success) {
           return rejectNetworkError({
-            status: 404,
-            data: {},
-            dev: 'NavigatorDataQueryOpts - 404 Failed to parse data',
-            error: parsedData.error,
+            errorName: 'Parsing Error',
+            errorDetails: {
+              callingFn: 'NavigatorDataQueryOpts',
+              error: parsedData.error,
+            },
           })
         }
 

--- a/src/pages/AccountSettings/tabs/OktaAccess/hooks/useUpdateOktaConfig.tsx
+++ b/src/pages/AccountSettings/tabs/OktaAccess/hooks/useUpdateOktaConfig.tsx
@@ -6,7 +6,8 @@ import z from 'zod'
 
 import { useAddNotification } from 'services/toastNotification'
 import Api from 'shared/api'
-import { Provider, rejectNetworkError } from 'shared/api/helpers'
+import { Provider } from 'shared/api/helpers'
+import { rejectNetworkError } from 'shared/api/rejectNetworkError'
 import A from 'ui/A'
 
 import { OktaConfigQueryOpts } from '../queries/OktaConfigQueryOpts'
@@ -105,10 +106,11 @@ export const useUpdateOktaConfig = ({ provider, owner }: URLParams) => {
       const parsedData = ResponseSchema.safeParse(data)
       if (!parsedData.success) {
         return rejectNetworkError({
-          status: 404,
-          data: {},
-          dev: 'useUpdateOktaConfig - 404 failed to parse',
-          error: parsedData.error,
+          errorName: 'Parsing Error',
+          errorDetails: {
+            callingFn: 'useUpdateOktaConfig',
+            error: parsedData.error,
+          },
         })
       }
 

--- a/src/pages/AccountSettings/tabs/OktaAccess/queries/OktaConfigQueryOpts.test.tsx
+++ b/src/pages/AccountSettings/tabs/OktaAccess/queries/OktaConfigQueryOpts.test.tsx
@@ -110,9 +110,8 @@ describe('useOktaConfig', () => {
         await waitFor(() =>
           expect(result.current.error).toEqual(
             expect.objectContaining({
-              status: 404,
-              data: {},
-              dev: 'OktaConfigQueryOpts - 404 failed to parse',
+              dev: 'OktaConfigQueryOpts - Parsing Error',
+              status: 400,
             })
           )
         )

--- a/src/pages/AccountSettings/tabs/OktaAccess/queries/OktaConfigQueryOpts.tsx
+++ b/src/pages/AccountSettings/tabs/OktaAccess/queries/OktaConfigQueryOpts.tsx
@@ -2,7 +2,7 @@ import { queryOptions as queryOptionsV5 } from '@tanstack/react-queryV5'
 import { z } from 'zod'
 
 import Api from 'shared/api'
-import { rejectNetworkError } from 'shared/api/helpers'
+import { rejectNetworkError } from 'shared/api/rejectNetworkError'
 
 export const OktaConfigSchema = z.object({
   enabled: z.boolean(),
@@ -66,10 +66,11 @@ export function OktaConfigQueryOpts({
 
         if (!parsedRes.success) {
           return rejectNetworkError({
-            status: 404,
-            data: {},
-            dev: 'OktaConfigQueryOpts - 404 failed to parse',
-            error: parsedRes.error,
+            errorName: 'Parsing Error',
+            errorDetails: {
+              callingFn: 'OktaConfigQueryOpts',
+              error: parsedRes.error,
+            },
           })
         }
 

--- a/src/pages/AccountSettings/tabs/OrgUploadToken/TokenlessSection/useSetUploadTokenRequired.test.tsx
+++ b/src/pages/AccountSettings/tabs/OrgUploadToken/TokenlessSection/useSetUploadTokenRequired.test.tsx
@@ -107,9 +107,8 @@ describe('useSetUploadTokenRequired', () => {
 
           expect(error).toBeDefined()
           expect(error).toEqual({
-            status: 404,
-            data: {},
-            dev: 'useSetUploadTokenRequired - 404 failed to parse',
+            dev: 'useSetUploadTokenRequired - Parsing Error',
+            status: 400,
           })
         })
       })

--- a/src/pages/AccountSettings/tabs/OrgUploadToken/TokenlessSection/useSetUploadTokenRequired.tsx
+++ b/src/pages/AccountSettings/tabs/OrgUploadToken/TokenlessSection/useSetUploadTokenRequired.tsx
@@ -4,7 +4,8 @@ import { z } from 'zod'
 
 import { useAddNotification } from 'services/toastNotification'
 import Api from 'shared/api'
-import { Provider, rejectNetworkError } from 'shared/api/helpers'
+import { Provider } from 'shared/api/helpers'
+import { rejectNetworkError } from 'shared/api/rejectNetworkError'
 
 const TOAST_DURATION = 10000
 
@@ -75,10 +76,11 @@ export const useSetUploadTokenRequired = ({
         const parsedData = ResponseSchema.safeParse(res.data)
         if (!parsedData.success) {
           return rejectNetworkError({
-            status: 404,
-            data: {},
-            dev: 'useSetUploadTokenRequired - 404 failed to parse',
-            error: parsedData.error,
+            errorName: 'Parsing Error',
+            errorDetails: {
+              callingFn: 'useSetUploadTokenRequired',
+              error: parsedData.error,
+            },
           })
         }
 

--- a/src/pages/CommitDetailPage/Header/HeaderDefault/queries/CommitHeaderDataQueryOpts.test.tsx
+++ b/src/pages/CommitDetailPage/Header/HeaderDefault/queries/CommitHeaderDataQueryOpts.test.tsx
@@ -286,7 +286,8 @@ describe('CommitHeaderDataQueryOpts', () => {
         await waitFor(() =>
           expect(result.current.error).toEqual(
             expect.objectContaining({
-              status: 404,
+              dev: 'CommitHeaderDataQueryOpts - Parsing Error',
+              status: 400,
             })
           )
         )

--- a/src/pages/CommitDetailPage/Header/HeaderDefault/queries/CommitHeaderDataQueryOpts.tsx
+++ b/src/pages/CommitDetailPage/Header/HeaderDefault/queries/CommitHeaderDataQueryOpts.tsx
@@ -6,7 +6,7 @@ import {
   RepoOwnerNotActivatedErrorSchema,
 } from 'services/repo'
 import Api from 'shared/api'
-import { rejectNetworkError } from 'shared/api/helpers'
+import { rejectNetworkError } from 'shared/api/rejectNetworkError'
 import A from 'ui/A'
 
 const RepositorySchema = z.object({
@@ -108,10 +108,11 @@ export const CommitHeaderDataQueryOpts = ({
 
         if (!parsedData.success) {
           return rejectNetworkError({
-            status: 404,
-            data: {},
-            dev: 'CommitHeaderDataQueryOpts - 404 Failed to parse schema',
-            error: parsedData.error,
+            errorName: 'Parsing Error',
+            errorDetails: {
+              callingFn: 'CommitHeaderDataQueryOpts',
+              error: parsedData.error,
+            },
           })
         }
 
@@ -119,15 +120,15 @@ export const CommitHeaderDataQueryOpts = ({
 
         if (data?.owner?.repository?.__typename === 'NotFoundError') {
           return rejectNetworkError({
-            status: 404,
-            data: {},
-            dev: 'CommitHeaderDataQueryOpts - 404 Not Found',
+            errorName: 'Not Found Error',
+            errorDetails: { callingFn: 'CommitHeaderDataQueryOpts' },
           })
         }
 
         if (data?.owner?.repository?.__typename === 'OwnerNotActivatedError') {
           return rejectNetworkError({
-            status: 403,
+            errorName: 'Owner Not Activated',
+            errorDetails: { callingFn: 'CommitHeaderDataQueryOpts' },
             data: {
               detail: (
                 <p>
@@ -138,7 +139,6 @@ export const CommitHeaderDataQueryOpts = ({
                 </p>
               ),
             },
-            dev: 'CommitHeaderDataQueryOpts - 403 Owner Not Activated',
           })
         }
 

--- a/src/pages/CommitDetailPage/Header/HeaderTeam/queries/CommitHeaderDataTeamQueryOpts.test.tsx
+++ b/src/pages/CommitDetailPage/Header/HeaderTeam/queries/CommitHeaderDataTeamQueryOpts.test.tsx
@@ -298,7 +298,8 @@ describe('CommitHeaderDataTeamQueryOpts', () => {
         await waitFor(() =>
           expect(result.current.error).toEqual(
             expect.objectContaining({
-              status: 404,
+              dev: 'CommitHeaderDataTeamQueryOpts - Parsing Error',
+              status: 400,
             })
           )
         )

--- a/src/pages/CommitDetailPage/Header/HeaderTeam/queries/CommitHeaderDataTeamQueryOpts.tsx
+++ b/src/pages/CommitDetailPage/Header/HeaderTeam/queries/CommitHeaderDataTeamQueryOpts.tsx
@@ -12,7 +12,7 @@ import {
   RepoOwnerNotActivatedErrorSchema,
 } from 'services/repo'
 import Api from 'shared/api'
-import { rejectNetworkError } from 'shared/api/helpers'
+import { rejectNetworkError } from 'shared/api/rejectNetworkError'
 import A from 'ui/A'
 
 const CoverageObjSchema = z.object({
@@ -167,10 +167,11 @@ export const CommitHeaderDataTeamQueryOpts = ({
 
         if (!parsedData.success) {
           return rejectNetworkError({
-            status: 404,
-            data: {},
-            dev: 'CommitHeaderDataTeamQueryOpts - 404 Failed to parse schema',
-            error: parsedData.error,
+            errorName: 'Parsing Error',
+            errorDetails: {
+              callingFn: 'CommitHeaderDataTeamQueryOpts',
+              error: parsedData.error,
+            },
           })
         }
 
@@ -178,15 +179,15 @@ export const CommitHeaderDataTeamQueryOpts = ({
 
         if (data?.owner?.repository?.__typename === 'NotFoundError') {
           return rejectNetworkError({
-            status: 404,
-            data: {},
-            dev: 'CommitHeaderDataTeamQueryOpts - 404 Not Found',
+            errorName: 'Not Found Error',
+            errorDetails: { callingFn: 'CommitHeaderDataTeamQueryOpts' },
           })
         }
 
         if (data?.owner?.repository?.__typename === 'OwnerNotActivatedError') {
           return rejectNetworkError({
-            status: 403,
+            errorName: 'Owner Not Activated',
+            errorDetails: { callingFn: 'CommitHeaderDataTeamQueryOpts' },
             data: {
               detail: (
                 <p>
@@ -197,7 +198,6 @@ export const CommitHeaderDataTeamQueryOpts = ({
                 </p>
               ),
             },
-            dev: 'CommitHeaderDataTeamQueryOpts - 403 Owner Not Activated',
           })
         }
 

--- a/src/pages/CommitDetailPage/queries/CommitPageDataQueryOpts.test.tsx
+++ b/src/pages/CommitDetailPage/queries/CommitPageDataQueryOpts.test.tsx
@@ -308,7 +308,8 @@ describe('CommitPageData', () => {
         await waitFor(() =>
           expect(result.current.error).toEqual(
             expect.objectContaining({
-              status: 404,
+              dev: 'CommitPageDataQueryOpts - Parsing Error',
+              status: 400,
             })
           )
         )

--- a/src/pages/CommitDetailPage/queries/CommitPageDataQueryOpts.tsx
+++ b/src/pages/CommitDetailPage/queries/CommitPageDataQueryOpts.tsx
@@ -12,7 +12,7 @@ import {
   RepoOwnerNotActivatedErrorSchema,
 } from 'services/repo'
 import Api from 'shared/api'
-import { rejectNetworkError } from 'shared/api/helpers'
+import { rejectNetworkError } from 'shared/api/rejectNetworkError'
 import A from 'ui/A'
 
 const BundleAnalysisReportSchema = z.object({
@@ -161,10 +161,11 @@ export const CommitPageDataQueryOpts = ({
 
         if (!parsedData.success) {
           return rejectNetworkError({
-            status: 404,
-            data: {},
-            dev: 'CommitPageDataQueryOpts - 404 Failed to parse schema',
-            error: parsedData.error,
+            errorName: 'Parsing Error',
+            errorDetails: {
+              callingFn: 'CommitPageDataQueryOpts',
+              error: parsedData.error,
+            },
           })
         }
 
@@ -172,15 +173,15 @@ export const CommitPageDataQueryOpts = ({
 
         if (data?.owner?.repository?.__typename === 'NotFoundError') {
           return rejectNetworkError({
-            status: 404,
-            data: {},
-            dev: 'CommitPageDataQueryOpts - 404 Not found',
+            errorName: 'Not Found Error',
+            errorDetails: { callingFn: 'CommitPageDataQueryOpts' },
           })
         }
 
         if (data?.owner?.repository?.__typename === 'OwnerNotActivatedError') {
           return rejectNetworkError({
-            status: 403,
+            errorName: 'Owner Not Activated',
+            errorDetails: { callingFn: 'CommitPageDataQueryOpts' },
             data: {
               detail: (
                 <p>
@@ -191,7 +192,6 @@ export const CommitPageDataQueryOpts = ({
                 </p>
               ),
             },
-            dev: 'CommitPageDataQueryOpts - 403 Owner not activated',
           })
         }
 

--- a/src/pages/PlanPage/queries/PlanPageDataQueryOpts.test.tsx
+++ b/src/pages/PlanPage/queries/PlanPageDataQueryOpts.test.tsx
@@ -110,8 +110,8 @@ describe('usePlanPageData', () => {
       await waitFor(() =>
         expect(result.current.error).toEqual(
           expect.objectContaining({
-            status: 404,
-            dev: 'usePlanPageData - 404 schema parsing failed',
+            dev: 'PlanPageDataQueryOpts - Parsing Error',
+            status: 400,
           })
         )
       )

--- a/src/pages/PlanPage/queries/PlanPageDataQueryOpts.ts
+++ b/src/pages/PlanPage/queries/PlanPageDataQueryOpts.ts
@@ -2,7 +2,7 @@ import { queryOptions as queryOptionsV5 } from '@tanstack/react-queryV5'
 import { z } from 'zod'
 
 import Api from 'shared/api'
-import { rejectNetworkError } from 'shared/api/helpers'
+import { rejectNetworkError } from 'shared/api/rejectNetworkError'
 
 const RequestSchema = z.object({
   owner: z
@@ -14,15 +14,13 @@ const RequestSchema = z.object({
     .nullable(),
 })
 
-const query = `
-  query PlanPageData($username: String!) {
-    owner(username: $username) {
-      username
-      isCurrentUserPartOfOrg
-      numberOfUploads
-    }
+const query = `query PlanPageData($username: String!) {
+  owner(username: $username) {
+    username
+    isCurrentUserPartOfOrg
+    numberOfUploads
   }
-`
+}`
 
 type PlanPageDataQueryArgs = {
   owner: string
@@ -50,10 +48,11 @@ export function PlanPageDataQueryOpts({
 
         if (!parsedRes.success) {
           return rejectNetworkError({
-            status: 404,
-            data: {},
-            dev: 'usePlanPageData - 404 schema parsing failed',
-            error: parsedRes.error,
+            errorName: 'Parsing Error',
+            errorDetails: {
+              callingFn: 'PlanPageDataQueryOpts',
+              error: parsedRes.error,
+            },
           })
         }
 

--- a/src/pages/PlanPage/subRoutes/CurrentOrgPlan/queries/EnterpriseAccountDetailsQueryOpts.test.tsx
+++ b/src/pages/PlanPage/subRoutes/CurrentOrgPlan/queries/EnterpriseAccountDetailsQueryOpts.test.tsx
@@ -78,9 +78,8 @@ describe('useEnterpriseAccountDetails', () => {
 
     await waitFor(() =>
       expect(result.current.failureReason).toMatchObject({
-        status: 404,
-        data: {},
-        dev: 'useEnterpriseAccountDetails - 404 Failed to parse data',
+        dev: 'EnterpriseAccountDetailsQueryOpts - Parsing Error',
+        status: 400,
       })
     )
   })

--- a/src/pages/PlanPage/subRoutes/CurrentOrgPlan/queries/EnterpriseAccountDetailsQueryOpts.ts
+++ b/src/pages/PlanPage/subRoutes/CurrentOrgPlan/queries/EnterpriseAccountDetailsQueryOpts.ts
@@ -2,7 +2,7 @@ import { queryOptions as queryOptionsV5 } from '@tanstack/react-queryV5'
 import { z } from 'zod'
 
 import Api from 'shared/api/api'
-import { rejectNetworkError } from 'shared/api/helpers'
+import { rejectNetworkError } from 'shared/api/rejectNetworkError'
 
 const AccountSchema = z.object({
   name: z.string(),
@@ -62,10 +62,11 @@ export function EnterpriseAccountDetailsQueryOpts({
 
         if (!parsedRes.success) {
           return rejectNetworkError({
-            status: 404,
-            data: {},
-            dev: 'useEnterpriseAccountDetails - 404 Failed to parse data',
-            error: parsedRes.error,
+            errorName: 'Parsing Error',
+            errorDetails: {
+              callingFn: 'EnterpriseAccountDetailsQueryOpts',
+              error: parsedRes.error,
+            },
           })
         }
 

--- a/src/pages/PlanPage/subRoutes/CurrentOrgPlan/queries/InfiniteAccountOrganizationsQueryOpts.test.tsx
+++ b/src/pages/PlanPage/subRoutes/CurrentOrgPlan/queries/InfiniteAccountOrganizationsQueryOpts.test.tsx
@@ -142,9 +142,8 @@ describe('useInfiniteAccountOrganizations', () => {
 
     await waitFor(() =>
       expect(result.current.failureReason).toMatchObject({
-        status: 404,
-        data: {},
-        dev: 'useInfiniteAccountOrganizations - 404 Failed to parse data',
+        dev: 'InfiniteAccountOrganizationsQueryOpts - Parsing Error',
+        status: 400,
       })
     )
   })
@@ -165,9 +164,8 @@ describe('useInfiniteAccountOrganizations', () => {
 
     await waitFor(() =>
       expect(result.current.failureReason).toMatchObject({
+        dev: 'InfiniteAccountOrganizationsQueryOpts - Not Found Error',
         status: 404,
-        data: {},
-        dev: 'useInfiniteAccountOrganizations - 404 Cannot find Account for Owner',
       })
     )
   })

--- a/src/pages/PlanPage/subRoutes/CurrentOrgPlan/queries/InfiniteAccountOrganizationsQueryOpts.ts
+++ b/src/pages/PlanPage/subRoutes/CurrentOrgPlan/queries/InfiniteAccountOrganizationsQueryOpts.ts
@@ -4,7 +4,7 @@ import { z } from 'zod'
 import { OrderingDirection } from 'types'
 
 import Api from 'shared/api/api'
-import { rejectNetworkError } from 'shared/api/helpers'
+import { rejectNetworkError } from 'shared/api/rejectNetworkError'
 import { mapEdges } from 'shared/utils/graphql'
 
 const RequestSchema = z.object({
@@ -102,10 +102,11 @@ export function InfiniteAccountOrganizationsQueryOpts({
 
         if (!parsedRes.success) {
           return rejectNetworkError({
-            status: 404,
-            data: {},
-            dev: 'useInfiniteAccountOrganizations - 404 Failed to parse data',
-            error: parsedRes.error,
+            errorName: 'Parsing Error',
+            errorDetails: {
+              callingFn: 'InfiniteAccountOrganizationsQueryOpts',
+              error: parsedRes.error,
+            },
           })
         }
 
@@ -113,9 +114,10 @@ export function InfiniteAccountOrganizationsQueryOpts({
 
         if (!account) {
           return rejectNetworkError({
-            status: 404,
-            data: {},
-            dev: 'useInfiniteAccountOrganizations - 404 Cannot find Account for Owner',
+            errorName: 'Not Found Error',
+            errorDetails: {
+              callingFn: 'InfiniteAccountOrganizationsQueryOpts',
+            },
           })
         }
 

--- a/src/pages/PlanPage/subRoutes/CurrentOrgPlan/useCurrentOrgPlanPageData.test.tsx
+++ b/src/pages/PlanPage/subRoutes/CurrentOrgPlan/useCurrentOrgPlanPageData.test.tsx
@@ -111,9 +111,8 @@ describe('useCurrentOrgPlanPageData', () => {
 
     await waitFor(() => expect(result.current.isError).toBeTruthy())
     expect(result.current.error).toEqual({
-      status: 404,
-      data: {},
-      dev: 'useCurrentOrgPlanPageData - 404 failed to parse',
+      dev: 'useCurrentOrgPlanPageData - Parsing Error',
+      status: 400,
     })
   })
 })

--- a/src/pages/PlanPage/subRoutes/CurrentOrgPlan/useCurrentOrgPlanPageData.tsx
+++ b/src/pages/PlanPage/subRoutes/CurrentOrgPlan/useCurrentOrgPlanPageData.tsx
@@ -2,7 +2,7 @@ import { useQuery } from '@tanstack/react-queryV5'
 import { z } from 'zod'
 
 import Api from 'shared/api'
-import { NetworkErrorObject, rejectNetworkError } from 'shared/api/helpers'
+import { rejectNetworkError } from 'shared/api/rejectNetworkError'
 import { Plans } from 'shared/utils/billing'
 
 const PlanSchema = z.object({
@@ -72,11 +72,12 @@ export const useCurrentOrgPlanPageData = ({
         const parsedRes = CurrentOrgPlanPageDataSchema.safeParse(res?.data)
         if (!parsedRes.success) {
           return rejectNetworkError({
-            status: 404,
-            error: parsedRes.error,
-            data: {},
-            dev: 'useCurrentOrgPlanPageData - 404 failed to parse',
-          } satisfies NetworkErrorObject)
+            errorName: 'Parsing Error',
+            errorDetails: {
+              callingFn: 'useCurrentOrgPlanPageData',
+              error: parsedRes.error,
+            },
+          })
         }
 
         return parsedRes.data?.owner ?? null

--- a/src/pages/PullRequestPage/PullCoverage/routes/ComponentsTab/queries/ComponentComparisonQueryOpts.test.tsx
+++ b/src/pages/PullRequestPage/PullCoverage/routes/ComponentsTab/queries/ComponentComparisonQueryOpts.test.tsx
@@ -255,7 +255,8 @@ describe('useComponentComparison', () => {
         await waitFor(() =>
           expect(result.current.error).toEqual(
             expect.objectContaining({
-              status: 404,
+              dev: 'ComponentComparisonQueryOpts - Parsing Error',
+              status: 400,
             })
           )
         )

--- a/src/pages/PullRequestPage/PullCoverage/routes/ComponentsTab/queries/ComponentComparisonQueryOpts.tsx
+++ b/src/pages/PullRequestPage/PullCoverage/routes/ComponentsTab/queries/ComponentComparisonQueryOpts.tsx
@@ -13,7 +13,7 @@ import {
   RepoOwnerNotActivatedErrorSchema,
 } from 'services/repo'
 import Api from 'shared/api'
-import { rejectNetworkError } from 'shared/api/helpers'
+import { rejectNetworkError } from 'shared/api/rejectNetworkError'
 import A from 'ui/A'
 
 const ComponentsComparisonSchema = z
@@ -176,10 +176,11 @@ export function ComponentComparisonQueryOpts({
 
         if (!parsedRes.success) {
           return rejectNetworkError({
-            status: 404,
-            data: {},
-            dev: `ComponentComparisonQueryOpts - 404 Failed to parse`,
-            error: parsedRes.error,
+            errorName: 'Parsing Error',
+            errorDetails: {
+              callingFn: 'ComponentComparisonQueryOpts',
+              error: parsedRes.error,
+            },
           })
         }
 
@@ -187,15 +188,15 @@ export function ComponentComparisonQueryOpts({
 
         if (data?.owner?.repository?.__typename === 'NotFoundError') {
           return rejectNetworkError({
-            status: 404,
-            data: {},
-            dev: `ComponentComparisonQueryOpts - 404 Not Found`,
+            errorName: 'Not Found Error',
+            errorDetails: { callingFn: 'ComponentComparisonQueryOpts' },
           })
         }
 
         if (data?.owner?.repository?.__typename === 'OwnerNotActivatedError') {
           return rejectNetworkError({
-            status: 403,
+            errorName: 'Owner Not Activated',
+            errorDetails: { callingFn: 'ComponentComparisonQueryOpts' },
             data: {
               detail: (
                 <p>
@@ -206,7 +207,6 @@ export function ComponentComparisonQueryOpts({
                 </p>
               ),
             },
-            dev: `ComponentComparisonQueryOpts - 403 Owner Not Activated`,
           })
         }
 

--- a/src/pages/PullRequestPage/queries/PullPageDataQueryOpts.test.tsx
+++ b/src/pages/PullRequestPage/queries/PullPageDataQueryOpts.test.tsx
@@ -361,7 +361,8 @@ describe('PullPageDataQueryOpts', () => {
         await waitFor(() =>
           expect(result.current.error).toEqual(
             expect.objectContaining({
-              status: 404,
+              dev: 'PullPageDataQueryOpts - Parsing Error',
+              status: 400,
             })
           )
         )

--- a/src/pages/PullRequestPage/queries/PullPageDataQueryOpts.tsx
+++ b/src/pages/PullRequestPage/queries/PullPageDataQueryOpts.tsx
@@ -12,7 +12,7 @@ import {
   RepoOwnerNotActivatedErrorSchema,
 } from 'services/repo'
 import Api from 'shared/api'
-import { rejectNetworkError } from 'shared/api/helpers'
+import { rejectNetworkError } from 'shared/api/rejectNetworkError'
 import A from 'ui/A'
 
 const BundleAnalysisReportSchema = z.object({
@@ -220,10 +220,11 @@ export const PullPageDataQueryOpts = ({
 
         if (!parsedData.success) {
           return rejectNetworkError({
-            status: 404,
-            data: {},
-            dev: 'PullPageDataQueryOpts - 404 Failed to parse schema',
-            error: parsedData.error,
+            errorName: 'Parsing Error',
+            errorDetails: {
+              callingFn: 'PullPageDataQueryOpts',
+              error: parsedData.error,
+            },
           })
         }
 
@@ -231,15 +232,15 @@ export const PullPageDataQueryOpts = ({
 
         if (data?.owner?.repository?.__typename === 'NotFoundError') {
           return rejectNetworkError({
-            status: 404,
-            data: {},
-            dev: 'PullPageDataQueryOpts - 404 Not found',
+            errorName: 'Not Found Error',
+            errorDetails: { callingFn: 'PullPageDataQueryOpts' },
           })
         }
 
         if (data?.owner?.repository?.__typename === 'OwnerNotActivatedError') {
           return rejectNetworkError({
-            status: 403,
+            errorName: 'Owner Not Activated',
+            errorDetails: { callingFn: 'PullPageDataQueryOpts' },
             data: {
               detail: (
                 <p>
@@ -250,7 +251,6 @@ export const PullPageDataQueryOpts = ({
                 </p>
               ),
             },
-            dev: 'PullPageDataQueryOpts - 403 Owner not activated',
           })
         }
 

--- a/src/pages/RepoPage/ConfigTab/tabs/ConfigurationManager/hooks/useRepoConfigurationStatus/RepoConfigurationStatusQueryOpts.test.tsx
+++ b/src/pages/RepoPage/ConfigTab/tabs/ConfigurationManager/hooks/useRepoConfigurationStatus/RepoConfigurationStatusQueryOpts.test.tsx
@@ -124,9 +124,8 @@ describe('RepoConfigurationStatusQueryOpts', () => {
 
     await waitFor(() =>
       expect(result.current.failureReason).toMatchObject({
-        status: 404,
-        data: {},
-        dev: 'RepoConfigurationStatusQueryOpts - 404 Failed to parse data',
+        status: 400,
+        dev: 'RepoConfigurationStatusQueryOpts - Parsing Error',
       })
     )
   })
@@ -152,7 +151,7 @@ describe('RepoConfigurationStatusQueryOpts', () => {
       expect(result.current.failureReason).toMatchObject({
         status: 404,
         data: {},
-        dev: 'RepoConfigurationStatusQueryOpts - 404 Not found error',
+        dev: 'RepoConfigurationStatusQueryOpts - Not Found Error',
       })
     )
   })
@@ -178,7 +177,7 @@ describe('RepoConfigurationStatusQueryOpts', () => {
       expect(result.current.failureReason).toMatchObject({
         status: 403,
         data: {},
-        dev: 'RepoConfigurationStatusQueryOpts - 403 Owner not activated error',
+        dev: 'RepoConfigurationStatusQueryOpts - Owner Not Activated',
       })
     )
   })

--- a/src/pages/RepoPage/ConfigTab/tabs/ConfigurationManager/hooks/useRepoConfigurationStatus/RepoConfigurationStatusQueryOpts.tsx
+++ b/src/pages/RepoPage/ConfigTab/tabs/ConfigurationManager/hooks/useRepoConfigurationStatus/RepoConfigurationStatusQueryOpts.tsx
@@ -6,7 +6,7 @@ import {
   RepoOwnerNotActivatedErrorSchema,
 } from 'services/repo'
 import Api from 'shared/api/api'
-import { rejectNetworkError } from 'shared/api/helpers'
+import { rejectNetworkError } from 'shared/api/rejectNetworkError'
 import A from 'ui/A'
 
 const RepositorySchema = z.object({
@@ -106,10 +106,11 @@ export function RepoConfigurationStatusQueryOpts({
 
         if (!parsedRes.success) {
           return rejectNetworkError({
-            status: 404,
-            data: {},
-            dev: 'RepoConfigurationStatusQueryOpts - 404 Failed to parse data',
-            error: parsedRes.error,
+            errorName: 'Parsing Error',
+            errorDetails: {
+              callingFn: 'RepoConfigurationStatusQueryOpts',
+              error: parsedRes.error,
+            },
           })
         }
 
@@ -117,15 +118,15 @@ export function RepoConfigurationStatusQueryOpts({
 
         if (data?.owner?.repository?.__typename === 'NotFoundError') {
           return rejectNetworkError({
-            status: 404,
-            data: {},
-            dev: 'RepoConfigurationStatusQueryOpts - 404 Not found error',
+            errorName: 'Not Found Error',
+            errorDetails: { callingFn: 'RepoConfigurationStatusQueryOpts' },
           })
         }
 
         if (data?.owner?.repository?.__typename === 'OwnerNotActivatedError') {
           return rejectNetworkError({
-            status: 403,
+            errorName: 'Owner Not Activated',
+            errorDetails: { callingFn: 'RepoConfigurationStatusQueryOpts' },
             data: {
               detail: (
                 <p>
@@ -136,7 +137,6 @@ export function RepoConfigurationStatusQueryOpts({
                 </p>
               ),
             },
-            dev: 'RepoConfigurationStatusQueryOpts - 403 Owner not activated error',
           })
         }
 

--- a/src/pages/RepoPage/ConfigTab/tabs/GeneralTab/queries/RepoForTokensTeamQueryOpts.test.tsx
+++ b/src/pages/RepoPage/ConfigTab/tabs/GeneralTab/queries/RepoForTokensTeamQueryOpts.test.tsx
@@ -256,7 +256,8 @@ describe('RepoForTokensTeamQueryOpts', () => {
         await waitFor(() =>
           expect(result.current.error).toEqual(
             expect.objectContaining({
-              status: 404,
+              dev: 'RepoForTokensTeamQueryOpts - Parsing Error',
+              status: 400,
             })
           )
         )

--- a/src/pages/RepoPage/ConfigTab/tabs/GeneralTab/queries/RepoForTokensTeamQueryOpts.tsx
+++ b/src/pages/RepoPage/ConfigTab/tabs/GeneralTab/queries/RepoForTokensTeamQueryOpts.tsx
@@ -6,7 +6,7 @@ import {
   RepoOwnerNotActivatedErrorSchema,
 } from 'services/repo'
 import Api from 'shared/api'
-import { rejectNetworkError } from 'shared/api/helpers'
+import { rejectNetworkError } from 'shared/api/rejectNetworkError'
 import A from 'ui/A'
 
 const RepositorySchema = z.object({
@@ -78,10 +78,11 @@ export const RepoForTokensTeamQueryOpts = ({
 
         if (!parsedData.success) {
           return rejectNetworkError({
-            status: 404,
-            data: {},
-            dev: `RepoForTokensTeamQueryOpts - 404 failed to parse schema`,
-            error: parsedData.error,
+            errorName: 'Parsing Error',
+            errorDetails: {
+              callingFn: 'RepoForTokensTeamQueryOpts',
+              error: parsedData.error,
+            },
           })
         }
 
@@ -89,15 +90,15 @@ export const RepoForTokensTeamQueryOpts = ({
 
         if (data?.owner?.repository?.__typename === 'NotFoundError') {
           return rejectNetworkError({
-            status: 404,
-            data: {},
-            dev: `RepoForTokensTeamQueryOpts - 404 not found`,
+            errorName: 'Not Found Error',
+            errorDetails: { callingFn: 'RepoForTokensTeamQueryOpts' },
           })
         }
 
         if (data?.owner?.repository?.__typename === 'OwnerNotActivatedError') {
           return rejectNetworkError({
-            status: 403,
+            errorName: 'Owner Not Activated',
+            errorDetails: { callingFn: 'RepoForTokensTeamQueryOpts' },
             data: {
               detail: (
                 <p>
@@ -108,7 +109,6 @@ export const RepoForTokensTeamQueryOpts = ({
                 </p>
               ),
             },
-            dev: `RepoForTokensTeamQueryOpts - 403 owner not activated`,
           })
         }
 

--- a/src/pages/RepoPage/CoverageTab/OverviewTab/queries/CoverageTabDataQueryOpts.test.tsx
+++ b/src/pages/RepoPage/CoverageTab/OverviewTab/queries/CoverageTabDataQueryOpts.test.tsx
@@ -184,8 +184,8 @@ describe('CoverageTabDataQueryOpts', () => {
       await waitFor(() =>
         expect(result.current.error).toEqual(
           expect.objectContaining({
+            dev: 'CoverageTabDataQueryOpts - Not Found Error',
             status: 404,
-            dev: 'useCoverageTabData - 404 NotFoundError',
           })
         )
       )
@@ -222,8 +222,8 @@ describe('CoverageTabDataQueryOpts', () => {
       await waitFor(() =>
         expect(result.current.error).toEqual(
           expect.objectContaining({
+            dev: 'CoverageTabDataQueryOpts - Owner Not Activated',
             status: 403,
-            dev: 'useCoverageTabData - 403 OwnerNotActivatedError',
           })
         )
       )
@@ -260,8 +260,8 @@ describe('CoverageTabDataQueryOpts', () => {
       await waitFor(() =>
         expect(result.current.error).toEqual(
           expect.objectContaining({
-            status: 404,
-            dev: 'useCoverageTabData - 404 schema parsing failed',
+            dev: 'CoverageTabDataQueryOpts - Parsing Error',
+            status: 400,
           })
         )
       )

--- a/src/pages/RepoPage/CoverageTab/OverviewTab/queries/CoverageTabDataQueryOpts.tsx
+++ b/src/pages/RepoPage/CoverageTab/OverviewTab/queries/CoverageTabDataQueryOpts.tsx
@@ -6,7 +6,7 @@ import {
   RepoOwnerNotActivatedErrorSchema,
 } from 'services/repo'
 import Api from 'shared/api'
-import { rejectNetworkError } from 'shared/api/helpers'
+import { rejectNetworkError } from 'shared/api/rejectNetworkError'
 import A from 'ui/A'
 
 const BranchSchema = z
@@ -100,10 +100,11 @@ export const CoverageTabDataQueryOpts = ({
 
         if (!parsedData.success) {
           return rejectNetworkError({
-            status: 404,
-            data: {},
-            dev: 'useCoverageTabData - 404 schema parsing failed',
-            error: parsedData.error,
+            errorName: 'Parsing Error',
+            errorDetails: {
+              callingFn: 'CoverageTabDataQueryOpts',
+              error: parsedData.error,
+            },
           })
         }
 
@@ -111,15 +112,15 @@ export const CoverageTabDataQueryOpts = ({
 
         if (data?.owner?.repository?.__typename === 'NotFoundError') {
           return rejectNetworkError({
-            status: 404,
-            data: {},
-            dev: 'useCoverageTabData - 404 NotFoundError',
+            errorName: 'Not Found Error',
+            errorDetails: { callingFn: 'CoverageTabDataQueryOpts' },
           })
         }
 
         if (data?.owner?.repository?.__typename === 'OwnerNotActivatedError') {
           return rejectNetworkError({
-            status: 403,
+            errorName: 'Owner Not Activated',
+            errorDetails: { callingFn: 'CoverageTabDataQueryOpts' },
             data: {
               detail: (
                 <p>
@@ -130,7 +131,6 @@ export const CoverageTabDataQueryOpts = ({
                 </p>
               ),
             },
-            dev: 'useCoverageTabData - 403 OwnerNotActivatedError',
           })
         }
 

--- a/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/hooks/useFlakeAggregates/useFlakeAggregates.test.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/hooks/useFlakeAggregates/useFlakeAggregates.test.tsx
@@ -138,8 +138,8 @@ describe('useFlakeAggregates', () => {
       await waitFor(() =>
         expect(result.current.error).toEqual(
           expect.objectContaining({
-            status: 404,
-            dev: 'useFlakeAggregates - 404 Failed to parse data',
+            dev: 'useFlakeAggregates - Parsing Error',
+            status: 400,
           })
         )
       )
@@ -169,8 +169,8 @@ describe('useFlakeAggregates', () => {
       await waitFor(() =>
         expect(result.current.error).toEqual(
           expect.objectContaining({
+            dev: 'useFlakeAggregates - Not Found Error',
             status: 404,
-            data: {},
           })
         )
       )

--- a/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/hooks/useFlakeAggregates/useFlakeAggregates.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/hooks/useFlakeAggregates/useFlakeAggregates.tsx
@@ -5,7 +5,7 @@ import { z } from 'zod'
 import { MeasurementInterval } from 'pages/RepoPage/shared/constants'
 import { RepoNotFoundErrorSchema } from 'services/repo'
 import Api from 'shared/api'
-import { NetworkErrorObject, rejectNetworkError } from 'shared/api/helpers'
+import { rejectNetworkError } from 'shared/api/rejectNetworkError'
 
 const FlakeAggregatesSchema = z.object({
   owner: z
@@ -99,21 +99,21 @@ export const useFlakeAggregates = ({
 
         if (!parsedData.success) {
           return rejectNetworkError({
-            status: 404,
-            data: {},
-            dev: 'useFlakeAggregates - 404 Failed to parse data',
-            error: parsedData.error,
-          } satisfies NetworkErrorObject)
+            errorName: 'Parsing Error',
+            errorDetails: {
+              callingFn: 'useFlakeAggregates',
+              error: parsedData.error,
+            },
+          })
         }
 
         const data = parsedData.data
 
         if (data?.owner?.repository?.__typename === 'NotFoundError') {
           return rejectNetworkError({
-            status: 404,
-            data: {},
-            dev: 'useFlakeAggregates - 404 Not found error',
-          } satisfies NetworkErrorObject)
+            errorName: 'Not Found Error',
+            errorDetails: { callingFn: 'useFlakeAggregates' },
+          })
         }
 
         return data.owner?.repository.testAnalytics?.flakeAggregates

--- a/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/hooks/useInfiniteTestResults/useInfiniteTestResults.test.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/hooks/useInfiniteTestResults/useInfiniteTestResults.test.tsx
@@ -269,8 +269,8 @@ describe('useInfiniteTestResults', () => {
         await waitFor(() =>
           expect(result.current.error).toEqual(
             expect.objectContaining({
+              dev: 'useInfiniteTestResults - Not Found Error',
               status: 404,
-              dev: 'useInfiniteTestResults - 404 Not found error',
             })
           )
         )
@@ -305,8 +305,8 @@ describe('useInfiniteTestResults', () => {
         await waitFor(() =>
           expect(result.current.error).toEqual(
             expect.objectContaining({
+              dev: 'useInfiniteTestResults - Owner Not Activated',
               status: 403,
-              dev: 'useInfiniteTestResults - 403 Owner not activated',
             })
           )
         )
@@ -341,8 +341,8 @@ describe('useInfiniteTestResults', () => {
         await waitFor(() =>
           expect(result.current.error).toEqual(
             expect.objectContaining({
-              status: 404,
-              dev: 'useInfiniteTestResults - 404 Failed to parse data',
+              dev: 'useInfiniteTestResults - Parsing Error',
+              status: 400,
             })
           )
         )

--- a/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/hooks/useInfiniteTestResults/useInfiniteTestResults.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/hooks/useInfiniteTestResults/useInfiniteTestResults.tsx
@@ -11,7 +11,7 @@ import {
   RepoOwnerNotActivatedErrorSchema,
 } from 'services/repo'
 import Api from 'shared/api'
-import { type NetworkErrorObject, rejectNetworkError } from 'shared/api/helpers'
+import { rejectNetworkError } from 'shared/api/rejectNetworkError'
 import { PlanName, Plans } from 'shared/utils/billing'
 import { mapEdges } from 'shared/utils/graphql'
 import A from 'ui/A'
@@ -240,26 +240,27 @@ export const useInfiniteTestResults = ({
 
         if (!parsedData.success) {
           return rejectNetworkError({
-            status: 404,
-            data: {},
-            dev: 'useInfiniteTestResults - 404 Failed to parse data',
-            error: parsedData.error,
-          } satisfies NetworkErrorObject)
+            errorName: 'Parsing Error',
+            errorDetails: {
+              callingFn: 'useInfiniteTestResults',
+              error: parsedData.error,
+            },
+          })
         }
 
         const data = parsedData.data
 
         if (data?.owner?.repository?.__typename === 'NotFoundError') {
           return rejectNetworkError({
-            status: 404,
-            data: {},
-            dev: 'useInfiniteTestResults - 404 Not found error',
-          } satisfies NetworkErrorObject)
+            errorName: 'Not Found Error',
+            errorDetails: { callingFn: 'useInfiniteTestResults' },
+          })
         }
 
         if (data?.owner?.repository?.__typename === 'OwnerNotActivatedError') {
           return rejectNetworkError({
-            status: 403,
+            errorName: 'Owner Not Activated',
+            errorDetails: { callingFn: 'useInfiniteTestResults' },
             data: {
               detail: (
                 <p>
@@ -270,8 +271,7 @@ export const useInfiniteTestResults = ({
                 </p>
               ),
             },
-            dev: 'useInfiniteTestResults - 403 Owner not activated',
-          } satisfies NetworkErrorObject)
+          })
         }
 
         return {

--- a/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/hooks/useTestResultsAggregates/useTestResultsAggregates.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/hooks/useTestResultsAggregates/useTestResultsAggregates.tsx
@@ -5,7 +5,7 @@ import { z } from 'zod'
 import { MeasurementInterval } from 'pages/RepoPage/shared/constants'
 import { RepoNotFoundErrorSchema } from 'services/repo'
 import Api from 'shared/api'
-import { NetworkErrorObject, rejectNetworkError } from 'shared/api/helpers'
+import { rejectNetworkError } from 'shared/api/rejectNetworkError'
 import { Plans } from 'shared/utils/billing'
 
 const TestResultsAggregatesSchema = z.object({
@@ -119,21 +119,21 @@ export const useTestResultsAggregates = ({
 
         if (!parsedData.success) {
           return rejectNetworkError({
-            status: 404,
-            data: {},
-            dev: 'useTestResultsAggregates - 404 Failed to parse data',
-            error: parsedData.error,
-          } satisfies NetworkErrorObject)
+            errorName: 'Parsing Error',
+            errorDetails: {
+              callingFn: 'useTestResultsAggregates',
+              error: parsedData.error,
+            },
+          })
         }
 
         const data = parsedData.data
 
         if (data?.owner?.repository?.__typename === 'NotFoundError') {
           return rejectNetworkError({
-            status: 404,
-            data: {},
-            dev: 'useTestResultsAggregates - 404 Not found error',
-          } satisfies NetworkErrorObject)
+            errorName: 'Not Found Error',
+            errorDetails: { callingFn: 'useTestResultsAggregates' },
+          })
         }
 
         return {

--- a/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/hooks/useTestResultsAggregates/useTestsResultsAggregates.test.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/hooks/useTestResultsAggregates/useTestsResultsAggregates.test.tsx
@@ -162,8 +162,8 @@ describe('useTestResultsAggregates', () => {
       await waitFor(() =>
         expect(result.current.error).toEqual(
           expect.objectContaining({
-            status: 404,
-            dev: 'useTestResultsAggregates - 404 Failed to parse data',
+            dev: 'useTestResultsAggregates - Parsing Error',
+            status: 400,
           })
         )
       )
@@ -189,8 +189,8 @@ describe('useTestResultsAggregates', () => {
       await waitFor(() =>
         expect(result.current.error).toEqual(
           expect.objectContaining({
-            status: 404,
-            data: {},
+            dev: 'useTestResultsAggregates - Parsing Error',
+            status: 400,
           })
         )
       )

--- a/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/hooks/useTestResultsFlags/useTestResultsFlags.test.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/hooks/useTestResultsFlags/useTestResultsFlags.test.tsx
@@ -116,8 +116,8 @@ describe('useTestResultsFlags', () => {
       await waitFor(() =>
         expect(result.current.error).toEqual(
           expect.objectContaining({
-            status: 404,
-            dev: 'useTestResultsFlags - 404 Failed to parse data',
+            dev: 'useTestResultsFlags - Parsing Error',
+            status: 400,
           })
         )
       )
@@ -143,8 +143,8 @@ describe('useTestResultsFlags', () => {
       await waitFor(() =>
         expect(result.current.error).toEqual(
           expect.objectContaining({
+            dev: 'useTestResultsFlags - Not Found Error',
             status: 404,
-            data: {},
           })
         )
       )

--- a/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/hooks/useTestResultsFlags/useTestResultsFlags.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/hooks/useTestResultsFlags/useTestResultsFlags.tsx
@@ -4,7 +4,7 @@ import { z } from 'zod'
 
 import { RepoNotFoundErrorSchema } from 'services/repo'
 import Api from 'shared/api'
-import { NetworkErrorObject, rejectNetworkError } from 'shared/api/helpers'
+import { rejectNetworkError } from 'shared/api/rejectNetworkError'
 
 const TestResultsFlagsSchema = z.object({
   owner: z
@@ -73,21 +73,21 @@ export const useTestResultsFlags = ({ term }: { term?: string }) => {
 
         if (!parsedData.success) {
           return rejectNetworkError({
-            status: 404,
-            data: {},
-            dev: 'useTestResultsFlags - 404 Failed to parse data',
-            error: parsedData.error,
-          } satisfies NetworkErrorObject)
+            errorName: 'Parsing Error',
+            errorDetails: {
+              callingFn: 'useTestResultsFlags',
+              error: parsedData.error,
+            },
+          })
         }
 
         const data = parsedData.data
 
         if (data?.owner?.repository?.__typename === 'NotFoundError') {
           return rejectNetworkError({
-            status: 404,
-            data: {},
-            dev: 'useTestResultsFlags - 404 Not found error',
-          } satisfies NetworkErrorObject)
+            errorName: 'Not Found Error',
+            errorDetails: { callingFn: 'useTestResultsFlags' },
+          })
         }
 
         return {

--- a/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/hooks/useTestResultsTestSuites/useTestResultsTestSuites.test.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/hooks/useTestResultsTestSuites/useTestResultsTestSuites.test.tsx
@@ -130,8 +130,8 @@ describe('useTestResultsTestSuites', () => {
       await waitFor(() =>
         expect(result.current.error).toEqual(
           expect.objectContaining({
-            status: 404,
-            dev: 'useTestResultsTestSuites - 404 Failed to parse data',
+            dev: 'useTestResultsTestSuites - Parsing Error',
+            status: 400,
           })
         )
       )
@@ -157,8 +157,8 @@ describe('useTestResultsTestSuites', () => {
       await waitFor(() =>
         expect(result.current.error).toEqual(
           expect.objectContaining({
+            dev: 'useTestResultsTestSuites - Not Found Error',
             status: 404,
-            data: {},
           })
         )
       )

--- a/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/hooks/useTestResultsTestSuites/useTestResultsTestSuites.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/hooks/useTestResultsTestSuites/useTestResultsTestSuites.tsx
@@ -4,7 +4,7 @@ import { z } from 'zod'
 
 import { RepoNotFoundErrorSchema } from 'services/repo'
 import Api from 'shared/api'
-import { NetworkErrorObject, rejectNetworkError } from 'shared/api/helpers'
+import { rejectNetworkError } from 'shared/api/rejectNetworkError'
 import { ErrorCodeEnum } from 'shared/utils/commit'
 
 const TestResultsTestSuitesSchema = z.object({
@@ -104,20 +104,20 @@ export const useTestResultsTestSuites = ({
 
         if (!parsedData.success) {
           return rejectNetworkError({
-            status: 404,
-            data: {},
-            dev: 'useTestResultsTestSuites - 404 Failed to parse data',
-            error: parsedData.error,
-          } satisfies NetworkErrorObject)
+            errorName: 'Parsing Error',
+            errorDetails: {
+              callingFn: 'useTestResultsTestSuites',
+              error: parsedData.error,
+            },
+          })
         }
         const data = parsedData.data
 
         if (data?.owner?.repository?.__typename === 'NotFoundError') {
           return rejectNetworkError({
-            status: 404,
-            data: {},
-            dev: 'useTestResultsTestSuites - 404 Not found error',
-          } satisfies NetworkErrorObject)
+            errorName: 'Not Found Error',
+            errorDetails: { callingFn: 'useTestResultsTestSuites' },
+          })
         }
 
         return {

--- a/src/services/access/useGenerateUserToken.ts
+++ b/src/services/access/useGenerateUserToken.ts
@@ -5,7 +5,7 @@ import {
 import { z } from 'zod'
 
 import Api from 'shared/api'
-import { rejectNetworkError } from 'shared/api/helpers'
+import { rejectNetworkError } from 'shared/api/rejectNetworkError'
 
 import { USER_TOKEN_TYPE } from './constants'
 import { SessionsQueryOpts } from './SessionsQueryOpts'
@@ -53,9 +53,11 @@ export function useGenerateUserToken({ provider }: { provider: string }) {
         const parsedData = UseGenerateTokenResponseSchema.safeParse(res?.data)
         if (!parsedData.success) {
           return rejectNetworkError({
-            status: 404,
-            data: {},
-            dev: 'useGenerateUserToken - 404 failed to parse',
+            errorName: 'Parsing Error',
+            errorDetails: {
+              callingFn: 'useGenerateUserToken',
+              error: parsedData.error,
+            },
           })
         }
 

--- a/src/services/account/useCreateStripeSetupIntent.ts
+++ b/src/services/account/useCreateStripeSetupIntent.ts
@@ -2,11 +2,8 @@ import { useQuery } from '@tanstack/react-query'
 import { z } from 'zod'
 
 import Api from 'shared/api'
-import {
-  NetworkErrorObject,
-  Provider,
-  rejectNetworkError,
-} from 'shared/api/helpers'
+import { Provider } from 'shared/api/helpers'
+import { rejectNetworkError } from 'shared/api/rejectNetworkError'
 
 export const CreateStripeSetupIntentSchema = z.object({
   createStripeSetupIntent: z.object({
@@ -75,11 +72,12 @@ export function useCreateStripeSetupIntent({
         const parsedRes = CreateStripeSetupIntentSchema.safeParse(res.data)
         if (!parsedRes.success) {
           return rejectNetworkError({
-            status: 404,
-            error: parsedRes.error,
-            data: {},
-            dev: 'useStripeSetupIntent - 404 failed to parse',
-          } satisfies NetworkErrorObject)
+            errorName: 'Parsing Error',
+            errorDetails: {
+              callingFn: 'useCreateStripeSetupIntent',
+              error: parsedRes.error,
+            },
+          })
         }
 
         const error = parsedRes.data.createStripeSetupIntent.error

--- a/src/services/account/useUnverifiedPaymentMethods.test.tsx
+++ b/src/services/account/useUnverifiedPaymentMethods.test.tsx
@@ -124,9 +124,8 @@ describe('useUnverifiedPaymentMethods', () => {
         await waitFor(() => expect(result.current.error).toBeTruthy())
         expect(result.current.error).toEqual(
           expect.objectContaining({
-            status: 404,
-            data: {},
-            dev: 'useHasUnverifiedPaymentMethods - 404 failed to parse',
+            dev: 'useUnverifiedPaymentMethods - Parsing Error',
+            status: 400,
           })
         )
       })

--- a/src/services/account/useUnverifiedPaymentMethods.tsx
+++ b/src/services/account/useUnverifiedPaymentMethods.tsx
@@ -2,7 +2,8 @@ import { useQuery } from '@tanstack/react-queryV5'
 import { z } from 'zod'
 
 import Api from 'shared/api'
-import { Provider, rejectNetworkError } from 'shared/api/helpers'
+import { Provider } from 'shared/api/helpers'
+import { rejectNetworkError } from 'shared/api/rejectNetworkError'
 
 const query = `
 query UnverifiedPaymentMethods($owner: String!) {
@@ -60,9 +61,11 @@ export const useUnverifiedPaymentMethods = ({
 
         if (!parsedData.success) {
           return rejectNetworkError({
-            status: 404,
-            data: {},
-            dev: 'useHasUnverifiedPaymentMethods - 404 failed to parse',
+            errorName: 'Parsing Error',
+            errorDetails: {
+              callingFn: 'useUnverifiedPaymentMethods',
+              error: parsedData.error,
+            },
           })
         }
 

--- a/src/services/bundleAnalysis/BranchBundleSummaryQueryOpts.test.tsx
+++ b/src/services/bundleAnalysis/BranchBundleSummaryQueryOpts.test.tsx
@@ -279,7 +279,7 @@ describe('useBranchBundleSummary', () => {
       await waitFor(() =>
         expect(result.current.error).toEqual(
           expect.objectContaining({
-            dev: 'BranchBundleSummaryQueryOpts - 403 Owner not activated',
+            dev: 'BranchBundleSummaryQueryOpts - Owner Not Activated',
             status: 403,
           })
         )
@@ -317,7 +317,8 @@ describe('useBranchBundleSummary', () => {
       await waitFor(() =>
         expect(result.current.error).toEqual(
           expect.objectContaining({
-            status: 404,
+            dev: 'BranchBundleSummaryQueryOpts - Parsing Error',
+            status: 400,
           })
         )
       )

--- a/src/services/bundleAnalysis/BranchBundleSummaryQueryOpts.tsx
+++ b/src/services/bundleAnalysis/BranchBundleSummaryQueryOpts.tsx
@@ -7,7 +7,7 @@ import {
   RepoOwnerNotActivatedErrorSchema,
 } from 'services/repo'
 import Api from 'shared/api'
-import { rejectNetworkError } from 'shared/api/helpers'
+import { rejectNetworkError } from 'shared/api/rejectNetworkError'
 import A from 'ui/A'
 
 const BundleSchema = z.object({
@@ -164,10 +164,11 @@ export const BranchBundleSummaryQueryOpts = ({
 
         if (!parsedData.success) {
           return rejectNetworkError({
-            status: 404,
-            data: {},
-            dev: 'BranchBundleSummaryQueryOpts - 404 Failed to parse',
-            error: parsedData.error,
+            errorName: 'Parsing Error',
+            errorDetails: {
+              callingFn: 'BranchBundleSummaryQueryOpts',
+              error: parsedData.error,
+            },
           })
         }
 
@@ -175,15 +176,15 @@ export const BranchBundleSummaryQueryOpts = ({
 
         if (data?.owner?.repository?.__typename === 'NotFoundError') {
           return rejectNetworkError({
-            status: 404,
-            data: {},
-            dev: 'BranchBundleSummaryQueryOpts - 404 Repository not found',
+            errorName: 'Not Found Error',
+            errorDetails: { callingFn: 'BranchBundleSummaryQueryOpts' },
           })
         }
 
         if (data?.owner?.repository?.__typename === 'OwnerNotActivatedError') {
           return rejectNetworkError({
-            status: 403,
+            errorName: 'Owner Not Activated',
+            errorDetails: { callingFn: 'BranchBundleSummaryQueryOpts' },
             data: {
               detail: (
                 <p>
@@ -194,7 +195,6 @@ export const BranchBundleSummaryQueryOpts = ({
                 </p>
               ),
             },
-            dev: 'BranchBundleSummaryQueryOpts - 403 Owner not activated',
           })
         }
 

--- a/src/services/bundleAnalysis/BranchBundlesNamesQueryOpts.test.tsx
+++ b/src/services/bundleAnalysis/BranchBundlesNamesQueryOpts.test.tsx
@@ -281,7 +281,8 @@ describe('useBranchBundlesNames', () => {
       await waitFor(() =>
         expect(result.current.error).toEqual(
           expect.objectContaining({
-            status: 404,
+            dev: 'BranchBundlesNamesQueryOpts - Parsing Error',
+            status: 400,
           })
         )
       )

--- a/src/services/bundleAnalysis/BranchBundlesNamesQueryOpts.tsx
+++ b/src/services/bundleAnalysis/BranchBundlesNamesQueryOpts.tsx
@@ -7,7 +7,7 @@ import {
   RepoOwnerNotActivatedErrorSchema,
 } from 'services/repo'
 import Api from 'shared/api'
-import { rejectNetworkError } from 'shared/api/helpers'
+import { rejectNetworkError } from 'shared/api/rejectNetworkError'
 import A from 'ui/A'
 
 const BundleSchema = z.object({
@@ -126,10 +126,11 @@ export const BranchBundlesNamesQueryOpts = ({
 
         if (!parsedData.success) {
           return rejectNetworkError({
-            status: 404,
-            data: {},
-            dev: 'BranchBundlesNamesQueryOpts - 404 Failed to parse',
-            error: parsedData.error,
+            errorName: 'Parsing Error',
+            errorDetails: {
+              callingFn: 'BranchBundlesNamesQueryOpts',
+              error: parsedData.error,
+            },
           })
         }
 
@@ -137,15 +138,15 @@ export const BranchBundlesNamesQueryOpts = ({
 
         if (data?.owner?.repository?.__typename === 'NotFoundError') {
           return rejectNetworkError({
-            status: 404,
-            data: {},
-            dev: 'BranchBundlesNamesQueryOpts - 404 Repository not found',
+            errorName: 'Not Found Error',
+            errorDetails: { callingFn: 'BranchBundlesNamesQueryOpts' },
           })
         }
 
         if (data?.owner?.repository?.__typename === 'OwnerNotActivatedError') {
           return rejectNetworkError({
-            status: 403,
+            errorName: 'Owner Not Activated',
+            errorDetails: { callingFn: 'BranchBundlesNamesQueryOpts' },
             data: {
               detail: (
                 <p>
@@ -156,7 +157,6 @@ export const BranchBundlesNamesQueryOpts = ({
                 </p>
               ),
             },
-            dev: 'BranchBundlesNamesQueryOpts - 403 Owner not activated',
           })
         }
 

--- a/src/services/bundleAnalysis/BundleAssetsQueryOpts.test.tsx
+++ b/src/services/bundleAnalysis/BundleAssetsQueryOpts.test.tsx
@@ -488,7 +488,8 @@ describe('useBundleAssets', () => {
       await waitFor(() =>
         expect(result.current.error).toEqual(
           expect.objectContaining({
-            status: 404,
+            dev: 'BundleAssetsQueryOpts - Parsing Error',
+            status: 400,
           })
         )
       )

--- a/src/services/bundleAnalysis/BundleAssetsQueryOpts.tsx
+++ b/src/services/bundleAnalysis/BundleAssetsQueryOpts.tsx
@@ -9,7 +9,7 @@ import {
   RepoOwnerNotActivatedErrorSchema,
 } from 'services/repo'
 import Api from 'shared/api'
-import { rejectNetworkError } from 'shared/api/helpers'
+import { rejectNetworkError } from 'shared/api/rejectNetworkError'
 import { mapEdges } from 'shared/utils/graphql'
 import A from 'ui/A'
 
@@ -282,10 +282,11 @@ export const BundleAssetsQueryOpts = ({
 
         if (!parsedData.success) {
           return rejectNetworkError({
-            status: 404,
-            data: {},
-            dev: 'BundleAssetsQueryOpts - 404 schema parsing failed',
-            error: parsedData.error,
+            errorName: 'Parsing Error',
+            errorDetails: {
+              callingFn: 'BundleAssetsQueryOpts',
+              error: parsedData.error,
+            },
           })
         }
 
@@ -293,15 +294,15 @@ export const BundleAssetsQueryOpts = ({
 
         if (data?.owner?.repository?.__typename === 'NotFoundError') {
           return rejectNetworkError({
-            status: 404,
-            data: {},
-            dev: 'BundleAssetsQueryOpts - 404 Repository not found',
+            errorName: 'Not Found Error',
+            errorDetails: { callingFn: 'BundleAssetsQueryOpts' },
           })
         }
 
         if (data?.owner?.repository?.__typename === 'OwnerNotActivatedError') {
           return rejectNetworkError({
-            status: 403,
+            errorName: 'Owner Not Activated',
+            errorDetails: { callingFn: 'BundleAssetsQueryOpts' },
             data: {
               detail: (
                 <p>
@@ -312,7 +313,6 @@ export const BundleAssetsQueryOpts = ({
                 </p>
               ),
             },
-            dev: 'BundleAssetsQueryOpts - 403 Owner not activated',
           })
         }
 

--- a/src/services/bundleAnalysis/BundleTrendDataQueryOpts.test.tsx
+++ b/src/services/bundleAnalysis/BundleTrendDataQueryOpts.test.tsx
@@ -354,7 +354,8 @@ describe('useBundleTrendData', () => {
       await waitFor(() =>
         expect(result.current.error).toEqual(
           expect.objectContaining({
-            status: 404,
+            dev: 'BundleTrendDataQueryOpts - Parsing Error',
+            status: 400,
           })
         )
       )

--- a/src/services/bundleAnalysis/BundleTrendDataQueryOpts.tsx
+++ b/src/services/bundleAnalysis/BundleTrendDataQueryOpts.tsx
@@ -8,7 +8,7 @@ import {
   RepoOwnerNotActivatedErrorSchema,
 } from 'services/repo'
 import Api from 'shared/api'
-import { rejectNetworkError } from 'shared/api/helpers'
+import { rejectNetworkError } from 'shared/api/rejectNetworkError'
 import A from 'ui/A'
 
 export const BUNDLE_TREND_INTERVALS = [
@@ -194,10 +194,11 @@ export const BundleTrendDataQueryOpts = ({
 
         if (!parsedData.success) {
           return rejectNetworkError({
-            status: 404,
-            data: {},
-            dev: 'BundleTrendDataQueryOpts - 404 Failed to parse schema',
-            error: parsedData.error,
+            errorName: 'Parsing Error',
+            errorDetails: {
+              callingFn: 'BundleTrendDataQueryOpts',
+              error: parsedData.error,
+            },
           })
         }
 
@@ -205,15 +206,15 @@ export const BundleTrendDataQueryOpts = ({
 
         if (data?.owner?.repository?.__typename === 'NotFoundError') {
           return rejectNetworkError({
-            status: 404,
-            data: {},
-            dev: 'BundleTrendDataQueryOpts - 404 Not found error',
+            errorName: 'Not Found Error',
+            errorDetails: { callingFn: 'BundleTrendDataQueryOpts' },
           })
         }
 
         if (data?.owner?.repository?.__typename === 'OwnerNotActivatedError') {
           return rejectNetworkError({
-            status: 403,
+            errorName: 'Owner Not Activated',
+            errorDetails: { callingFn: 'BundleTrendDataQueryOpts' },
             data: {
               detail: (
                 <p>
@@ -224,7 +225,6 @@ export const BundleTrendDataQueryOpts = ({
                 </p>
               ),
             },
-            dev: 'BundleTrendDataQueryOpts - 403 Owner not activated',
           })
         }
 

--- a/src/services/bundleAnalysis/CachedBundlesQueryOpts.test.tsx
+++ b/src/services/bundleAnalysis/CachedBundlesQueryOpts.test.tsx
@@ -281,7 +281,8 @@ describe('CachedBundlesQueryOpts', () => {
       await waitFor(() =>
         expect(result.current.error).toEqual(
           expect.objectContaining({
-            status: 404,
+            dev: 'CachedBundlesQueryOpts - Parsing Error',
+            status: 400,
           })
         )
       )

--- a/src/services/bundleAnalysis/CachedBundlesQueryOpts.tsx
+++ b/src/services/bundleAnalysis/CachedBundlesQueryOpts.tsx
@@ -7,7 +7,7 @@ import {
   RepoOwnerNotActivatedErrorSchema,
 } from 'services/repo'
 import Api from 'shared/api'
-import { rejectNetworkError } from 'shared/api/helpers'
+import { rejectNetworkError } from 'shared/api/rejectNetworkError'
 import A from 'ui/A'
 
 const BundleSchema = z.object({
@@ -122,10 +122,11 @@ export const CachedBundlesQueryOpts = ({
 
         if (!parsedData.success) {
           return rejectNetworkError({
-            status: 404,
-            data: {},
-            dev: 'CachedBundlesQueryOpts - 404 Failed to parse',
-            error: parsedData.error,
+            errorName: 'Parsing Error',
+            errorDetails: {
+              callingFn: 'CachedBundlesQueryOpts',
+              error: parsedData.error,
+            },
           })
         }
 
@@ -133,15 +134,15 @@ export const CachedBundlesQueryOpts = ({
 
         if (data?.owner?.repository?.__typename === 'NotFoundError') {
           return rejectNetworkError({
-            status: 404,
-            data: {},
-            dev: 'CachedBundlesQueryOpts - 404 Repository not found',
+            errorName: 'Not Found Error',
+            errorDetails: { callingFn: 'CachedBundlesQueryOpts' },
           })
         }
 
         if (data?.owner?.repository?.__typename === 'OwnerNotActivatedError') {
           return rejectNetworkError({
-            status: 403,
+            errorName: 'Owner Not Activated',
+            errorDetails: { callingFn: 'CachedBundlesQueryOpts' },
             data: {
               detail: (
                 <p>
@@ -152,7 +153,6 @@ export const CachedBundlesQueryOpts = ({
                 </p>
               ),
             },
-            dev: 'CachedBundlesQueryOpts - 403 Owner not activated',
           })
         }
 

--- a/src/services/bundleAnalysis/useBundleAssetModules.test.tsx
+++ b/src/services/bundleAnalysis/useBundleAssetModules.test.tsx
@@ -338,7 +338,8 @@ describe('useBranchBundleSummary', () => {
       await waitFor(() =>
         expect(result.current.error).toEqual(
           expect.objectContaining({
-            status: 404,
+            dev: 'BundleAssetModulesQueryOpts - Parsing Error',
+            status: 400,
           })
         )
       )

--- a/src/services/bundleAnalysis/useBundleAssetModules.tsx
+++ b/src/services/bundleAnalysis/useBundleAssetModules.tsx
@@ -10,7 +10,7 @@ import {
   RepoOwnerNotActivatedErrorSchema,
 } from 'services/repo'
 import Api from 'shared/api'
-import { rejectNetworkError } from 'shared/api/helpers'
+import { rejectNetworkError } from 'shared/api/rejectNetworkError'
 import A from 'ui/A'
 
 const BundleAssetModuleSchema = z.object({
@@ -178,10 +178,11 @@ export const BundleAssetModulesQueryOpts = ({
 
         if (!parsedData.success) {
           return rejectNetworkError({
-            status: 404,
-            data: {},
-            dev: 'BundleAssetModulesQueryOpts - 404 Failed to parse',
-            error: parsedData.error,
+            errorName: 'Parsing Error',
+            errorDetails: {
+              callingFn: 'BundleAssetModulesQueryOpts',
+              error: parsedData.error,
+            },
           })
         }
 
@@ -189,15 +190,15 @@ export const BundleAssetModulesQueryOpts = ({
 
         if (data?.owner?.repository?.__typename === 'NotFoundError') {
           return rejectNetworkError({
-            status: 404,
-            data: {},
-            dev: 'BundleAssetModulesQueryOpts - 404 Repository not found',
+            errorName: 'Not Found Error',
+            errorDetails: { callingFn: 'BundleAssetModulesQueryOpts' },
           })
         }
 
         if (data?.owner?.repository?.__typename === 'OwnerNotActivatedError') {
           return rejectNetworkError({
-            status: 403,
+            errorName: 'Owner Not Activated',
+            errorDetails: { callingFn: 'BundleAssetModulesQueryOpts' },
             data: {
               detail: (
                 <p>
@@ -208,7 +209,6 @@ export const BundleAssetModulesQueryOpts = ({
                 </p>
               ),
             },
-            dev: 'BundleAssetModulesQueryOpts - 403 Owner not activated',
           })
         }
 

--- a/src/services/bundleAnalysis/useBundleSummary.test.tsx
+++ b/src/services/bundleAnalysis/useBundleSummary.test.tsx
@@ -408,7 +408,8 @@ describe('useBundleSummary', () => {
       await waitFor(() =>
         expect(result.current.error).toEqual(
           expect.objectContaining({
-            status: 404,
+            dev: 'BundleSummaryQueryOpts - Parsing Error',
+            status: 400,
           })
         )
       )

--- a/src/services/bundleAnalysis/useBundleSummary.tsx
+++ b/src/services/bundleAnalysis/useBundleSummary.tsx
@@ -11,7 +11,7 @@ import {
   useRepoOverview,
 } from 'services/repo'
 import Api from 'shared/api/api'
-import { rejectNetworkError } from 'shared/api/helpers'
+import { rejectNetworkError } from 'shared/api/rejectNetworkError'
 import A from 'ui/A'
 
 const BundleDataSchema = z.object({
@@ -156,10 +156,11 @@ export const BundleSummaryQueryOpts = ({
 
         if (!parsedData.success) {
           return rejectNetworkError({
-            status: 404,
-            data: {},
-            dev: 'BundleSummaryQueryOpts - 404 Failed to parse data',
-            error: parsedData.error,
+            errorName: 'Parsing Error',
+            errorDetails: {
+              callingFn: 'BundleSummaryQueryOpts',
+              error: parsedData.error,
+            },
           })
         }
 
@@ -167,15 +168,15 @@ export const BundleSummaryQueryOpts = ({
 
         if (data?.owner?.repository?.__typename === 'NotFoundError') {
           return rejectNetworkError({
-            status: 404,
-            data: {},
-            dev: 'BundleSummaryQueryOpts - 404 Not found error',
+            errorName: 'Not Found Error',
+            errorDetails: { callingFn: 'BundleSummaryQueryOpts' },
           })
         }
 
         if (data?.owner?.repository?.__typename === 'OwnerNotActivatedError') {
           return rejectNetworkError({
-            status: 403,
+            errorName: 'Owner Not Activated',
+            errorDetails: { callingFn: 'BundleSummaryQueryOpts' },
             data: {
               detail: (
                 <p>
@@ -186,7 +187,6 @@ export const BundleSummaryQueryOpts = ({
                 </p>
               ),
             },
-            dev: 'BundleSummaryQueryOpts - 403 Owner not activated',
           })
         }
 

--- a/src/services/bundleAnalysis/useUpdateBundleCache.test.tsx
+++ b/src/services/bundleAnalysis/useUpdateBundleCache.test.tsx
@@ -140,8 +140,7 @@ describe('useUpdateBundleCache', () => {
           await waitFor(() => expect(result.current.isError).toBe(true))
 
           expect(result.current.error).toEqual({
-            data: {},
-            dev: 'useUpdateBundleCache - 400 failed to parse input',
+            dev: 'useUpdateBundleCache - Parsing Error',
             status: 400,
           })
         })
@@ -168,8 +167,7 @@ describe('useUpdateBundleCache', () => {
           await waitFor(() => expect(result.current.isError).toBe(true))
 
           expect(result.current.error).toEqual({
-            data: {},
-            dev: 'useUpdateBundleCache - 400 failed to parse data',
+            dev: 'useUpdateBundleCache - Parsing Error',
             status: 400,
           })
         })

--- a/src/services/bundleAnalysis/useUpdateBundleCache.tsx
+++ b/src/services/bundleAnalysis/useUpdateBundleCache.tsx
@@ -2,7 +2,7 @@ import { useMutation as useMutationV5 } from '@tanstack/react-queryV5'
 import { z } from 'zod'
 
 import Api from 'shared/api'
-import { rejectNetworkError } from 'shared/api/helpers'
+import { rejectNetworkError } from 'shared/api/rejectNetworkError'
 
 const UpdateBundleCacheInputSchema = z.array(
   z.object({
@@ -79,10 +79,11 @@ export const useUpdateBundleCache = ({
       const parsedInput = UpdateBundleCacheInputSchema.safeParse(input)
       if (!parsedInput.success) {
         return rejectNetworkError({
-          status: 400,
-          error: parsedInput.error,
-          data: {},
-          dev: 'useUpdateBundleCache - 400 failed to parse input',
+          errorName: 'Parsing Error',
+          errorDetails: {
+            callingFn: 'useUpdateBundleCache',
+            error: parsedInput.error,
+          },
         })
       }
 
@@ -96,10 +97,11 @@ export const useUpdateBundleCache = ({
 
         if (!parsedData.success) {
           return rejectNetworkError({
-            status: 400,
-            error: parsedData.error,
-            data: {},
-            dev: 'useUpdateBundleCache - 400 failed to parse data',
+            errorName: 'Parsing Error',
+            errorDetails: {
+              callingFn: 'useUpdateBundleCache',
+              error: parsedData.error,
+            },
           })
         }
 

--- a/src/services/charts/BranchCoverageMeasurementsQueryOpts.test.tsx
+++ b/src/services/charts/BranchCoverageMeasurementsQueryOpts.test.tsx
@@ -283,7 +283,8 @@ describe('useBranchCoverageMeasurements', () => {
       await waitFor(() =>
         expect(result.current.error).toEqual(
           expect.objectContaining({
-            status: 404,
+            dev: 'BranchCoverageMeasurementsQueryOpts - Parsing Error',
+            status: 400,
           })
         )
       )

--- a/src/services/charts/BranchCoverageMeasurementsQueryOpts.tsx
+++ b/src/services/charts/BranchCoverageMeasurementsQueryOpts.tsx
@@ -6,7 +6,7 @@ import {
   RepoOwnerNotActivatedErrorSchema,
 } from 'services/repo'
 import Api from 'shared/api'
-import { rejectNetworkError } from 'shared/api/helpers'
+import { rejectNetworkError } from 'shared/api/rejectNetworkError'
 import A from 'ui/A'
 
 type MeasurementIntervals =
@@ -127,10 +127,11 @@ export const BranchCoverageMeasurementsQueryOpts = ({
 
         if (!parsedData.success) {
           return rejectNetworkError({
-            status: 404,
-            data: {},
-            dev: 'BranchCoverageMeasurementsQueryOpts - 404 Failed to parse data',
-            error: parsedData.error,
+            errorName: 'Parsing Error',
+            errorDetails: {
+              callingFn: 'BranchCoverageMeasurementsQueryOpts',
+              error: parsedData.error,
+            },
           })
         }
 
@@ -138,15 +139,15 @@ export const BranchCoverageMeasurementsQueryOpts = ({
 
         if (data?.owner?.repository?.__typename === 'NotFoundError') {
           return rejectNetworkError({
-            status: 404,
-            data: {},
-            dev: 'BranchCoverageMeasurementsQueryOpts - 404 Not found error',
+            errorName: 'Not Found Error',
+            errorDetails: { callingFn: 'BranchCoverageMeasurementsQueryOpts' },
           })
         }
 
         if (data?.owner?.repository?.__typename === 'OwnerNotActivatedError') {
           return rejectNetworkError({
-            status: 403,
+            errorName: 'Owner Not Activated',
+            errorDetails: { callingFn: 'BranchCoverageMeasurementsQueryOpts' },
             data: {
               detail: (
                 <p>
@@ -157,7 +158,6 @@ export const BranchCoverageMeasurementsQueryOpts = ({
                 </p>
               ),
             },
-            dev: 'BranchCoverageMeasurementsQueryOpts - 403 Owner not activated',
           })
         }
 

--- a/src/services/charts/ReposCoverageMeasurementsQueryOpts.test.tsx
+++ b/src/services/charts/ReposCoverageMeasurementsQueryOpts.test.tsx
@@ -151,7 +151,8 @@ describe('useReposCoverageMeasurements', () => {
         await waitFor(() =>
           expect(result.current.error).toEqual(
             expect.objectContaining({
-              status: 404,
+              dev: 'ReposCoverageMeasurementsQueryOpts - Parsing Error',
+              status: 400,
             })
           )
         )

--- a/src/services/charts/ReposCoverageMeasurementsQueryOpts.ts
+++ b/src/services/charts/ReposCoverageMeasurementsQueryOpts.ts
@@ -2,7 +2,7 @@ import { queryOptions as queryOptionsV5 } from '@tanstack/react-queryV5'
 import { z } from 'zod'
 
 import Api from 'shared/api'
-import { rejectNetworkError } from 'shared/api/helpers'
+import { rejectNetworkError } from 'shared/api/rejectNetworkError'
 
 const ReposCoverageMeasurementsConfig = z.array(
   z.object({
@@ -90,10 +90,11 @@ export const ReposCoverageMeasurementsQueryOpts = ({
 
         if (!parsedData.success) {
           return rejectNetworkError({
-            status: 404,
-            data: {},
-            dev: 'ReposCoverageMeasurementsQueryOpts - 404 schema parsing failed',
-            error: parsedData.error,
+            errorName: 'Parsing Error',
+            errorDetails: {
+              callingFn: 'ReposCoverageMeasurementsQueryOpts',
+              error: parsedData.error,
+            },
           })
         }
 

--- a/src/services/charts/SunburstCoverageQueryOpts.ts
+++ b/src/services/charts/SunburstCoverageQueryOpts.ts
@@ -2,7 +2,8 @@ import { queryOptions as queryOptionsV5 } from '@tanstack/react-queryV5'
 import { z } from 'zod'
 
 import Api from 'shared/api'
-import { Provider, rejectNetworkError } from 'shared/api/helpers'
+import { Provider } from 'shared/api/helpers'
+import { rejectNetworkError } from 'shared/api/rejectNetworkError'
 import { providerToInternalProvider } from 'shared/utils/provider'
 
 function getSunburstCoverage({ provider, owner, repo }: SunburstCoverageArgs) {
@@ -56,10 +57,11 @@ export function SunburstCoverageQueryOpts({
 
         if (!parsedRes.success) {
           return rejectNetworkError({
-            status: 404,
-            data: {},
-            dev: 'SunburstCoverageQueryOpts - 404 Failed to parse data',
-            error: parsedRes.error,
+            errorName: 'Parsing Error',
+            errorDetails: {
+              callingFn: 'SunburstCoverageQueryOpts',
+              error: parsedRes.error,
+            },
           })
         }
 

--- a/src/services/commit/useCommit.test.tsx
+++ b/src/services/commit/useCommit.test.tsx
@@ -549,8 +549,8 @@ describe('useCommit', () => {
       await waitFor(() =>
         expect(result.current.error).toEqual(
           expect.objectContaining({
+            dev: 'useCommit - Not Found Error',
             status: 404,
-            dev: 'useCommit - 404 not found',
           })
         )
       )
@@ -587,8 +587,8 @@ describe('useCommit', () => {
       await waitFor(() =>
         expect(result.current.error).toEqual(
           expect.objectContaining({
+            dev: 'useCommit - Owner Not Activated',
             status: 403,
-            dev: 'useCommit - 403 owner not activated',
           })
         )
       )
@@ -625,8 +625,8 @@ describe('useCommit', () => {
       await waitFor(() =>
         expect(result.current.error).toEqual(
           expect.objectContaining({
-            status: 404,
-            dev: 'useCommit - 404 failed to parse',
+            dev: 'useCommit - Parsing Error',
+            status: 400,
           })
         )
       )

--- a/src/services/commit/useCommit.tsx
+++ b/src/services/commit/useCommit.tsx
@@ -16,7 +16,7 @@ import {
   RepoOwnerNotActivatedErrorSchema,
 } from 'services/repo/schemas'
 import Api from 'shared/api'
-import { rejectNetworkError } from 'shared/api/helpers'
+import { rejectNetworkError } from 'shared/api/rejectNetworkError'
 import {
   ErrorCodeEnum,
   UploadStateEnum,
@@ -353,10 +353,11 @@ export function useCommit({
 
         if (!parsedRes.success) {
           return rejectNetworkError({
-            status: 404,
-            data: {},
-            dev: 'useCommit - 404 failed to parse',
-            error: parsedRes.error,
+            errorName: 'Parsing Error',
+            errorDetails: {
+              callingFn: 'useCommit',
+              error: parsedRes.error,
+            },
           })
         }
 
@@ -364,15 +365,15 @@ export function useCommit({
 
         if (data?.owner?.repository?.__typename === 'NotFoundError') {
           return rejectNetworkError({
-            status: 404,
-            data: {},
-            dev: 'useCommit - 404 not found',
+            errorName: 'Not Found Error',
+            errorDetails: { callingFn: 'useCommit' },
           })
         }
 
         if (data?.owner?.repository?.__typename === 'OwnerNotActivatedError') {
           return rejectNetworkError({
-            status: 403,
+            errorName: 'Owner Not Activated',
+            errorDetails: { callingFn: 'useCommit' },
             data: {
               detail: (
                 <p>
@@ -383,7 +384,6 @@ export function useCommit({
                 </p>
               ),
             },
-            dev: 'useCommit - 403 owner not activated',
           })
         }
 

--- a/src/services/config/SyncProvidersQueryOpts.test.tsx
+++ b/src/services/config/SyncProvidersQueryOpts.test.tsx
@@ -120,7 +120,10 @@ describe('useSyncProviders', () => {
 
       await waitFor(() => expect(result.current.isError).toBeTruthy())
       expect(result.current.error).toEqual(
-        expect.objectContaining({ status: 404 })
+        expect.objectContaining({
+          dev: 'SyncProvidersQueryOpts - Parsing Error',
+          status: 400,
+        })
       )
     })
   })

--- a/src/services/config/SyncProvidersQueryOpts.ts
+++ b/src/services/config/SyncProvidersQueryOpts.ts
@@ -2,7 +2,7 @@ import { queryOptions as queryOptionsV5 } from '@tanstack/react-queryV5'
 import { z } from 'zod'
 
 import Api from 'shared/api'
-import { rejectNetworkError } from 'shared/api/helpers'
+import { rejectNetworkError } from 'shared/api/rejectNetworkError'
 
 const EnterpriseSyncProvidersUnionSchema = z.union([
   z.literal('GITHUB'),
@@ -43,10 +43,11 @@ export const SyncProvidersQueryOpts = () => {
 
         if (!parsedRes.success) {
           return rejectNetworkError({
-            status: 404,
-            data: {},
-            dev: `SyncProvidersQueryOpts - 404 Failed to parse`,
-            error: parsedRes.error,
+            errorName: 'Parsing Error',
+            errorDetails: {
+              callingFn: 'SyncProvidersQueryOpts',
+              error: parsedRes.error,
+            },
           })
         }
 

--- a/src/services/events/hooks.test.tsx
+++ b/src/services/events/hooks.test.tsx
@@ -185,8 +185,8 @@ describe('useEventContext', () => {
         await waitFor(() =>
           expect(result.current.error).toEqual(
             expect.objectContaining({
-              status: 404,
-              dev: 'OwnerContextQueryOpts - 404 Failed to parse data',
+              dev: 'OwnerContextQueryOpts - Parsing Error',
+              status: 400,
             })
           )
         )
@@ -234,8 +234,8 @@ describe('useEventContext', () => {
         await waitFor(() =>
           expect(result.current.error).toEqual(
             expect.objectContaining({
-              status: 404,
-              dev: 'RepoContextQueryOpts - 404 Failed to parse data',
+              dev: 'RepoContextQueryOpts - Parsing Error',
+              status: 400,
             })
           )
         )
@@ -262,8 +262,8 @@ describe('useEventContext', () => {
         await waitFor(() =>
           expect(result.current.error).toEqual(
             expect.objectContaining({
+              dev: 'RepoContextQueryOpts - Not Found Error',
               status: 404,
-              dev: 'RepoContextQueryOpts - 404 NotFoundError',
             })
           )
         )
@@ -290,8 +290,8 @@ describe('useEventContext', () => {
         await waitFor(() =>
           expect(result.current.error).toEqual(
             expect.objectContaining({
+              dev: 'RepoContextQueryOpts - Owner Not Activated',
               status: 403,
-              dev: 'RepoContextQueryOpts - 403 OwnerNotActivatedError',
             })
           )
         )

--- a/src/services/events/hooks.tsx
+++ b/src/services/events/hooks.tsx
@@ -11,7 +11,8 @@ import {
   RepoOwnerNotActivatedErrorSchema,
 } from 'services/repo'
 import Api from 'shared/api'
-import { Provider, rejectNetworkError } from 'shared/api/helpers'
+import { Provider } from 'shared/api/helpers'
+import { rejectNetworkError } from 'shared/api/rejectNetworkError'
 import A from 'ui/A'
 
 import { eventTracker } from './events'
@@ -92,10 +93,11 @@ export const OwnerContextQueryOpts = ({
 
         if (!parsedRes.success) {
           return rejectNetworkError({
-            status: 404,
-            data: {},
-            dev: 'OwnerContextQueryOpts - 404 Failed to parse data',
-            error: parsedRes.error,
+            errorName: 'Parsing Error',
+            errorDetails: {
+              callingFn: 'OwnerContextQueryOpts',
+              error: parsedRes.error,
+            },
           })
         }
 
@@ -174,18 +176,18 @@ export const RepoContextQueryOpts = ({
 
         if (!parsedRes.success) {
           return rejectNetworkError({
-            status: 404,
-            data: {},
-            dev: 'RepoContextQueryOpts - 404 Failed to parse data',
-            error: parsedRes.error,
+            errorName: 'Parsing Error',
+            errorDetails: {
+              callingFn: 'RepoContextQueryOpts',
+              error: parsedRes.error,
+            },
           })
         }
 
         if (parsedRes.data?.owner?.repository?.__typename === 'NotFoundError') {
           return rejectNetworkError({
-            status: 404,
-            data: {},
-            dev: 'RepoContextQueryOpts - 404 NotFoundError',
+            errorName: 'Not Found Error',
+            errorDetails: { callingFn: 'RepoContextQueryOpts' },
           })
         }
 
@@ -194,7 +196,8 @@ export const RepoContextQueryOpts = ({
           'OwnerNotActivatedError'
         ) {
           return rejectNetworkError({
-            status: 403,
+            errorName: 'Owner Not Activated',
+            errorDetails: { callingFn: 'RepoContextQueryOpts' },
             data: {
               detail: (
                 <p>
@@ -205,7 +208,6 @@ export const RepoContextQueryOpts = ({
                 </p>
               ),
             },
-            dev: 'RepoContextQueryOpts - 403 OwnerNotActivatedError',
           })
         }
 

--- a/src/services/orgUploadToken/useOrgUploadToken.test.tsx
+++ b/src/services/orgUploadToken/useOrgUploadToken.test.tsx
@@ -127,7 +127,8 @@ describe('useOrgUploadToken', () => {
         await waitFor(() =>
           expect(result.current.error).toEqual(
             expect.objectContaining({
-              status: 404,
+              dev: 'useOrgUploadToken - Parsing Error',
+              status: 400,
             })
           )
         )

--- a/src/services/orgUploadToken/useOrgUploadToken.ts
+++ b/src/services/orgUploadToken/useOrgUploadToken.ts
@@ -2,7 +2,7 @@ import { useQuery } from '@tanstack/react-query'
 import { z } from 'zod'
 
 import Api from 'shared/api'
-import { NetworkErrorObject, rejectNetworkError } from 'shared/api/helpers'
+import { rejectNetworkError } from 'shared/api/rejectNetworkError'
 
 const RequestSchema = z.object({
   owner: z
@@ -39,10 +39,12 @@ export const useOrgUploadToken = ({ provider, owner }: UseOrgUploadTokenArgs) =>
 
         if (!parsedRes.success) {
           return rejectNetworkError({
-            status: 404,
-            data: {},
-            dev: 'useOrgUploadToken - 404 Failed to parse data',
-          } satisfies NetworkErrorObject)
+            errorName: 'Parsing Error',
+            errorDetails: {
+              callingFn: 'useOrgUploadToken',
+              error: parsedRes.error,
+            },
+          })
         }
 
         return parsedRes?.data?.owner?.orgUploadToken ?? null

--- a/src/services/orgUploadToken/useRegenerateOrgUploadToken.test.tsx
+++ b/src/services/orgUploadToken/useRegenerateOrgUploadToken.test.tsx
@@ -4,11 +4,11 @@ import { graphql, HttpResponse } from 'msw'
 import { setupServer } from 'msw/node'
 import { MemoryRouter, Route } from 'react-router-dom'
 
-import * as apiHelpers from 'shared/api/helpers'
+import * as apiHelpers from 'shared/api/rejectNetworkError'
 
 import { useRegenerateOrgUploadToken } from './useRegenerateOrgUploadToken'
 
-vi.mock('shared/api/helpers')
+vi.mock('shared/api/rejectNetworkError')
 
 const mocks = {
   rejectNetworkError: vi.spyOn(apiHelpers, 'rejectNetworkError'),
@@ -96,11 +96,7 @@ describe('useRegenerateOrgUploadToken', () => {
           await waitFor(() => !result.current.isLoading)
 
           expect(mocks.rejectNetworkError).toHaveBeenCalledWith(
-            expect.objectContaining({
-              status: 404,
-              dev: 'useRegenerateOrgUploadToken - 404 schema parsing failed',
-              data: {},
-            })
+            expect.objectContaining({ errorName: 'Parsing Error' })
           )
         })
       })

--- a/src/services/orgUploadToken/useRegenerateOrgUploadToken.tsx
+++ b/src/services/orgUploadToken/useRegenerateOrgUploadToken.tsx
@@ -3,7 +3,8 @@ import { useParams } from 'react-router-dom'
 import { z } from 'zod'
 
 import Api from 'shared/api'
-import { Provider, rejectNetworkError } from 'shared/api/helpers'
+import { Provider } from 'shared/api/helpers'
+import { rejectNetworkError } from 'shared/api/rejectNetworkError'
 
 const query = `
   mutation RegenerateOrgUploadToken(
@@ -67,10 +68,11 @@ export function useRegenerateOrgUploadToken({
         const parsedRes = ResponseSchema.safeParse(data)
         if (!parsedRes.success) {
           return rejectNetworkError({
-            status: 404,
-            data: {},
-            dev: 'useRegenerateOrgUploadToken - 404 schema parsing failed',
-            error: parsedRes.error,
+            errorName: 'Parsing Error',
+            errorDetails: {
+              callingFn: 'useRegenerateOrgUploadToken',
+              error: parsedRes.error,
+            },
           })
         }
 

--- a/src/services/repos/ReposQueryOpts.test.tsx
+++ b/src/services/repos/ReposQueryOpts.test.tsx
@@ -191,8 +191,8 @@ describe('ReposQueryOpts', () => {
       await waitFor(() =>
         expect(result.current.error).toEqual(
           expect.objectContaining({
-            status: 404,
-            dev: 'ReposQueryOpts - 404 Failed to parse schema',
+            dev: 'ReposQueryOpts - Parsing Error',
+            status: 400,
           })
         )
       )

--- a/src/services/repos/ReposQueryOpts.tsx
+++ b/src/services/repos/ReposQueryOpts.tsx
@@ -3,7 +3,7 @@ import { z } from 'zod'
 
 import { RepositoryConfigSchema } from 'services/repo/useRepoConfig'
 import Api from 'shared/api'
-import { rejectNetworkError } from 'shared/api/helpers'
+import { rejectNetworkError } from 'shared/api/rejectNetworkError'
 import { mapEdges } from 'shared/utils/graphql'
 
 import {
@@ -154,10 +154,11 @@ function ReposQueryOpts({
         const parsedRes = RequestSchema.safeParse(res?.data)
         if (!parsedRes.success) {
           return rejectNetworkError({
-            status: 404,
-            data: {},
-            dev: 'ReposQueryOpts - 404 Failed to parse schema',
-            error: parsedRes.error,
+            errorName: 'Parsing Error',
+            errorDetails: {
+              callingFn: 'ReposQueryOpts',
+              error: parsedRes.error,
+            },
           })
         }
 

--- a/src/services/repos/ReposTeamQueryOpts.test.tsx
+++ b/src/services/repos/ReposTeamQueryOpts.test.tsx
@@ -235,8 +235,8 @@ describe('ReposTeamQueryOpts', () => {
       await waitFor(() =>
         expect(result.current.error).toEqual(
           expect.objectContaining({
-            status: 404,
-            dev: 'ReposTeamQueryOpts - 404 Failed to parse schema',
+            dev: 'ReposTeamQueryOpts - Parsing Error',
+            status: 400,
           })
         )
       )

--- a/src/services/repos/ReposTeamQueryOpts.tsx
+++ b/src/services/repos/ReposTeamQueryOpts.tsx
@@ -2,7 +2,7 @@ import { infiniteQueryOptions as infiniteQueryOptionsV5 } from '@tanstack/react-
 import { z } from 'zod'
 
 import Api from 'shared/api'
-import { rejectNetworkError } from 'shared/api/helpers'
+import { rejectNetworkError } from 'shared/api/rejectNetworkError'
 import { mapEdges } from 'shared/utils/graphql'
 
 import {
@@ -145,10 +145,11 @@ function ReposTeamQueryOpts({
 
         if (!parsedRes.success) {
           return rejectNetworkError({
-            status: 404,
-            data: {},
-            dev: 'ReposTeamQueryOpts - 404 Failed to parse schema',
-            error: parsedRes.error,
+            errorName: 'Parsing Error',
+            errorDetails: {
+              callingFn: 'ReposTeamQueryOpts',
+              error: parsedRes.error,
+            },
           })
         }
 

--- a/src/services/selfHosted/SelfHostedCurrentUserQueryOpts.ts
+++ b/src/services/selfHosted/SelfHostedCurrentUserQueryOpts.ts
@@ -2,7 +2,7 @@ import { queryOptions as queryOptionsV5 } from '@tanstack/react-queryV5'
 import { z } from 'zod'
 
 import Api from 'shared/api'
-import { rejectNetworkError } from 'shared/api/helpers'
+import { rejectNetworkError } from 'shared/api/rejectNetworkError'
 
 const SelfHostedCurrentUserSchema = z
   .object({
@@ -30,10 +30,11 @@ export const SelfHostedCurrentUserQueryOpts = ({
 
         if (!parsedData.success) {
           return rejectNetworkError({
-            status: 404,
-            data: {},
-            dev: 'SelfHostedCurrentUserQueryOpts - 404 schema parsing failed',
-            error: parsedData.error,
+            errorName: 'Parsing Error',
+            errorDetails: {
+              callingFn: 'SelfHostedCurrentUserQueryOpts',
+              error: parsedData.error,
+            },
           })
         }
         return parsedData.data

--- a/src/services/selfHosted/SelfHostedHasAdminsQueryOpts.ts
+++ b/src/services/selfHosted/SelfHostedHasAdminsQueryOpts.ts
@@ -5,7 +5,7 @@ import {
 import { z } from 'zod'
 
 import Api from 'shared/api'
-import { rejectNetworkError } from 'shared/api/helpers'
+import { rejectNetworkError } from 'shared/api/rejectNetworkError'
 
 export const HasAdminsSchema = z.object({
   config: z
@@ -35,10 +35,11 @@ export const SelfHostedHasAdminsQueryOpts = ({
 
         if (!parsedRes.success) {
           return rejectNetworkError({
-            status: 404,
-            data: {},
-            dev: 'SelfHostedHasAdminsQueryOpts - 404 schema parsing failed',
-            error: parsedRes.error,
+            errorName: 'Parsing Error',
+            errorDetails: {
+              callingFn: 'SelfHostedHasAdminsQueryOpts',
+              error: parsedRes.error,
+            },
           })
         }
 

--- a/src/services/selfHosted/SelfHostedSeatsAndLicenseQueryOpts.test.tsx
+++ b/src/services/selfHosted/SelfHostedSeatsAndLicenseQueryOpts.test.tsx
@@ -107,7 +107,10 @@ describe('useSelfHostedSeatsAndLicense', () => {
 
         await waitFor(() =>
           expect(result.current.error).toEqual(
-            expect.objectContaining({ status: 404 })
+            expect.objectContaining({
+              dev: 'SelfHostedSeatsAndLicenseQueryOpts - Parsing Error',
+              status: 400,
+            })
           )
         )
       })

--- a/src/services/selfHosted/SelfHostedSeatsAndLicenseQueryOpts.ts
+++ b/src/services/selfHosted/SelfHostedSeatsAndLicenseQueryOpts.ts
@@ -2,7 +2,7 @@ import { queryOptions as queryOptionsV5 } from '@tanstack/react-queryV5'
 import { z } from 'zod'
 
 import Api from 'shared/api'
-import { rejectNetworkError } from 'shared/api/helpers'
+import { rejectNetworkError } from 'shared/api/rejectNetworkError'
 
 export const SelfHostedSeatsAndLicenseSchema = z
   .object({
@@ -49,10 +49,11 @@ export const SelfHostedSeatsAndLicenseQueryOpts = ({
 
         if (!parsedRes.success) {
           return rejectNetworkError({
-            status: 404,
-            data: {},
-            dev: `SelfHostedSeatsAndLicenseQueryOpts - 404 Failed to parse`,
-            error: parsedRes.error,
+            errorName: 'Parsing Error',
+            errorDetails: {
+              callingFn: 'SelfHostedSeatsAndLicenseQueryOpts',
+              error: parsedRes.error,
+            },
           })
         }
 

--- a/src/services/selfHosted/SelfHostedSeatsConfigQueryOpts.ts
+++ b/src/services/selfHosted/SelfHostedSeatsConfigQueryOpts.ts
@@ -2,7 +2,7 @@ import { queryOptions as queryOptionsV5 } from '@tanstack/react-queryV5'
 import { z } from 'zod'
 
 import Api from 'shared/api'
-import { rejectNetworkError } from 'shared/api/helpers'
+import { rejectNetworkError } from 'shared/api/rejectNetworkError'
 
 export const SeatsSchema = z
   .object({
@@ -38,10 +38,11 @@ export const SelfHostedSeatsConfigQueryOpts = ({
 
         if (!parsedRes.success) {
           return rejectNetworkError({
-            status: 404,
-            data: {},
-            dev: 'SelfHostedSeatsConfigQueryOpts - 404 schema parsing failed',
-            error: parsedRes.error,
+            errorName: 'Parsing Error',
+            errorDetails: {
+              callingFn: 'SelfHostedSeatsConfigQueryOpts',
+              error: parsedRes.error,
+            },
           })
         }
 

--- a/src/services/selfHosted/SelfHostedSettingsQueryOpts.test.tsx
+++ b/src/services/selfHosted/SelfHostedSettingsQueryOpts.test.tsx
@@ -93,8 +93,8 @@ describe('useSelfHostedSettings', () => {
       await waitFor(() =>
         expect(result.current.error).toEqual(
           expect.objectContaining({
-            status: 404,
-            dev: 'SelfHostedSettingsQueryOpts - 404 schema parsing failed',
+            dev: 'SelfHostedSettingsQueryOpts - Parsing Error',
+            status: 400,
           })
         )
       )

--- a/src/services/selfHosted/SelfHostedSettingsQueryOpts.tsx
+++ b/src/services/selfHosted/SelfHostedSettingsQueryOpts.tsx
@@ -2,7 +2,7 @@ import { queryOptions as queryOptionsV5 } from '@tanstack/react-queryV5'
 import { z } from 'zod'
 
 import Api from 'shared/api'
-import { rejectNetworkError } from 'shared/api/helpers'
+import { rejectNetworkError } from 'shared/api/rejectNetworkError'
 
 const RequestSchema = z.object({
   config: z.object({
@@ -42,10 +42,11 @@ export const SelfHostedSettingsQueryOpts = ({
 
         if (!parsedData.success) {
           return rejectNetworkError({
-            status: 404,
-            data: {},
-            dev: 'SelfHostedSettingsQueryOpts - 404 schema parsing failed',
-            error: parsedData.error,
+            errorName: 'Parsing Error',
+            errorDetails: {
+              callingFn: 'SelfHostedSettingsQueryOpts',
+              error: parsedData.error,
+            },
           })
         }
 

--- a/src/services/selfHosted/SelfHostedUserListQueryOpts.test.tsx
+++ b/src/services/selfHosted/SelfHostedUserListQueryOpts.test.tsx
@@ -266,8 +266,8 @@ describe('useSelfHostedUserList', () => {
       await waitFor(() =>
         expect(result.current.error).toEqual(
           expect.objectContaining({
-            status: 404,
-            dev: 'SelfHostedUserListQueryOpts - 404 schema parsing failed',
+            dev: 'SelfHostedUserListQueryOpts - Parsing Error',
+            status: 400,
           })
         )
       )

--- a/src/services/selfHosted/SelfHostedUserListQueryOpts.ts
+++ b/src/services/selfHosted/SelfHostedUserListQueryOpts.ts
@@ -2,7 +2,7 @@ import { infiniteQueryOptions as infiniteQueryOptionsV5 } from '@tanstack/react-
 import { z } from 'zod'
 
 import Api from 'shared/api'
-import { rejectNetworkError } from 'shared/api/helpers'
+import { rejectNetworkError } from 'shared/api/rejectNetworkError'
 
 const OwnerSchema = z.object({
   ownerid: z.number(),
@@ -51,10 +51,11 @@ export const SelfHostedUserListQueryOpts = ({
 
         if (!parsedData.success) {
           return rejectNetworkError({
-            status: 404,
-            data: {},
-            dev: 'SelfHostedUserListQueryOpts - 404 schema parsing failed',
-            error: parsedData.error,
+            errorName: 'Parsing Error',
+            errorDetails: {
+              callingFn: 'SelfHostedUserListQueryOpts',
+              error: parsedData.error,
+            },
           })
         }
 

--- a/src/services/user/useOwner.ts
+++ b/src/services/user/useOwner.ts
@@ -3,7 +3,8 @@ import { useParams } from 'react-router-dom'
 import { z } from 'zod'
 
 import Api from 'shared/api'
-import { Provider, rejectNetworkError } from 'shared/api/helpers'
+import { Provider } from 'shared/api/helpers'
+import { rejectNetworkError } from 'shared/api/rejectNetworkError'
 
 const OwnerSchema = z.object({
   ownerid: z.number().nullish(),
@@ -66,10 +67,11 @@ export function useOwner({
 
         if (!parsedRes.success) {
           return rejectNetworkError({
-            status: 404,
-            data: {},
-            dev: 'useOwner - 404 Failed to parse data',
-            error: parsedRes.error,
+            errorName: 'Parsing Error',
+            errorDetails: {
+              callingFn: 'useOwner',
+              error: parsedRes.error,
+            },
           })
         }
 

--- a/src/services/user/useUpdateProfile.ts
+++ b/src/services/user/useUpdateProfile.ts
@@ -4,7 +4,7 @@ import { z } from 'zod'
 import config from 'config'
 
 import Api from 'shared/api'
-import { NetworkErrorObject, rejectNetworkError } from 'shared/api/helpers'
+import { rejectNetworkError } from 'shared/api/rejectNetworkError'
 
 import { GoalsSchema, TypeProjectsSchema } from './useUser'
 
@@ -135,10 +135,12 @@ export function useUpdateProfile({ provider }: { provider: string }) {
         const parsedData = UpdateProfileResponseSchema.safeParse(res.data)
         if (!parsedData.success) {
           return rejectNetworkError({
-            status: 404,
-            data: {},
-            dev: 'useUpdateProfile - 404 failed to parse',
-          } satisfies NetworkErrorObject)
+            errorName: 'Parsing Error',
+            errorDetails: {
+              callingFn: 'useUpdateProfile',
+              error: parsedData.error,
+            },
+          })
         }
         return parsedData.data.updateProfile?.me
       })

--- a/src/shared/api/helpers.test.ts
+++ b/src/shared/api/helpers.test.ts
@@ -2,32 +2,7 @@ import Cookie from 'js-cookie'
 
 import config from 'config'
 
-import { generatePath, getHeaders, rejectNetworkError } from './helpers'
-
-const mocks = vi.hoisted(() => ({
-  withScope: vi.fn(),
-  addBreadcrumb: vi.fn(),
-  captureMessage: vi.fn(),
-  setFingerprint: vi.fn(),
-}))
-
-vi.mock('@sentry/react', async () => {
-  const actual = await vi.importActual('@sentry/react')
-  return {
-    ...actual,
-    withScope: mocks.withScope.mockImplementation((fn) =>
-      fn({
-        addBreadcrumb: mocks.addBreadcrumb,
-        setFingerprint: mocks.setFingerprint,
-        captureMessage: mocks.captureMessage,
-      })
-    ),
-  }
-})
-
-afterEach(() => {
-  vi.clearAllMocks()
-})
+import { generatePath, getHeaders } from './helpers'
 
 describe('generatePath', () => {
   it('generates a path without a query', () => {
@@ -99,64 +74,6 @@ describe('getHeaders', () => {
     expect(getHeaders(undefined)).toStrictEqual({
       Accept: 'application/json',
       'Content-Type': 'application/json; charset=utf-8',
-    })
-  })
-})
-
-describe('rejectNetworkError', () => {
-  describe('when the error has a dev message and error', () => {
-    it('adds a breadcrumb', () => {
-      rejectNetworkError({
-        status: 404,
-        data: {},
-        dev: 'useCoolHook - 404 not found',
-        error: Error('not found'),
-      }).catch((_e) => {})
-
-      expect(mocks.addBreadcrumb).toHaveBeenCalledWith({
-        category: 'network.error',
-        level: 'error',
-        message: 'useCoolHook - 404 not found',
-        data: Error('not found'),
-      })
-    })
-
-    it('sets the fingerprint', () => {
-      rejectNetworkError({
-        status: 404,
-        data: {},
-        dev: 'useCoolHook - 404 not found',
-        error: Error('not found'),
-      }).catch((_e) => {})
-
-      expect(mocks.setFingerprint).toHaveBeenCalledWith([
-        'useCoolHook - 404 not found',
-      ])
-    })
-
-    it('captures the error with Sentry', () => {
-      rejectNetworkError({
-        status: 404,
-        data: {},
-        dev: 'useCoolHook - 404 not found',
-        error: Error('not found'),
-      }).catch((_e) => {})
-
-      expect(mocks.captureMessage).toHaveBeenCalledWith('Network Error')
-    })
-  })
-
-  describe('when the error does not have an error', () => {
-    it('does not call any Sentry methods', () => {
-      rejectNetworkError({
-        status: 404,
-        data: {},
-        dev: 'useCoolHook - 404 not found',
-      }).catch((_e) => {})
-
-      expect(mocks.addBreadcrumb).not.toHaveBeenCalled()
-      expect(mocks.setFingerprint).not.toHaveBeenCalled()
-      expect(mocks.captureMessage).not.toHaveBeenCalled()
     })
   })
 })

--- a/src/shared/api/helpers.ts
+++ b/src/shared/api/helpers.ts
@@ -1,5 +1,4 @@
 /* eslint-disable camelcase */
-import * as Sentry from '@sentry/react'
 import qs from 'qs'
 
 import config from 'config'
@@ -13,29 +12,6 @@ export interface NetworkErrorObject {
   }
   dev: `${string} - ${number} ${string}`
   error?: Error
-}
-
-export function rejectNetworkError(error: NetworkErrorObject) {
-  // only capture network errors if they are not a rate limit error
-  // this will typically only be schema parsing errors
-  if (error.status !== 429 && error.dev && error.error) {
-    Sentry.withScope((scope) => {
-      scope.addBreadcrumb({
-        category: 'network.error',
-        level: 'error',
-        message: error.dev,
-        data: error.error,
-      })
-      scope.setFingerprint([error.dev])
-      scope.captureMessage('Network Error')
-    })
-  }
-
-  return Promise.reject({
-    status: error.status,
-    dev: error.dev,
-    data: error.data,
-  })
 }
 
 export const AllProvidersArray = [

--- a/src/shared/api/rejectNetworkError.test.ts
+++ b/src/shared/api/rejectNetworkError.test.ts
@@ -41,14 +41,14 @@ const parsingError: ParsingErrorObject = {
   errorName: 'Parsing Error',
   errorDetails: {
     error: Error('bad parsing'),
-    caller: 'TestQueryOpts',
+    callingFn: 'TestQueryOpts',
   },
 }
 
 const notFoundError: NotFoundErrorObject = {
   errorName: 'Not Found Error',
   errorDetails: {
-    caller: 'TestQueryOpts',
+    callingFn: 'TestQueryOpts',
   },
 }
 
@@ -56,7 +56,7 @@ const ownerNotActivatedError: OwnerNotActivatedErrorObject = {
   errorName: 'Owner Not Activated',
   data: { detail: 'test' },
   errorDetails: {
-    caller: 'TestQueryOpts',
+    callingFn: 'TestQueryOpts',
   },
 }
 
@@ -76,7 +76,7 @@ describe('rejectNetworkError', () => {
         expect(mocks.addBreadcrumb).toHaveBeenCalledWith({
           category: 'network.error',
           level,
-          message: `${errorObject.errorDetails.caller} - ${errorObject.errorName}`,
+          message: `${errorObject.errorDetails.callingFn} - ${errorObject.errorName}`,
           data:
             'error' in errorObject.errorDetails
               ? errorObject.errorDetails.error
@@ -88,7 +88,7 @@ describe('rejectNetworkError', () => {
         _rejectNetworkError(errorObject).catch((_e) => {})
 
         expect(mocks.setTags).toHaveBeenCalledWith({
-          caller: errorObject.errorDetails.caller,
+          callingFn: errorObject.errorDetails.callingFn,
           errorName: errorObject.errorName,
         })
       })
@@ -102,7 +102,7 @@ describe('rejectNetworkError', () => {
       it('sets the fingerprint', () => {
         _rejectNetworkError(errorObject).catch((_e) => {
           expect(mocks.setFingerprint).toHaveBeenCalledWith([
-            `${errorObject.errorDetails.caller} - ${errorObject.errorName}`,
+            `${errorObject.errorDetails.callingFn} - ${errorObject.errorName}`,
           ])
         })
       })
@@ -111,7 +111,7 @@ describe('rejectNetworkError', () => {
         _rejectNetworkError(errorObject).catch((_e) => {})
 
         expect(mocks.captureMessage).toHaveBeenCalledWith(
-          `${errorObject.errorDetails.caller} - ${errorObject.errorName}`
+          `${errorObject.errorDetails.callingFn} - ${errorObject.errorName}`
         )
       })
 
@@ -119,7 +119,7 @@ describe('rejectNetworkError', () => {
         const result = _rejectNetworkError(errorObject)
 
         expect(result).rejects.toStrictEqual({
-          dev: `${errorObject.errorDetails.caller} - ${errorObject.errorName}`,
+          dev: `${errorObject.errorDetails.callingFn} - ${errorObject.errorName}`,
           data: 'data' in errorObject ? errorObject.data : undefined,
           status,
         })

--- a/src/shared/api/rejectNetworkError.test.ts
+++ b/src/shared/api/rejectNetworkError.test.ts
@@ -1,11 +1,11 @@
 import {
-  _rejectNetworkError,
   determineSentryLevel,
   determineStatusCode,
   NetworkErrorName,
   NotFoundErrorObject,
   OwnerNotActivatedErrorObject,
   ParsingErrorObject,
+  rejectNetworkError,
 } from './rejectNetworkError'
 
 const mocks = vi.hoisted(() => ({
@@ -71,7 +71,7 @@ describe('rejectNetworkError', () => {
     'when the error is $errorObject.errorName',
     ({ errorObject, level, status }) => {
       it('adds a breadcrumb', () => {
-        _rejectNetworkError(errorObject).catch((_e) => {})
+        rejectNetworkError(errorObject).catch((_e) => {})
 
         expect(mocks.addBreadcrumb).toHaveBeenCalledWith({
           category: 'network.error',
@@ -85,7 +85,7 @@ describe('rejectNetworkError', () => {
       })
 
       it('sets the tags', () => {
-        _rejectNetworkError(errorObject).catch((_e) => {})
+        rejectNetworkError(errorObject).catch((_e) => {})
 
         expect(mocks.setTags).toHaveBeenCalledWith({
           callingFn: errorObject.errorDetails.callingFn,
@@ -94,13 +94,13 @@ describe('rejectNetworkError', () => {
       })
 
       it('sets the level', () => {
-        _rejectNetworkError(errorObject).catch((_e) => {})
+        rejectNetworkError(errorObject).catch((_e) => {})
 
         expect(mocks.setLevel).toHaveBeenCalledWith(level)
       })
 
       it('sets the fingerprint', () => {
-        _rejectNetworkError(errorObject).catch((_e) => {
+        rejectNetworkError(errorObject).catch((_e) => {
           expect(mocks.setFingerprint).toHaveBeenCalledWith([
             `${errorObject.errorDetails.callingFn} - ${errorObject.errorName}`,
           ])
@@ -108,7 +108,7 @@ describe('rejectNetworkError', () => {
       })
 
       it('captures the error with Sentry', () => {
-        _rejectNetworkError(errorObject).catch((_e) => {})
+        rejectNetworkError(errorObject).catch((_e) => {})
 
         expect(mocks.captureMessage).toHaveBeenCalledWith(
           `${errorObject.errorDetails.callingFn} - ${errorObject.errorName}`
@@ -116,7 +116,7 @@ describe('rejectNetworkError', () => {
       })
 
       it('returns a rejected promise', () => {
-        const result = _rejectNetworkError(errorObject)
+        const result = rejectNetworkError(errorObject)
 
         expect(result).rejects.toStrictEqual({
           dev: `${errorObject.errorDetails.callingFn} - ${errorObject.errorName}`,

--- a/src/shared/api/rejectNetworkError.ts
+++ b/src/shared/api/rejectNetworkError.ts
@@ -62,7 +62,7 @@ export function determineStatusCode(errorName: NetworkErrorName) {
   }
 }
 
-export function _rejectNetworkError(error: NetworkErrorObject) {
+export function rejectNetworkError(error: NetworkErrorObject) {
   const {
     errorName,
     errorDetails: { callingFn },

--- a/src/shared/api/rejectNetworkError.ts
+++ b/src/shared/api/rejectNetworkError.ts
@@ -11,18 +11,18 @@ export type NetworkErrorName =
 
 export type ParsingErrorObject = {
   errorName: ParsingError
-  errorDetails: { error: Error; caller: string }
+  errorDetails: { error: Error; callingFn: string }
 }
 
 export type NotFoundErrorObject = {
   errorName: NotFoundError
-  errorDetails: { caller: string }
+  errorDetails: { callingFn: string }
 }
 
 export type OwnerNotActivatedErrorObject = {
   errorName: OwnerNotActivatedError
   data: { detail?: React.ReactNode }
-  errorDetails: { caller: string }
+  errorDetails: { callingFn: string }
 }
 
 type NetworkErrorObject =
@@ -65,10 +65,10 @@ export function determineStatusCode(errorName: NetworkErrorName) {
 export function _rejectNetworkError(error: NetworkErrorObject) {
   const {
     errorName,
-    errorDetails: { caller },
+    errorDetails: { callingFn },
   } = error
 
-  const devMsg = `${caller} - ${errorName}`
+  const devMsg = `${callingFn} - ${errorName}`
 
   Sentry.withScope((scope) => {
     const level = determineSentryLevel(errorName)
@@ -81,7 +81,7 @@ export function _rejectNetworkError(error: NetworkErrorObject) {
     })
 
     scope.setTags({
-      caller: caller,
+      callingFn: callingFn,
       errorName: errorName,
     })
 


### PR DESCRIPTION
# Description

This PR adjusts somethings in the new `rejectNetworkError`, remove the old `rejectNetworkError` implementation, and updates all current usage of `rejectNetworkError` to the new implementation.

Ticket: codecov/engineering-team#3329

# Notable Changes

- Rename `caller` to `callingFn` in `errorDetails`
- Remove old implementation of `rejectNetworkError`
- Update usage to the new implementation of `rejectNetworkError`