### PR TITLE
feat: Add rejectNetworkError to calls (part three)

### DIFF
--- a/src/services/pull/usePullBundleComparisonList.test.tsx
+++ b/src/services/pull/usePullBundleComparisonList.test.tsx
@@ -18,41 +18,19 @@ const mockPullBundleListData = {
               name: 'bundle.js',
               changeType: 'added',
               bundleChange: {
-                loadTime: {
-                  threeG: 3,
-                },
-                size: {
-                  uncompress: 1,
-                },
+                loadTime: { threeG: 3 },
+                size: { uncompress: 1 },
               },
-              bundleData: {
-                loadTime: {
-                  threeG: 4,
-                },
-                size: {
-                  uncompress: 2,
-                },
-              },
+              bundleData: { loadTime: { threeG: 4 }, size: { uncompress: 2 } },
             },
             {
               name: 'bundle.css',
               changeType: 'removed',
               bundleChange: {
-                loadTime: {
-                  threeG: 7,
-                },
-                size: {
-                  uncompress: 5,
-                },
+                loadTime: { threeG: 7 },
+                size: { uncompress: 5 },
               },
-              bundleData: {
-                loadTime: {
-                  threeG: 8,
-                },
-                size: {
-                  uncompress: 6,
-                },
-              },
+              bundleData: { loadTime: { threeG: 8 }, size: { uncompress: 6 } },
             },
           ],
         },
@@ -165,40 +143,24 @@ describe('usePullBundleComparisonList', () => {
                 name: 'bundle.js',
                 changeType: 'added',
                 bundleChange: {
-                  loadTime: {
-                    threeG: 3,
-                  },
-                  size: {
-                    uncompress: 1,
-                  },
+                  loadTime: { threeG: 3 },
+                  size: { uncompress: 1 },
                 },
                 bundleData: {
-                  loadTime: {
-                    threeG: 4,
-                  },
-                  size: {
-                    uncompress: 2,
-                  },
+                  loadTime: { threeG: 4 },
+                  size: { uncompress: 2 },
                 },
               },
               {
                 name: 'bundle.css',
                 changeType: 'removed',
                 bundleChange: {
-                  loadTime: {
-                    threeG: 7,
-                  },
-                  size: {
-                    uncompress: 5,
-                  },
+                  loadTime: { threeG: 7 },
+                  size: { uncompress: 5 },
                 },
                 bundleData: {
-                  loadTime: {
-                    threeG: 8,
-                  },
-                  size: {
-                    uncompress: 6,
-                  },
+                  loadTime: { threeG: 8 },
+                  size: { uncompress: 6 },
                 },
               },
             ],
@@ -242,7 +204,7 @@ describe('usePullBundleComparisonList', () => {
       consoleSpy.mockRestore()
     })
 
