### PR TITLE
feat: Add rejectNetworkError to API calls (part four)

### DIFF
--- a/src/services/repo/useRepoComponentsSelect.test.tsx
+++ b/src/services/repo/useRepoComponentsSelect.test.tsx
@@ -5,8 +5,6 @@ import { setupServer } from 'msw/node'
 import { MemoryRouter, Route } from 'react-router-dom'
 import { type MockInstance } from 'vitest'
 
-import A from 'ui/A'
-
 import { useRepoComponentsSelect } from './useRepoComponentsSelect'
 
 const queryClient = new QueryClient({
@@ -45,14 +43,8 @@ const dataReturned = {
       __typename: 'Repository',
       coverageAnalytics: {
         componentsYaml: [
-          {
-            name: 'foo',
-            id: '1',
-          },
-          {
-            name: 'bar',
-            id: '2',
-          },
+          { name: 'foo', id: '1' },
+          { name: 'bar', id: '2' },
         ],
       },
     },
@@ -135,6 +127,7 @@ describe('RepoComponentsYamlSelector', () => {
     afterAll(() => {
       consoleSpy.mockRestore()
     })
+
     it('returns an error', async () => {
       setup({ isSchemaInvalid: true })
       const { result } = renderHook(() => useRepoComponentsSelect(), {
@@ -142,11 +135,12 @@ describe('RepoComponentsYamlSelector', () => {
       })
 
       await waitFor(() =>
-        expect(result.current.error).toEqual({
-          status: 404,
-          data: {},
-          dev: 'useRepoComponentsSelect - 404 Error parsing repo components data',
-        })
+        expect(result.current.error).toEqual(
+          expect.objectContaining({
+            dev: 'useRepoComponentsSelect - Parsing Error',
+            status: 400,
+          })
+        )
       )
     })
   })
@@ -168,11 +162,12 @@ describe('RepoComponentsYamlSelector', () => {
       })
 
       await waitFor(() =>
-        expect(result.current.error).toEqual({
-          status: 404,
-          data: {},
-          dev: 'useRepoComponentsSelect - 404 RepoNotFoundError',
-        })
+        expect(result.current.error).toEqual(
+          expect.objectContaining({
+            dev: 'useRepoComponentsSelect - Not Found Error',
+            status: 404,
+          })
+        )
       )
     })
   })
@@ -194,25 +189,12 @@ describe('RepoComponentsYamlSelector', () => {
       })
 
       await waitFor(() =>
-        expect(result.current.error).toEqual({
-          status: 403,
-          data: {
-            detail: (
-              <p>
-                Activation is required to view this repo, please{' '}
-                <A
-                  to={{ pageName: 'membersTab' }}
-                  hook="members-page-link"
-                  isExternal={false}
-                >
-                  click here{' '}
-                </A>{' '}
-                to activate your account.
-              </p>
-            ),
-          },
-          dev: 'useRepoComponentsSelect - 403 OwnerNotActivatedError',
-        })
+        expect(result.current.error).toEqual(
+          expect.objectContaining({
+            dev: 'useRepoComponentsSelect - Owner Not Activated',
+            status: 403,
+          })
+        )
       )
     })
   })

--- a/src/services/repo/useRepoComponentsSelect.tsx
+++ b/src/services/repo/useRepoComponentsSelect.tsx
@@ -7,7 +7,7 @@ import {
   RepoOwnerNotActivatedErrorSchema,
 } from 'services/repo'
 import Api from 'shared/api'
