### PR TITLE
Update FailedTestsErrorBanner.tsx

### DIFF
--- a/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/FailedTestsErrorBanner/FailedTestsErrorBanner.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/FailedTestsErrorBanner/FailedTestsErrorBanner.tsx
@@ -26,8 +26,8 @@ const FileNotFoundBanner = () => (
     </BannerHeading>
     <BannerContent>
       <p>
-        No result to display because Test Analytics couldn&apos;t locate a JUnit
-        XML file. Please rename the file to include{' '}
+        Some test results could not be displayed because Test Analytics couldn&apos;t locate a JUnit
+        XML file on the latest commit to this branch. Please rename the file to include{' '}
         <CodeSnippet>junit</CodeSnippet>, ensure CLI file search is enabled, or
         use the <CodeSnippet>file</CodeSnippet> or{' '}
         <CodeSnippet>search_dir</CodeSnippet> arguments to specify the file(s)


### PR DESCRIPTION
Test result report upload / processing errors happen on a commit level, whereas the UI aggregates and displays results on a branch level. 

Consequently, we may show test results even if the latest commit had errors previously. At which point seeing the banner as written today could invite confusion - see below

![image](https://github.com/user-attachments/assets/5f50ea1d-c760-451f-a494-a9b4057ce2e3)


I've changed the copy to more accurately describe the behaviour. Feedback welcome

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.