-    it('throws a 404', async () => {
+    it('throws a 400', async () => {
       setup({ isUnsuccessfulParseError: true })
       const { result } = renderHook(
         () =>
@@ -259,8 +221,8 @@ describe('usePullBundleComparisonList', () => {
       await waitFor(() =>
         expect(result.current.error).toEqual(
           expect.objectContaining({
-            status: 404,
-            data: null,
+            dev: 'usePullBundleComparisonList - Parsing Error',
+            status: 400,
           })
         )
       )
@@ -294,8 +256,8 @@ describe('usePullBundleComparisonList', () => {
       await waitFor(() =>
         expect(result.current.error).toEqual(
           expect.objectContaining({
+            dev: 'usePullBundleComparisonList - Not Found Error',
             status: 404,
-            data: {},
           })
         )
       )
@@ -329,6 +291,7 @@ describe('usePullBundleComparisonList', () => {
       await waitFor(() =>
         expect(result.current.error).toEqual(
           expect.objectContaining({
+            dev: 'usePullBundleComparisonList - Owner Not Activated',
             status: 403,
           })
         )

--- a/src/services/pull/usePullBundleComparisonList.tsx
+++ b/src/services/pull/usePullBundleComparisonList.tsx
@@ -11,6 +11,7 @@ import {
   RepoOwnerNotActivatedErrorSchema,
 } from 'services/repo/schemas'
 import Api from 'shared/api'
+import { rejectNetworkError } from 'shared/api/rejectNetworkError'
 import A from 'ui/A'
 
 const BundleSchema = z.object({
@@ -160,24 +161,28 @@ export function usePullBundleComparisonList({
         const parsedRes = RequestSchema.safeParse(res?.data)
 
         if (!parsedRes.success) {
-          return Promise.reject({
-            status: 404,
-            data: null,
+          return rejectNetworkError({
+            errorName: 'Parsing Error',
+            errorDetails: {
+              callingFn: 'usePullBundleComparisonList',
+              error: parsedRes.error,
+            },
           })
         }
 
         const data = parsedRes.data
 
         if (data?.owner?.repository?.__typename === 'NotFoundError') {
-          return Promise.reject({
-            status: 404,
-            data: {},
+          return rejectNetworkError({
+            errorName: 'Not Found Error',
+            errorDetails: { callingFn: 'usePullBundleComparisonList' },
           })
         }
 
         if (data?.owner?.repository?.__typename === 'OwnerNotActivatedError') {
-          return Promise.reject({
-            status: 403,
+          return rejectNetworkError({
+            errorName: 'Owner Not Activated',
+            errorDetails: { callingFn: 'usePullBundleComparisonList' },
             data: {
               detail: (
                 <p>

--- a/src/services/pull/usePullBundleHeadList.test.tsx
+++ b/src/services/pull/usePullBundleHeadList.test.tsx
@@ -73,11 +73,7 @@ const mockOwnerNotActivated = {
 
 const server = setupServer()
 const queryClient = new QueryClient({
-  defaultOptions: {
-    queries: {
-      retry: false,
-    },
-  },
+  defaultOptions: { queries: { retry: false } },
 })
 
 const wrapper: React.FC<React.PropsWithChildren> = ({ children }) => (
@@ -225,6 +221,7 @@ describe('usePullBundleHeadList', () => {
       await waitFor(() =>
         expect(result.current.error).toEqual(
           expect.objectContaining({
+            dev: 'usePullBundleHeadList - Not Found Error',
             status: 404,
           })
         )
@@ -259,6 +256,7 @@ describe('usePullBundleHeadList', () => {
       await waitFor(() =>
         expect(result.current.error).toEqual(
           expect.objectContaining({
+            dev: 'usePullBundleHeadList - Owner Not Activated',
             status: 403,
           })
         )
@@ -276,7 +274,7 @@ describe('usePullBundleHeadList', () => {
       consoleSpy.mockRestore()
     })
 
-    it('throws a 404', async () => {
+    it('throws a 400', async () => {
       setup({ isUnsuccessfulParseError: true })
       const { result } = renderHook(
         () =>
@@ -293,7 +291,8 @@ describe('usePullBundleHeadList', () => {
       await waitFor(() =>
         expect(result.current.error).toEqual(
           expect.objectContaining({
-            status: 404,
+            dev: 'usePullBundleHeadList - Parsing Error',
+            status: 400,
           })
         )
       )

--- a/src/services/pull/usePullCompareTotalsTeam.test.tsx
+++ b/src/services/pull/usePullCompareTotalsTeam.test.tsx
@@ -61,11 +61,7 @@ const mockUnsuccessfulParseError = {}
 
 const server = setupServer()
 const queryClient = new QueryClient({
-  defaultOptions: {
-    queries: {
-      retry: false,
-    },
-  },
+  defaultOptions: { queries: { retry: false } },
 })
 
 const wrapper: React.FC<React.PropsWithChildren> = ({ children }) => (
@@ -140,15 +136,11 @@ describe('usePullCompareTotalsTeam', () => {
                 {
                   headName: 'src/App.tsx',
                   missesCount: 0,
-                  patchCoverage: {
-                    coverage: 100,
-                  },
+                  patchCoverage: { coverage: 100 },
                 },
               ],
             },
-            patchTotals: {
-              coverage: 100,
-            },
+            patchTotals: { coverage: 100 },
             state: 'processed',
           },
         }
@@ -205,8 +197,8 @@ describe('usePullCompareTotalsTeam', () => {
       await waitFor(() =>
         expect(result.current.error).toEqual(
           expect.objectContaining({
+            dev: 'usePullCompareTotalsTeam - Not Found Error',
             status: 404,
-            dev: 'usePullCompareTotalsTeam - 404 not found',
           })
         )
       )
@@ -240,8 +232,8 @@ describe('usePullCompareTotalsTeam', () => {
       await waitFor(() =>
         expect(result.current.error).toEqual(
           expect.objectContaining({
+            dev: 'usePullCompareTotalsTeam - Owner Not Activated',
             status: 403,
-            dev: 'usePullCompareTotalsTeam - 403 owner not activated',
           })
         )
       )
@@ -258,7 +250,7 @@ describe('usePullCompareTotalsTeam', () => {
       consoleSpy.mockRestore()
     })
 
-    it('throws a 404', async () => {
+    it('throws a 400', async () => {
       setup({ isUnsuccessfulParseError: true })
       const { result } = renderHook(
         () =>
@@ -275,8 +267,8 @@ describe('usePullCompareTotalsTeam', () => {
       await waitFor(() =>
         expect(result.current.error).toEqual(
           expect.objectContaining({
-            status: 404,
-            dev: 'usePullCompareTotalsTeam - 404 failed to parse',
+            dev: 'usePullCompareTotalsTeam - Parsing Error',
+            status: 400,
           })
         )
       )

--- a/src/services/pull/usePullComponents.test.tsx
+++ b/src/services/pull/usePullComponents.test.tsx
@@ -15,12 +15,8 @@ const mockCompareData = {
         compareWithBase: {
           __typename: 'Comparison',
           componentComparisons: [
-            {
-              name: 'component1',
-            },
-            {
-              name: 'component2',
-            },
+            { name: 'component1' },
+            { name: 'component2' },
           ],
         },
       },
@@ -123,12 +119,8 @@ describe('usePullComponents', () => {
           compareWithBase: {
             __typename: 'Comparison',
             componentComparisons: [
-              {
-                name: 'component1',
-              },
-              {
-                name: 'component2',
-              },
+              { name: 'component1' },
+              { name: 'component2' },
             ],
           },
         },
@@ -160,7 +152,7 @@ describe('usePullComponents', () => {
       consoleSpy.mockRestore()
     })
 
-    it('throws a 404', async () => {
+    it('throws a 400', async () => {
       setup({ isUnsuccessfulParseError: true })
       const { result } = renderHook(() => usePullComponents(), { wrapper })
 
@@ -168,10 +160,8 @@ describe('usePullComponents', () => {
       await waitFor(() =>
         expect(result.current.error).toEqual(
           expect.objectContaining({
-            status: 404,
-            data: {
-              message: 'Error parsing pull components selector data',
-            },
+            dev: 'usePullComponents - Parsing Error',
+            status: 400,
           })
         )
       )
@@ -198,10 +188,8 @@ describe('usePullComponents', () => {
       await waitFor(() =>
         expect(result.current.error).toEqual(
           expect.objectContaining({
+            dev: 'usePullComponents - Not Found Error',
             status: 404,
-            data: {
-              message: 'Repo not found',
-            },
           })
         )
       )
@@ -228,6 +216,7 @@ describe('usePullComponents', () => {
       await waitFor(() =>
         expect(result.current.error).toEqual(
           expect.objectContaining({
+            dev: 'usePullComponents - Owner Not Activated',
             status: 403,
           })
         )

--- a/src/services/pull/usePullComponents.tsx
+++ b/src/services/pull/usePullComponents.tsx
@@ -13,6 +13,7 @@ import {
   RepoOwnerNotActivatedErrorSchema,
 } from 'services/repo'
 import Api from 'shared/api'
+import { rejectNetworkError } from 'shared/api/rejectNetworkError'
 import A from 'ui/A'
 
 const query = `
@@ -156,10 +157,11 @@ export function usePullComponents({
         const parsedData = PullComponentsSchema.safeParse(res?.data)
 
         if (!parsedData.success) {
-          return Promise.reject({
-            status: 404,
-            data: {
-              message: 'Error parsing pull components selector data',
+          return rejectNetworkError({
+            errorName: 'Parsing Error',
+            errorDetails: {
+              callingFn: 'usePullComponents',
+              error: parsedData.error,
             },
           })
         }
@@ -167,17 +169,16 @@ export function usePullComponents({
         const data = parsedData.data
 
         if (data?.owner?.repository?.__typename === 'NotFoundError') {
-          return Promise.reject({
-            status: 404,
-            data: {
-              message: 'Repo not found',
-            },
+          return rejectNetworkError({
+            errorName: 'Not Found Error',
+            errorDetails: { callingFn: 'usePullComponents' },
           })
         }
 
         if (data?.owner?.repository?.__typename === 'OwnerNotActivatedError') {
-          return Promise.reject({
-            status: 403,
+          return rejectNetworkError({
+            errorName: 'Owner Not Activated',
+            errorDetails: { callingFn: 'usePullComponents' },
             data: {
               detail: (
                 <p>

--- a/src/services/pull/usePullCoverageDropdownSummary.test.tsx
+++ b/src/services/pull/usePullCoverageDropdownSummary.test.tsx
@@ -13,10 +13,7 @@ const mockPullSummaryData = {
       pull: {
         compareWithBase: {
           __typename: 'Comparison',
-          patchTotals: {
-            missesCount: 1,
-            partialsCount: 2,
-          },
+          patchTotals: { missesCount: 1, partialsCount: 2 },
         },
       },
     },
@@ -122,10 +119,7 @@ describe('usePullCoverageDropdownSummary', () => {
         pull: {
           compareWithBase: {
             __typename: 'Comparison',
-            patchTotals: {
-              missesCount: 1,
-              partialsCount: 2,
-            },
+            patchTotals: { missesCount: 1, partialsCount: 2 },
           },
         },
       }
@@ -166,7 +160,7 @@ describe('usePullCoverageDropdownSummary', () => {
       consoleSpy.mockRestore()
     })
 
-    it('throws a 404', async () => {
+    it('throws a 400', async () => {
       setup({ isUnsuccessfulParseError: true })
       const { result } = renderHook(
         () =>
@@ -183,8 +177,8 @@ describe('usePullCoverageDropdownSummary', () => {
       await waitFor(() =>
         expect(result.current.error).toEqual(
           expect.objectContaining({
-            status: 404,
-            data: null,
+            dev: 'usePullCoverageDropdownSummary - Parsing Error',
+            status: 400,
           })
         )
       )
@@ -218,8 +212,8 @@ describe('usePullCoverageDropdownSummary', () => {
       await waitFor(() =>
         expect(result.current.error).toEqual(
           expect.objectContaining({
+            dev: 'usePullCoverageDropdownSummary - Not Found Error',
             status: 404,
-            data: {},
           })
         )
       )
@@ -253,6 +247,7 @@ describe('usePullCoverageDropdownSummary', () => {
       await waitFor(() =>
         expect(result.current.error).toEqual(
           expect.objectContaining({
+            dev: 'usePullCoverageDropdownSummary - Owner Not Activated',
             status: 403,
           })
         )

--- a/src/services/pull/usePullCoverageDropdownSummary.tsx
+++ b/src/services/pull/usePullCoverageDropdownSummary.tsx
@@ -12,6 +12,7 @@ import {
   RepoOwnerNotActivatedErrorSchema,
 } from 'services/repo/schemas'
 import Api from 'shared/api'
+import { rejectNetworkError } from 'shared/api/rejectNetworkError'
 import A from 'ui/A'
 
 const ComparisonSchema = z.object({
@@ -128,24 +129,28 @@ export function usePullCoverageDropdownSummary({
         const parsedRes = RequestSchema.safeParse(res?.data)
 
         if (!parsedRes.success) {
-          return Promise.reject({
-            status: 404,
-            data: null,
+          return rejectNetworkError({
+            errorName: 'Parsing Error',
+            errorDetails: {
+              callingFn: 'usePullCoverageDropdownSummary',
+              error: parsedRes.error,
+            },
           })
         }
 
         const data = parsedRes.data
 
         if (data?.owner?.repository?.__typename === 'NotFoundError') {
-          return Promise.reject({
-            status: 404,
-            data: {},
+          return rejectNetworkError({
+            errorName: 'Not Found Error',
+            errorDetails: { callingFn: 'usePullCoverageDropdownSummary' },
           })
         }
 
         if (data?.owner?.repository?.__typename === 'OwnerNotActivatedError') {
-          return Promise.reject({
-            status: 403,
+          return rejectNetworkError({
+            errorName: 'Owner Not Activated',
+            errorDetails: { callingFn: 'usePullCoverageDropdownSummary' },
             data: {
               detail: (
                 <p>

--- a/src/services/pull/usePullTeam.test.tsx
+++ b/src/services/pull/usePullTeam.test.tsx
@@ -14,9 +14,7 @@ const mockCompareData = {
         compareWithBase: {
           __typename: 'Comparison',
           state: 'processed',
-          patchTotals: {
-            coverage: 100,
-          },
+          patchTotals: { coverage: 100 },
           impactedFiles: {
             __typename: 'ImpactedFiles',
             results: [
@@ -42,9 +40,7 @@ const mockPullData = {
         compareWithBase: {
           __typename: 'Comparison',
           state: 'pending',
-          patchTotals: {
-            coverage: 100,
-          },
+          patchTotals: { coverage: 100 },
           impactedFiles: {
             __typename: 'ImpactedFiles',
             results: [
@@ -180,15 +176,11 @@ describe('usePullTeam', () => {
                   {
                     headName: 'src/App.tsx',
                     missesCount: 0,
-                    patchCoverage: {
-                      coverage: 100,
-                    },
+                    patchCoverage: { coverage: 100 },
                   },
                 ],
               },
-              patchTotals: {
-                coverage: 100,
-              },
+              patchTotals: { coverage: 100 },
               state: 'processed',
             },
             pullId: 10,
@@ -253,8 +245,8 @@ describe('usePullTeam', () => {
       await waitFor(() =>
         expect(result.current.error).toEqual(
           expect.objectContaining({
+            dev: 'usePullTeam - Not Found Error',
             status: 404,
-            dev: 'usePullTeam - 404 not found',
           })
         )
       )
@@ -290,8 +282,8 @@ describe('usePullTeam', () => {
       await waitFor(() =>
         expect(result.current.error).toEqual(
           expect.objectContaining({
+            dev: 'usePullTeam - Owner Not Activated',
             status: 403,
-            dev: 'usePullTeam - 403 owner not activated',
           })
         )
       )
@@ -308,7 +300,7 @@ describe('usePullTeam', () => {
       consoleSpy.mockRestore()
     })
 
-    it('throws a 404', async () => {
+    it('throws a 400', async () => {
       setup({ isUnsuccessfulParseError: true })
       const { result } = renderHook(
         () =>
@@ -327,8 +319,8 @@ describe('usePullTeam', () => {
       await waitFor(() =>
         expect(result.current.error).toEqual(
           expect.objectContaining({
-            status: 404,
-            dev: 'usePullTeam - 404 failed to parse',
+            dev: 'usePullTeam - Parsing Error',
+            status: 400,
           })
         )
       )

--- a/src/services/pull/useSingularImpactedFileComparison.test.tsx
+++ b/src/services/pull/useSingularImpactedFileComparison.test.tsx
@@ -16,13 +16,18 @@ const wrapper: React.FC<React.PropsWithChildren> = ({ children }) => (
 )
 
 const server = setupServer()
+beforeAll(() => {
+  server.listen()
+})
 
-beforeAll(() => server.listen())
 afterEach(() => {
   queryClient.clear()
   server.resetHandlers()
 })
-afterAll(() => server.close())
+
+afterAll(() => {
+  server.close()
+})
 
 const mockNotFoundError = {
   owner: {
@@ -64,15 +69,9 @@ const mockResponse = {
             isRenamedFile: false,
             isNewFile: false,
             isDeletedFile: false,
-            baseCoverage: {
-              percentCovered: 23,
-            },
-            headCoverage: {
-              percentCovered: 24,
-            },
-            patchCoverage: {
-              percentCovered: 25,
-            },
+            baseCoverage: { percentCovered: 23 },
+            headCoverage: { percentCovered: 24 },
+            patchCoverage: { percentCovered: 25 },
             changeCoverage: 0,
             segments: {
               __typename: 'SegmentComparisons',
@@ -137,13 +136,9 @@ describe('useSingularImpactedFileComparison', () => {
   }
 
   describe('when called with successful res', () => {
-    beforeEach(() => {
-      setup({})
-    })
-    afterEach(() => server.resetHandlers())
-
     describe('when data is loaded', () => {
       it('returns the data', async () => {
+        setup({})
         const { result } = renderHook(
           () =>
             useSingularImpactedFileComparison({
@@ -207,8 +202,8 @@ describe('useSingularImpactedFileComparison', () => {
       await waitFor(() =>
         expect(result.current.error).toEqual(
           expect.objectContaining({
-            status: 404,
-            dev: 'useSingularImpactedFileComparison - 404 failed to parse',
+            dev: 'useSingularImpactedFileComparison - Parsing Error',
+            status: 400,
           })
         )
       )
@@ -235,8 +230,8 @@ describe('useSingularImpactedFileComparison', () => {
       await waitFor(() =>
         expect(result.current.error).toEqual(
           expect.objectContaining({
+            dev: 'useSingularImpactedFileComparison - Not Found Error',
             status: 404,
-            data: {},
           })
         )
       )
@@ -263,6 +258,7 @@ describe('useSingularImpactedFileComparison', () => {
       await waitFor(() =>
         expect(result.current.error).toEqual(
           expect.objectContaining({
+            dev: 'useSingularImpactedFileComparison - Owner Not Activated',
             status: 403,
           })
         )
@@ -286,14 +282,8 @@ describe('useSingularImpactedFileComparison', () => {
           wrapper,
         }
       )
-      await waitFor(() => expect(result.current.isError).toBeTruthy())
-      await waitFor(() =>
-        expect(result.current.error).toEqual(
-          expect.objectContaining({
-            status: 404,
-          })
-        )
-      )
+
+      await waitFor(() => expect(result.current.error).toBeNull())
     })
   })
 })

--- a/src/services/pulls/usePulls.test.tsx
+++ b/src/services/pulls/usePulls.test.tsx
@@ -10,23 +10,15 @@ const node1 = {
   title: 'first pull',
   state: 'MERGED',
   updatestamp: '20-2-2021',
-  author: {
-    username: 'cool-user',
-    avatarUrl: 'http://127.0.0.1/avatar-url',
-  },
-  head: {
-    bundleStatus: 'PENDING',
-    coverageStatus: 'PENDING',
-  },
+  author: { username: 'cool-user', avatarUrl: 'http://127.0.0.1/avatar-url' },
+  head: { bundleStatus: 'PENDING', coverageStatus: 'PENDING' },
   bundleAnalysisCompareWithBase: {
     __typename: 'MissingHeadReport',
     message: 'Missing head report',
   },
   compareWithBase: {
     __typename: 'Comparison',
-    patchTotals: {
-      percentCovered: 87,
-    },
+    patchTotals: { percentCovered: 87 },
   },
 }
 
@@ -35,23 +27,15 @@ const node2 = {
   title: 'second pull',
   state: 'MERGED',
   updatestamp: '20-2-2021',
-  author: {
-    username: 'cool-user',
-    avatarUrl: 'http://127.0.0.1/avatar-url',
-  },
-  head: {
-    bundleStatus: 'PENDING',
-    coverageStatus: 'PENDING',
-  },
+  author: { username: 'cool-user', avatarUrl: 'http://127.0.0.1/avatar-url' },
+  head: { bundleStatus: 'PENDING', coverageStatus: 'PENDING' },
   bundleAnalysisCompareWithBase: {
     __typename: 'MissingHeadReport',
     message: 'Missing head report',
   },
   compareWithBase: {
     __typename: 'Comparison',
-    patchTotals: {
-      percentCovered: 87,
-    },
+    patchTotals: { percentCovered: 87 },
   },
 }
 
@@ -60,23 +44,15 @@ const node3 = {
   title: 'third pull',
   state: 'MERGED',
   updatestamp: '20-2-2021',
-  author: {
-    username: 'cool-user',
-    avatarUrl: 'http://127.0.0.1/avatar-url',
-  },
-  head: {
-    bundleStatus: 'PENDING',
-    coverageStatus: 'PENDING',
-  },
+  author: { username: 'cool-user', avatarUrl: 'http://127.0.0.1/avatar-url' },
+  head: { bundleStatus: 'PENDING', coverageStatus: 'PENDING' },
   bundleAnalysisCompareWithBase: {
     __typename: 'MissingHeadReport',
     message: 'Missing head report',
   },
   compareWithBase: {
     __typename: 'Comparison',
-    patchTotals: {
-      percentCovered: 87,
-    },
+    patchTotals: { percentCovered: 87 },
   },
 }
 
@@ -200,7 +176,6 @@ describe('GetPulls', () => {
       describe('when data is loaded', () => {
         it('returns expected pulls nodes', async () => {
           setup({})
-
           const { result } = renderHook(
             () =>
               usePulls({
@@ -212,9 +187,7 @@ describe('GetPulls', () => {
                 },
                 orderingDirection: 'ASC',
               }),
-            {
-              wrapper,
-            }
+            { wrapper }
           )
 
           await waitFor(() => result.current.isLoading)
@@ -229,7 +202,6 @@ describe('GetPulls', () => {
       describe('when call next page', () => {
         it('returns prev and next page pulls of the user', async () => {
           setup({})
-
           const { result } = renderHook(
             () =>
               usePulls({
@@ -241,9 +213,7 @@ describe('GetPulls', () => {
                 },
                 orderingDirection: 'ASC',
               }),
-            {
-              wrapper,
-            }
+            { wrapper }
           )
 
           await waitFor(() => result.current.isFetching)
@@ -264,7 +234,6 @@ describe('GetPulls', () => {
     describe('when null owner is returned', () => {
       it('returns an empty list', async () => {
         setup({ isNullOwner: true })
-
         const { result } = renderHook(
           () =>
             usePulls({
@@ -276,9 +245,7 @@ describe('GetPulls', () => {
               },
               orderingDirection: 'ASC',
             }),
-          {
-            wrapper,
-          }
+          { wrapper }
         )
 
         await waitFor(() => result.current.isLoading)
@@ -313,15 +280,14 @@ describe('GetPulls', () => {
             },
             orderingDirection: 'ASC',
           }),
-        {
-          wrapper,
-        }
+        { wrapper }
       )
 
       await waitFor(() => expect(result.current.isError).toBeTruthy())
       await waitFor(() =>
         expect(result.current.error).toEqual(
           expect.objectContaining({
+            dev: 'usePulls - Not Found Error',
             status: 404,
           })
         )
@@ -353,15 +319,14 @@ describe('GetPulls', () => {
             },
             orderingDirection: 'ASC',
           }),
-        {
-          wrapper,
-        }
+        { wrapper }
       )
 
       await waitFor(() => expect(result.current.isError).toBeTruthy())
       await waitFor(() =>
         expect(result.current.error).toEqual(
           expect.objectContaining({
+            dev: 'usePulls - Owner Not Activated',
             status: 403,
           })
         )
@@ -380,7 +345,7 @@ describe('GetPulls', () => {
       console.error = oldConsoleError
     })
 
-    it('throws a 404', async () => {
+    it('throws a 400', async () => {
       setup({ isUnsuccessfulParseError: true })
       const { result } = renderHook(
         () =>
@@ -393,16 +358,15 @@ describe('GetPulls', () => {
             },
             orderingDirection: 'ASC',
           }),
-        {
-          wrapper,
-        }
+        { wrapper }
       )
 
       await waitFor(() => expect(result.current.isError).toBeTruthy())
       await waitFor(() =>
         expect(result.current.error).toEqual(
           expect.objectContaining({
-            status: 404,
+            dev: 'usePulls - Parsing Error',
+            status: 400,
           })
         )
       )

--- a/src/services/pulls/usePulls.tsx
+++ b/src/services/pulls/usePulls.tsx
@@ -17,6 +17,7 @@ import {
   RepoOwnerNotActivatedErrorSchema,
 } from 'services/repo'
 import Api from 'shared/api'
+import { rejectNetworkError } from 'shared/api/rejectNetworkError'
 import { mapEdges } from 'shared/utils/graphql'
 import A from 'ui/A'
 
@@ -269,24 +270,25 @@ export function usePulls({
         const parsedData = GetPullsSchema.safeParse(res?.data)
 
         if (!parsedData.success) {
-          return Promise.reject({
-            status: 404,
-            data: {},
+          return rejectNetworkError({
+            errorName: 'Parsing Error',
+            errorDetails: { callingFn: 'usePulls', error: parsedData.error },
           })
         }
 
         const data = parsedData.data
 
         if (data?.owner?.repository?.__typename === 'NotFoundError') {
-          return Promise.reject({
-            status: 404,
-            data: {},
+          return rejectNetworkError({
+            errorName: 'Not Found Error',
+            errorDetails: { callingFn: 'usePulls' },
           })
         }
 
         if (data?.owner?.repository?.__typename === 'OwnerNotActivatedError') {
-          return Promise.reject({
-            status: 403,
+          return rejectNetworkError({
+            errorName: 'Owner Not Activated',
+            errorDetails: { callingFn: 'usePulls' },
             data: {
               detail: (
                 <p>

--- a/src/services/repo/useActivateMeasurements.test.tsx
+++ b/src/services/repo/useActivateMeasurements.test.tsx
@@ -41,18 +41,14 @@ describe('useActivateMeasurements', () => {
               repo: 'bassuras',
               measurementType: MEASUREMENT_TYPE.FLAG_COVERAGE,
             }),
-          {
-            wrapper,
-          }
+          { wrapper }
         )
 
         result.current.mutate()
 
         await waitFor(() =>
           expect(result.current.data).toEqual({
-            data: {
-              activateMeasurements: null,
-            },
+            data: { activateMeasurements: null },
           })
         )
       })
@@ -92,9 +88,7 @@ describe('useActivateMeasurements', () => {
               repo: 'bassuras',
               measurementType: MEASUREMENT_TYPE.FLAG_COVERAGE,
             }),
-          {
-            wrapper,
-          }
+          { wrapper }
         )
 
         result.current.mutate()
@@ -139,19 +133,18 @@ describe('useActivateMeasurements', () => {
               repo: 'bassuras',
               measurementType: MEASUREMENT_TYPE.FLAG_COVERAGE,
             }),
-          {
-            wrapper,
-          }
+          { wrapper }
         )
 
         result.current.mutate()
 
         await waitFor(() =>
-          expect(result.current.error).toEqual({
-            data: {},
-            dev: 'useActivateMeasurements - 404 failed to parse',
-            status: 404,
-          })
+          expect(result.current.error).toEqual(
+            expect.objectContaining({
+              dev: 'useActivateMeasurements - Parsing Error',
+              status: 400,
+            })
+          )
         )
       })
     })

--- a/src/services/repo/useActivateMeasurements.tsx
+++ b/src/services/repo/useActivateMeasurements.tsx
@@ -3,7 +3,7 @@ import z from 'zod'
 
 import { renderToast } from 'services/toast'
 import Api from 'shared/api'
-import { NetworkErrorObject } from 'shared/api/helpers'
+import { rejectNetworkError } from 'shared/api/rejectNetworkError'
 
 export const MEASUREMENT_TYPE = {
   FLAG_COVERAGE: 'FLAG_COVERAGE',
@@ -80,11 +80,13 @@ export function useActivateMeasurements({
     onSuccess: ({ data }) => {
       const parsedData = ResponseSchema.safeParse(data)
       if (!parsedData.success) {
-        return Promise.reject({
-          status: 404,
-          data: {},
-          dev: 'useActivateMeasurements - 404 failed to parse',
-        } satisfies NetworkErrorObject)
+        return rejectNetworkError({
+          errorName: 'Parsing Error',
+          errorDetails: {
+            callingFn: 'useActivateMeasurements',
+            error: parsedData.error,
+          },
+        })
       }
 
       const error = parsedData.data.activateMeasurements?.error

--- a/src/services/repo/useComponentsBackfilled.test.tsx
+++ b/src/services/repo/useComponentsBackfilled.test.tsx
@@ -5,8 +5,6 @@ import { setupServer } from 'msw/node'
 import { MemoryRouter, Route } from 'react-router-dom'
 import { type MockInstance } from 'vitest'
 
-import A from 'ui/A'
-
 import { useComponentsBackfilled } from './index'
 
 const queryClient = new QueryClient({
@@ -101,11 +99,12 @@ describe('useComponentsBackfilled', () => {
       })
 
       await waitFor(() =>
-        expect(result.current.error).toEqual({
-          status: 404,
-          data: {},
-          dev: 'useComponentsBackfilled - 404 failed to parse',
-        })
+        expect(result.current.error).toEqual(
+          expect.objectContaining({
+            dev: 'useComponentsBackfilled - Parsing Error',
+            status: 400,
+          })
+        )
       )
     })
   })
@@ -143,11 +142,12 @@ describe('useComponentsBackfilled', () => {
       })
 
       await waitFor(() =>
-        expect(result.current.error).toEqual({
-          status: 404,
-          data: {},
-          dev: 'useComponentsBackfilled - 404 NotFoundError',
-        })
+        expect(result.current.error).toEqual(
+          expect.objectContaining({
+            dev: 'useComponentsBackfilled - Not Found Error',
+            status: 404,
+          })
+        )
       )
     })
   })
@@ -185,25 +185,12 @@ describe('useComponentsBackfilled', () => {
       })
 
       await waitFor(() =>
-        expect(result.current.error).toEqual({
-          status: 403,
-          data: {
-            detail: (
-              <p>
-                Activation is required to view this repo, please{' '}
-                <A
-                  to={{ pageName: 'membersTab' }}
-                  hook="activate-members"
-                  isExternal={false}
-                >
-                  click here{' '}
-                </A>{' '}
-                to activate your account.
-              </p>
-            ),
-          },
-          dev: 'useComponentsBackfilled - 403 OwnerNotActivatedError',
-        })
+        expect(result.current.error).toEqual(
+          expect.objectContaining({
+            dev: 'useComponentsBackfilled - Owner Not Activated',
+            status: 403,
+          })
+        )
       )
     })
   })

--- a/src/services/repo/useComponentsBackfilled.tsx
+++ b/src/services/repo/useComponentsBackfilled.tsx
@@ -7,7 +7,7 @@ import {
   RepoOwnerNotActivatedErrorSchema,
 } from 'services/repo/schemas'
 import Api from 'shared/api'
-import { type NetworkErrorObject } from 'shared/api/helpers'
+import { rejectNetworkError } from 'shared/api/rejectNetworkError'
 import A from 'ui/A'
 
 const query = `
@@ -80,26 +80,28 @@ export function useComponentsBackfilled() {
         )
 
         if (!parsedData.success) {
-          return Promise.reject({
-            status: 404,
-            data: {},
-            dev: 'useComponentsBackfilled - 404 failed to parse',
-          } satisfies NetworkErrorObject)
+          return rejectNetworkError({
+            errorName: 'Parsing Error',
+            errorDetails: {
+              callingFn: 'useComponentsBackfilled',
+              error: parsedData.error,
+            },
+          })
         }
 
         const data = parsedData.data
 
         if (data?.owner?.repository?.__typename === 'NotFoundError') {
-          return Promise.reject({
-            status: 404,
-            data: {},
-            dev: `useComponentsBackfilled - 404 NotFoundError`,
-          } satisfies NetworkErrorObject)
+          return rejectNetworkError({
+            errorName: 'Not Found Error',
+            errorDetails: { callingFn: 'useComponentsBackfilled' },
+          })
         }
 
         if (data?.owner?.repository?.__typename === 'OwnerNotActivatedError') {
-          return Promise.reject({
-            status: 403,
+          return rejectNetworkError({
+            errorName: 'Owner Not Activated',
+            errorDetails: { callingFn: 'useComponentsBackfilled' },
             data: {
               detail: (
                 <p>
@@ -115,8 +117,7 @@ export function useComponentsBackfilled() {
                 </p>
               ),
             },
-            dev: `useComponentsBackfilled - 403 OwnerNotActivatedError`,
-          } satisfies NetworkErrorObject)
+          })
         }
 
         return {

--- a/src/services/repo/useRepo.test.tsx
+++ b/src/services/repo/useRepo.test.tsx
@@ -185,8 +185,8 @@ describe('useRepo', () => {
       await waitFor(() =>
         expect(result.current.error).toEqual(
           expect.objectContaining({
-            status: 404,
-            dev: 'useRepo - 404 failed to parse',
+            dev: 'useRepo - Parsing Error',
+            status: 400,
           })
         )
       )
@@ -218,8 +218,8 @@ describe('useRepo', () => {
       await waitFor(() =>
         expect(result.current.error).toEqual(
           expect.objectContaining({
+            dev: 'useRepo - Not Found Error',
             status: 404,
-            dev: 'useRepo - 404 NotFoundError',
           })
         )
       )

--- a/src/services/repo/useRepo.tsx
+++ b/src/services/repo/useRepo.tsx
@@ -2,7 +2,7 @@ import { useQuery } from '@tanstack/react-query'
 import { z } from 'zod'
 
 import Api from 'shared/api'
-import { NetworkErrorObject } from 'shared/api/helpers'
+import { rejectNetworkError } from 'shared/api/rejectNetworkError'
 
 import {
   RepoNotFoundErrorSchema,
@@ -92,21 +92,22 @@ export function useRepo({ provider, owner, repo, opts = {} }: UseRepoArgs) {
         const parsedRes = RepoSchema.safeParse(res?.data)
 
         if (!parsedRes.success) {
-          return Promise.reject({
-            status: 404,
-            data: {},
-            dev: 'useRepo - 404 failed to parse',
-          } satisfies NetworkErrorObject)
+          return rejectNetworkError({
+            errorName: 'Parsing Error',
+            errorDetails: {
+              callingFn: 'useRepo',
+              error: parsedRes.error,
+            },
+          })
         }
 
         const { data } = parsedRes
 
         if (data?.owner?.repository?.__typename === 'NotFoundError') {
-          return Promise.reject({
-            status: 404,
-            data: {},
-            dev: 'useRepo - 404 NotFoundError',
-          } satisfies NetworkErrorObject)
+          return rejectNetworkError({
+            errorName: 'Not Found Error',
+            errorDetails: { callingFn: 'useRepo' },
+          })
         }
 
         if (data?.owner?.repository?.__typename === 'OwnerNotActivatedError') {

--- a/src/services/repo/useRepoBackfilled.test.tsx
+++ b/src/services/repo/useRepoBackfilled.test.tsx
@@ -135,7 +135,8 @@ describe('useRepoBackfilled', () => {
         await waitFor(() =>
           expect(result.current.error).toEqual(
             expect.objectContaining({
-              status: 404,
+              dev: 'useRepoBackfilled - Parsing Error',
+              status: 400,
             })
           )
         )
@@ -151,6 +152,7 @@ describe('useRepoBackfilled', () => {
         await waitFor(() =>
           expect(result.current.error).toEqual(
             expect.objectContaining({
+              dev: 'useRepoBackfilled - Not Found Error',
               status: 404,
             })
           )
@@ -167,6 +169,7 @@ describe('useRepoBackfilled', () => {
         await waitFor(() =>
           expect(result.current.error).toEqual(
             expect.objectContaining({
+              dev: 'useRepoBackfilled - Owner Not Activated',
               status: 403,
             })
           )

--- a/src/services/repo/useRepoBackfilled.tsx
+++ b/src/services/repo/useRepoBackfilled.tsx
@@ -3,7 +3,7 @@ import { useParams } from 'react-router-dom'
 import { z } from 'zod'
 
 import Api from 'shared/api'
-import { NetworkErrorObject } from 'shared/api/helpers'
+import { rejectNetworkError } from 'shared/api/rejectNetworkError'
 import A from 'ui/A'
 
 import {
@@ -90,26 +90,28 @@ export function useRepoBackfilled() {
         const parsedRes = RepoBackfilledSchema.safeParse(res?.data)
 
         if (!parsedRes.success) {
-          return Promise.reject({
-            status: 404,
-            data: {},
-            dev: 'useRepoBackfilled - 404 Not Found Error',
-          } satisfies NetworkErrorObject)
+          return rejectNetworkError({
+            errorName: 'Parsing Error',
+            errorDetails: {
+              callingFn: 'useRepoBackfilled',
+              error: parsedRes.error,
+            },
+          })
         }
 
         const data = parsedRes.data
 
         if (data?.owner?.repository?.__typename === 'NotFoundError') {
-          return Promise.reject({
-            status: 404,
-            data: {},
-            dev: 'useRepoBackfilled - 404 not found error',
-          } satisfies NetworkErrorObject)
+          return rejectNetworkError({
+            errorName: 'Not Found Error',
+            errorDetails: { callingFn: 'useRepoBackfilled' },
+          })
         }
 
         if (data?.owner?.repository?.__typename === 'OwnerNotActivatedError') {
-          return Promise.reject({
-            status: 403,
+          return rejectNetworkError({
+            errorName: 'Owner Not Activated',
+            errorDetails: { callingFn: 'useRepoBackfilled' },
             data: {
               detail: (
                 <p>
@@ -120,7 +122,6 @@ export function useRepoBackfilled() {
                 </p>
               ),
             },
-            dev: 'useRepoBackfilled - 403 owner not activated error',
           })
         }
 

--- a/src/services/repo/useRepoComponents.test.tsx
+++ b/src/services/repo/useRepoComponents.test.tsx
@@ -5,8 +5,6 @@ import { setupServer } from 'msw/node'
 import { MemoryRouter, Route } from 'react-router-dom'
 import { type MockInstance } from 'vitest'
 
-import A from 'ui/A'
-
 import { useRepoComponents } from './useRepoComponents'
 
 const queryClient = new QueryClient({
@@ -133,9 +131,7 @@ describe('ComponentMeasurements', () => {
               after: '2021-09-01',
               before: '2021-09-30',
             }),
-          {
-            wrapper,
-          }
+          { wrapper }
         )
 
         await waitFor(() =>
@@ -166,17 +162,16 @@ describe('ComponentMeasurements', () => {
             after: '2021-09-01',
             before: '2021-09-30',
           }),
-        {
-          wrapper,
-        }
+        { wrapper }
       )
 
       await waitFor(() =>
-        expect(result.current.error).toEqual({
-          status: 404,
-          data: {},
-          dev: 'useRepoComponents - 404 failed to parse',
-        })
+        expect(result.current.error).toEqual(
+          expect.objectContaining({
+            dev: 'useRepoComponentsArgs - Parsing Error',
+            status: 400,
+          })
+        )
       )
     })
   })
@@ -200,17 +195,16 @@ describe('ComponentMeasurements', () => {
             after: '2021-09-01',
             before: '2021-09-30',
           }),
-        {
-          wrapper,
-        }
+        { wrapper }
       )
 
       await waitFor(() =>
-        expect(result.current.error).toEqual({
-          status: 404,
-          data: {},
-          dev: 'useRepoComponents - 404 NotFoundError',
-        })
+        expect(result.current.error).toEqual(
+          expect.objectContaining({
+            dev: 'useRepoComponentsArgs - Not Found Error',
+            status: 404,
+          })
+        )
       )
     })
   })
@@ -234,31 +228,16 @@ describe('ComponentMeasurements', () => {
             after: '2021-09-01',
             before: '2021-09-30',
           }),
-        {
-          wrapper,
-        }
+        { wrapper }
       )
 
       await waitFor(() =>
-        expect(result.current.error).toEqual({
-          status: 403,
-          data: {
-            detail: (
-              <p>
-                Activation is required to view this repo, please{' '}
-                <A
-                  to={{ pageName: 'membersTab' }}
-                  hook="activate-members"
-                  isExternal={false}
-                >
-                  click here{' '}
-                </A>{' '}
-                to activate your account.
-              </p>
-            ),
-          },
-          dev: 'useRepoComponents - 403 OwnerNotActivatedError',
-        })
+        expect(result.current.error).toEqual(
+          expect.objectContaining({
+            dev: 'useRepoComponentsArgs - Owner Not Activated',
+            status: 403,
+          })
+        )
       )
     })
   })

--- a/src/services/repo/useRepoComponents.tsx
+++ b/src/services/repo/useRepoComponents.tsx
@@ -9,7 +9,7 @@ import {
   RepoOwnerNotActivatedErrorSchema,
 } from 'services/repo/schemas'
 import Api from 'shared/api'
-import { type NetworkErrorObject } from 'shared/api/helpers'
+import { rejectNetworkError } from 'shared/api/rejectNetworkError'
 import A from 'ui/A'
 
 const query = `
@@ -86,97 +86,6 @@ const RequestSchema = z.object({
     .nullable(),
 })
 
-interface FetchRepoComponentsArgs {
-  provider: string
-  owner: string
-  repo: string
-  filters?: {
-    components?: string[]
-  }
-  branch?: string
-  orderingDirection: OrderingDirection
-  interval: 'INTERVAL_30_DAY' | 'INTERVAL_7_DAY' | 'INTERVAL_1_DAY'
-  after: string
-  before: string
-  signal?: AbortSignal
-}
-
-function fetchRepoComponents({
-  provider,
-  owner: name,
-  repo,
-  filters,
-  orderingDirection,
-  interval,
-  after,
-  before,
-  branch,
-  signal,
-}: FetchRepoComponentsArgs) {
-  return Api.graphql({
-    provider,
-    query,
-    signal,
-    variables: {
-      name,
-      repo,
-      filters,
-      orderingDirection,
-      interval,
-      after,
-      before,
-      branch,
-    },
-  }).then((res) => {
-    const parsedRes = RequestSchema.safeParse(res?.data)
-
-    if (!parsedRes.success) {
-      return Promise.reject({
-        status: 404,
-        data: {},
-        dev: `useRepoComponents - 404 failed to parse`,
-      } satisfies NetworkErrorObject)
-    }
-
-    const data = parsedRes.data
-
-    if (data?.owner?.repository?.__typename === 'NotFoundError') {
-      return Promise.reject({
-        status: 404,
-        data: {},
-        dev: `useRepoComponents - 404 NotFoundError`,
-      } satisfies NetworkErrorObject)
-    }
-
-    if (data?.owner?.repository?.__typename === 'OwnerNotActivatedError') {
-      return Promise.reject({
-        status: 403,
-        data: {
-          detail: (
-            <p>
-              Activation is required to view this repo, please{' '}
-              <A
-                to={{ pageName: 'membersTab' }}
-                hook="activate-members"
-                isExternal={false}
-              >
-                click here{' '}
-              </A>{' '}
-              to activate your account.
-            </p>
-          ),
-        },
-        dev: `useRepoComponents - 403 OwnerNotActivatedError`,
-      } satisfies NetworkErrorObject)
-    }
-
-    // This returns something else 2
-    return {
-      components: data?.owner?.repository?.coverageAnalytics?.components,
-    }
-  })
-}
-
 interface useRepoComponentsArgs {
   filters?: {
     components?: string[]
@@ -219,19 +128,71 @@ export function useRepoComponents({
       before,
       branch,
     ],
-    queryFn: ({ signal }) =>
-      fetchRepoComponents({
+    queryFn: ({ signal }) => {
+      return Api.graphql({
         provider,
-        owner,
-        repo,
-        filters: filters,
-        orderingDirection,
-        interval,
-        after,
-        before,
-        branch,
+        query,
         signal,
-      }),
+        variables: {
+          name: owner,
+          repo,
+          filters,
+          orderingDirection,
+          interval,
+          after,
+          before,
+          branch,
+        },
+      }).then((res) => {
+        const parsedRes = RequestSchema.safeParse(res?.data)
+
+        if (!parsedRes.success) {
+          return rejectNetworkError({
+            errorName: 'Parsing Error',
+            errorDetails: {
+              callingFn: 'useRepoComponentsArgs',
+              error: parsedRes.error,
+            },
+          })
+        }
+
+        const data = parsedRes.data
+
+        if (data?.owner?.repository?.__typename === 'NotFoundError') {
+          return rejectNetworkError({
+            errorName: 'Not Found Error',
+            errorDetails: { callingFn: 'useRepoComponentsArgs' },
+          })
+        }
+
+        if (data?.owner?.repository?.__typename === 'OwnerNotActivatedError') {
+          return rejectNetworkError({
+            errorName: 'Owner Not Activated',
+            errorDetails: { callingFn: 'useRepoComponentsArgs' },
+            data: {
+              detail: (
+                <p>
+                  Activation is required to view this repo, please{' '}
+                  <A
+                    to={{ pageName: 'membersTab' }}
+                    hook="activate-members"
+                    isExternal={false}
+                  >
+                    click here{' '}
+                  </A>{' '}
+                  to activate your account.
+                </p>
+              ),
+            },
+          })
+        }
+
+        // This returns something else 2
+        return {
+          components: data?.owner?.repository?.coverageAnalytics?.components,
+        }
+      })
+    },
     ...opts,
   })
 }


### PR DESCRIPTION
# Description

This PR is part three in a series, where we're going through and updating our query requests to utilize the new `rejectNetworkError` helper function.

Ticket: codecov/engineering-team#3329

# Notable Changes

- Update hooks to use `rejectNetworkError` (see [commits](https://github.com/codecov/gazebo/pull/TBD/commits))
- Remove redundant function in `useRepoComponentsArgs`
- Update tests