### PR TITLE
fix: Remove use of structuredClone

### DIFF
--- a/src/ui/SunburstChart/SunburstChart.jsx
+++ b/src/ui/SunburstChart/SunburstChart.jsx
@@ -44,7 +44,8 @@ function SunburstChart({
       // if the node has children, process them
       if (Array.isArray(node.children)) {
         currentNode.children = node.children.map((child) => {
-          const newChild = structuredClone(child)
+          // sad ... some browsers still lack support for structuredClone
+          const newChild = JSON.parse(JSON.stringify(child))
           Object.assign(newChild, { value: selectorHandler.current(child) })
 
           nodeMap.set(child, newChild)


### PR DESCRIPTION
# Description

Pretty quick PR to replace the usage of `structuredClone`, as some (edge) users are running into issues with it.

Can see this [Sentry issue](https://codecov.sentry.io/issues/6318271732/?environment=production&project=5514400&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=issue-stream&sort=date&statsPeriod=14d&stream_index=10), for more details.