-import { type NetworkErrorObject } from 'shared/api/helpers'
+import { rejectNetworkError } from 'shared/api/rejectNetworkError'
 import A from 'ui/A'
 
 const query = `
@@ -101,26 +101,32 @@ export function useRepoComponentsSelect({
         const parsedData = RequestSchema.safeParse(res?.data)
 
         if (!parsedData.success) {
-          return Promise.reject({
-            status: 404,
-            data: {},
-            dev: 'useRepoComponentsSelect - 404 Error parsing repo components data',
-          } satisfies NetworkErrorObject)
+          return rejectNetworkError({
+            errorName: 'Parsing Error',
+            errorDetails: {
+              callingFn: 'useRepoComponentsSelect',
+              error: parsedData.error,
+            },
+          })
         }
 
         const data = parsedData.data
 
         if (data?.owner?.repository?.__typename === 'NotFoundError') {
-          return Promise.reject({
-            status: 404,
-            data: {},
-            dev: 'useRepoComponentsSelect - 404 RepoNotFoundError',
-          } satisfies NetworkErrorObject)
+          return rejectNetworkError({
+            errorName: 'Not Found Error',
+            errorDetails: {
+              callingFn: 'useRepoComponentsSelect',
+            },
+          })
         }
 
         if (data?.owner?.repository?.__typename === 'OwnerNotActivatedError') {
-          return Promise.reject({
-            status: 403,
+          return rejectNetworkError({
+            errorName: 'Owner Not Activated',
+            errorDetails: {
+              callingFn: 'useRepoComponentsSelect',
+            },
             data: {
               detail: (
                 <p>
@@ -136,8 +142,7 @@ export function useRepoComponentsSelect({
                 </p>
               ),
             },
-            dev: 'useRepoComponentsSelect - 403 OwnerNotActivatedError',
-          } satisfies NetworkErrorObject)
+          })
         }
 
         return {

--- a/src/services/repo/useRepoConfig.test.tsx
+++ b/src/services/repo/useRepoConfig.test.tsx
@@ -163,7 +163,8 @@ describe('useRepoConfig', () => {
       await waitFor(() =>
         expect(result.current.error).toEqual(
           expect.objectContaining({
-            status: 404,
+            dev: 'useRepoConfig - Parsing Error',
+            status: 400,
           })
         )
       )
@@ -187,11 +188,13 @@ describe('useRepoConfig', () => {
       await waitFor(() =>
         expect(result.current.error).toEqual(
           expect.objectContaining({
+            dev: 'useRepoConfig - Owner Not Activated',
             status: 403,
           })
         )
       )
     })
+
     it('can return not found error', async () => {
       setup({ isNotFoundError: true })
       const { result } = renderHook(
@@ -210,6 +213,7 @@ describe('useRepoConfig', () => {
       await waitFor(() =>
         expect(result.current.error).toEqual(
           expect.objectContaining({
+            dev: 'useRepoConfig - Not Found Error',
             status: 404,
           })
         )

--- a/src/services/repo/useRepoConfig.tsx
+++ b/src/services/repo/useRepoConfig.tsx
@@ -2,7 +2,7 @@ import { useQuery, type UseQueryOptions } from '@tanstack/react-query'
 import { z } from 'zod'
 
 import Api from 'shared/api'
-import { NetworkErrorObject } from 'shared/api/helpers'
+import { rejectNetworkError } from 'shared/api/rejectNetworkError'
 import A from 'ui/A'
 
 import {
@@ -97,26 +97,32 @@ export const useRepoConfig = ({
         const parsedRes = UseRepoConfigSchema.safeParse(res?.data)
 
         if (!parsedRes.success) {
-          return Promise.reject({
-            status: 404,
-            data: {},
-            dev: 'useRepoConfig - 404 schema parsing failed',
-          } satisfies NetworkErrorObject)
+          return rejectNetworkError({
+            errorName: 'Parsing Error',
+            errorDetails: {
+              callingFn: 'useRepoConfig',
+              error: parsedRes.error,
+            },
+          })
         }
 
         const data = parsedRes.data
 
         if (data?.owner?.repository?.__typename === 'NotFoundError') {
-          return Promise.reject({
-            status: 404,
-            data: {},
-            dev: 'useRepoConfig - 404 NotFoundError',
-          } satisfies NetworkErrorObject)
+          return rejectNetworkError({
+            errorName: 'Not Found Error',
+            errorDetails: {
+              callingFn: 'useRepoConfig',
+            },
+          })
         }
 
         if (data?.owner?.repository?.__typename === 'OwnerNotActivatedError') {
-          return Promise.reject({
-            status: 403,
+          return rejectNetworkError({
+            errorName: 'Owner Not Activated',
+            errorDetails: {
+              callingFn: 'useRepoConfig',
+            },
             data: {
               detail: (
                 <p>
@@ -127,8 +133,7 @@ export const useRepoConfig = ({
                 </p>
               ),
             },
-            dev: 'useRepoConfig - 403 OwnerNotActivatedError',
-          } satisfies NetworkErrorObject)
+          })
         }
 
         return res?.data?.owner?.repository?.repositoryConfig ?? {}

--- a/src/services/repo/useRepoCoverage.test.tsx
+++ b/src/services/repo/useRepoCoverage.test.tsx
@@ -15,11 +15,7 @@ const mockRepoCoverage = {
         head: {
           yamlState: 'DEFAULT',
           coverageAnalytics: {
-            totals: {
-              percentCovered: 70.44,
-              lineCount: 90,
-              hitsCount: 80,
-            },
+            totals: { percentCovered: 70.44, lineCount: 90, hitsCount: 80 },
           },
         },
       },
@@ -115,9 +111,7 @@ describe('useRepoCoverage', () => {
             repo: 'woof',
             branch: 'main',
           }),
-        {
-          wrapper,
-        }
+        { wrapper }
       )
 
       await waitFor(() =>
@@ -126,11 +120,7 @@ describe('useRepoCoverage', () => {
           head: {
             yamlState: 'DEFAULT',
             coverageAnalytics: {
-              totals: {
-                percentCovered: 70.44,
-                lineCount: 90,
-                hitsCount: 80,
-              },
+              totals: { percentCovered: 70.44, lineCount: 90, hitsCount: 80 },
             },
           },
         })
@@ -149,9 +139,7 @@ describe('useRepoCoverage', () => {
             repo: 'woof',
             branch: 'main',
           }),
-        {
-          wrapper,
-        }
+        { wrapper }
       )
 
       await waitFor(() => {
@@ -170,7 +158,7 @@ describe('useRepoCoverage', () => {
       consoleSpy.mockRestore()
     })
 
-    it('rejects with 404', async () => {
+    it('rejects with 400', async () => {
       setup({ badResponse: true })
       const { result } = renderHook(
         () =>
@@ -188,8 +176,8 @@ describe('useRepoCoverage', () => {
       await waitFor(() =>
         expect(result.current.error).toEqual(
           expect.objectContaining({
-            status: 404,
-            dev: 'useRepoCoverage - 404 failed to parse',
+            dev: 'useRepoCoverage - Parsing Error',
+            status: 400,
           })
         )
       )
@@ -216,16 +204,14 @@ describe('useRepoCoverage', () => {
             repo: 'woof',
             branch: 'main',
           }),
-        {
-          wrapper,
-        }
+        { wrapper }
       )
 
       await waitFor(() =>
         expect(result.current.error).toEqual(
           expect.objectContaining({
+            dev: 'useRepoCoverage - Not Found Error',
             status: 404,
-            dev: 'useRepoCoverage - 404 NotFoundError',
           })
         )
       )
@@ -252,9 +238,7 @@ describe('useRepoCoverage', () => {
             repo: 'woof',
             branch: 'main',
           }),
-        {
-          wrapper,
-        }
+        { wrapper }
       )
 
       await waitFor(() => expect(result.current.isError).toBeTruthy())
@@ -262,8 +246,8 @@ describe('useRepoCoverage', () => {
       await waitFor(() =>
         expect(result.current.error).toEqual(
           expect.objectContaining({
+            dev: 'useRepoCoverage - Owner Not Activated',
             status: 403,
-            dev: 'useRepoCoverage - 403 OwnerNotActivated Error',
           })
         )
       )

--- a/src/services/repo/useRepoFlags.test.tsx
+++ b/src/services/repo/useRepoFlags.test.tsx
@@ -5,8 +5,6 @@ import { setupServer } from 'msw/node'
 import { MemoryRouter, Route } from 'react-router-dom'
 import { type MockInstance } from 'vitest'
 
-import A from 'ui/A'
-
 import { useRepoFlags } from './useRepoFlags'
 
 const queryClient = new QueryClient({
@@ -119,7 +117,6 @@ const expectedNextPageData = [
     name: 'flag3',
     percentCovered: 92.95,
     percentChange: 1.38,
-
     measurements: [
       { avg: 92.92690138723546 },
       { avg: 92.99535449712643 },
@@ -265,11 +262,12 @@ describe('FlagMeasurements', () => {
       )
 
       await waitFor(() =>
-        expect(result.current.error).toEqual({
-          status: 404,
-          data: {},
-          dev: 'useRepoFlags - 404 failed to parse',
-        })
+        expect(result.current.error).toEqual(
+          expect.objectContaining({
+            dev: 'useRepoFlags - Parsing Error',
+            status: 400,
+          })
+        )
       )
     })
   })
@@ -297,11 +295,12 @@ describe('FlagMeasurements', () => {
       )
 
       await waitFor(() =>
-        expect(result.current.error).toEqual({
-          status: 404,
-          data: {},
-          dev: 'useRepoFlags - 404 NotFoundError',
-        })
+        expect(result.current.error).toEqual(
+          expect.objectContaining({
+            dev: 'useRepoFlags - Not Found Error',
+            status: 404,
+          })
+        )
       )
     })
   })
@@ -329,25 +328,12 @@ describe('FlagMeasurements', () => {
       )
 
       await waitFor(() =>
-        expect(result.current.error).toEqual({
-          status: 403,
-          data: {
-            detail: (
-              <p>
-                Activation is required to view this repo, please{' '}
-                <A
-                  to={{ pageName: 'membersTab' }}
-                  hook="activate-members"
-                  isExternal={false}
-                >
-                  click here{' '}
-                </A>{' '}
-                to activate your account.
-              </p>
-            ),
-          },
-          dev: 'useRepoFlags - 403 OwnerNotActivatedError',
-        })
+        expect(result.current.error).toEqual(
+          expect.objectContaining({
+            dev: 'useRepoFlags - Owner Not Activated',
+            status: 403,
+          })
+        )
       )
     })
   })

--- a/src/services/repo/useRepoFlags.tsx
+++ b/src/services/repo/useRepoFlags.tsx
@@ -9,7 +9,7 @@ import {
   RepoOwnerNotActivatedErrorSchema,
 } from 'services/repo/schemas'
 import Api from 'shared/api'
-import { type NetworkErrorObject } from 'shared/api/helpers'
+import { rejectNetworkError } from 'shared/api/rejectNetworkError'
 import { mapEdges } from 'shared/utils/graphql'
 import A from 'ui/A'
 
@@ -103,99 +103,6 @@ const RequestSchema = z.object({
     .nullable(),
 })
 
-interface FetchRepoFlagsArgs {
-  provider: string
-  owner: string
-  repo: string
-  filters?: {
-    flagNames?: string[]
-    ter?: string
-  }
-  orderingDirection: OrderingDirection
-  interval: 'INTERVAL_30_DAY' | 'INTERVAL_7_DAY' | 'INTERVAL_1_DAY'
-  afterDate: string
-  beforeDate: string
-  after: string
-  signal?: AbortSignal
-}
-
-function fetchRepoFlags({
-  provider,
-  owner: name,
-  repo,
-  filters,
-  orderingDirection,
-  interval,
-  afterDate,
-  beforeDate,
-  after,
-  signal,
-}: FetchRepoFlagsArgs) {
-  return Api.graphql({
-    provider,
-    query,
-    signal,
-    variables: {
-      name,
-      repo,
-      filters,
-      orderingDirection,
-      interval,
-      afterDate,
-      beforeDate,
-      after,
-    },
-  }).then((res) => {
-    const parsedRes = RequestSchema.safeParse(res?.data)
-
-    if (!parsedRes.success) {
-      return Promise.reject({
-        status: 404,
-        data: {},
-        dev: `useRepoFlags - 404 failed to parse`,
-      } satisfies NetworkErrorObject)
-    }
-
-    const data = parsedRes.data
-
-    if (data?.owner?.repository?.__typename === 'NotFoundError') {
-      return Promise.reject({
-        status: 404,
-        data: {},
-        dev: `useRepoFlags - 404 NotFoundError`,
-      } satisfies NetworkErrorObject)
-    }
-
-    if (data?.owner?.repository?.__typename === 'OwnerNotActivatedError') {
-      return Promise.reject({
-        status: 403,
-        data: {
-          detail: (
-            <p>
-              Activation is required to view this repo, please{' '}
-              <A
-                to={{ pageName: 'membersTab' }}
-                hook="activate-members"
-                isExternal={false}
-              >
-                click here{' '}
-              </A>{' '}
-              to activate your account.
-            </p>
-          ),
-        },
-        dev: `useRepoFlags - 403 OwnerNotActivatedError`,
-      } satisfies NetworkErrorObject)
-    }
-
-    const flags = data?.owner?.repository?.coverageAnalytics?.flags
-    return {
-      flags: mapEdges(flags),
-      pageInfo: flags?.pageInfo,
-    }
-  })
-}
-
 interface UseRepoFlagsArgs {
   filters?: {
     flagNames?: string[]
@@ -236,19 +143,76 @@ export function useRepoFlags({
       afterDate,
       beforeDate,
     ],
-    queryFn: ({ pageParam: after, signal }) =>
-      fetchRepoFlags({
+    queryFn: ({ pageParam: after, signal }) => {
+      return Api.graphql({
         provider,
-        owner,
-        repo,
-        filters: filters,
-        orderingDirection,
-        interval,
-        afterDate,
-        beforeDate,
-        after,
+        query,
         signal,
-      }),
+        variables: {
+          name: owner,
+          repo,
+          filters,
+          orderingDirection,
+          interval,
+          afterDate,
+          beforeDate,
+          after,
+        },
+      }).then((res) => {
+        const parsedRes = RequestSchema.safeParse(res?.data)
+
+        if (!parsedRes.success) {
+          return rejectNetworkError({
+            errorName: 'Parsing Error',
+            errorDetails: {
+              callingFn: 'useRepoFlags',
+              error: parsedRes.error,
+            },
+          })
+        }
+
+        const data = parsedRes.data
+
+        if (data?.owner?.repository?.__typename === 'NotFoundError') {
+          return rejectNetworkError({
+            errorName: 'Not Found Error',
+            errorDetails: {
+              callingFn: 'useRepoFlags',
+            },
+          })
+        }
+
+        if (data?.owner?.repository?.__typename === 'OwnerNotActivatedError') {
+          return rejectNetworkError({
+            errorName: 'Owner Not Activated',
+            errorDetails: {
+              callingFn: 'useRepoFlags',
+            },
+            data: {
+              detail: (
+                <p>
+                  Activation is required to view this repo, please{' '}
+                  <A
+                    to={{ pageName: 'membersTab' }}
+                    hook="activate-members"
+                    isExternal={false}
+                  >
+                    click here{' '}
+                  </A>{' '}
+                  to activate your account.
+                </p>
+              ),
+            },
+          })
+        }
+
+        const flags = data?.owner?.repository?.coverageAnalytics?.flags
+        return {
+          flags: mapEdges(flags),
+          pageInfo: flags?.pageInfo,
+        }
+      })
+    },
     getNextPageParam: (data) =>
       data?.pageInfo?.hasNextPage ? data.pageInfo.endCursor : undefined,
     ...opts,

--- a/src/services/repo/useRepoFlagsSelect.test.tsx
+++ b/src/services/repo/useRepoFlagsSelect.test.tsx
@@ -8,11 +8,7 @@ import { type MockInstance } from 'vitest'
 import { useRepoFlagsSelect } from './useRepoFlagsSelect'
 
 const queryClient = new QueryClient({
-  defaultOptions: {
-    queries: {
-      retry: false,
-    },
-  },
+  defaultOptions: { queries: { retry: false } },
 })
 
 const wrapper: React.FC<React.PropsWithChildren> = ({ children }) => (
@@ -52,27 +48,11 @@ afterAll(() => {
 })
 
 const initialData = [
-  {
-    node: {
-      name: 'flag1',
-      percentCovered: 93.26,
-    },
-  },
-  {
-    node: {
-      name: 'flag2',
-      percentCovered: 92.72,
-    },
-  },
+  { node: { name: 'flag1', percentCovered: 93.26 } },
+  { node: { name: 'flag2', percentCovered: 92.72 } },
 ]
 
-const invalidData = [
-  {
-    node: {
-      defaultBranch: 'main',
-    },
-  },
-]
+const invalidData = [{ node: { defaultBranch: 'main' } }]
 
 const mockNotFoundError = {
   owner: {
@@ -93,16 +73,7 @@ const mockOwnerNotActivatedError = {
 }
 
 const expectedInitialData = [{ name: 'flag1' }, { name: 'flag2' }]
-
-const nextPageData = [
-  {
-    node: {
-      name: 'flag3',
-      percentCovered: 92.95,
-    },
-  },
-]
-
+const nextPageData = [{ node: { name: 'flag3', percentCovered: 92.95 } }]
 const expectedNextPageData = [{ name: 'flag3' }]
 
 describe('FlagsSelect', () => {
@@ -158,12 +129,8 @@ describe('FlagsSelect', () => {
                 compareWithBase: {
                   __typename: 'Comparison',
                   flagComparisons: [
-                    {
-                      name: 'unit',
-                    },
-                    {
-                      name: 'unit-latest-uploader',
-                    },
+                    { name: 'unit' },
+                    { name: 'unit-latest-uploader' },
                   ],
                 },
               },
@@ -210,7 +177,8 @@ describe('FlagsSelect', () => {
         await waitFor(() =>
           expect(result.current.error).toEqual(
             expect.objectContaining({
-              status: 404,
+              dev: 'fetchRepoFlags - Parsing Error',
+              status: 400,
             })
           )
         )
@@ -225,9 +193,8 @@ describe('FlagsSelect', () => {
         await waitFor(() =>
           expect(result.current.error).toEqual(
             expect.objectContaining({
+              dev: 'fetchRepoFlags - Not Found Error',
               status: 404,
-              data: {},
-              dev: 'useRepoFlagsSelect - 404 NotFoundError',
             })
           )
         )
@@ -242,8 +209,8 @@ describe('FlagsSelect', () => {
         await waitFor(() =>
           expect(result.current.error).toEqual(
             expect.objectContaining({
+              dev: 'fetchRepoFlags - Owner Not Activated',
               status: 403,
-              dev: 'useRepoFlagsSelect - 403 OwnerNotActivatedError',
             })
           )
         )
@@ -307,7 +274,8 @@ describe('FlagsSelect', () => {
         await waitFor(() =>
           expect(result.current.error).toEqual(
             expect.objectContaining({
-              status: 404,
+              dev: 'fetchRepoFlagsForPull - Parsing Error',
+              status: 400,
             })
           )
         )
@@ -322,9 +290,8 @@ describe('FlagsSelect', () => {
         await waitFor(() =>
           expect(result.current.error).toEqual(
             expect.objectContaining({
+              dev: 'fetchRepoFlagsForPull - Not Found Error',
               status: 404,
-              data: {},
-              dev: 'useRepoFlagsSelect - 404 NotFoundError',
             })
           )
         )
@@ -339,8 +306,8 @@ describe('FlagsSelect', () => {
         await waitFor(() =>
           expect(result.current.error).toEqual(
             expect.objectContaining({
+              dev: 'fetchRepoFlagsForPull - Owner Not Activated',
               status: 403,
-              dev: 'useRepoFlagsSelect - 403 OwnerNotActivatedError',
             })
           )
         )

--- a/src/services/repo/useRepoFlagsSelect.tsx
+++ b/src/services/repo/useRepoFlagsSelect.tsx
@@ -13,7 +13,7 @@ import {
   RepoOwnerNotActivatedErrorSchema,
 } from 'services/repo/schemas'
 import Api from 'shared/api'
-import { NetworkErrorObject } from 'shared/api/helpers'
+import { rejectNetworkError } from 'shared/api/rejectNetworkError'
 import A from 'ui/A'
 
 import { mapEdges } from '../../shared/utils/graphql'
@@ -120,26 +120,32 @@ function fetchRepoFlags({
     const parsedRes = FetchRepoFlagsSchema.safeParse(res?.data)
 
     if (!parsedRes.success) {
-      return Promise.reject({
-        status: 404,
-        data: {},
-        dev: `useRepoFlagsSelect - 404 failed to parse`,
-      } satisfies NetworkErrorObject)
+      return rejectNetworkError({
+        errorName: 'Parsing Error',
+        errorDetails: {
+          callingFn: 'fetchRepoFlags',
+          error: parsedRes.error,
+        },
+      })
     }
 
     const data = parsedRes.data
 
     if (data?.owner?.repository?.__typename === 'NotFoundError') {
-      return Promise.reject({
-        status: 404,
-        data: {},
-        dev: `useRepoFlagsSelect - 404 NotFoundError`,
-      } satisfies NetworkErrorObject)
+      return rejectNetworkError({
+        errorName: 'Not Found Error',
+        errorDetails: {
+          callingFn: 'fetchRepoFlags',
+        },
+      })
     }
 
     if (data?.owner?.repository?.__typename === 'OwnerNotActivatedError') {
-      return Promise.reject({
-        status: 403,
+      return rejectNetworkError({
+        errorName: 'Owner Not Activated',
+        errorDetails: {
+          callingFn: 'fetchRepoFlags',
+        },
         data: {
           detail: (
             <p>
@@ -155,8 +161,7 @@ function fetchRepoFlags({
             </p>
           ),
         },
-        dev: `useRepoFlagsSelect - 403 OwnerNotActivatedError`,
-      } satisfies NetworkErrorObject)
+      })
     }
 
     const flags = data?.owner?.repository?.coverageAnalytics?.flags
@@ -293,25 +298,31 @@ function fetchRepoFlagsForPull({
     const parsedRes = FetchRepoFlagsForPullSchema.safeParse(res?.data)
 
     if (!parsedRes.success) {
-      return Promise.reject({
-        status: 404,
-        data: {},
-        dev: `useRepoFlagsSelect - 404 failed to parse`,
-      } satisfies NetworkErrorObject)
+      return rejectNetworkError({
+        errorName: 'Parsing Error',
+        errorDetails: {
+          callingFn: 'fetchRepoFlagsForPull',
+          error: parsedRes.error,
+        },
+      })
     }
 
     const data = parsedRes.data
     if (data?.owner?.repository?.__typename === 'NotFoundError') {
-      return Promise.reject({
-        status: 404,
-        data: {},
-        dev: `useRepoFlagsSelect - 404 NotFoundError`,
+      return rejectNetworkError({
+        errorName: 'Not Found Error',
+        errorDetails: {
+          callingFn: 'fetchRepoFlagsForPull',
+        },
       })
     }
 
     if (data?.owner?.repository?.__typename === 'OwnerNotActivatedError') {
-      return Promise.reject({
-        status: 403,
+      return rejectNetworkError({
+        errorName: 'Owner Not Activated',
+        errorDetails: {
+          callingFn: 'fetchRepoFlagsForPull',
+        },
         data: {
           detail: (
             <p>
@@ -322,7 +333,6 @@ function fetchRepoFlagsForPull({
             </p>
           ),
         },
-        dev: `useRepoFlagsSelect - 403 OwnerNotActivatedError`,
       })
     }
 

--- a/src/services/repo/useRepoOverview.test.tsx
+++ b/src/services/repo/useRepoOverview.test.tsx
@@ -31,7 +31,7 @@ const mockOverview = (language?: string) => {
 
 const mockNotFoundError = {
   owner: {
-    isCurrentUserPartOfOrg: true,
+    isCurrentUserActivated: true,
     repository: {
       __typename: 'NotFoundError',
       message: 'commit not found',
@@ -229,6 +229,7 @@ describe('useRepoOverview', () => {
       await waitFor(() =>
         expect(result.current.error).toEqual(
           expect.objectContaining({
+            dev: 'useRepoOverview - Not Found Error',
             status: 404,
           })
         )
@@ -246,7 +247,7 @@ describe('useRepoOverview', () => {
       consoleSpy.mockRestore()
     })
 
-    it('throws a 404', async () => {
+    it('throws a 400', async () => {
       setup({ isUnsuccessfulParseError: true })
       const { result } = renderHook(
         () =>
@@ -261,7 +262,8 @@ describe('useRepoOverview', () => {
       await waitFor(() =>
         expect(result.current.error).toEqual(
           expect.objectContaining({
-            status: 404,
+            dev: 'useRepoOverview - Parsing Error',
+            status: 400,
           })
         )
       )

--- a/src/services/repo/useRepoOverview.tsx
+++ b/src/services/repo/useRepoOverview.tsx
@@ -85,7 +85,6 @@ export function useRepoOverview({
         const parsedData = RequestSchema.safeParse(res?.data)
 
         if (!parsedData.success) {
-          console.debug(parsedData.error)
           return rejectNetworkError({
             errorName: 'Parsing Error',
             errorDetails: {

--- a/src/services/repo/useRepoOverview.tsx
+++ b/src/services/repo/useRepoOverview.tsx
@@ -2,7 +2,7 @@ import { useQuery } from '@tanstack/react-query'
 import { z } from 'zod'
 
 import Api from 'shared/api'
-import { NetworkErrorObject } from 'shared/api/helpers'
+import { rejectNetworkError } from 'shared/api/rejectNetworkError'
 
 import { RepoNotFoundErrorSchema } from './schemas'
 
@@ -85,21 +85,25 @@ export function useRepoOverview({
         const parsedData = RequestSchema.safeParse(res?.data)
 
         if (!parsedData.success) {
-          return Promise.reject({
-            status: 404,
-            data: {},
-            dev: 'useRepoOverview - 404 failed to parse',
-          } satisfies NetworkErrorObject)
+          console.debug(parsedData.error)
+          return rejectNetworkError({
+            errorName: 'Parsing Error',
+            errorDetails: {
+              callingFn: 'useRepoOverview',
+              error: parsedData.error,
+            },
+          })
         }
 
         const data = parsedData.data
 
         if (data?.owner?.repository?.__typename === 'NotFoundError') {
-          return Promise.reject({
-            status: 404,
-            data: {},
-            dev: 'useRepoOverview - 404 NotFoundError',
-          } satisfies NetworkErrorObject)
+          return rejectNetworkError({
+            errorName: 'Not Found Error',
+            errorDetails: {
+              callingFn: 'useRepoOverview',
+            },
+          })
         }
 
         if (!data?.owner?.repository) {

--- a/src/services/repo/useRepoRateLimitStatus.test.tsx
+++ b/src/services/repo/useRepoRateLimitStatus.test.tsx
@@ -162,6 +162,7 @@ describe('useRepoRateLimitStatus', () => {
         await waitFor(() =>
           expect(result.current.error).toEqual(
             expect.objectContaining({
+              dev: 'useRepoRateLimitStatus - Not Found Error',
               status: 404,
             })
           )
@@ -220,7 +221,8 @@ describe('useRepoRateLimitStatus', () => {
         await waitFor(() =>
           expect(result.current.error).toEqual(
             expect.objectContaining({
-              status: 404,
+              dev: 'useRepoRateLimitStatus - Parsing Error',
+              status: 400,
             })
           )
         )

--- a/src/services/repo/useRepoRateLimitStatus.tsx
+++ b/src/services/repo/useRepoRateLimitStatus.tsx
@@ -2,6 +2,7 @@ import { useQuery } from '@tanstack/react-query'
 import { z } from 'zod'
 
 import Api from 'shared/api'
+import { rejectNetworkError } from 'shared/api/rejectNetworkError'
 
 import {
   RepoNotFoundErrorSchema,
@@ -67,18 +68,23 @@ export function useRepoRateLimitStatus({
       }).then((res) => {
         const parsedData = RequestSchema.safeParse(res?.data)
         if (!parsedData.success) {
-          return Promise.reject({
-            status: 404,
-            data: {},
+          return rejectNetworkError({
+            errorName: 'Parsing Error',
+            errorDetails: {
+              callingFn: 'useRepoRateLimitStatus',
+              error: parsedData.error,
+            },
           })
         }
 
         const data = parsedData.data
 
         if (data?.owner?.repository?.__typename === 'NotFoundError') {
-          return Promise.reject({
-            status: 404,
-            data: {},
+          return rejectNetworkError({
+            errorName: 'Not Found Error',
+            errorDetails: {
+              callingFn: 'useRepoRateLimitStatus',
+            },
           })
         }
 

--- a/src/services/repo/useRepoSettings.test.tsx
+++ b/src/services/repo/useRepoSettings.test.tsx
@@ -20,7 +20,6 @@ const wrapper: React.FC<React.PropsWithChildren> = ({ children }) => (
 )
 
 const server = setupServer()
-
 beforeAll(() => {
   server.listen()
 })
@@ -70,9 +69,7 @@ const mockResponse = {
       staticAnalysisToken: 'static analysis token',
       graphToken: 'token',
       yaml: 'yaml',
-      bot: {
-        username: 'test',
-      },
+      bot: { username: 'test' },
       activated: true,
     },
   },
@@ -113,16 +110,13 @@ describe('useRepoSettings', () => {
           expect(result.current.data).toEqual({
             repository: {
               __typename: 'Repository',
-
               defaultBranch: 'master',
               private: true,
               uploadToken: 'token',
               staticAnalysisToken: 'static analysis token',
               graphToken: 'token',
               yaml: 'yaml',
-              bot: {
-                username: 'test',
-              },
+              bot: { username: 'test' },
               activated: true,
             },
           })
@@ -150,8 +144,8 @@ describe('useRepoSettings', () => {
       await waitFor(() =>
         expect(result.current.error).toEqual(
           expect.objectContaining({
-            status: 404,
-            dev: 'useRepoSettings - 404 schema parsing failed',
+            dev: 'fetchRepoSettingsDetails - Parsing Error',
+            status: 400,
           })
         )
       )
@@ -177,8 +171,8 @@ describe('useRepoSettings', () => {
       await waitFor(() =>
         expect(result.current.error).toEqual(
           expect.objectContaining({
+            dev: 'fetchRepoSettingsDetails - Not Found Error',
             status: 404,
-            data: {},
           })
         )
       )
@@ -204,6 +198,7 @@ describe('useRepoSettings', () => {
       await waitFor(() =>
         expect(result.current.error).toEqual(
           expect.objectContaining({
+            dev: 'fetchRepoSettingsDetails - Owner Not Activated',
             status: 403,
           })
         )

--- a/src/services/repo/useRepoSettings.test.tsx
+++ b/src/services/repo/useRepoSettings.test.tsx
@@ -144,7 +144,7 @@ describe('useRepoSettings', () => {
       await waitFor(() =>
         expect(result.current.error).toEqual(
           expect.objectContaining({
-            dev: 'fetchRepoSettingsDetails - Parsing Error',
+            dev: 'useRepoSettings - Parsing Error',
             status: 400,
           })
         )
@@ -171,7 +171,7 @@ describe('useRepoSettings', () => {
       await waitFor(() =>
         expect(result.current.error).toEqual(
           expect.objectContaining({
-            dev: 'fetchRepoSettingsDetails - Not Found Error',
+            dev: 'useRepoSettings - Not Found Error',
             status: 404,
           })
         )
@@ -198,7 +198,7 @@ describe('useRepoSettings', () => {
       await waitFor(() =>
         expect(result.current.error).toEqual(
           expect.objectContaining({
-            dev: 'fetchRepoSettingsDetails - Owner Not Activated',
+            dev: 'useRepoSettings - Owner Not Activated',
             status: 403,
           })
         )

--- a/src/services/repo/useRepoSettings.tsx
+++ b/src/services/repo/useRepoSettings.tsx
@@ -3,7 +3,7 @@ import { useParams } from 'react-router-dom'
 import { z } from 'zod'
 
 import Api from 'shared/api'
-import { NetworkErrorObject } from 'shared/api/helpers'
+import { rejectNetworkError } from 'shared/api/rejectNetworkError'
 import A from 'ui/A'
 
 import { RepoNotFoundErrorSchema } from './schemas/RepoNotFoundError'
@@ -24,13 +24,6 @@ const RepositorySchema = z.object({
     })
     .nullable(),
 })
-
-interface FetchRepoSettingsArgs {
-  provider: string
-  owner: string
-  repo: string
-  signal?: AbortSignal
-}
 
 const RequestSchema = z.object({
   owner: z
@@ -73,66 +66,6 @@ query GetRepoSettings($name: String!, $repo: String!) {
   }
 }`
 
