### PR TITLE
feat: Add rejectNetworkError to calls (part one)

### DIFF
--- a/src/pages/AdminSettings/AdminAccess/AdminAccessTable/useAdminAccessList.test.tsx
+++ b/src/pages/AdminSettings/AdminAccess/AdminAccessTable/useAdminAccessList.test.tsx
@@ -157,7 +157,7 @@ describe('useAdminAccessList', () => {
       consoleSpy.mockRestore()
     })
 
-    it('rejects with 404', async () => {
+    it('rejects with 400', async () => {
       setup({ invalidResponse: true })
       const { result } = renderHook(() => useAdminAccessList(), {
         wrapper: wrapper(),

--- a/src/pages/AdminSettings/AdminAccess/AdminAccessTable/useAdminAccessList.test.tsx
+++ b/src/pages/AdminSettings/AdminAccess/AdminAccessTable/useAdminAccessList.test.tsx
@@ -166,8 +166,8 @@ describe('useAdminAccessList', () => {
       await waitFor(() => expect(result.current.isError).toBeTruthy())
       expect(result.current.error).toEqual(
         expect.objectContaining({
-          status: 404,
-          dev: 'useAdminAccessList - 404 schema parsing failed',
+          dev: 'useAdminAccessList - Parsing Error',
+          status: 400,
         })
       )
     })

--- a/src/pages/AdminSettings/AdminAccess/AdminAccessTable/useAdminAccessList.ts
+++ b/src/pages/AdminSettings/AdminAccess/AdminAccessTable/useAdminAccessList.ts
@@ -3,7 +3,7 @@ import { useMemo } from 'react'
 import { z } from 'zod'
 
 import Api from 'shared/api'
-import { NetworkErrorObject } from 'shared/api/helpers'
+import { rejectNetworkError } from 'shared/api/rejectNetworkError'
 
 const RequestSchema = z.object({
   count: z.number(),
@@ -23,7 +23,15 @@ const RequestSchema = z.object({
 })
 
 export const useAdminAccessList = () => {
-  const { data, ...rest } = useInfiniteQuery({
+  const {
+    data,
+    error,
+    isLoading,
+    isError,
+    isFetching,
+    hasNextPage,
+    fetchNextPage,
+  } = useInfiniteQuery({
     queryKey: ['AdminAccessList'],
     queryFn: ({ pageParam = 1, signal }) =>
       Api.get({
@@ -33,11 +41,13 @@ export const useAdminAccessList = () => {
         const parsedData = RequestSchema.safeParse(res)
 
         if (!parsedData.success) {
-          return Promise.reject({
-            status: 404,
-            data: {},
-            dev: 'useAdminAccessList - 404 schema parsing failed',
-          } satisfies NetworkErrorObject)
+          return rejectNetworkError({
+            errorName: 'Parsing Error',
+            errorDetails: {
+              callingFn: 'useAdminAccessList',
+              error: parsedData.error,
+            },
+          })
         }
         return parsedData.data
       }),
@@ -55,6 +65,11 @@ export const useAdminAccessList = () => {
       () => data?.pages.flatMap((page) => page.results) ?? [],
       [data?.pages]
     ),
-    ...rest,
+    error,
+    isLoading,
+    isError,
+    isFetching,
+    hasNextPage,
+    fetchNextPage,
   }
 }

--- a/src/pages/PullRequestPage/Header/HeaderDefault/queries/PullHeadDataQueryOpts.test.tsx
+++ b/src/pages/PullRequestPage/Header/HeaderDefault/queries/PullHeadDataQueryOpts.test.tsx
@@ -17,13 +17,8 @@ const mockPullData = {
         pullId: 1,
         title: 'Cool Pull Request',
         state: 'OPEN',
-        author: {
-          username: 'cool-user',
-        },
-        head: {
-          branchName: 'cool-branch',
-          ciPassed: true,
-        },
+        author: { username: 'cool-user' },
+        head: { branchName: 'cool-branch', ciPassed: true },
         updatestamp: '',
       },
     },
@@ -32,10 +27,7 @@ const mockPullData = {
 
 const mockNotFoundError = {
   owner: {
-    repository: {
-      __typename: 'NotFoundError',
-      message: 'commit not found',
-    },
+    repository: { __typename: 'NotFoundError', message: 'commit not found' },
   },
 }
 
@@ -209,6 +201,7 @@ describe('usePullHeadData', () => {
         await waitFor(() =>
           expect(result.current.error).toEqual(
             expect.objectContaining({
+              dev: 'PullHeadDataQueryOpts - Not Found Error',
               status: 404,
             })
           )
@@ -246,6 +239,7 @@ describe('usePullHeadData', () => {
         await waitFor(() =>
           expect(result.current.error).toEqual(
             expect.objectContaining({
+              dev: 'PullHeadDataQueryOpts - Owner Not Activated',
               status: 403,
             })
           )
@@ -283,7 +277,8 @@ describe('usePullHeadData', () => {
         await waitFor(() =>
           expect(result.current.error).toEqual(
             expect.objectContaining({
-              status: 404,
+              dev: 'PullHeadDataQueryOpts - Parsing Error',
+              status: 400,
             })
           )
         )

--- a/src/pages/PullRequestPage/Header/HeaderDefault/queries/PullHeadDataQueryOpts.test.tsx
+++ b/src/pages/PullRequestPage/Header/HeaderDefault/queries/PullHeadDataQueryOpts.test.tsx
@@ -258,7 +258,7 @@ describe('usePullHeadData', () => {
         console.error = oldConsoleError
       })
 
-      it('throws a 404', async () => {
+      it('throws a 400', async () => {
         setup({ isUnsuccessfulParseError: true })
         const { result } = renderHook(
           () =>

--- a/src/pages/PullRequestPage/Header/HeaderDefault/queries/PullHeadDataQueryOpts.tsx
+++ b/src/pages/PullRequestPage/Header/HeaderDefault/queries/PullHeadDataQueryOpts.tsx
@@ -6,6 +6,7 @@ import {
   RepoOwnerNotActivatedErrorSchema,
 } from 'services/repo'
 import Api from 'shared/api'
+import { rejectNetworkError } from 'shared/api/rejectNetworkError'
 import A from 'ui/A'
 
 const RepositorySchema = z.object({
@@ -110,24 +111,28 @@ export const PullHeadDataQueryOpts = ({
         const parsedData = PullHeadDataSchema.safeParse(res?.data)
 
         if (!parsedData.success) {
-          return Promise.reject({
-            status: 404,
-            data: {},
+          return rejectNetworkError({
+            errorName: 'Parsing Error',
+            errorDetails: {
+              callingFn: 'PullHeadDataQueryOpts',
+              error: parsedData.error,
+            },
           })
         }
 
         const data = parsedData.data
 
         if (data?.owner?.repository?.__typename === 'NotFoundError') {
-          return Promise.reject({
-            status: 404,
-            data: {},
+          return rejectNetworkError({
+            errorName: 'Not Found Error',
+            errorDetails: { callingFn: 'PullHeadDataQueryOpts' },
           })
         }
 
         if (data?.owner?.repository?.__typename === 'OwnerNotActivatedError') {
-          return Promise.reject({
-            status: 403,
+          return rejectNetworkError({
+            errorName: 'Owner Not Activated',
+            errorDetails: { callingFn: 'PullHeadDataQueryOpts' },
             data: {
               detail: (
                 <p>

--- a/src/pages/PullRequestPage/Header/HeaderTeam/queries/PullHeadDataTeamQueryOpts.test.tsx
+++ b/src/pages/PullRequestPage/Header/HeaderTeam/queries/PullHeadDataTeamQueryOpts.test.tsx
@@ -221,6 +221,7 @@ describe('usePullHeadDataTeam', () => {
         await waitFor(() =>
           expect(result.current.error).toEqual(
             expect.objectContaining({
+              dev: 'PullHeadDataTeamQueryOpts - Not Found Error',
               status: 404,
             })
           )
@@ -258,6 +259,7 @@ describe('usePullHeadDataTeam', () => {
         await waitFor(() =>
           expect(result.current.error).toEqual(
             expect.objectContaining({
+              dev: 'PullHeadDataTeamQueryOpts - Owner Not Activated',
               status: 403,
             })
           )
@@ -295,7 +297,8 @@ describe('usePullHeadDataTeam', () => {
         await waitFor(() =>
           expect(result.current.error).toEqual(
             expect.objectContaining({
-              status: 404,
+              dev: 'PullHeadDataTeamQueryOpts - Parsing Error',
+              status: 400,
             })
           )
         )

--- a/src/pages/PullRequestPage/Header/HeaderTeam/queries/PullHeadDataTeamQueryOpts.test.tsx
+++ b/src/pages/PullRequestPage/Header/HeaderTeam/queries/PullHeadDataTeamQueryOpts.test.tsx
@@ -278,7 +278,7 @@ describe('usePullHeadDataTeam', () => {
         console.error = oldConsoleError
       })
 
-      it('throws a 404', async () => {
+      it('throws a 400', async () => {
         setup({ isUnsuccessfulParseError: true })
         const { result } = renderHook(
           () =>

--- a/src/pages/PullRequestPage/Header/HeaderTeam/queries/PullHeadDataTeamQueryOpts.tsx
+++ b/src/pages/PullRequestPage/Header/HeaderTeam/queries/PullHeadDataTeamQueryOpts.tsx
@@ -12,6 +12,7 @@ import {
   RepoOwnerNotActivatedErrorSchema,
 } from 'services/repo'
 import Api from 'shared/api'
+import { rejectNetworkError } from 'shared/api/rejectNetworkError'
 import A from 'ui/A'
 
 const CoverageObjSchema = z.object({
@@ -162,24 +163,28 @@ export const PullHeadDataTeamQueryOpts = ({
         const parsedData = PullHeadDataSchema.safeParse(res?.data)
 
         if (!parsedData.success) {
-          return Promise.reject({
-            status: 404,
-            data: {},
+          return rejectNetworkError({
+            errorName: 'Parsing Error',
+            errorDetails: {
+              callingFn: 'PullHeadDataTeamQueryOpts',
+              error: parsedData.error,
+            },
           })
         }
 
         const data = parsedData.data
 
         if (data?.owner?.repository?.__typename === 'NotFoundError') {
-          return Promise.reject({
-            status: 404,
-            data: {},
+          return rejectNetworkError({
+            errorName: 'Not Found Error',
+            errorDetails: { callingFn: 'PullHeadDataTeamQueryOpts' },
           })
         }
 
         if (data?.owner?.repository?.__typename === 'OwnerNotActivatedError') {
-          return Promise.reject({
-            status: 403,
+          return rejectNetworkError({
+            errorName: 'Owner Not Activated',
+            errorDetails: { callingFn: 'PullHeadDataTeamQueryOpts' },
             data: {
               detail: (
                 <p>

--- a/src/services/access/SessionsQueryOpts.test.tsx
+++ b/src/services/access/SessionsQueryOpts.test.tsx
@@ -45,22 +45,8 @@ const sessions: { edges: { node: Session }[] } = {
 
 const tokens: { edges: { node: UserToken }[] } = {
   edges: [
-    {
-      node: {
-        lastFour: '1234',
-        type: 'api',
-        name: 'token1',
-        id: 'id-0',
-      },
-    },
-    {
-      node: {
-        lastFour: '4254',
-        type: 'api',
-        name: 'token2',
-        id: 'id-1',
-      },
-    },
+    { node: { lastFour: '1234', type: 'api', name: 'token1', id: 'id-0' } },
+    { node: { lastFour: '4254', type: 'api', name: 'token2', id: 'id-1' } },
   ],
 }
 
@@ -134,8 +120,8 @@ describe('useSessions', () => {
       await waitFor(() =>
         expect(result.current.error).toEqual(
           expect.objectContaining({
-            status: 404,
-            dev: 'useSessions - 404 schema parsing failed',
+            dev: 'SessionsQueryOpts - Parsing Error',
+            status: 400,
           })
         )
       )

--- a/src/services/access/SessionsQueryOpts.test.tsx
+++ b/src/services/access/SessionsQueryOpts.test.tsx
@@ -109,7 +109,7 @@ describe('useSessions', () => {
   }
 
   describe('when called and response parsing fails', () => {
-    it('throws a 404', async () => {
+    it('throws a 400', async () => {
       setup({ isUnsuccessfulParseError: true })
       const { result } = renderHook(
         () => useQueryV5(SessionsQueryOpts({ provider })),

--- a/src/services/access/SessionsQueryOpts.ts
+++ b/src/services/access/SessionsQueryOpts.ts
@@ -2,7 +2,7 @@ import { queryOptions as queryOptionsV5 } from '@tanstack/react-queryV5'
 import { z } from 'zod'
 
 import Api from 'shared/api'
-import { NetworkErrorObject } from 'shared/api/helpers'
+import { rejectNetworkError } from 'shared/api/rejectNetworkError'
 import { mapEdges } from 'shared/utils/graphql'
 
 const SessionSchema = z.object({
@@ -91,11 +91,13 @@ export function SessionsQueryOpts({ provider }: SessionsQueryArgs) {
         const parsedRes = RequestSchema.safeParse(res?.data)
 
         if (!parsedRes.success) {
-          return Promise.reject({
-            status: 404,
-            data: {},
-            dev: 'useSessions - 404 schema parsing failed',
-          } satisfies NetworkErrorObject)
+          return rejectNetworkError({
+            errorName: 'Parsing Error',
+            errorDetails: {
+              callingFn: 'SessionsQueryOpts',
+              error: parsedRes.error,
+            },
+          })
         }
 
         const data = parsedRes.data

--- a/src/services/account/useAccountDetails.test.tsx
+++ b/src/services/account/useAccountDetails.test.tsx
@@ -105,4 +105,26 @@ describe('useAccountDetails', () => {
       )
     })
   })
+
+  describe('when the data is not valid', () => {
+    it('returns an error', async () => {
+      // @ts-expect-error - testing parsing error
+      setup({ badData: true })
+
+      const { result } = renderHook(
+        () => useAccountDetails({ provider, owner }),
+        { wrapper: wrapper() }
+      )
+
+      await waitFor(() => expect(result.current.isError).toBeTruthy())
+      await waitFor(() =>
+        expect(result.current.error).toEqual(
+          expect.objectContaining({
+            dev: 'useAccountDetails - Parsing Error',
+            status: 400,
+          })
+        )
+      )
+    })
+  })
 })

--- a/src/services/account/useAccountDetails.test.tsx
+++ b/src/services/account/useAccountDetails.test.tsx
@@ -107,7 +107,7 @@ describe('useAccountDetails', () => {
   })
 
   describe('when the data is not valid', () => {
-    it('returns an error', async () => {
+    it('throws a 400', async () => {
       // @ts-expect-error - testing parsing error
       setup({ badData: true })
 

--- a/src/services/account/useAccountDetails.ts
+++ b/src/services/account/useAccountDetails.ts
@@ -2,7 +2,8 @@ import { useQuery } from '@tanstack/react-query'
 import { z } from 'zod'
 
 import Api from 'shared/api'
-import { NetworkErrorObject, Provider } from 'shared/api/helpers'
+import { Provider } from 'shared/api/helpers'
+import { rejectNetworkError } from 'shared/api/rejectNetworkError'
 
 const InvoiceSchema = z
   .object({
@@ -201,11 +202,13 @@ export function useAccountDetails({
         const parsedRes = AccountDetailsSchema.safeParse(res)
 
         if (!parsedRes.success) {
-          return Promise.reject({
-            status: 404,
-            data: {},
-            dev: 'useAccountDetails - 404 failed to parse',
-          } satisfies NetworkErrorObject)
+          return rejectNetworkError({
+            errorName: 'Parsing Error',
+            errorDetails: {
+              callingFn: 'useAccountDetails',
+              error: parsedRes.error,
+            },
+          })
         }
 
         return parsedRes.data

--- a/src/services/account/useAvailablePlans.test.tsx
+++ b/src/services/account/useAvailablePlans.test.tsx
@@ -214,7 +214,7 @@ describe('useAvailablePlans', () => {
         vi.restoreAllMocks()
       })
 
-      it('throws a 404', async () => {
+      it('throws a 400', async () => {
         setup({ isUnsuccessfulParseError: true })
         const { result } = renderHook(
           () =>

--- a/src/services/account/useAvailablePlans.test.tsx
+++ b/src/services/account/useAvailablePlans.test.tsx
@@ -229,7 +229,8 @@ describe('useAvailablePlans', () => {
         await waitFor(() =>
           expect(result.current.error).toEqual(
             expect.objectContaining({
-              status: 404,
+              dev: 'useAvailablePlans - Parsing Error',
+              status: 400,
             })
           )
         )

--- a/src/services/account/useAvailablePlans.ts
+++ b/src/services/account/useAvailablePlans.ts
@@ -2,6 +2,7 @@ import { useQuery } from '@tanstack/react-query'
 import { z } from 'zod'
 
 import Api from 'shared/api'
+import { rejectNetworkError } from 'shared/api/rejectNetworkError'
 import { BillingRate, Plans } from 'shared/utils/billing'
 
 const IndividualPlanSchema = z.object({
@@ -67,9 +68,12 @@ export const useAvailablePlans = ({
         const parsedRes = PlansSchema.safeParse(res?.data)
 
         if (!parsedRes.success) {
-          return Promise.reject({
-            status: 404,
-            data: null,
+          return rejectNetworkError({
+            errorName: 'Parsing Error',
+            errorDetails: {
+              callingFn: 'useAvailablePlans',
+              error: parsedRes.error,
+            },
           })
         }
 

--- a/src/services/account/useInvoice.test.tsx
+++ b/src/services/account/useInvoice.test.tsx
@@ -75,7 +75,7 @@ describe('useInvoice', () => {
         vi.restoreAllMocks()
       })
 
-      it('fails to parse if bad data', async () => {
+      it('throws a 400', async () => {
         setup(true)
         const { result } = renderHook(
           () => useInvoice({ provider, owner, id: 'blah' }),

--- a/src/services/account/useInvoice.test.tsx
+++ b/src/services/account/useInvoice.test.tsx
@@ -83,6 +83,14 @@ describe('useInvoice', () => {
         )
 
         await waitFor(() => expect(result.current.error).toBeTruthy())
+        await waitFor(() =>
+          expect(result.current.error).toEqual(
+            expect.objectContaining({
+              dev: 'useInvoice - Parsing Error',
+              status: 400,
+            })
+          )
+        )
       })
     })
   })

--- a/src/services/account/useInvoice.ts
+++ b/src/services/account/useInvoice.ts
@@ -2,7 +2,7 @@ import { useQuery } from '@tanstack/react-query'
 import { z } from 'zod'
 
 import Api from 'shared/api'
-import { NetworkErrorObject } from 'shared/api/helpers'
+import { rejectNetworkError } from 'shared/api/rejectNetworkError'
 
 import { InvoiceSchema } from './useInvoices'
 
@@ -90,11 +90,13 @@ export const useInvoice = ({ provider, owner, id }: UseInvoiceArgs) =>
         const parsedData = OwnerInvoiceSchema.safeParse(res?.data)
 
         if (!parsedData.success) {
-          return Promise.reject({
-            status: 404,
-            data: {},
-            dev: 'useInvoice - 404 failed to parse',
-          } satisfies NetworkErrorObject)
+          return rejectNetworkError({
+            errorName: 'Parsing Error',
+            errorDetails: {
+              callingFn: 'useInvoice',
+              error: parsedData.error,
+            },
+          })
         }
 
         return parsedData.data.owner?.invoice ?? null

--- a/src/services/account/useInvoices.test.tsx
+++ b/src/services/account/useInvoices.test.tsx
@@ -86,6 +86,14 @@ describe('useInvoices', () => {
         })
 
         await waitFor(() => expect(result.current.error).toBeTruthy())
+        await waitFor(() =>
+          expect(result.current.error).toEqual(
+            expect.objectContaining({
+              dev: 'useInvoices - Parsing Error',
+              status: 400,
+            })
+          )
+        )
       })
     })
   })

--- a/src/services/account/useInvoices.test.tsx
+++ b/src/services/account/useInvoices.test.tsx
@@ -79,7 +79,7 @@ describe('useInvoices', () => {
         vi.restoreAllMocks()
       })
 
-      it('fails to parse if bad data', async () => {
+      it('throws a 400', async () => {
         setup(true)
         const { result } = renderHook(() => useInvoices({ provider, owner }), {
           wrapper: wrapper(),

--- a/src/services/account/useInvoices.ts
+++ b/src/services/account/useInvoices.ts
@@ -2,7 +2,7 @@ import { useQuery } from '@tanstack/react-query'
 import { z } from 'zod'
 
 import Api from 'shared/api'
-import { NetworkErrorObject } from 'shared/api/helpers'
+import { rejectNetworkError } from 'shared/api/rejectNetworkError'
 
 const DefaultPaymentMethodSchema = z
   .object({
@@ -140,11 +140,13 @@ export const useInvoices = ({ provider, owner }: UseInvoicesArgs) =>
         const parsedData = OwnerInvoiceSchema.safeParse(res?.data)
 
         if (!parsedData.success) {
-          return Promise.reject({
-            status: 404,
-            data: {},
-            dev: 'useInvoices - 404 failed to parse',
-          } satisfies NetworkErrorObject)
+          return rejectNetworkError({
+            errorName: 'Parsing Error',
+            errorDetails: {
+              callingFn: 'useInvoices',
+              error: parsedData.error,
+            },
+          })
         }
 
         return parsedData.data.owner?.invoices ?? []

--- a/src/services/account/usePlanData.test.tsx
+++ b/src/services/account/usePlanData.test.tsx
@@ -147,4 +147,28 @@ describe('usePlanData', () => {
       })
     })
   })
+
+  describe('when the data is not valid', () => {
+    it('returns an error', async () => {
+      setup({ trialData: { hasPrivateRepos: 'string' } })
+      const { result } = renderHook(
+        () =>
+          usePlanData({
+            provider: 'gh',
+            owner: 'codecov',
+          }),
+        { wrapper }
+      )
+
+      await waitFor(() => expect(result.current.isError).toBeTruthy())
+      await waitFor(() =>
+        expect(result.current.error).toEqual(
+          expect.objectContaining({
+            dev: 'usePlanData - Parsing Error',
+            status: 400,
+          })
+        )
+      )
+    })
+  })
 })

--- a/src/services/account/usePlanData.test.tsx
+++ b/src/services/account/usePlanData.test.tsx
@@ -149,7 +149,7 @@ describe('usePlanData', () => {
   })
 
   describe('when the data is not valid', () => {
-    it('returns an error', async () => {
+    it('throws a 400', async () => {
       setup({ trialData: { hasPrivateRepos: 'string' } })
       const { result } = renderHook(
         () =>

--- a/src/services/account/usePlanData.ts
+++ b/src/services/account/usePlanData.ts
@@ -2,6 +2,7 @@ import { useQuery } from '@tanstack/react-query'
 import { z } from 'zod'
 
 import Api from 'shared/api'
+import { rejectNetworkError } from 'shared/api/rejectNetworkError'
 import { BillingRate, Plans } from 'shared/utils/billing'
 
 export const TrialStatuses = {
@@ -118,10 +119,14 @@ export const usePlanData = ({ provider, owner, opts }: UsePlanDataArgs) =>
         },
       }).then((res) => {
         const parsedRes = PlanDataSchema.safeParse(res?.data)
+
         if (!parsedRes.success) {
-          return Promise.reject({
-            status: 404,
-            data: null,
+          return rejectNetworkError({
+            errorName: 'Parsing Error',
+            errorDetails: {
+              callingFn: 'usePlanData',
+              error: parsedRes.error,
+            },
           })
         }
 

--- a/src/services/ats/useRepoATS.test.tsx
+++ b/src/services/ats/useRepoATS.test.tsx
@@ -172,6 +172,7 @@ describe('RepoATSInfo', () => {
         await waitFor(() =>
           expect(result.current.error).toEqual(
             expect.objectContaining({
+              dev: 'useRepoATS - Not Found Error',
               status: 404,
             })
           )
@@ -207,6 +208,7 @@ describe('RepoATSInfo', () => {
         await waitFor(() =>
           expect(result.current.error).toEqual(
             expect.objectContaining({
+              dev: 'useRepoATS - Owner Not Activated',
               status: 403,
             })
           )
@@ -242,7 +244,8 @@ describe('RepoATSInfo', () => {
         await waitFor(() =>
           expect(result.current.error).toEqual(
             expect.objectContaining({
-              status: 404,
+              dev: 'useRepoATS - Parsing Error',
+              status: 400,
             })
           )
         )

--- a/src/services/ats/useRepoATS.test.tsx
+++ b/src/services/ats/useRepoATS.test.tsx
@@ -227,7 +227,7 @@ describe('RepoATSInfo', () => {
         console.error = oldConsoleError
       })
 
-      it('throws an error', async () => {
+      it('throws a 400', async () => {
         setup({ isUnsuccessfulParseError: true })
 
         const { result } = renderHook(

--- a/src/services/ats/useRepoATS.tsx
+++ b/src/services/ats/useRepoATS.tsx
@@ -6,6 +6,7 @@ import {
   RepoOwnerNotActivatedErrorSchema,
 } from 'services/repo'
 import Api from 'shared/api'
+import { rejectNetworkError } from 'shared/api/rejectNetworkError'
 import A from 'ui/A'
 
 const RepositorySchema = z.object({
@@ -73,24 +74,30 @@ export const useRepoATS = ({ provider, owner, repo }: RepoATSInfoArgs) =>
         const parsedData = GetRepoATSDataSchema.safeParse(res?.data)
 
         if (!parsedData.success) {
-          return Promise.reject({
-            status: 404,
-            data: {},
+          return rejectNetworkError({
+            errorName: 'Parsing Error',
+            errorDetails: {
+              callingFn: 'useRepoATS',
+              error: parsedData.error,
+            },
           })
         }
 
         const { data } = parsedData
 
         if (data?.owner?.repository?.__typename === 'NotFoundError') {
-          return Promise.reject({
-            status: 404,
-            data: {},
+          return rejectNetworkError({
+            errorName: 'Not Found Error',
+            errorDetails: {
+              callingFn: 'useRepoATS',
+            },
           })
         }
 
         if (data?.owner?.repository?.__typename === 'OwnerNotActivatedError') {
-          return Promise.reject({
-            status: 403,
+          return rejectNetworkError({
+            errorName: 'Owner Not Activated',
+            errorDetails: { callingFn: 'useRepoATS' },
             data: {
               detail: (
                 <p>

--- a/src/services/branches/useBranch.test.tsx
+++ b/src/services/branches/useBranch.test.tsx
@@ -172,8 +172,8 @@ describe('useBranch', () => {
         await waitFor(() =>
           expect(result.current.error).toEqual(
             expect.objectContaining({
+              dev: 'useBranch - Not Found Error',
               status: 404,
-              dev: 'useBranch - 404 NotFoundError',
             })
           )
         )
@@ -208,8 +208,8 @@ describe('useBranch', () => {
         await waitFor(() =>
           expect(result.current.error).toEqual(
             expect.objectContaining({
+              dev: 'useBranch - Owner Not Activated',
               status: 403,
-              dev: 'useBranch - 403 OwnerNotActivatedError',
             })
           )
         )
@@ -244,8 +244,8 @@ describe('useBranch', () => {
         await waitFor(() =>
           expect(result.current.error).toEqual(
             expect.objectContaining({
-              status: 404,
-              dev: 'useBranch - 404 schema parsing failed',
+              dev: 'useBranch - Parsing Error',
+              status: 400,
             })
           )
         )

--- a/src/services/branches/useBranch.test.tsx
+++ b/src/services/branches/useBranch.test.tsx
@@ -227,7 +227,7 @@ describe('useBranch', () => {
         consoleSpy.mockRestore()
       })
 
-      it('throws a 404', async () => {
+      it('throws a 400', async () => {
         setup({ isUnsuccessfulParseError: true })
         const { result } = renderHook(
           () =>

--- a/src/services/branches/useBranchComponents.test.tsx
+++ b/src/services/branches/useBranchComponents.test.tsx
@@ -16,14 +16,8 @@ const mockBranchComponents = {
           commitid: 'commit-123',
           coverageAnalytics: {
             components: [
-              {
-                id: 'compOneId',
-                name: 'compOneName',
-              },
-              {
-                id: 'compTwoId',
-                name: 'compTwoName',
-              },
+              { id: 'compOneId', name: 'compOneName' },
+              { id: 'compTwoId', name: 'compTwoName' },
             ],
           },
         },
@@ -41,12 +35,7 @@ const mockBranchComponentsFiltered = {
         head: {
           commitid: 'commit-123',
           coverageAnalytics: {
-            components: [
-              {
-                id: 'compOneId',
-                name: 'compOneName',
-              },
-            ],
+            components: [{ id: 'compOneId', name: 'compOneName' }],
           },
         },
       },
@@ -159,14 +148,8 @@ describe('useBranchComponents', () => {
                 head: {
                   coverageAnalytics: {
                     components: [
-                      {
-                        id: 'compOneId',
-                        name: 'compOneName',
-                      },
-                      {
-                        id: 'compTwoId',
-                        name: 'compTwoName',
-                      },
+                      { id: 'compOneId', name: 'compOneName' },
+                      { id: 'compTwoId', name: 'compTwoName' },
                     ],
                   },
                 },
@@ -194,12 +177,7 @@ describe('useBranchComponents', () => {
               branch: {
                 head: {
                   coverageAnalytics: {
-                    components: [
-                      {
-                        id: 'compOneId',
-                        name: 'compOneName',
-                      },
-                    ],
+                    components: [{ id: 'compOneId', name: 'compOneName' }],
                   },
                 },
               },
@@ -259,6 +237,7 @@ describe('useBranchComponents', () => {
         await waitFor(() =>
           expect(result.current.error).toEqual(
             expect.objectContaining({
+              dev: 'useBranchComponents - Not Found Error',
               status: 404,
             })
           )
@@ -294,6 +273,7 @@ describe('useBranchComponents', () => {
         await waitFor(() =>
           expect(result.current.error).toEqual(
             expect.objectContaining({
+              dev: 'useBranchComponents - Owner Not Activated',
               status: 403,
             })
           )
@@ -329,7 +309,8 @@ describe('useBranchComponents', () => {
         await waitFor(() =>
           expect(result.current.error).toEqual(
             expect.objectContaining({
-              status: 404,
+              dev: 'useBranchComponents - Parsing Error',
+              status: 400,
             })
           )
         )

--- a/src/services/branches/useBranchComponents.test.tsx
+++ b/src/services/branches/useBranchComponents.test.tsx
@@ -292,7 +292,7 @@ describe('useBranchComponents', () => {
         consoleSpy.mockRestore()
       })
 
-      it('throws a 404', async () => {
+      it('throws a 400', async () => {
         setup({ isUnsuccessfulParseError: true })
         const { result } = renderHook(
           () =>

--- a/src/services/branches/useBranchComponents.tsx
+++ b/src/services/branches/useBranchComponents.tsx
@@ -6,6 +6,7 @@ import {
   RepoOwnerNotActivatedErrorSchema,
 } from 'services/repo'
 import Api from 'shared/api'
+import { rejectNetworkError } from 'shared/api/rejectNetworkError'
 import A from 'ui/A'
 
 const BranchComponentsSchema = z
@@ -117,24 +118,32 @@ export const useBranchComponents = ({
         const parsedData = GetBranchComponentsSchema.safeParse(res?.data)
 
         if (!parsedData.success) {
-          return Promise.reject({
-            status: 404,
-            data: {},
+          return rejectNetworkError({
+            errorName: 'Parsing Error',
+            errorDetails: {
+              callingFn: 'useBranchComponents',
+              error: parsedData.error,
+            },
           })
         }
 
         const data = parsedData.data
 
         if (data?.owner?.repository?.__typename === 'NotFoundError') {
-          return Promise.reject({
-            status: 404,
-            data: {},
+          return rejectNetworkError({
+            errorName: 'Not Found Error',
+            errorDetails: {
+              callingFn: 'useBranchComponents',
+            },
           })
         }
 
         if (data?.owner?.repository?.__typename === 'OwnerNotActivatedError') {
-          return Promise.reject({
-            status: 403,
+          return rejectNetworkError({
+            errorName: 'Owner Not Activated',
+            errorDetails: {
+              callingFn: 'useBranchComponents',
+            },
             data: {
               detail: (
                 <p>

--- a/src/services/branches/useBranchHasCommits.test.tsx
+++ b/src/services/branches/useBranchHasCommits.test.tsx
@@ -12,13 +12,7 @@ const mockBranchHasCommits = {
     repository: {
       __typename: 'Repository',
       commits: {
-        edges: [
-          {
-            node: {
-              commitid: 'commit-123',
-            },
-          },
-        ],
+        edges: [{ node: { commitid: 'commit-123' } }],
       },
     },
   },
@@ -28,9 +22,7 @@ const mockBranchHasNoCommits = {
   owner: {
     repository: {
       __typename: 'Repository',
-      commits: {
-        edges: [],
-      },
+      commits: { edges: [] },
     },
   },
 }
@@ -248,6 +240,7 @@ describe('useBranchHasCommits', () => {
         await waitFor(() =>
           expect(result.current.error).toEqual(
             expect.objectContaining({
+              dev: 'useBranchHasCommits - Not Found Error',
               status: 404,
             })
           )
@@ -283,6 +276,7 @@ describe('useBranchHasCommits', () => {
         await waitFor(() =>
           expect(result.current.error).toEqual(
             expect.objectContaining({
+              dev: 'useBranchHasCommits - Owner Not Activated',
               status: 403,
             })
           )
@@ -318,7 +312,8 @@ describe('useBranchHasCommits', () => {
         await waitFor(() =>
           expect(result.current.error).toEqual(
             expect.objectContaining({
-              status: 404,
+              dev: 'useBranchHasCommits - Parsing Error',
+              status: 400,
             })
           )
         )

--- a/src/services/branches/useBranchHasCommits.tsx
+++ b/src/services/branches/useBranchHasCommits.tsx
@@ -7,6 +7,7 @@ import {
   RepoOwnerNotActivatedErrorSchema,
 } from 'services/repo'
 import Api from 'shared/api'
+import { rejectNetworkError } from 'shared/api/rejectNetworkError'
 import A from 'ui/A'
 
 const CommitSchema = z.object({
@@ -98,24 +99,32 @@ export const useBranchHasCommits = ({
         const parsedData = GetBranchCommitsSchema.safeParse(res.data)
 
         if (!parsedData.success) {
-          return Promise.reject({
-            status: 404,
-            data: {},
+          return rejectNetworkError({
+            errorName: 'Parsing Error',
+            errorDetails: {
+              callingFn: 'useBranchHasCommits',
+              error: parsedData.error,
+            },
           })
         }
 
         const data = parsedData.data
 
         if (data?.owner?.repository?.__typename === 'NotFoundError') {
-          return Promise.reject({
-            status: 404,
-            data: {},
+          return rejectNetworkError({
+            errorName: 'Not Found Error',
+            errorDetails: {
+              callingFn: 'useBranchHasCommits',
+            },
           })
         }
 
         if (data?.owner?.repository?.__typename === 'OwnerNotActivatedError') {
-          return Promise.reject({
-            status: 403,
+          return rejectNetworkError({
+            errorName: 'Owner Not Activated',
+            errorDetails: {
+              callingFn: 'useBranchHasCommits',
+            },
             data: {
               detail: (
                 <p>

--- a/src/services/branches/useBranches.test.tsx
+++ b/src/services/branches/useBranches.test.tsx
@@ -106,16 +106,8 @@ describe('GetBranches', () => {
             repository: {
               __typename: 'Repository',
               branches: {
-                edges: [
-                  {
-                    node: branchData,
-                  },
-                  null,
-                ],
-                pageInfo: {
-                  hasNextPage,
-                  endCursor,
-                },
+                edges: [{ node: branchData }, null],
+                pageInfo: { hasNextPage, endCursor },
               },
             },
           },
@@ -138,14 +130,7 @@ describe('GetBranches', () => {
           await waitFor(() => expect(result.current.isSuccess).toBe(true))
 
           const expectedResponse = {
-            branches: [
-              {
-                name: 'branch1',
-                head: {
-                  commitid: '1',
-                },
-              },
-            ],
+            branches: [{ name: 'branch1', head: { commitid: '1' } }],
           }
 
           await waitFor(() =>
@@ -170,18 +155,8 @@ describe('GetBranches', () => {
 
           const expectedData = {
             branches: [
-              {
-                name: 'branch1',
-                head: {
-                  commitid: '1',
-                },
-              },
-              {
-                name: 'branch2',
-                head: {
-                  commitid: '2',
-                },
-              },
+              { name: 'branch1', head: { commitid: '1' } },
+              { name: 'branch2', head: { commitid: '2' } },
             ],
           }
 
@@ -237,8 +212,8 @@ describe('GetBranches', () => {
       await waitFor(() =>
         expect(result.current.error).toEqual(
           expect.objectContaining({
+            dev: 'useBranches - Not Found Error',
             status: 404,
-            dev: 'useBranches - 404 NotFoundError',
           })
         )
       )
@@ -267,8 +242,8 @@ describe('GetBranches', () => {
       await waitFor(() =>
         expect(result.current.error).toEqual(
           expect.objectContaining({
+            dev: 'useBranches - Owner Not Activated',
             status: 403,
-            dev: 'useBranches - 403 OwnerNotActivatedError',
           })
         )
       )
@@ -297,8 +272,8 @@ describe('GetBranches', () => {
       await waitFor(() =>
         expect(result.current.error).toEqual(
           expect.objectContaining({
-            status: 404,
-            dev: 'useBranches - 404 schema parsing failed',
+            dev: 'useBranches - Parsing Error',
+            status: 400,
           })
         )
       )

--- a/src/services/codecovAI/useCodecovAIInstallation.test.tsx
+++ b/src/services/codecovAI/useCodecovAIInstallation.test.tsx
@@ -86,7 +86,7 @@ describe('useCodecovAIInstallation', () => {
       console.error = oldConsoleError
     })
 
-    it('throws a 404', async () => {
+    it('throws a 400', async () => {
       setup({ isUnsuccessfulParseError: true })
       const { result } = renderHook(
         () =>

--- a/src/services/codecovAI/useCodecovAIInstallation.test.tsx
+++ b/src/services/codecovAI/useCodecovAIInstallation.test.tsx
@@ -101,7 +101,8 @@ describe('useCodecovAIInstallation', () => {
       await waitFor(() =>
         expect(result.current.error).toEqual(
           expect.objectContaining({
-            status: 404,
+            dev: 'useCodecovAIInstallation - Parsing Error',
+            status: 400,
           })
         )
       )

--- a/src/services/codecovAI/useCodecovAIInstallation.tsx
+++ b/src/services/codecovAI/useCodecovAIInstallation.tsx
@@ -2,7 +2,7 @@ import { useQuery } from '@tanstack/react-query'
 import z from 'zod'
 
 import Api from 'shared/api'
-import { NetworkErrorObject } from 'shared/api/helpers'
+import { rejectNetworkError } from 'shared/api/rejectNetworkError'
 
 const ResponseSchema = z.object({
   owner: z
@@ -42,11 +42,13 @@ export function useCodecovAIInstallation({
       }).then((res) => {
         const parsedRes = ResponseSchema.safeParse(res?.data)
         if (!parsedRes.success) {
-          return Promise.reject({
-            status: 404,
-            data: {},
-            dev: 'useCodecovAIInstallation - 404 failed to parse',
-          } satisfies NetworkErrorObject)
+          return rejectNetworkError({
+            errorName: 'Parsing Error',
+            errorDetails: {
+              callingFn: 'useCodecovAIInstallation',
+              error: parsedRes.error,
+            },
+          })
         }
 
         return {

--- a/src/services/codecovAI/useCodecovAIInstalledRepos.test.tsx
+++ b/src/services/codecovAI/useCodecovAIInstalledRepos.test.tsx
@@ -86,7 +86,7 @@ describe('useCodecovAIInstalledRepos', () => {
       console.error = oldConsoleError
     })
 
-    it('throws a 404', async () => {
+    it('throws a 400', async () => {
       setup({ isUnsuccessfulParseError: true })
       const { result } = renderHook(
         () =>
@@ -101,7 +101,8 @@ describe('useCodecovAIInstalledRepos', () => {
       await waitFor(() =>
         expect(result.current.error).toEqual(
           expect.objectContaining({
-            status: 404,
+            dev: 'useCodecovAIInstalledRepos - Parsing Error',
+            status: 400,
           })
         )
       )

--- a/src/services/codecovAI/useCodecovAIInstalledRepos.tsx
+++ b/src/services/codecovAI/useCodecovAIInstalledRepos.tsx
@@ -2,7 +2,7 @@ import { useQuery } from '@tanstack/react-query'
 import z from 'zod'
 
 import Api from 'shared/api'
-import { NetworkErrorObject } from 'shared/api/helpers'
+import { rejectNetworkError } from 'shared/api/rejectNetworkError'
 
 const ResponseSchema = z.object({
   owner: z
@@ -43,11 +43,13 @@ export function useCodecovAIInstalledRepos({
         const parsedRes = ResponseSchema.safeParse(res?.data)
 
         if (!parsedRes.success) {
-          return Promise.reject({
-            status: 404,
-            data: {},
-            dev: 'useCodecovAIInstalledRepos - 404 failed to parse',
-          } satisfies NetworkErrorObject)
+          return rejectNetworkError({
+            errorName: 'Parsing Error',
+            errorDetails: {
+              callingFn: 'useCodecovAIInstalledRepos',
+              error: parsedRes.error,
+            },
+          })
         }
 
         return {

--- a/src/services/commit/useCommitBADropdownSummary.test.tsx
+++ b/src/services/commit/useCommitBADropdownSummary.test.tsx
@@ -13,14 +13,7 @@ const mockCommitBASummaryData = {
         bundleAnalysis: {
           bundleAnalysisCompareWithParent: {
             __typename: 'BundleAnalysisComparison',
-            bundleChange: {
-              loadTime: {
-                threeG: 2,
-              },
-              size: {
-                uncompress: 1,
-              },
-            },
+            bundleChange: { loadTime: { threeG: 2 }, size: { uncompress: 1 } },
           },
         },
       },
@@ -54,11 +47,7 @@ const mockOwnerNotActivatedError = {
 
 const server = setupServer()
 const queryClient = new QueryClient({
-  defaultOptions: {
-    queries: {
-      retry: false,
-    },
-  },
+  defaultOptions: { queries: { retry: false } },
 })
 
 const wrapper: React.FC<React.PropsWithChildren> = ({ children }) => (
@@ -129,12 +118,8 @@ describe('useCommitBADropdownSummary', () => {
             bundleAnalysisCompareWithParent: {
               __typename: 'BundleAnalysisComparison',
               bundleChange: {
-                loadTime: {
-                  threeG: 2,
-                },
-                size: {
-                  uncompress: 1,
-                },
+                loadTime: { threeG: 2 },
+                size: { uncompress: 1 },
               },
             },
           },
@@ -178,7 +163,7 @@ describe('useCommitBADropdownSummary', () => {
       console.error = oldConsoleError
     })
 
-    it('throws a 404', async () => {
+    it('throws a 400', async () => {
       setup({ isUnsuccessfulParseError: true })
       const { result } = renderHook(
         () =>
@@ -195,8 +180,8 @@ describe('useCommitBADropdownSummary', () => {
       await waitFor(() =>
         expect(result.current.error).toEqual(
           expect.objectContaining({
-            status: 404,
-            data: {},
+            dev: 'useCommitBADropdownSummary - Parsing Error',
+            status: 400,
           })
         )
       )
@@ -231,8 +216,8 @@ describe('useCommitBADropdownSummary', () => {
       await waitFor(() =>
         expect(result.current.error).toEqual(
           expect.objectContaining({
+            dev: 'useCommitBADropdownSummary - Not Found Error',
             status: 404,
-            data: {},
           })
         )
       )
@@ -267,6 +252,7 @@ describe('useCommitBADropdownSummary', () => {
       await waitFor(() =>
         expect(result.current.error).toEqual(
           expect.objectContaining({
+            dev: 'useCommitBADropdownSummary - Owner Not Activated',
             status: 403,
           })
         )

--- a/src/services/commit/useCommitBundleList.test.tsx
+++ b/src/services/commit/useCommitBundleList.test.tsx
@@ -19,40 +19,24 @@ const mockCommitBundleListData = {
                 name: 'bundle.js',
                 changeType: 'added',
                 bundleChange: {
-                  loadTime: {
-                    threeG: 3,
-                  },
-                  size: {
-                    uncompress: 1,
-                  },
+                  loadTime: { threeG: 3 },
+                  size: { uncompress: 1 },
                 },
                 bundleData: {
-                  loadTime: {
-                    threeG: 4,
-                  },
-                  size: {
-                    uncompress: 2,
-                  },
+                  loadTime: { threeG: 4 },
+                  size: { uncompress: 2 },
                 },
               },
               {
                 name: 'bundle.css',
                 changeType: 'removed',
                 bundleChange: {
-                  loadTime: {
-                    threeG: 7,
-                  },
-                  size: {
-                    uncompress: 5,
-                  },
+                  loadTime: { threeG: 7 },
+                  size: { uncompress: 5 },
                 },
                 bundleData: {
-                  loadTime: {
-                    threeG: 8,
-                  },
-                  size: {
-                    uncompress: 6,
-                  },
+                  loadTime: { threeG: 8 },
+                  size: { uncompress: 6 },
                 },
               },
             ],
@@ -89,11 +73,7 @@ const mockOwnerNotActivatedError = {
 
 const server = setupServer()
 const queryClient = new QueryClient({
-  defaultOptions: {
-    queries: {
-      retry: false,
-    },
-  },
+  defaultOptions: { queries: { retry: false } },
 })
 
 const wrapper: React.FC<React.PropsWithChildren> = ({ children }) => (
@@ -168,40 +148,24 @@ describe('useCommitBundleList', () => {
                   name: 'bundle.js',
                   changeType: 'added',
                   bundleChange: {
-                    loadTime: {
-                      threeG: 3,
-                    },
-                    size: {
-                      uncompress: 1,
-                    },
+                    loadTime: { threeG: 3 },
+                    size: { uncompress: 1 },
                   },
                   bundleData: {
-                    loadTime: {
-                      threeG: 4,
-                    },
-                    size: {
-                      uncompress: 2,
-                    },
+                    loadTime: { threeG: 4 },
+                    size: { uncompress: 2 },
                   },
                 },
                 {
                   name: 'bundle.css',
                   changeType: 'removed',
                   bundleChange: {
-                    loadTime: {
-                      threeG: 7,
-                    },
-                    size: {
-                      uncompress: 5,
-                    },
+                    loadTime: { threeG: 7 },
+                    size: { uncompress: 5 },
                   },
                   bundleData: {
-                    loadTime: {
-                      threeG: 8,
-                    },
-                    size: {
-                      uncompress: 6,
-                    },
+                    loadTime: { threeG: 8 },
+                    size: { uncompress: 6 },
                   },
                 },
               ],
@@ -247,7 +211,7 @@ describe('useCommitBundleList', () => {
       consoleSpy.mockRestore()
     })
 
-    it('throws a 404', async () => {
+    it('throws a 400', async () => {
       setup({ isUnsuccessfulParseError: true })
       const { result } = renderHook(
         () =>
@@ -264,8 +228,8 @@ describe('useCommitBundleList', () => {
       await waitFor(() =>
         expect(result.current.error).toEqual(
           expect.objectContaining({
-            status: 404,
-            data: {},
+            dev: 'useCommitBundleList - Parsing Error',
+            status: 400,
           })
         )
       )
@@ -300,8 +264,8 @@ describe('useCommitBundleList', () => {
       await waitFor(() =>
         expect(result.current.error).toEqual(
           expect.objectContaining({
+            dev: 'useCommitBundleList - Not Found Error',
             status: 404,
-            data: {},
           })
         )
       )
@@ -336,6 +300,7 @@ describe('useCommitBundleList', () => {
       await waitFor(() =>
         expect(result.current.error).toEqual(
           expect.objectContaining({
+            dev: 'useCommitBundleList - Owner Not Activated',
             status: 403,
           })
         )

--- a/src/services/commit/useCommitComponents.test.tsx
+++ b/src/services/commit/useCommitComponents.test.tsx
@@ -46,11 +46,7 @@ const mockOwnerNotActivatedError = {
 
 const server = setupServer()
 const queryClient = new QueryClient({
-  defaultOptions: {
-    queries: {
-      retry: false,
-    },
-  },
+  defaultOptions: { queries: { retry: false } },
 })
 
 const wrapper: React.FC<React.PropsWithChildren> = ({ children }) => (
@@ -139,7 +135,7 @@ describe('useCommitComponents', () => {
       consoleSpy.mockRestore()
     })
 
-    it('throws a 404', async () => {
+    it('throws a 400', async () => {
       setup({ isUnsuccessfulParseError: true })
       const { result } = renderHook(() => useCommitComponents(), { wrapper })
 
@@ -147,10 +143,8 @@ describe('useCommitComponents', () => {
       await waitFor(() =>
         expect(result.current.error).toEqual(
           expect.objectContaining({
-            status: 404,
-            data: {
-              message: 'Error parsing commit components data',
-            },
+            dev: 'useCommitComponents - Parsing Error',
+            status: 400,
           })
         )
       )
@@ -178,10 +172,8 @@ describe('useCommitComponents', () => {
       await waitFor(() =>
         expect(result.current.error).toEqual(
           expect.objectContaining({
+            dev: 'useCommitComponents - Not Found Error',
             status: 404,
-            data: {
-              message: 'Repo not found',
-            },
           })
         )
       )
@@ -209,6 +201,7 @@ describe('useCommitComponents', () => {
       await waitFor(() =>
         expect(result.current.error).toEqual(
           expect.objectContaining({
+            dev: 'useCommitComponents - Owner Not Activated',
             status: 403,
           })
         )

--- a/src/services/commit/useCommitComponents.tsx
+++ b/src/services/commit/useCommitComponents.tsx
@@ -7,6 +7,7 @@ import {
   RepoOwnerNotActivatedErrorSchema,
 } from 'services/repo'
 import Api from 'shared/api'
+import { rejectNetworkError } from 'shared/api/rejectNetworkError'
 import A from 'ui/A'
 
 const RepositorySchema = z.object({
@@ -122,10 +123,11 @@ export function useCommitComponents({
         const parsedData = CommitComponentsSchema.safeParse(res?.data)
 
         if (!parsedData.success) {
-          return Promise.reject({
-            status: 404,
-            data: {
-              message: 'Error parsing commit components data',
+          return rejectNetworkError({
+            errorName: 'Parsing Error',
+            errorDetails: {
+              callingFn: 'useCommitComponents',
+              error: parsedData.error,
             },
           })
         }
@@ -133,17 +135,20 @@ export function useCommitComponents({
         const data = parsedData.data
 
         if (data?.owner?.repository?.__typename === 'NotFoundError') {
-          return Promise.reject({
-            status: 404,
-            data: {
-              message: 'Repo not found',
+          return rejectNetworkError({
+            errorName: 'Not Found Error',
+            errorDetails: {
+              callingFn: 'useCommitComponents',
             },
           })
         }
 
         if (data?.owner?.repository?.__typename === 'OwnerNotActivatedError') {
-          return Promise.reject({
-            status: 403,
+          return rejectNetworkError({
+            errorName: 'Owner Not Activated',
+            errorDetails: {
+              callingFn: 'useCommitComponents',
+            },
             data: {
               detail: (
                 <p>

--- a/src/services/commit/useCommitCoverageDropdownSummary.test.tsx
+++ b/src/services/commit/useCommitCoverageDropdownSummary.test.tsx
@@ -13,19 +13,10 @@ const mockCommitSummaryData = {
       commit: {
         compareWithParent: {
           __typename: 'Comparison',
-          patchTotals: {
-            missesCount: 1,
-            partialsCount: 2,
-          },
+          patchTotals: { missesCount: 1, partialsCount: 2 },
         },
         uploads: {
-          edges: [
-            {
-              node: {
-                state: 'COMPLETE',
-              },
-            },
-          ],
+          edges: [{ node: { state: 'COMPLETE' } }],
         },
       },
     },
@@ -58,11 +49,7 @@ const mockOwnerNotActivatedError = {
 
 const server = setupServer()
 const queryClient = new QueryClient({
-  defaultOptions: {
-    queries: {
-      retry: false,
-    },
-  },
+  defaultOptions: { queries: { retry: false } },
 })
 
 const wrapper: React.FC<React.PropsWithChildren> = ({ children }) => (
@@ -182,7 +169,7 @@ describe('useCommitCoverageDropdownSummary', () => {
       consoleSpy.mockRestore()
     })
 
-    it('throws a 404', async () => {
+    it('throws a 400', async () => {
       setup({ isUnsuccessfulParseError: true })
       const { result } = renderHook(
         () =>
@@ -199,8 +186,8 @@ describe('useCommitCoverageDropdownSummary', () => {
       await waitFor(() =>
         expect(result.current.error).toEqual(
           expect.objectContaining({
-            status: 404,
-            data: null,
+            dev: 'useCommitCoverageDropdownSummary - Parsing Error',
+            status: 400,
           })
         )
       )
@@ -235,8 +222,8 @@ describe('useCommitCoverageDropdownSummary', () => {
       await waitFor(() =>
         expect(result.current.error).toEqual(
           expect.objectContaining({
+            dev: 'useCommitCoverageDropdownSummary - Not Found Error',
             status: 404,
-            data: {},
           })
         )
       )
@@ -271,6 +258,7 @@ describe('useCommitCoverageDropdownSummary', () => {
       await waitFor(() =>
         expect(result.current.error).toEqual(
           expect.objectContaining({
+            dev: 'useCommitCoverageDropdownSummary - Owner Not Activated',
             status: 403,
           })
         )

--- a/src/services/commit/useCommitCoverageDropdownSummary.tsx
+++ b/src/services/commit/useCommitCoverageDropdownSummary.tsx
@@ -12,6 +12,7 @@ import {
   RepoOwnerNotActivatedErrorSchema,
 } from 'services/repo/schemas'
 import Api from 'shared/api'
+import { rejectNetworkError } from 'shared/api/rejectNetworkError'
 import { UploadStateEnum } from 'shared/utils/commit'
 import { mapEdges } from 'shared/utils/graphql'
 import A from 'ui/A'
@@ -170,24 +171,32 @@ export function useCommitCoverageDropdownSummary({
         const parsedRes = RequestSchema.safeParse(res?.data)
 
         if (!parsedRes.success) {
-          return Promise.reject({
-            status: 404,
-            data: null,
+          return rejectNetworkError({
+            errorName: 'Parsing Error',
+            errorDetails: {
+              callingFn: 'useCommitCoverageDropdownSummary',
+              error: parsedRes.error,
+            },
           })
         }
 
         const data = parsedRes.data
 
         if (data?.owner?.repository?.__typename === 'NotFoundError') {
-          return Promise.reject({
-            status: 404,
-            data: {},
+          return rejectNetworkError({
+            errorName: 'Not Found Error',
+            errorDetails: {
+              callingFn: 'useCommitCoverageDropdownSummary',
+            },
           })
         }
 
         if (data?.owner?.repository?.__typename === 'OwnerNotActivatedError') {
-          return Promise.reject({
-            status: 403,
+          return rejectNetworkError({
+            errorName: 'Owner Not Activated',
+            errorDetails: {
+              callingFn: 'useCommitCoverageDropdownSummary',
+            },
             data: {
               detail: (
                 <p>

--- a/src/services/commit/useCommitTeam.test.tsx
+++ b/src/services/commit/useCommitTeam.test.tsx
@@ -14,9 +14,7 @@ const mockCompareData = {
         compareWithParent: {
           __typename: 'Comparison',
           state: 'processed',
-          patchTotals: {
-            coverage: 100,
-          },
+          patchTotals: { coverage: 100 },
           impactedFiles: {
             __typename: 'ImpactedFiles',
             results: [
@@ -38,9 +36,7 @@ const mockCommitData = {
         commitid: 'f00162848a3cebc0728d915763c2fd9e92132408',
         pullId: 10,
         createdAt: '2020-08-25T16:35:32',
-        author: {
-          username: 'febg',
-        },
+        author: { username: 'febg' },
         state: 'complete',
         uploads: {
           edges: [
@@ -89,29 +85,21 @@ const mockCommitData = {
           state: 'pending',
           indirectChangedFilesCount: 1,
           directChangedFilesCount: 1,
-          patchTotals: {
-            coverage: 100,
-          },
+          patchTotals: { coverage: 100 },
           impactedFiles: {
             __typename: 'ImpactedFiles',
             results: [
               {
                 headName: 'src/App.jsx',
                 missesCount: 0,
-                patchCoverage: {
-                  coverage: 100,
-                },
+                patchCoverage: { coverage: 100 },
               },
             ],
           },
         },
         parent: {
           commitid: 'd773f5bc170caec7f6e64420b0967e7bac978a8f',
-          coverageAnalytics: {
-            totals: {
-              coverage: 38.30846,
-            },
-          },
+          coverageAnalytics: { totals: { coverage: 38.30846 } },
         },
       },
     },
@@ -308,9 +296,7 @@ describe('useCommitTeam', () => {
               repo: 'repo-test',
               commitid: 'a23sda3',
             }),
-          {
-            wrapper,
-          }
+          { wrapper }
         )
 
         await waitFor(() =>
@@ -333,7 +319,7 @@ describe('useCommitTeam', () => {
       consoleSpy.mockRestore()
     })
 
-    it('throws a 404', async () => {
+    it('throws a 400', async () => {
       setup({ isNotFoundError: true })
       const { result } = renderHook(
         () =>
@@ -343,17 +329,15 @@ describe('useCommitTeam', () => {
             repo: 'repo-test',
             commitid: 'a23sda3',
           }),
-        {
-          wrapper,
-        }
+        { wrapper }
       )
 
       await waitFor(() => expect(result.current.isError).toBeTruthy())
       await waitFor(() =>
         expect(result.current.error).toEqual(
           expect.objectContaining({
+            dev: 'useCommitTeam - Not Found Error',
             status: 404,
-            dev: 'useCommitTeam - 404 not found',
           })
         )
       )
@@ -381,17 +365,15 @@ describe('useCommitTeam', () => {
             repo: 'repo-test',
             commitid: 'a23sda3',
           }),
-        {
-          wrapper,
-        }
+        { wrapper }
       )
 
       await waitFor(() => expect(result.current.isError).toBeTruthy())
       await waitFor(() =>
         expect(result.current.error).toEqual(
           expect.objectContaining({
+            dev: 'useCommitTeam - Owner Not Activated',
             status: 403,
-            dev: 'useCommitTeam - 403 owner not activated',
           })
         )
       )
@@ -409,7 +391,7 @@ describe('useCommitTeam', () => {
       consoleSpy.mockRestore()
     })
 
-    it('throws a 404', async () => {
+    it('throws a 400', async () => {
       setup({ isUnsuccessfulParseError: true })
       const { result } = renderHook(
         () =>
@@ -419,17 +401,15 @@ describe('useCommitTeam', () => {
             repo: 'repo-test',
             commitid: 'a23sda3',
           }),
-        {
-          wrapper,
-        }
+        { wrapper }
       )
 
       await waitFor(() => expect(result.current.isError).toBeTruthy())
       await waitFor(() =>
         expect(result.current.error).toEqual(
           expect.objectContaining({
-            status: 404,
-            dev: 'useCommitTeam - 404 failed to parse',
+            dev: 'useCommitTeam - Parsing Error',
+            status: 400,
           })
         )
       )

--- a/src/services/commit/useCommitYaml.test.tsx
+++ b/src/services/commit/useCommitYaml.test.tsx
@@ -10,20 +10,13 @@ const mockCommitYaml = (yaml: string) => ({
   owner: {
     repository: {
       __typename: 'Repository',
-      commit: {
-        commitid: 'asdf',
-        yaml,
-      },
+      commit: { commitid: 'asdf', yaml },
     },
   },
 })
 
 const mockCommitYamlBadSchema = {
-  owner: {
-    repository: {
-      asdf: 'asdf',
-    },
-  },
+  owner: { repository: { asdf: 'asdf' } },
 }
 
 const mockCommitYamlNotFound = {
@@ -130,7 +123,7 @@ describe('useCommitYaml', () => {
   })
 
   describe('when bad response', () => {
-    it('returns 404 failed to parse', async () => {
+    it('returns 400 failed to parse', async () => {
       setup({ badSchema: true })
       const { result } = renderHook(
         () =>
@@ -140,15 +133,14 @@ describe('useCommitYaml', () => {
             repo: 'repo-test',
             commitid: 'a23sda3',
           }),
-        {
-          wrapper,
-        }
+        { wrapper }
       )
 
       await waitFor(() => expect(result.current.isError).toBeTruthy())
       expect(result.current.error).toEqual(
         expect.objectContaining({
-          status: 404,
+          dev: 'useCommitYaml - Parsing Error',
+          status: 400,
         })
       )
     })
@@ -165,14 +157,13 @@ describe('useCommitYaml', () => {
             repo: 'repo-test',
             commitid: 'a23sda3',
           }),
-        {
-          wrapper,
-        }
+        { wrapper }
       )
 
       await waitFor(() => expect(result.current.isError).toBeTruthy())
       expect(result.current.error).toEqual(
         expect.objectContaining({
+          dev: 'useCommitYaml - Not Found Error',
           status: 404,
         })
       )
@@ -190,14 +181,13 @@ describe('useCommitYaml', () => {
             repo: 'repo-test',
             commitid: 'a23sda3',
           }),
-        {
-          wrapper,
-        }
+        { wrapper }
       )
 
       await waitFor(() => expect(result.current.isError).toBeTruthy())
       expect(result.current.error).toEqual(
         expect.objectContaining({
+          dev: 'useCommitYaml - Owner Not Activated',
           status: 403,
         })
       )


### PR DESCRIPTION
# Description

This PR updates the first round of network calls, replacing `Promise.reject` with the newly updated `rejectNetworkError` helper function. As well I've gone through and updated the respective tests.

Ticket: codecov/engineering-team#3329

# Notable Changes

- Replace `Promise.reject` with `rejectNetworkError`
- Update tests