-function fetchRepoSettingsDetails({
-  provider,
-  owner,
-  repo,
-  signal,
-}: FetchRepoSettingsArgs) {
-  return Api.graphql({
-    provider,
-    query,
-    signal,
-    variables: {
-      name: owner,
-      repo,
-    },
-  }).then((res) => {
-    const parsedRes = RequestSchema.safeParse(res?.data)
-
-    if (!parsedRes.success) {
-      return Promise.reject({
-        status: 404,
-        data: {},
-        dev: 'useRepoSettings - 404 schema parsing failed',
-      } satisfies NetworkErrorObject)
-    }
-
-    const data = parsedRes.data
-
-    if (data?.owner?.repository?.__typename === 'NotFoundError') {
-      return Promise.reject({
-        status: 404,
-        data: {},
-        dev: 'useRepoSettings - 404 not found error',
-      })
-    }
-
-    if (data?.owner?.repository?.__typename === 'OwnerNotActivatedError') {
-      return Promise.reject({
-        status: 403,
-        data: {
-          detail: (
-            <p>
-              Activation is required to view this repo, please{' '}
-              {/* @ts-expect-error - A hasn't been typed yet */}
-              <A to={{ pageName: 'membersTab' }}>click here </A> to activate
-              your account.
-            </p>
-          ),
-        },
-        dev: 'useRepoSettings - 403 owner not activated error',
-      })
-    }
-
-    const repository = data.owner?.repository
-
-    return {
-      repository,
-    }
-  })
-}
-
 interface URLParams {
   provider: string
   owner: string
@@ -145,6 +78,62 @@ export function useRepoSettings() {
   return useQuery({
     queryKey: ['GetRepoSettings', provider, owner, repo],
     queryFn: ({ signal }) =>
-      fetchRepoSettingsDetails({ provider, owner, repo, signal }),
+      Api.graphql({
+        provider,
+        query,
+        signal,
+        variables: {
+          name: owner,
+          repo,
+        },
+      }).then((res) => {
+        const parsedRes = RequestSchema.safeParse(res?.data)
+
+        if (!parsedRes.success) {
+          return rejectNetworkError({
+            errorName: 'Parsing Error',
+            errorDetails: {
+              callingFn: 'fetchRepoSettingsDetails',
+              error: parsedRes.error,
+            },
+          })
+        }
+
+        const data = parsedRes.data
+
+        if (data?.owner?.repository?.__typename === 'NotFoundError') {
+          return rejectNetworkError({
+            errorName: 'Not Found Error',
+            errorDetails: {
+              callingFn: 'fetchRepoSettingsDetails',
+            },
+          })
+        }
+
+        if (data?.owner?.repository?.__typename === 'OwnerNotActivatedError') {
+          return rejectNetworkError({
+            errorName: 'Owner Not Activated',
+            errorDetails: {
+              callingFn: 'fetchRepoSettingsDetails',
+            },
+            data: {
+              detail: (
+                <p>
+                  Activation is required to view this repo, please{' '}
+                  {/* @ts-expect-error - A hasn't been typed yet */}
+                  <A to={{ pageName: 'membersTab' }}>click here </A> to activate
+                  your account.
+                </p>
+              ),
+            },
+          })
+        }
+
+        const repository = data.owner?.repository
+
+        return {
+          repository,
+        }
+      }),
   })
 }

--- a/src/services/repo/useRepoSettings.tsx
+++ b/src/services/repo/useRepoSettings.tsx
@@ -93,7 +93,7 @@ export function useRepoSettings() {
           return rejectNetworkError({
             errorName: 'Parsing Error',
             errorDetails: {
-              callingFn: 'fetchRepoSettingsDetails',
+              callingFn: 'useRepoSettings',
               error: parsedRes.error,
             },
           })
@@ -105,7 +105,7 @@ export function useRepoSettings() {
           return rejectNetworkError({
             errorName: 'Not Found Error',
             errorDetails: {
-              callingFn: 'fetchRepoSettingsDetails',
+              callingFn: 'useRepoSettings',
             },
           })
         }
@@ -114,7 +114,7 @@ export function useRepoSettings() {
           return rejectNetworkError({
             errorName: 'Owner Not Activated',
             errorDetails: {
-              callingFn: 'fetchRepoSettingsDetails',
+              callingFn: 'useRepoSettings',
             },
             data: {
               detail: (

--- a/src/services/repo/useRepoSettingsTeam.test.tsx
+++ b/src/services/repo/useRepoSettingsTeam.test.tsx
@@ -141,8 +141,8 @@ describe('useRepoSettingsTeam', () => {
       await waitFor(() =>
         expect(result.current.error).toEqual(
           expect.objectContaining({
-            status: 404,
-            dev: 'useRepoSettingsTeam - 404 schema parsing failed',
+            dev: 'useRepoSettingsTeam - Parsing Error',
+            status: 400,
           })
         )
       )
@@ -168,8 +168,8 @@ describe('useRepoSettingsTeam', () => {
       await waitFor(() =>
         expect(result.current.error).toEqual(
           expect.objectContaining({
+            dev: 'useRepoSettingsTeam - Not Found Error',
             status: 404,
-            data: {},
           })
         )
       )

--- a/src/services/uploadTokenRequired/useUploadTokenRequired.test.tsx
+++ b/src/services/uploadTokenRequired/useUploadTokenRequired.test.tsx
@@ -124,16 +124,15 @@ describe('useUploadTokenRequired', () => {
               provider: 'gh',
               owner: 'codecov',
             }),
-          {
-            wrapper,
-          }
+          { wrapper }
         )
 
         await waitFor(() => expect(result.current.isError).toBeTruthy())
         await waitFor(() =>
           expect(result.current.error).toEqual(
             expect.objectContaining({
-              status: 404,
+              dev: 'useUploadTokenRequired - Parsing Error',
+              status: 400,
             })
           )
         )

--- a/src/services/uploadTokenRequired/useUploadTokenRequired.tsx
+++ b/src/services/uploadTokenRequired/useUploadTokenRequired.tsx
@@ -2,6 +2,7 @@ import { useQuery } from '@tanstack/react-query'
 import { z } from 'zod'
 
 import Api from 'shared/api'
+import { rejectNetworkError } from 'shared/api/rejectNetworkError'
 
 const RequestSchema = z.object({
   owner: z
@@ -46,10 +47,12 @@ export const useUploadTokenRequired = ({
         const parsedRes = RequestSchema.safeParse(res?.data)
 
         if (!parsedRes.success) {
-          return Promise.reject({
-            status: 404,
-            data: null,
-            dev: 'Failed parse for GetUploadTokenRequired',
+          return rejectNetworkError({
+            errorName: 'Parsing Error',
+            errorDetails: {
+              callingFn: 'useUploadTokenRequired',
+              error: parsedRes.error,
+            },
           })
         }
 

--- a/src/services/useIsTeamPlan/useIsTeamPlan.test.tsx
+++ b/src/services/useIsTeamPlan/useIsTeamPlan.test.tsx
@@ -5,17 +5,9 @@ import { setupServer } from 'msw/node'
 
 import { useIsTeamPlan } from './useIsTeamPlan'
 
-const mockIsTeamPlan = {
-  owner: {
-    plan: {
-      isTeamPlan: true,
-    },
-  },
-}
+const mockIsTeamPlan = { owner: { plan: { isTeamPlan: true } } }
 
-const mockNullOwner = {
-  owner: null,
-}
+const mockNullOwner = { owner: null }
 
 const mockUnsuccessfulParseError = {}
 
@@ -118,16 +110,15 @@ describe('useIsTeamPlan', () => {
               provider: 'gh',
               owner: 'codecov',
             }),
-          {
-            wrapper,
-          }
+          { wrapper }
         )
 
         await waitFor(() => expect(result.current.isError).toBeTruthy())
         await waitFor(() =>
           expect(result.current.error).toEqual(
             expect.objectContaining({
-              status: 404,
+              dev: 'useIsTeamPlan - Parsing Error',
+              status: 400,
             })
           )
         )

--- a/src/services/useIsTeamPlan/useIsTeamPlan.ts
+++ b/src/services/useIsTeamPlan/useIsTeamPlan.ts
@@ -2,16 +2,13 @@ import { useQuery } from '@tanstack/react-query'
 import { z } from 'zod'
 
 import Api from 'shared/api'
+import { rejectNetworkError } from 'shared/api/rejectNetworkError'
 
 export const PlanSchema = z
   .object({
     owner: z
       .object({
-        plan: z
-          .object({
-            isTeamPlan: z.boolean(),
-          })
-          .nullable(),
+        plan: z.object({ isTeamPlan: z.boolean() }).nullable(),
       })
       .nullable(),
   })
@@ -47,9 +44,12 @@ export const useIsTeamPlan = ({ provider, owner }: UseIsTeamPlanArgs) =>
         const parsedRes = PlanSchema.safeParse(res?.data)
 
         if (!parsedRes.success) {
-          return Promise.reject({
-            status: 404,
-            data: null,
+          return rejectNetworkError({
+            errorName: 'Parsing Error',
+            errorDetails: {
+              callingFn: 'useIsTeamPlan',
+              error: parsedRes.error,
+            },
           })
         }
 

--- a/src/services/user/useInternalUser.test.tsx
+++ b/src/services/user/useInternalUser.test.tsx
@@ -5,7 +5,9 @@ import { setupServer } from 'msw/node'
 
 import { useInternalUser } from './useInternalUser'
 
-const queryClient = new QueryClient()
+const queryClient = new QueryClient({
+  defaultOptions: { queries: { retry: false } },
+})
 const server = setupServer()
 
 const wrapper: React.FC<React.PropsWithChildren> = ({ children }) => (
@@ -25,12 +27,19 @@ afterAll(() => {
   server.close()
 })
 
+interface SetupArgs {
+  hasError?: boolean
+  parsingError?: boolean
+}
+
 describe('useInternalUser', () => {
-  function setup(hasError = false) {
+  function setup({ hasError = false, parsingError = false }: SetupArgs) {
     server.use(
       http.get('/internal/user', () => {
         if (hasError) {
           return HttpResponse.json({}, { status: 400 })
+        } else if (parsingError) {
+          return HttpResponse.json({ email: 123 }, { status: 200 })
         }
         return HttpResponse.json({
           email: 'cool@email.com',
@@ -45,7 +54,7 @@ describe('useInternalUser', () => {
 
   describe('calling hook', () => {
     it('returns api response', async () => {
-      setup()
+      setup({})
       const { result } = renderHook(() => useInternalUser({}), { wrapper })
 
       await waitFor(() =>
@@ -61,11 +70,38 @@ describe('useInternalUser', () => {
   })
 
   describe('when hook call errors', () => {
-    it('returns empty object', async () => {
-      setup(true)
-      const { result } = renderHook(() => useInternalUser({}), { wrapper })
+    describe('there is a network error', () => {
+      it('returns empty object', async () => {
+        setup({ hasError: true })
+        const { result } = renderHook(() => useInternalUser({}), { wrapper })
 
-      await waitFor(() => expect(result.current.data).toStrictEqual({}))
+        await waitFor(() => expect(result.current.data).toStrictEqual({}))
+      })
+    })
+
+    describe('there is a parsing error', () => {
+      beforeEach(() => {
+        vi.spyOn(console, 'error').mockImplementation(() => {})
+      })
+
+      afterEach(() => {
+        vi.resetAllMocks()
+      })
+
+      it('returns empty object', async () => {
+        setup({ parsingError: true })
+        const { result } = renderHook(() => useInternalUser({}), { wrapper })
+
+        await waitFor(() => expect(result.current.isError).toBeTruthy())
+        await waitFor(() =>
+          expect(result.current.error).toEqual(
+            expect.objectContaining({
+              dev: 'useInternalUser - Parsing Error',
+              status: 400,
+            })
+          )
+        )
+      })
     })
   })
 })

--- a/src/services/user/useInternalUser.ts
+++ b/src/services/user/useInternalUser.ts
@@ -2,6 +2,7 @@ import { useQuery, type UseQueryOptions } from '@tanstack/react-query'
 import { z } from 'zod'
 
 import Api from 'shared/api'
+import { rejectNetworkError } from 'shared/api/rejectNetworkError'
 
 const OwnerSchema = z
   .object({
@@ -54,9 +55,12 @@ export const useInternalUser = (opts: UseInternalUserArgs) =>
       const parsedData = InternalUserSchema.safeParse(response)
 
       if (!parsedData.success) {
-        return Promise.reject({
-          status: 404,
-          data: null,
+        return rejectNetworkError({
+          errorName: 'Parsing Error',
+          errorDetails: {
+            callingFn: 'useInternalUser',
+            error: parsedData.error,
+          },
         })
       }
 


### PR DESCRIPTION
# Description

This PR is part four in a series going through Gazebo updating our API calls to utilize `rejectNetworkError` in functions where we call the API.

Ticket: codecov/engineering-team#3329

# Notable Changes

- Update API calls to use `rejectNetworkError` (see [commits](https://github.com/codecov/gazebo/pull/3768/commits))
- Update tests