### PR TITLE
ref: Move callingFn from string literals to a shared const

### DIFF
--- a/src/layouts/BaseLayout/hooks/NavigatorDataQueryOpts.ts
+++ b/src/layouts/BaseLayout/hooks/NavigatorDataQueryOpts.ts
@@ -67,15 +67,13 @@ export const NavigatorDataQueryOpts = ({
           repo,
         },
       }).then((res) => {
+        const callingFn = 'NavigatorDataQueryOpts'
         const parsedData = RequestSchema.safeParse(res.data)
 
         if (!parsedData.success) {
           return rejectNetworkError({
             errorName: 'Parsing Error',
-            errorDetails: {
-              callingFn: 'NavigatorDataQueryOpts',
-              error: parsedData.error,
-            },
+            errorDetails: { callingFn, error: parsedData.error },
           })
         }
 

--- a/src/pages/AccountSettings/tabs/OktaAccess/hooks/useUpdateOktaConfig.tsx
+++ b/src/pages/AccountSettings/tabs/OktaAccess/hooks/useUpdateOktaConfig.tsx
@@ -103,14 +103,13 @@ export const useUpdateOktaConfig = ({ provider, owner }: URLParams) => {
       })
     },
     onSuccess: ({ data }) => {
+      const callingFn = 'useUpdateOktaConfig'
       const parsedData = ResponseSchema.safeParse(data)
+
       if (!parsedData.success) {
         return rejectNetworkError({
           errorName: 'Parsing Error',
-          errorDetails: {
-            callingFn: 'useUpdateOktaConfig',
-            error: parsedData.error,
-          },
+          errorDetails: { callingFn, error: parsedData.error },
         })
       }
 

--- a/src/pages/AccountSettings/tabs/OktaAccess/queries/OktaConfigQueryOpts.tsx
+++ b/src/pages/AccountSettings/tabs/OktaAccess/queries/OktaConfigQueryOpts.tsx
@@ -62,15 +62,13 @@ export function OktaConfigQueryOpts({
           username,
         },
       }).then((res) => {
+        const callingFn = 'OktaConfigQueryOpts'
         const parsedRes = OktaConfigRequestSchema.safeParse(res?.data)
 
         if (!parsedRes.success) {
           return rejectNetworkError({
             errorName: 'Parsing Error',
-            errorDetails: {
-              callingFn: 'OktaConfigQueryOpts',
-              error: parsedRes.error,
-            },
+            errorDetails: { callingFn, error: parsedRes.error },
           })
         }
 

--- a/src/pages/AccountSettings/tabs/OrgUploadToken/TokenlessSection/useSetUploadTokenRequired.tsx
+++ b/src/pages/AccountSettings/tabs/OrgUploadToken/TokenlessSection/useSetUploadTokenRequired.tsx
@@ -73,14 +73,13 @@ export const useSetUploadTokenRequired = ({
         },
         mutationPath: 'setUploadTokenRequired',
       }).then((res) => {
+        const callingFn = 'useSetUploadTokenRequired'
         const parsedData = ResponseSchema.safeParse(res.data)
+
         if (!parsedData.success) {
           return rejectNetworkError({
             errorName: 'Parsing Error',
-            errorDetails: {
-              callingFn: 'useSetUploadTokenRequired',
-              error: parsedData.error,
-            },
+            errorDetails: { callingFn, error: parsedData.error },
           })
         }
 

--- a/src/pages/AdminSettings/AdminAccess/AdminAccessTable/useAdminAccessList.ts
+++ b/src/pages/AdminSettings/AdminAccess/AdminAccessTable/useAdminAccessList.ts
@@ -38,15 +38,13 @@ export const useAdminAccessList = () => {
         path: `/users?is_admin=true&page=${pageParam}`,
         signal,
       }).then((res) => {
+        const callingFn = 'useAdminAccessList'
         const parsedData = RequestSchema.safeParse(res)
 
         if (!parsedData.success) {
           return rejectNetworkError({
             errorName: 'Parsing Error',
-            errorDetails: {
-              callingFn: 'useAdminAccessList',
-              error: parsedData.error,
-            },
+            errorDetails: { callingFn, error: parsedData.error },
           })
         }
         return parsedData.data

--- a/src/pages/CommitDetailPage/Header/HeaderDefault/queries/CommitHeaderDataQueryOpts.tsx
+++ b/src/pages/CommitDetailPage/Header/HeaderDefault/queries/CommitHeaderDataQueryOpts.tsx
@@ -104,15 +104,13 @@ export const CommitHeaderDataQueryOpts = ({
           commitId,
         },
       }).then((res) => {
+        const callingFn = 'CommitHeaderDataQueryOpts'
         const parsedData = CommitHeaderDataSchema.safeParse(res?.data)
 
         if (!parsedData.success) {
           return rejectNetworkError({
             errorName: 'Parsing Error',
-            errorDetails: {
-              callingFn: 'CommitHeaderDataQueryOpts',
-              error: parsedData.error,
-            },
+            errorDetails: { callingFn, error: parsedData.error },
           })
         }
 
@@ -121,14 +119,14 @@ export const CommitHeaderDataQueryOpts = ({
         if (data?.owner?.repository?.__typename === 'NotFoundError') {
           return rejectNetworkError({
             errorName: 'Not Found Error',
-            errorDetails: { callingFn: 'CommitHeaderDataQueryOpts' },
+            errorDetails: { callingFn },
           })
         }
 
         if (data?.owner?.repository?.__typename === 'OwnerNotActivatedError') {
           return rejectNetworkError({
             errorName: 'Owner Not Activated',
-            errorDetails: { callingFn: 'CommitHeaderDataQueryOpts' },
+            errorDetails: { callingFn },
             data: {
               detail: (
                 <p>

--- a/src/pages/CommitDetailPage/Header/HeaderTeam/queries/CommitHeaderDataTeamQueryOpts.tsx
+++ b/src/pages/CommitDetailPage/Header/HeaderTeam/queries/CommitHeaderDataTeamQueryOpts.tsx
@@ -163,15 +163,13 @@ export const CommitHeaderDataTeamQueryOpts = ({
           commitId,
         },
       }).then((res) => {
+        const callingFn = 'CommitHeaderDataTeamQueryOpts'
         const parsedData = CommitHeaderDataTeamSchema.safeParse(res?.data)
 
         if (!parsedData.success) {
           return rejectNetworkError({
             errorName: 'Parsing Error',
-            errorDetails: {
-              callingFn: 'CommitHeaderDataTeamQueryOpts',
-              error: parsedData.error,
-            },
+            errorDetails: { callingFn, error: parsedData.error },
           })
         }
 
@@ -180,14 +178,14 @@ export const CommitHeaderDataTeamQueryOpts = ({
         if (data?.owner?.repository?.__typename === 'NotFoundError') {
           return rejectNetworkError({
             errorName: 'Not Found Error',
-            errorDetails: { callingFn: 'CommitHeaderDataTeamQueryOpts' },
+            errorDetails: { callingFn },
           })
         }
 
         if (data?.owner?.repository?.__typename === 'OwnerNotActivatedError') {
           return rejectNetworkError({
             errorName: 'Owner Not Activated',
-            errorDetails: { callingFn: 'CommitHeaderDataTeamQueryOpts' },
+            errorDetails: { callingFn },
             data: {
               detail: (
                 <p>

--- a/src/pages/CommitDetailPage/queries/CommitPageDataQueryOpts.tsx
+++ b/src/pages/CommitDetailPage/queries/CommitPageDataQueryOpts.tsx
@@ -157,15 +157,13 @@ export const CommitPageDataQueryOpts = ({
           commitId,
         },
       }).then((res) => {
+        const callingFn = 'CommitPageDataQueryOpts'
         const parsedData = CommitPageDataSchema.safeParse(res?.data)
 
         if (!parsedData.success) {
           return rejectNetworkError({
             errorName: 'Parsing Error',
-            errorDetails: {
-              callingFn: 'CommitPageDataQueryOpts',
-              error: parsedData.error,
-            },
+            errorDetails: { callingFn, error: parsedData.error },
           })
         }
 
@@ -174,14 +172,14 @@ export const CommitPageDataQueryOpts = ({
         if (data?.owner?.repository?.__typename === 'NotFoundError') {
           return rejectNetworkError({
             errorName: 'Not Found Error',
-            errorDetails: { callingFn: 'CommitPageDataQueryOpts' },
+            errorDetails: { callingFn },
           })
         }
 
         if (data?.owner?.repository?.__typename === 'OwnerNotActivatedError') {
           return rejectNetworkError({
             errorName: 'Owner Not Activated',
-            errorDetails: { callingFn: 'CommitPageDataQueryOpts' },
+            errorDetails: { callingFn },
             data: {
               detail: (
                 <p>

--- a/src/pages/PlanPage/queries/PlanPageDataQueryOpts.ts
+++ b/src/pages/PlanPage/queries/PlanPageDataQueryOpts.ts
@@ -44,15 +44,13 @@ export function PlanPageDataQueryOpts({
         variables,
         signal,
       }).then((res) => {
+        const callingFn = 'PlanPageDataQueryOpts'
         const parsedRes = RequestSchema.safeParse(res?.data)
 
         if (!parsedRes.success) {
           return rejectNetworkError({
             errorName: 'Parsing Error',
-            errorDetails: {
-              callingFn: 'PlanPageDataQueryOpts',
-              error: parsedRes.error,
-            },
+            errorDetails: { callingFn, error: parsedRes.error },
           })
         }
 

--- a/src/pages/PlanPage/subRoutes/CurrentOrgPlan/queries/EnterpriseAccountDetailsQueryOpts.ts
+++ b/src/pages/PlanPage/subRoutes/CurrentOrgPlan/queries/EnterpriseAccountDetailsQueryOpts.ts
@@ -56,6 +56,7 @@ export function EnterpriseAccountDetailsQueryOpts({
           owner,
         },
       }).then((res) => {
+        const callingFn = 'EnterpriseAccountDetailsQueryOpts'
         const parsedRes = EnterpriseAccountDetailsRequestSchema.safeParse(
           res?.data
         )
@@ -63,10 +64,7 @@ export function EnterpriseAccountDetailsQueryOpts({
         if (!parsedRes.success) {
           return rejectNetworkError({
             errorName: 'Parsing Error',
-            errorDetails: {
-              callingFn: 'EnterpriseAccountDetailsQueryOpts',
-              error: parsedRes.error,
-            },
+            errorDetails: { callingFn, error: parsedRes.error },
           })
         }
 

--- a/src/pages/PlanPage/subRoutes/CurrentOrgPlan/queries/InfiniteAccountOrganizationsQueryOpts.ts
+++ b/src/pages/PlanPage/subRoutes/CurrentOrgPlan/queries/InfiniteAccountOrganizationsQueryOpts.ts
@@ -98,15 +98,13 @@ export function InfiniteAccountOrganizationsQueryOpts({
           after,
         },
       }).then((res) => {
+        const callingFn = 'InfiniteAccountOrganizationsQueryOpts'
         const parsedRes = RequestSchema.safeParse(res.data)
 
         if (!parsedRes.success) {
           return rejectNetworkError({
             errorName: 'Parsing Error',
-            errorDetails: {
-              callingFn: 'InfiniteAccountOrganizationsQueryOpts',
-              error: parsedRes.error,
-            },
+            errorDetails: { callingFn, error: parsedRes.error },
           })
         }
 
@@ -115,9 +113,7 @@ export function InfiniteAccountOrganizationsQueryOpts({
         if (!account) {
           return rejectNetworkError({
             errorName: 'Not Found Error',
-            errorDetails: {
-              callingFn: 'InfiniteAccountOrganizationsQueryOpts',
-            },
+            errorDetails: { callingFn },
           })
         }
 

--- a/src/pages/PlanPage/subRoutes/CurrentOrgPlan/useCurrentOrgPlanPageData.tsx
+++ b/src/pages/PlanPage/subRoutes/CurrentOrgPlan/useCurrentOrgPlanPageData.tsx
@@ -69,14 +69,13 @@ export const useCurrentOrgPlanPageData = ({
           owner,
         },
       }).then((res) => {
+        const callingFn = 'useCurrentOrgPlanPageData'
         const parsedRes = CurrentOrgPlanPageDataSchema.safeParse(res?.data)
+
         if (!parsedRes.success) {
           return rejectNetworkError({
             errorName: 'Parsing Error',
-            errorDetails: {
-              callingFn: 'useCurrentOrgPlanPageData',
-              error: parsedRes.error,
-            },
+            errorDetails: { callingFn, error: parsedRes.error },
           })
         }
 

--- a/src/pages/PullRequestPage/Header/HeaderDefault/queries/PullHeadDataQueryOpts.tsx
+++ b/src/pages/PullRequestPage/Header/HeaderDefault/queries/PullHeadDataQueryOpts.tsx
@@ -108,15 +108,13 @@ export const PullHeadDataQueryOpts = ({
           pullId: parseInt(pullId, 10),
         },
       }).then((res) => {
+        const callingFn = 'PullHeadDataQueryOpts'
         const parsedData = PullHeadDataSchema.safeParse(res?.data)
 
         if (!parsedData.success) {
           return rejectNetworkError({
             errorName: 'Parsing Error',
-            errorDetails: {
-              callingFn: 'PullHeadDataQueryOpts',
-              error: parsedData.error,
-            },
+            errorDetails: { callingFn, error: parsedData.error },
           })
         }
 
@@ -125,14 +123,14 @@ export const PullHeadDataQueryOpts = ({
         if (data?.owner?.repository?.__typename === 'NotFoundError') {
           return rejectNetworkError({
             errorName: 'Not Found Error',
-            errorDetails: { callingFn: 'PullHeadDataQueryOpts' },
+            errorDetails: { callingFn },
           })
         }
 
         if (data?.owner?.repository?.__typename === 'OwnerNotActivatedError') {
           return rejectNetworkError({
             errorName: 'Owner Not Activated',
-            errorDetails: { callingFn: 'PullHeadDataQueryOpts' },
+            errorDetails: { callingFn },
             data: {
               detail: (
                 <p>

--- a/src/pages/PullRequestPage/Header/HeaderTeam/queries/PullHeadDataTeamQueryOpts.tsx
+++ b/src/pages/PullRequestPage/Header/HeaderTeam/queries/PullHeadDataTeamQueryOpts.tsx
@@ -160,15 +160,13 @@ export const PullHeadDataTeamQueryOpts = ({
           pullId: parseInt(pullId, 10),
         },
       }).then((res) => {
+        const callingFn = 'PullHeadDataTeamQueryOpts'
         const parsedData = PullHeadDataSchema.safeParse(res?.data)
 
         if (!parsedData.success) {
           return rejectNetworkError({
             errorName: 'Parsing Error',
-            errorDetails: {
-              callingFn: 'PullHeadDataTeamQueryOpts',
-              error: parsedData.error,
-            },
+            errorDetails: { callingFn, error: parsedData.error },
           })
         }
 
@@ -177,14 +175,14 @@ export const PullHeadDataTeamQueryOpts = ({
         if (data?.owner?.repository?.__typename === 'NotFoundError') {
           return rejectNetworkError({
             errorName: 'Not Found Error',
-            errorDetails: { callingFn: 'PullHeadDataTeamQueryOpts' },
+            errorDetails: { callingFn },
           })
         }
 
         if (data?.owner?.repository?.__typename === 'OwnerNotActivatedError') {
           return rejectNetworkError({
             errorName: 'Owner Not Activated',
-            errorDetails: { callingFn: 'PullHeadDataTeamQueryOpts' },
+            errorDetails: { callingFn },
             data: {
               detail: (
                 <p>

--- a/src/pages/PullRequestPage/PullCoverage/routes/ComponentsTab/queries/ComponentComparisonQueryOpts.tsx
+++ b/src/pages/PullRequestPage/PullCoverage/routes/ComponentsTab/queries/ComponentComparisonQueryOpts.tsx
@@ -172,15 +172,13 @@ export function ComponentComparisonQueryOpts({
           pullId: parseInt(pullId, 10),
         },
       }).then((res) => {
+        const callingFn = 'ComponentComparisonQueryOpts'
         const parsedRes = ComponentComparisonSchema.safeParse(res?.data)
 
         if (!parsedRes.success) {
           return rejectNetworkError({
             errorName: 'Parsing Error',
-            errorDetails: {
-              callingFn: 'ComponentComparisonQueryOpts',
-              error: parsedRes.error,
-            },
+            errorDetails: { callingFn, error: parsedRes.error },
           })
         }
 
@@ -189,14 +187,14 @@ export function ComponentComparisonQueryOpts({
         if (data?.owner?.repository?.__typename === 'NotFoundError') {
           return rejectNetworkError({
             errorName: 'Not Found Error',
-            errorDetails: { callingFn: 'ComponentComparisonQueryOpts' },
+            errorDetails: { callingFn },
           })
         }
 
         if (data?.owner?.repository?.__typename === 'OwnerNotActivatedError') {
           return rejectNetworkError({
             errorName: 'Owner Not Activated',
-            errorDetails: { callingFn: 'ComponentComparisonQueryOpts' },
+            errorDetails: { callingFn },
             data: {
               detail: (
                 <p>

--- a/src/pages/PullRequestPage/queries/PullPageDataQueryOpts.tsx
+++ b/src/pages/PullRequestPage/queries/PullPageDataQueryOpts.tsx
@@ -216,15 +216,13 @@ export const PullPageDataQueryOpts = ({
           isTeamPlan,
         },
       }).then((res) => {
+        const callingFn = 'PullPageDataQueryOpts'
         const parsedData = PullPageDataSchema.safeParse(res?.data)
 
         if (!parsedData.success) {
           return rejectNetworkError({
             errorName: 'Parsing Error',
-            errorDetails: {
-              callingFn: 'PullPageDataQueryOpts',
-              error: parsedData.error,
-            },
+            errorDetails: { callingFn, error: parsedData.error },
           })
         }
 
@@ -233,14 +231,14 @@ export const PullPageDataQueryOpts = ({
         if (data?.owner?.repository?.__typename === 'NotFoundError') {
           return rejectNetworkError({
             errorName: 'Not Found Error',
-            errorDetails: { callingFn: 'PullPageDataQueryOpts' },
+            errorDetails: { callingFn },
           })
         }
 
         if (data?.owner?.repository?.__typename === 'OwnerNotActivatedError') {
           return rejectNetworkError({
             errorName: 'Owner Not Activated',
-            errorDetails: { callingFn: 'PullPageDataQueryOpts' },
+            errorDetails: { callingFn },
             data: {
               detail: (
                 <p>

--- a/src/pages/RepoPage/ConfigTab/tabs/ConfigurationManager/hooks/useRepoConfigurationStatus/RepoConfigurationStatusQueryOpts.tsx
+++ b/src/pages/RepoPage/ConfigTab/tabs/ConfigurationManager/hooks/useRepoConfigurationStatus/RepoConfigurationStatusQueryOpts.tsx
@@ -102,15 +102,13 @@ export function RepoConfigurationStatusQueryOpts({
           repo,
         },
       }).then((res) => {
+        const callingFn = 'RepoConfigurationStatusQueryOpts'
         const parsedRes = RequestSchema.safeParse(res?.data)
 
         if (!parsedRes.success) {
           return rejectNetworkError({
             errorName: 'Parsing Error',
-            errorDetails: {
-              callingFn: 'RepoConfigurationStatusQueryOpts',
-              error: parsedRes.error,
-            },
+            errorDetails: { callingFn, error: parsedRes.error },
           })
         }
 
@@ -119,14 +117,14 @@ export function RepoConfigurationStatusQueryOpts({
         if (data?.owner?.repository?.__typename === 'NotFoundError') {
           return rejectNetworkError({
             errorName: 'Not Found Error',
-            errorDetails: { callingFn: 'RepoConfigurationStatusQueryOpts' },
+            errorDetails: { callingFn },
           })
         }
 
         if (data?.owner?.repository?.__typename === 'OwnerNotActivatedError') {
           return rejectNetworkError({
             errorName: 'Owner Not Activated',
-            errorDetails: { callingFn: 'RepoConfigurationStatusQueryOpts' },
+            errorDetails: { callingFn },
             data: {
               detail: (
                 <p>

--- a/src/pages/RepoPage/ConfigTab/tabs/GeneralTab/queries/RepoForTokensTeamQueryOpts.tsx
+++ b/src/pages/RepoPage/ConfigTab/tabs/GeneralTab/queries/RepoForTokensTeamQueryOpts.tsx
@@ -74,15 +74,13 @@ export const RepoForTokensTeamQueryOpts = ({
           repo,
         },
       }).then((res) => {
+        const callingFn = 'RepoForTokensTeamQueryOpts'
         const parsedData = GetRepoDataSchema.safeParse(res?.data)
 
         if (!parsedData.success) {
           return rejectNetworkError({
             errorName: 'Parsing Error',
-            errorDetails: {
-              callingFn: 'RepoForTokensTeamQueryOpts',
-              error: parsedData.error,
-            },
+            errorDetails: { callingFn, error: parsedData.error },
           })
         }
 
@@ -91,14 +89,14 @@ export const RepoForTokensTeamQueryOpts = ({
         if (data?.owner?.repository?.__typename === 'NotFoundError') {
           return rejectNetworkError({
             errorName: 'Not Found Error',
-            errorDetails: { callingFn: 'RepoForTokensTeamQueryOpts' },
+            errorDetails: { callingFn },
           })
         }
 
         if (data?.owner?.repository?.__typename === 'OwnerNotActivatedError') {
           return rejectNetworkError({
             errorName: 'Owner Not Activated',
-            errorDetails: { callingFn: 'RepoForTokensTeamQueryOpts' },
+            errorDetails: { callingFn },
             data: {
               detail: (
                 <p>

--- a/src/pages/RepoPage/CoverageTab/OverviewTab/queries/CoverageTabDataQueryOpts.tsx
+++ b/src/pages/RepoPage/CoverageTab/OverviewTab/queries/CoverageTabDataQueryOpts.tsx
@@ -96,15 +96,13 @@ export const CoverageTabDataQueryOpts = ({
           branch,
         },
       }).then((res) => {
+        const callingFn = 'CoverageTabDataQueryOpts'
         const parsedData = GetBranchSchema.safeParse(res?.data)
 
         if (!parsedData.success) {
           return rejectNetworkError({
             errorName: 'Parsing Error',
-            errorDetails: {
-              callingFn: 'CoverageTabDataQueryOpts',
-              error: parsedData.error,
-            },
+            errorDetails: { callingFn, error: parsedData.error },
           })
         }
 
@@ -113,14 +111,14 @@ export const CoverageTabDataQueryOpts = ({
         if (data?.owner?.repository?.__typename === 'NotFoundError') {
           return rejectNetworkError({
             errorName: 'Not Found Error',
-            errorDetails: { callingFn: 'CoverageTabDataQueryOpts' },
+            errorDetails: { callingFn },
           })
         }
 
         if (data?.owner?.repository?.__typename === 'OwnerNotActivatedError') {
           return rejectNetworkError({
             errorName: 'Owner Not Activated',
-            errorDetails: { callingFn: 'CoverageTabDataQueryOpts' },
+            errorDetails: { callingFn },
             data: {
               detail: (
                 <p>

--- a/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/hooks/useFlakeAggregates/useFlakeAggregates.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/hooks/useFlakeAggregates/useFlakeAggregates.tsx
@@ -95,15 +95,13 @@ export const useFlakeAggregates = ({
           interval,
         },
       }).then((res) => {
+        const callingFn = 'useFlakeAggregates'
         const parsedData = FlakeAggregatesSchema.safeParse(res?.data)
 
         if (!parsedData.success) {
           return rejectNetworkError({
             errorName: 'Parsing Error',
-            errorDetails: {
-              callingFn: 'useFlakeAggregates',
-              error: parsedData.error,
-            },
+            errorDetails: { callingFn, error: parsedData.error },
           })
         }
 
@@ -112,7 +110,7 @@ export const useFlakeAggregates = ({
         if (data?.owner?.repository?.__typename === 'NotFoundError') {
           return rejectNetworkError({
             errorName: 'Not Found Error',
-            errorDetails: { callingFn: 'useFlakeAggregates' },
+            errorDetails: { callingFn },
           })
         }
 

--- a/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/hooks/useInfiniteTestResults/useInfiniteTestResults.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/hooks/useInfiniteTestResults/useInfiniteTestResults.tsx
@@ -236,15 +236,13 @@ export const useInfiniteTestResults = ({
           before,
         },
       }).then((res) => {
+        const callingFn = 'useInfiniteTestResults'
         const parsedData = GetTestResultsSchema.safeParse(res?.data)
 
         if (!parsedData.success) {
           return rejectNetworkError({
             errorName: 'Parsing Error',
-            errorDetails: {
-              callingFn: 'useInfiniteTestResults',
-              error: parsedData.error,
-            },
+            errorDetails: { callingFn, error: parsedData.error },
           })
         }
 
@@ -253,14 +251,14 @@ export const useInfiniteTestResults = ({
         if (data?.owner?.repository?.__typename === 'NotFoundError') {
           return rejectNetworkError({
             errorName: 'Not Found Error',
-            errorDetails: { callingFn: 'useInfiniteTestResults' },
+            errorDetails: { callingFn },
           })
         }
 
         if (data?.owner?.repository?.__typename === 'OwnerNotActivatedError') {
           return rejectNetworkError({
             errorName: 'Owner Not Activated',
-            errorDetails: { callingFn: 'useInfiniteTestResults' },
+            errorDetails: { callingFn },
             data: {
               detail: (
                 <p>

--- a/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/hooks/useTestResultsAggregates/useTestResultsAggregates.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/hooks/useTestResultsAggregates/useTestResultsAggregates.tsx
@@ -115,15 +115,13 @@ export const useTestResultsAggregates = ({
           interval,
         },
       }).then((res) => {
+        const callingFn = 'useTestResultsAggregates'
         const parsedData = TestResultsAggregatesSchema.safeParse(res?.data)
 
         if (!parsedData.success) {
           return rejectNetworkError({
             errorName: 'Parsing Error',
-            errorDetails: {
-              callingFn: 'useTestResultsAggregates',
-              error: parsedData.error,
-            },
+            errorDetails: { callingFn, error: parsedData.error },
           })
         }
 
@@ -132,7 +130,7 @@ export const useTestResultsAggregates = ({
         if (data?.owner?.repository?.__typename === 'NotFoundError') {
           return rejectNetworkError({
             errorName: 'Not Found Error',
-            errorDetails: { callingFn: 'useTestResultsAggregates' },
+            errorDetails: { callingFn },
           })
         }
 

--- a/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/hooks/useTestResultsFlags/useTestResultsFlags.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/hooks/useTestResultsFlags/useTestResultsFlags.tsx
@@ -69,15 +69,13 @@ export const useTestResultsFlags = ({ term }: { term?: string }) => {
           term,
         },
       }).then((res) => {
+        const callingFn = 'useTestResultsFlags'
         const parsedData = TestResultsFlagsSchema.safeParse(res?.data)
 
         if (!parsedData.success) {
           return rejectNetworkError({
             errorName: 'Parsing Error',
-            errorDetails: {
-              callingFn: 'useTestResultsFlags',
-              error: parsedData.error,
-            },
+            errorDetails: { callingFn, error: parsedData.error },
           })
         }
 
@@ -86,7 +84,7 @@ export const useTestResultsFlags = ({ term }: { term?: string }) => {
         if (data?.owner?.repository?.__typename === 'NotFoundError') {
           return rejectNetworkError({
             errorName: 'Not Found Error',
-            errorDetails: { callingFn: 'useTestResultsFlags' },
+            errorDetails: { callingFn },
           })
         }
 

--- a/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/hooks/useTestResultsTestSuites/useTestResultsTestSuites.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/hooks/useTestResultsTestSuites/useTestResultsTestSuites.tsx
@@ -100,15 +100,13 @@ export const useTestResultsTestSuites = ({
           branch: branch ?? '',
         },
       }).then((res) => {
+        const callingFn = 'useTestResultsTestSuites'
         const parsedData = TestResultsTestSuitesSchema.safeParse(res?.data)
 
         if (!parsedData.success) {
           return rejectNetworkError({
             errorName: 'Parsing Error',
-            errorDetails: {
-              callingFn: 'useTestResultsTestSuites',
-              error: parsedData.error,
-            },
+            errorDetails: { callingFn, error: parsedData.error },
           })
         }
         const data = parsedData.data
@@ -116,7 +114,7 @@ export const useTestResultsTestSuites = ({
         if (data?.owner?.repository?.__typename === 'NotFoundError') {
           return rejectNetworkError({
             errorName: 'Not Found Error',
-            errorDetails: { callingFn: 'useTestResultsTestSuites' },
+            errorDetails: { callingFn },
           })
         }
 

--- a/src/services/access/SessionsQueryOpts.ts
+++ b/src/services/access/SessionsQueryOpts.ts
@@ -88,15 +88,13 @@ export function SessionsQueryOpts({ provider }: SessionsQueryArgs) {
         query,
         signal,
       }).then((res) => {
+        const callingFn = 'SessionsQueryOpts'
         const parsedRes = RequestSchema.safeParse(res?.data)
 
         if (!parsedRes.success) {
           return rejectNetworkError({
             errorName: 'Parsing Error',
-            errorDetails: {
-              callingFn: 'SessionsQueryOpts',
-              error: parsedRes.error,
-            },
+            errorDetails: { callingFn, error: parsedRes.error },
           })
         }
 

--- a/src/services/access/useGenerateUserToken.ts
+++ b/src/services/access/useGenerateUserToken.ts
@@ -50,14 +50,13 @@ export function useGenerateUserToken({ provider }: { provider: string }) {
         variables,
         mutationPath: 'createUserToken',
       }).then((res) => {
+        const callingFn = 'useGenerateUserToken'
         const parsedData = UseGenerateTokenResponseSchema.safeParse(res?.data)
+
         if (!parsedData.success) {
           return rejectNetworkError({
             errorName: 'Parsing Error',
-            errorDetails: {
-              callingFn: 'useGenerateUserToken',
-              error: parsedData.error,
-            },
+            errorDetails: { callingFn, error: parsedData.error },
           })
         }
 

--- a/src/services/account/useAccountDetails.ts
+++ b/src/services/account/useAccountDetails.ts
@@ -199,15 +199,13 @@ export function useAccountDetails({
           return res as z.infer<typeof AccountDetailsSchema>
         }
 
+        const callingFn = 'useAccountDetails'
         const parsedRes = AccountDetailsSchema.safeParse(res)
 
         if (!parsedRes.success) {
           return rejectNetworkError({
             errorName: 'Parsing Error',
-            errorDetails: {
-              callingFn: 'useAccountDetails',
-              error: parsedRes.error,
-            },
+            errorDetails: { callingFn, error: parsedRes.error },
           })
         }
 

--- a/src/services/account/useAvailablePlans.ts
+++ b/src/services/account/useAvailablePlans.ts
@@ -65,15 +65,13 @@ export const useAvailablePlans = ({
           owner,
         },
       }).then((res) => {
+        const callingFn = 'useAvailablePlans'
         const parsedRes = PlansSchema.safeParse(res?.data)
 
         if (!parsedRes.success) {
           return rejectNetworkError({
             errorName: 'Parsing Error',
-            errorDetails: {
-              callingFn: 'useAvailablePlans',
-              error: parsedRes.error,
-            },
+            errorDetails: { callingFn, error: parsedRes.error },
           })
         }
 

--- a/src/services/account/useCreateStripeSetupIntent.ts
+++ b/src/services/account/useCreateStripeSetupIntent.ts
@@ -69,14 +69,13 @@ export function useCreateStripeSetupIntent({
     queryKey: ['setupIntent', provider, owner],
     queryFn: ({ signal }) =>
       createStripeSetupIntent({ provider, owner, signal }).then((res) => {
+        const callingFn = 'useCreateStripeSetupIntent'
         const parsedRes = CreateStripeSetupIntentSchema.safeParse(res.data)
+
         if (!parsedRes.success) {
           return rejectNetworkError({
             errorName: 'Parsing Error',
-            errorDetails: {
-              callingFn: 'useCreateStripeSetupIntent',
-              error: parsedRes.error,
-            },
+            errorDetails: { callingFn, error: parsedRes.error },
           })
         }
 

--- a/src/services/account/useInvoice.ts
+++ b/src/services/account/useInvoice.ts
@@ -87,15 +87,13 @@ export const useInvoice = ({ provider, owner, id }: UseInvoiceArgs) =>
           id,
         },
       }).then((res) => {
+        const callingFn = 'useInvoice'
         const parsedData = OwnerInvoiceSchema.safeParse(res?.data)
 
         if (!parsedData.success) {
           return rejectNetworkError({
             errorName: 'Parsing Error',
-            errorDetails: {
-              callingFn: 'useInvoice',
-              error: parsedData.error,
-            },
+            errorDetails: { callingFn, error: parsedData.error },
           })
         }
 

--- a/src/services/account/useInvoices.ts
+++ b/src/services/account/useInvoices.ts
@@ -137,15 +137,13 @@ export const useInvoices = ({ provider, owner }: UseInvoicesArgs) =>
           owner,
         },
       }).then((res) => {
+        const callingFn = 'useInvoices'
         const parsedData = OwnerInvoiceSchema.safeParse(res?.data)
 
         if (!parsedData.success) {
           return rejectNetworkError({
             errorName: 'Parsing Error',
-            errorDetails: {
-              callingFn: 'useInvoices',
-              error: parsedData.error,
-            },
+            errorDetails: { callingFn, error: parsedData.error },
           })
         }
 

--- a/src/services/account/usePlanData.ts
+++ b/src/services/account/usePlanData.ts
@@ -118,15 +118,13 @@ export const usePlanData = ({ provider, owner, opts }: UsePlanDataArgs) =>
           owner,
         },
       }).then((res) => {
+        const callingFn = 'usePlanData'
         const parsedRes = PlanDataSchema.safeParse(res?.data)
 
         if (!parsedRes.success) {
           return rejectNetworkError({
             errorName: 'Parsing Error',
-            errorDetails: {
-              callingFn: 'usePlanData',
-              error: parsedRes.error,
-            },
+            errorDetails: { callingFn, error: parsedRes.error },
           })
         }
 

--- a/src/services/account/useUnverifiedPaymentMethods.tsx
+++ b/src/services/account/useUnverifiedPaymentMethods.tsx
@@ -57,15 +57,13 @@ export const useUnverifiedPaymentMethods = ({
           owner,
         },
       }).then((res) => {
+        const callingFn = 'useUnverifiedPaymentMethods'
         const parsedData = UnverifiedPaymentMethodsSchema.safeParse(res?.data)
 
         if (!parsedData.success) {
           return rejectNetworkError({
             errorName: 'Parsing Error',
-            errorDetails: {
-              callingFn: 'useUnverifiedPaymentMethods',
-              error: parsedData.error,
-            },
+            errorDetails: { callingFn, error: parsedData.error },
           })
         }
 

--- a/src/services/ats/useRepoATS.tsx
+++ b/src/services/ats/useRepoATS.tsx
@@ -71,15 +71,13 @@ export const useRepoATS = ({ provider, owner, repo }: RepoATSInfoArgs) =>
           repo,
         },
       }).then((res) => {
+        const callingFn = 'useRepoATS'
         const parsedData = GetRepoATSDataSchema.safeParse(res?.data)
 
         if (!parsedData.success) {
           return rejectNetworkError({
             errorName: 'Parsing Error',
-            errorDetails: {
-              callingFn: 'useRepoATS',
-              error: parsedData.error,
-            },
+            errorDetails: { callingFn, error: parsedData.error },
           })
         }
 
@@ -88,16 +86,14 @@ export const useRepoATS = ({ provider, owner, repo }: RepoATSInfoArgs) =>
         if (data?.owner?.repository?.__typename === 'NotFoundError') {
           return rejectNetworkError({
             errorName: 'Not Found Error',
-            errorDetails: {
-              callingFn: 'useRepoATS',
-            },
+            errorDetails: { callingFn },
           })
         }
 
         if (data?.owner?.repository?.__typename === 'OwnerNotActivatedError') {
           return rejectNetworkError({
             errorName: 'Owner Not Activated',
-            errorDetails: { callingFn: 'useRepoATS' },
+            errorDetails: { callingFn },
             data: {
               detail: (
                 <p>

--- a/src/services/branches/useBranch.tsx
+++ b/src/services/branches/useBranch.tsx
@@ -90,15 +90,13 @@ export const useBranch = ({
           branch,
         },
       }).then((res) => {
+        const callingFn = 'useBranch'
         const parsedData = GetBranchSchema.safeParse(res?.data)
 
         if (!parsedData.success) {
           return rejectNetworkError({
             errorName: 'Parsing Error',
-            errorDetails: {
-              callingFn: 'useBranch',
-              error: parsedData.error,
-            },
+            errorDetails: { callingFn, error: parsedData.error },
           })
         }
 
@@ -107,18 +105,14 @@ export const useBranch = ({
         if (data?.owner?.repository?.__typename === 'NotFoundError') {
           return rejectNetworkError({
             errorName: 'Not Found Error',
-            errorDetails: {
-              callingFn: 'useBranch',
-            },
+            errorDetails: { callingFn },
           })
         }
 
         if (data?.owner?.repository?.__typename === 'OwnerNotActivatedError') {
           return rejectNetworkError({
             errorName: 'Owner Not Activated',
-            errorDetails: {
-              callingFn: 'useBranch',
-            },
+            errorDetails: { callingFn },
             data: {
               detail: (
                 <p>

--- a/src/services/branches/useBranchComponents.tsx
+++ b/src/services/branches/useBranchComponents.tsx
@@ -115,15 +115,13 @@ export const useBranchComponents = ({
           filters,
         },
       }).then((res) => {
+        const callingFn = 'useBranchComponents'
         const parsedData = GetBranchComponentsSchema.safeParse(res?.data)
 
         if (!parsedData.success) {
           return rejectNetworkError({
             errorName: 'Parsing Error',
-            errorDetails: {
-              callingFn: 'useBranchComponents',
-              error: parsedData.error,
-            },
+            errorDetails: { callingFn, error: parsedData.error },
           })
         }
 
@@ -132,18 +130,14 @@ export const useBranchComponents = ({
         if (data?.owner?.repository?.__typename === 'NotFoundError') {
           return rejectNetworkError({
             errorName: 'Not Found Error',
-            errorDetails: {
-              callingFn: 'useBranchComponents',
-            },
+            errorDetails: { callingFn },
           })
         }
 
         if (data?.owner?.repository?.__typename === 'OwnerNotActivatedError') {
           return rejectNetworkError({
             errorName: 'Owner Not Activated',
-            errorDetails: {
-              callingFn: 'useBranchComponents',
-            },
+            errorDetails: { callingFn },
             data: {
               detail: (
                 <p>

--- a/src/services/branches/useBranchHasCommits.tsx
+++ b/src/services/branches/useBranchHasCommits.tsx
@@ -96,15 +96,13 @@ export const useBranchHasCommits = ({
           branch,
         },
       }).then((res) => {
+        const callingFn = 'useBranchHasCommits'
         const parsedData = GetBranchCommitsSchema.safeParse(res.data)
 
         if (!parsedData.success) {
           return rejectNetworkError({
             errorName: 'Parsing Error',
-            errorDetails: {
-              callingFn: 'useBranchHasCommits',
-              error: parsedData.error,
-            },
+            errorDetails: { callingFn, error: parsedData.error },
           })
         }
 
@@ -113,18 +111,14 @@ export const useBranchHasCommits = ({
         if (data?.owner?.repository?.__typename === 'NotFoundError') {
           return rejectNetworkError({
             errorName: 'Not Found Error',
-            errorDetails: {
-              callingFn: 'useBranchHasCommits',
-            },
+            errorDetails: { callingFn },
           })
         }
 
         if (data?.owner?.repository?.__typename === 'OwnerNotActivatedError') {
           return rejectNetworkError({
             errorName: 'Owner Not Activated',
-            errorDetails: {
-              callingFn: 'useBranchHasCommits',
-            },
+            errorDetails: { callingFn },
             data: {
               detail: (
                 <p>

--- a/src/services/branches/useBranches.tsx
+++ b/src/services/branches/useBranches.tsx
@@ -140,15 +140,13 @@ export function useBranches({
           after: pageParam,
         },
       }).then((res) => {
+        const callingFn = 'useBranches'
         const parsedData = GetBranchesSchema.safeParse(res?.data)
 
         if (!parsedData.success) {
           return rejectNetworkError({
             errorName: 'Parsing Error',
-            errorDetails: {
-              callingFn: 'useBranches',
-              error: parsedData.error,
-            },
+            errorDetails: { callingFn, error: parsedData.error },
           })
         }
 
@@ -157,18 +155,14 @@ export function useBranches({
         if (data?.owner?.repository?.__typename === 'NotFoundError') {
           return rejectNetworkError({
             errorName: 'Not Found Error',
-            errorDetails: {
-              callingFn: 'useBranches',
-            },
+            errorDetails: { callingFn },
           })
         }
 
         if (data?.owner?.repository?.__typename === 'OwnerNotActivatedError') {
           return rejectNetworkError({
             errorName: 'Owner Not Activated',
-            errorDetails: {
-              callingFn: 'useBranches',
-            },
+            errorDetails: { callingFn },
             data: {
               detail: (
                 <p>

--- a/src/services/bundleAnalysis/BranchBundleSummaryQueryOpts.tsx
+++ b/src/services/bundleAnalysis/BranchBundleSummaryQueryOpts.tsx
@@ -160,15 +160,13 @@ export const BranchBundleSummaryQueryOpts = ({
           branch,
         },
       }).then((res) => {
+        const callingFn = 'BranchBundleSummaryQueryOpts'
         const parsedData = BranchBundleSummaryDataSchema.safeParse(res?.data)
 
         if (!parsedData.success) {
           return rejectNetworkError({
             errorName: 'Parsing Error',
-            errorDetails: {
-              callingFn: 'BranchBundleSummaryQueryOpts',
-              error: parsedData.error,
-            },
+            errorDetails: { callingFn, error: parsedData.error },
           })
         }
 
@@ -177,14 +175,14 @@ export const BranchBundleSummaryQueryOpts = ({
         if (data?.owner?.repository?.__typename === 'NotFoundError') {
           return rejectNetworkError({
             errorName: 'Not Found Error',
-            errorDetails: { callingFn: 'BranchBundleSummaryQueryOpts' },
+            errorDetails: { callingFn },
           })
         }
 
         if (data?.owner?.repository?.__typename === 'OwnerNotActivatedError') {
           return rejectNetworkError({
             errorName: 'Owner Not Activated',
-            errorDetails: { callingFn: 'BranchBundleSummaryQueryOpts' },
+            errorDetails: { callingFn },
             data: {
               detail: (
                 <p>

--- a/src/services/bundleAnalysis/BranchBundlesNamesQueryOpts.tsx
+++ b/src/services/bundleAnalysis/BranchBundlesNamesQueryOpts.tsx
@@ -122,15 +122,13 @@ export const BranchBundlesNamesQueryOpts = ({
           branch,
         },
       }).then((res) => {
+        const callingFn = 'BranchBundlesNamesQueryOpts'
         const parsedData = BranchBundleSummaryDataSchema.safeParse(res?.data)
 
         if (!parsedData.success) {
           return rejectNetworkError({
             errorName: 'Parsing Error',
-            errorDetails: {
-              callingFn: 'BranchBundlesNamesQueryOpts',
-              error: parsedData.error,
-            },
+            errorDetails: { callingFn, error: parsedData.error },
           })
         }
 
@@ -139,14 +137,14 @@ export const BranchBundlesNamesQueryOpts = ({
         if (data?.owner?.repository?.__typename === 'NotFoundError') {
           return rejectNetworkError({
             errorName: 'Not Found Error',
-            errorDetails: { callingFn: 'BranchBundlesNamesQueryOpts' },
+            errorDetails: { callingFn },
           })
         }
 
         if (data?.owner?.repository?.__typename === 'OwnerNotActivatedError') {
           return rejectNetworkError({
             errorName: 'Owner Not Activated',
-            errorDetails: { callingFn: 'BranchBundlesNamesQueryOpts' },
+            errorDetails: { callingFn },
             data: {
               detail: (
                 <p>

--- a/src/services/bundleAnalysis/BundleAssetsQueryOpts.tsx
+++ b/src/services/bundleAnalysis/BundleAssetsQueryOpts.tsx
@@ -278,15 +278,13 @@ export const BundleAssetsQueryOpts = ({
           orderingDirection,
         },
       }).then((res) => {
+        const callingFn = 'BundleAssetsQueryOpts'
         const parsedData = RequestSchema.safeParse(res?.data)
 
         if (!parsedData.success) {
           return rejectNetworkError({
             errorName: 'Parsing Error',
-            errorDetails: {
-              callingFn: 'BundleAssetsQueryOpts',
-              error: parsedData.error,
-            },
+            errorDetails: { callingFn, error: parsedData.error },
           })
         }
 
@@ -295,14 +293,14 @@ export const BundleAssetsQueryOpts = ({
         if (data?.owner?.repository?.__typename === 'NotFoundError') {
           return rejectNetworkError({
             errorName: 'Not Found Error',
-            errorDetails: { callingFn: 'BundleAssetsQueryOpts' },
+            errorDetails: { callingFn },
           })
         }
 
         if (data?.owner?.repository?.__typename === 'OwnerNotActivatedError') {
           return rejectNetworkError({
             errorName: 'Owner Not Activated',
-            errorDetails: { callingFn: 'BundleAssetsQueryOpts' },
+            errorDetails: { callingFn },
             data: {
               detail: (
                 <p>

--- a/src/services/bundleAnalysis/BundleTrendDataQueryOpts.tsx
+++ b/src/services/bundleAnalysis/BundleTrendDataQueryOpts.tsx
@@ -190,15 +190,13 @@ export const BundleTrendDataQueryOpts = ({
           filters,
         },
       }).then((res) => {
+        const callingFn = 'BundleTrendDataQueryOpts'
         const parsedData = RequestSchema.safeParse(res?.data)
 
         if (!parsedData.success) {
           return rejectNetworkError({
             errorName: 'Parsing Error',
-            errorDetails: {
-              callingFn: 'BundleTrendDataQueryOpts',
-              error: parsedData.error,
-            },
+            errorDetails: { callingFn, error: parsedData.error },
           })
         }
 
@@ -207,14 +205,14 @@ export const BundleTrendDataQueryOpts = ({
         if (data?.owner?.repository?.__typename === 'NotFoundError') {
           return rejectNetworkError({
             errorName: 'Not Found Error',
-            errorDetails: { callingFn: 'BundleTrendDataQueryOpts' },
+            errorDetails: { callingFn },
           })
         }
 
         if (data?.owner?.repository?.__typename === 'OwnerNotActivatedError') {
           return rejectNetworkError({
             errorName: 'Owner Not Activated',
-            errorDetails: { callingFn: 'BundleTrendDataQueryOpts' },
+            errorDetails: { callingFn },
             data: {
               detail: (
                 <p>

--- a/src/services/bundleAnalysis/CachedBundlesQueryOpts.tsx
+++ b/src/services/bundleAnalysis/CachedBundlesQueryOpts.tsx
@@ -118,15 +118,13 @@ export const CachedBundlesQueryOpts = ({
         signal,
         variables,
       }).then((res) => {
+        const callingFn = 'CachedBundlesQueryOpts'
         const parsedData = BranchBundleSummaryDataSchema.safeParse(res?.data)
 
         if (!parsedData.success) {
           return rejectNetworkError({
             errorName: 'Parsing Error',
-            errorDetails: {
-              callingFn: 'CachedBundlesQueryOpts',
-              error: parsedData.error,
-            },
+            errorDetails: { callingFn, error: parsedData.error },
           })
         }
 
@@ -135,14 +133,14 @@ export const CachedBundlesQueryOpts = ({
         if (data?.owner?.repository?.__typename === 'NotFoundError') {
           return rejectNetworkError({
             errorName: 'Not Found Error',
-            errorDetails: { callingFn: 'CachedBundlesQueryOpts' },
+            errorDetails: { callingFn },
           })
         }
 
         if (data?.owner?.repository?.__typename === 'OwnerNotActivatedError') {
           return rejectNetworkError({
             errorName: 'Owner Not Activated',
-            errorDetails: { callingFn: 'CachedBundlesQueryOpts' },
+            errorDetails: { callingFn },
             data: {
               detail: (
                 <p>

--- a/src/services/bundleAnalysis/useBundleAssetModules.tsx
+++ b/src/services/bundleAnalysis/useBundleAssetModules.tsx
@@ -174,15 +174,13 @@ export const BundleAssetModulesQueryOpts = ({
           asset,
         },
       }).then((res) => {
+        const callingFn = 'BundleAssetModulesQueryOpts'
         const parsedData = RequestSchema.safeParse(res.data)
 
         if (!parsedData.success) {
           return rejectNetworkError({
             errorName: 'Parsing Error',
-            errorDetails: {
-              callingFn: 'BundleAssetModulesQueryOpts',
-              error: parsedData.error,
-            },
+            errorDetails: { callingFn, error: parsedData.error },
           })
         }
 
@@ -191,14 +189,14 @@ export const BundleAssetModulesQueryOpts = ({
         if (data?.owner?.repository?.__typename === 'NotFoundError') {
           return rejectNetworkError({
             errorName: 'Not Found Error',
-            errorDetails: { callingFn: 'BundleAssetModulesQueryOpts' },
+            errorDetails: { callingFn },
           })
         }
 
         if (data?.owner?.repository?.__typename === 'OwnerNotActivatedError') {
           return rejectNetworkError({
             errorName: 'Owner Not Activated',
-            errorDetails: { callingFn: 'BundleAssetModulesQueryOpts' },
+            errorDetails: { callingFn },
             data: {
               detail: (
                 <p>

--- a/src/services/bundleAnalysis/useBundleSummary.tsx
+++ b/src/services/bundleAnalysis/useBundleSummary.tsx
@@ -152,15 +152,13 @@ export const BundleSummaryQueryOpts = ({
         signal,
         variables: { owner, repo, branch, bundle, filters },
       }).then((res) => {
+        const callingFn = 'BundleSummaryQueryOpts'
         const parsedData = RequestSchema.safeParse(res?.data)
 
         if (!parsedData.success) {
           return rejectNetworkError({
             errorName: 'Parsing Error',
-            errorDetails: {
-              callingFn: 'BundleSummaryQueryOpts',
-              error: parsedData.error,
-            },
+            errorDetails: { callingFn, error: parsedData.error },
           })
         }
 
@@ -169,14 +167,14 @@ export const BundleSummaryQueryOpts = ({
         if (data?.owner?.repository?.__typename === 'NotFoundError') {
           return rejectNetworkError({
             errorName: 'Not Found Error',
-            errorDetails: { callingFn: 'BundleSummaryQueryOpts' },
+            errorDetails: { callingFn },
           })
         }
 
         if (data?.owner?.repository?.__typename === 'OwnerNotActivatedError') {
           return rejectNetworkError({
             errorName: 'Owner Not Activated',
-            errorDetails: { callingFn: 'BundleSummaryQueryOpts' },
+            errorDetails: { callingFn },
             data: {
               detail: (
                 <p>

--- a/src/services/bundleAnalysis/useUpdateBundleCache.tsx
+++ b/src/services/bundleAnalysis/useUpdateBundleCache.tsx
@@ -76,14 +76,13 @@ export const useUpdateBundleCache = ({
   return useMutationV5({
     throwOnError: false,
     mutationFn: (input: z.infer<typeof UpdateBundleCacheInputSchema>) => {
+      const callingFn = 'useUpdateBundleCache'
       const parsedInput = UpdateBundleCacheInputSchema.safeParse(input)
+
       if (!parsedInput.success) {
         return rejectNetworkError({
           errorName: 'Parsing Error',
-          errorDetails: {
-            callingFn: 'useUpdateBundleCache',
-            error: parsedInput.error,
-          },
+          errorDetails: { callingFn, error: parsedInput.error },
         })
       }
 
@@ -98,10 +97,7 @@ export const useUpdateBundleCache = ({
         if (!parsedData.success) {
           return rejectNetworkError({
             errorName: 'Parsing Error',
-            errorDetails: {
-              callingFn: 'useUpdateBundleCache',
-              error: parsedData.error,
-            },
+            errorDetails: { callingFn, error: parsedData.error },
           })
         }
 

--- a/src/services/charts/BranchCoverageMeasurementsQueryOpts.tsx
+++ b/src/services/charts/BranchCoverageMeasurementsQueryOpts.tsx
@@ -121,6 +121,7 @@ export const BranchCoverageMeasurementsQueryOpts = ({
           branch,
         },
       }).then((res) => {
+        const callingFn = 'BranchCoverageMeasurementsQueryOpts'
         const parsedData = GetBranchCoverageMeasurementsSchema.safeParse(
           res?.data
         )
@@ -128,10 +129,7 @@ export const BranchCoverageMeasurementsQueryOpts = ({
         if (!parsedData.success) {
           return rejectNetworkError({
             errorName: 'Parsing Error',
-            errorDetails: {
-              callingFn: 'BranchCoverageMeasurementsQueryOpts',
-              error: parsedData.error,
-            },
+            errorDetails: { callingFn, error: parsedData.error },
           })
         }
 
@@ -140,14 +138,14 @@ export const BranchCoverageMeasurementsQueryOpts = ({
         if (data?.owner?.repository?.__typename === 'NotFoundError') {
           return rejectNetworkError({
             errorName: 'Not Found Error',
-            errorDetails: { callingFn: 'BranchCoverageMeasurementsQueryOpts' },
+            errorDetails: { callingFn },
           })
         }
 
         if (data?.owner?.repository?.__typename === 'OwnerNotActivatedError') {
           return rejectNetworkError({
             errorName: 'Owner Not Activated',
-            errorDetails: { callingFn: 'BranchCoverageMeasurementsQueryOpts' },
+            errorDetails: { callingFn },
             data: {
               detail: (
                 <p>

--- a/src/services/charts/ReposCoverageMeasurementsQueryOpts.ts
+++ b/src/services/charts/ReposCoverageMeasurementsQueryOpts.ts
@@ -86,15 +86,13 @@ export const ReposCoverageMeasurementsQueryOpts = ({
           isPublic,
         },
       }).then((res) => {
+        const callingFn = 'ReposCoverageMeasurementsQueryOpts'
         const parsedData = RequestSchema.safeParse(res?.data)
 
         if (!parsedData.success) {
           return rejectNetworkError({
             errorName: 'Parsing Error',
-            errorDetails: {
-              callingFn: 'ReposCoverageMeasurementsQueryOpts',
-              error: parsedData.error,
-            },
+            errorDetails: { callingFn, error: parsedData.error },
           })
         }
 

--- a/src/services/charts/SunburstCoverageQueryOpts.ts
+++ b/src/services/charts/SunburstCoverageQueryOpts.ts
@@ -53,15 +53,13 @@ export function SunburstCoverageQueryOpts({
     queryFn: ({ signal }) => {
       const path = getSunburstCoverage({ provider, owner, repo })
       return Api.get({ path, provider, query, signal }).then((res) => {
+        const callingFn = 'SunburstCoverageQueryOpts'
         const parsedRes = ResponseSchema.safeParse(res)
 
         if (!parsedRes.success) {
           return rejectNetworkError({
             errorName: 'Parsing Error',
-            errorDetails: {
-              callingFn: 'SunburstCoverageQueryOpts',
-              error: parsedRes.error,
-            },
+            errorDetails: { callingFn, error: parsedRes.error },
           })
         }
 

--- a/src/services/codecovAI/useCodecovAIInstallation.tsx
+++ b/src/services/codecovAI/useCodecovAIInstallation.tsx
@@ -40,14 +40,13 @@ export function useCodecovAIInstallation({
           username: owner,
         },
       }).then((res) => {
+        const callingFn = 'useCodecovAIInstallation'
         const parsedRes = ResponseSchema.safeParse(res?.data)
+
         if (!parsedRes.success) {
           return rejectNetworkError({
             errorName: 'Parsing Error',
-            errorDetails: {
-              callingFn: 'useCodecovAIInstallation',
-              error: parsedRes.error,
-            },
+            errorDetails: { callingFn, error: parsedRes.error },
           })
         }
 

--- a/src/services/codecovAI/useCodecovAIInstalledRepos.tsx
+++ b/src/services/codecovAI/useCodecovAIInstalledRepos.tsx
@@ -40,15 +40,13 @@ export function useCodecovAIInstalledRepos({
           username: owner,
         },
       }).then((res) => {
+        const callingFn = 'useCodecovAIInstalledRepos'
         const parsedRes = ResponseSchema.safeParse(res?.data)
 
         if (!parsedRes.success) {
           return rejectNetworkError({
             errorName: 'Parsing Error',
-            errorDetails: {
-              callingFn: 'useCodecovAIInstalledRepos',
-              error: parsedRes.error,
-            },
+            errorDetails: { callingFn, error: parsedRes.error },
           })
         }
 

--- a/src/services/commit/useCommit.tsx
+++ b/src/services/commit/useCommit.tsx
@@ -349,15 +349,13 @@ export function useCommit({
           isTeamPlan,
         },
       }).then((res) => {
+        const callingFn = 'useCommit'
         const parsedRes = RequestSchema.safeParse(res?.data)
 
         if (!parsedRes.success) {
           return rejectNetworkError({
             errorName: 'Parsing Error',
-            errorDetails: {
-              callingFn: 'useCommit',
-              error: parsedRes.error,
-            },
+            errorDetails: { callingFn, error: parsedRes.error },
           })
         }
 
@@ -366,14 +364,14 @@ export function useCommit({
         if (data?.owner?.repository?.__typename === 'NotFoundError') {
           return rejectNetworkError({
             errorName: 'Not Found Error',
-            errorDetails: { callingFn: 'useCommit' },
+            errorDetails: { callingFn },
           })
         }
 
         if (data?.owner?.repository?.__typename === 'OwnerNotActivatedError') {
           return rejectNetworkError({
             errorName: 'Owner Not Activated',
-            errorDetails: { callingFn: 'useCommit' },
+            errorDetails: { callingFn },
             data: {
               detail: (
                 <p>

--- a/src/services/commit/useCommitBADropdownSummary.tsx
+++ b/src/services/commit/useCommitBADropdownSummary.tsx
@@ -142,15 +142,13 @@ export function useCommitBADropdownSummary({
           commitid,
         },
       }).then((res) => {
+        const callingFn = 'useCommitBADropdownSummary'
         const parsedRes = RequestSchema.safeParse(res?.data)
 
         if (!parsedRes.success) {
           return rejectNetworkError({
             errorName: 'Parsing Error',
-            errorDetails: {
-              callingFn: 'useCommitBADropdownSummary',
-              error: parsedRes.error,
-            },
+            errorDetails: { callingFn, error: parsedRes.error },
           })
         }
 
@@ -159,18 +157,14 @@ export function useCommitBADropdownSummary({
         if (data?.owner?.repository?.__typename === 'NotFoundError') {
           return rejectNetworkError({
             errorName: 'Not Found Error',
-            errorDetails: {
-              callingFn: 'useCommitBADropdownSummary',
-            },
+            errorDetails: { callingFn },
           })
         }
 
         if (data?.owner?.repository?.__typename === 'OwnerNotActivatedError') {
           return rejectNetworkError({
             errorName: 'Owner Not Activated',
-            errorDetails: {
-              callingFn: 'useCommitBADropdownSummary',
-            },
+            errorDetails: { callingFn },
             data: {
               detail: (
                 <p>

--- a/src/services/commit/useCommitBundleList.tsx
+++ b/src/services/commit/useCommitBundleList.tsx
@@ -164,15 +164,13 @@ export function useCommitBundleList({
           commitid,
         },
       }).then((res) => {
+        const callingFn = 'useCommitBundleList'
         const parsedRes = RequestSchema.safeParse(res?.data)
 
         if (!parsedRes.success) {
           return rejectNetworkError({
             errorName: 'Parsing Error',
-            errorDetails: {
-              callingFn: 'useCommitBundleList',
-              error: parsedRes.error,
-            },
+            errorDetails: { callingFn, error: parsedRes.error },
           })
         }
 
@@ -181,18 +179,14 @@ export function useCommitBundleList({
         if (data?.owner?.repository?.__typename === 'NotFoundError') {
           return rejectNetworkError({
             errorName: 'Not Found Error',
-            errorDetails: {
-              callingFn: 'useCommitBundleList',
-            },
+            errorDetails: { callingFn },
           })
         }
 
         if (data?.owner?.repository?.__typename === 'OwnerNotActivatedError') {
           return rejectNetworkError({
             errorName: 'Owner Not Activated',
-            errorDetails: {
-              callingFn: 'useCommitBundleList',
-            },
+            errorDetails: { callingFn },
             data: {
               detail: (
                 <p>

--- a/src/services/commit/useCommitComponents.tsx
+++ b/src/services/commit/useCommitComponents.tsx
@@ -120,15 +120,13 @@ export function useCommitComponents({
           commitId,
         },
       }).then((res) => {
+        const callingFn = 'useCommitComponents'
         const parsedData = CommitComponentsSchema.safeParse(res?.data)
 
         if (!parsedData.success) {
           return rejectNetworkError({
             errorName: 'Parsing Error',
-            errorDetails: {
-              callingFn: 'useCommitComponents',
-              error: parsedData.error,
-            },
+            errorDetails: { callingFn, error: parsedData.error },
           })
         }
 
@@ -137,18 +135,14 @@ export function useCommitComponents({
         if (data?.owner?.repository?.__typename === 'NotFoundError') {
           return rejectNetworkError({
             errorName: 'Not Found Error',
-            errorDetails: {
-              callingFn: 'useCommitComponents',
-            },
+            errorDetails: { callingFn },
           })
         }
 
         if (data?.owner?.repository?.__typename === 'OwnerNotActivatedError') {
           return rejectNetworkError({
             errorName: 'Owner Not Activated',
-            errorDetails: {
-              callingFn: 'useCommitComponents',
-            },
+            errorDetails: { callingFn },
             data: {
               detail: (
                 <p>

--- a/src/services/commit/useCommitCoverageDropdownSummary.tsx
+++ b/src/services/commit/useCommitCoverageDropdownSummary.tsx
@@ -168,15 +168,13 @@ export function useCommitCoverageDropdownSummary({
           commitid,
         },
       }).then((res) => {
+        const callingFn = 'useCommitCoverageDropdownSummary'
         const parsedRes = RequestSchema.safeParse(res?.data)
 
         if (!parsedRes.success) {
           return rejectNetworkError({
             errorName: 'Parsing Error',
-            errorDetails: {
-              callingFn: 'useCommitCoverageDropdownSummary',
-              error: parsedRes.error,
-            },
+            errorDetails: { callingFn, error: parsedRes.error },
           })
         }
 
@@ -185,18 +183,14 @@ export function useCommitCoverageDropdownSummary({
         if (data?.owner?.repository?.__typename === 'NotFoundError') {
           return rejectNetworkError({
             errorName: 'Not Found Error',
-            errorDetails: {
-              callingFn: 'useCommitCoverageDropdownSummary',
-            },
+            errorDetails: { callingFn },
           })
         }
 
         if (data?.owner?.repository?.__typename === 'OwnerNotActivatedError') {
           return rejectNetworkError({
             errorName: 'Owner Not Activated',
-            errorDetails: {
-              callingFn: 'useCommitCoverageDropdownSummary',
-            },
+            errorDetails: { callingFn },
             data: {
               detail: (
                 <p>

--- a/src/services/commit/useCommitTeam.tsx
+++ b/src/services/commit/useCommitTeam.tsx
@@ -312,15 +312,13 @@ export function useCommitTeam({
           filters,
         },
       }).then((res) => {
+        const callingFn = 'useCommitTeam'
         const parsedRes = RequestSchema.safeParse(res?.data)
 
         if (!parsedRes.success) {
           return rejectNetworkError({
             errorName: 'Parsing Error',
-            errorDetails: {
-              callingFn: 'useCommitTeam',
-              error: parsedRes.error,
-            },
+            errorDetails: { callingFn, error: parsedRes.error },
           })
         }
 
@@ -329,18 +327,14 @@ export function useCommitTeam({
         if (data?.owner?.repository?.__typename === 'NotFoundError') {
           return rejectNetworkError({
             errorName: 'Not Found Error',
-            errorDetails: {
-              callingFn: 'useCommitTeam',
-            },
+            errorDetails: { callingFn },
           })
         }
 
         if (data?.owner?.repository?.__typename === 'OwnerNotActivatedError') {
           return rejectNetworkError({
             errorName: 'Owner Not Activated',
-            errorDetails: {
-              callingFn: 'useCommitTeam',
-            },
+            errorDetails: { callingFn },
             data: {
               detail: (
                 <p>

--- a/src/services/commit/useCommitYaml.tsx
+++ b/src/services/commit/useCommitYaml.tsx
@@ -80,15 +80,13 @@ export function useCommitYaml({
           commitid,
         },
       }).then((res) => {
+        const callingFn = 'useCommitYaml'
         const parsedData = RequestSchema.safeParse(res?.data)
 
         if (!parsedData.success) {
           return rejectNetworkError({
             errorName: 'Parsing Error',
-            errorDetails: {
-              callingFn: 'useCommitYaml',
-              error: parsedData.error,
-            },
+            errorDetails: { callingFn, error: parsedData.error },
           })
         }
 
@@ -97,18 +95,14 @@ export function useCommitYaml({
         if (data?.owner?.repository?.__typename === 'NotFoundError') {
           return rejectNetworkError({
             errorName: 'Not Found Error',
-            errorDetails: {
-              callingFn: 'useCommitYaml',
-            },
+            errorDetails: { callingFn },
           })
         }
 
         if (data?.owner?.repository?.__typename === 'OwnerNotActivatedError') {
           return rejectNetworkError({
             errorName: 'Owner Not Activated',
-            errorDetails: {
-              callingFn: 'useCommitYaml',
-            },
+            errorDetails: { callingFn },
             data: {
               detail: (
                 <p>

--- a/src/services/commit/useCompareTotals.tsx
+++ b/src/services/commit/useCompareTotals.tsx
@@ -193,15 +193,13 @@ export function useCompareTotals({
           filters,
         },
       }).then((res) => {
+        const callingFn = 'useCompareTotals'
         const parsedRes = RequestSchema.safeParse(res?.data)
 
         if (!parsedRes.success) {
           return rejectNetworkError({
             errorName: 'Parsing Error',
-            errorDetails: {
-              callingFn: 'useCompareTotals',
-              error: parsedRes.error,
-            },
+            errorDetails: { callingFn, error: parsedRes.error },
           })
         }
 
@@ -210,16 +208,14 @@ export function useCompareTotals({
         if (data?.owner?.repository?.__typename === 'NotFoundError') {
           return rejectNetworkError({
             errorName: 'Not Found Error',
-            errorDetails: {
-              callingFn: 'useCompareTotals',
-            },
+            errorDetails: { callingFn },
           })
         }
 
         if (data?.owner?.repository?.__typename === 'OwnerNotActivatedError') {
           return rejectNetworkError({
             errorName: 'Owner Not Activated',
-            errorDetails: { callingFn: 'useCompareTotals' },
+            errorDetails: { callingFn },
             data: {
               detail: (
                 <p>

--- a/src/services/commit/useCompareTotalsTeam.tsx
+++ b/src/services/commit/useCompareTotalsTeam.tsx
@@ -181,15 +181,13 @@ export function useCompareTotalsTeam({
           filters,
         },
       }).then((res) => {
+        const callingFn = 'useCompareTotalsTeam'
         const parsedRes = RequestSchema.safeParse(res?.data)
 
         if (!parsedRes.success) {
           return rejectNetworkError({
             errorName: 'Parsing Error',
-            errorDetails: {
-              callingFn: 'useCompareTotalsTeam',
-              error: parsedRes.error,
-            },
+            errorDetails: { callingFn, error: parsedRes.error },
           })
         }
 
@@ -198,18 +196,14 @@ export function useCompareTotalsTeam({
         if (data?.owner?.repository?.__typename === 'NotFoundError') {
           return rejectNetworkError({
             errorName: 'Not Found Error',
-            errorDetails: {
-              callingFn: 'useCompareTotalsTeam',
-            },
+            errorDetails: { callingFn },
           })
         }
 
         if (data?.owner?.repository?.__typename === 'OwnerNotActivatedError') {
           return rejectNetworkError({
             errorName: 'Owner Not Activated',
-            errorDetails: {
-              callingFn: 'useCompareTotalsTeam',
-            },
+            errorDetails: { callingFn },
             data: {
               detail: (
                 <p>

--- a/src/services/commitErrors/useCommitErrors.tsx
+++ b/src/services/commitErrors/useCommitErrors.tsx
@@ -104,15 +104,13 @@ export function useCommitErrors() {
           commitid,
         },
       }).then((res) => {
+        const callingFn = 'useCommitErrors'
         const parsedData = useCommitErrorsSchema.safeParse(res?.data)
 
         if (!parsedData.success) {
           return rejectNetworkError({
             errorName: 'Parsing Error',
-            errorDetails: {
-              callingFn: 'useCommitErrors',
-              error: parsedData.error,
-            },
+            errorDetails: { callingFn, error: parsedData.error },
           })
         }
 
@@ -121,18 +119,14 @@ export function useCommitErrors() {
         if (data?.owner?.repository?.__typename === 'NotFoundError') {
           return rejectNetworkError({
             errorName: 'Not Found Error',
-            errorDetails: {
-              callingFn: 'useCommitErrors',
-            },
+            errorDetails: { callingFn },
           })
         }
 
         if (data?.owner?.repository?.__typename === 'OwnerNotActivatedError') {
           return rejectNetworkError({
             errorName: 'Owner Not Activated',
-            errorDetails: {
-              callingFn: 'useCommitErrors',
-            },
+            errorDetails: { callingFn },
             data: {
               detail: (
                 <p>

--- a/src/services/commits/useCommits.tsx
+++ b/src/services/commits/useCommits.tsx
@@ -265,15 +265,13 @@ export function useCommits({
           after: pageParam,
         },
       }).then((res) => {
+        const callingFn = 'useCommits'
         const parsedData = GetCommitsSchema.safeParse(res?.data)
 
         if (!parsedData.success) {
           return rejectNetworkError({
             errorName: 'Parsing Error',
-            errorDetails: {
-              callingFn: 'useCommits',
-              error: parsedData.error,
-            },
+            errorDetails: { callingFn, error: parsedData.error },
           })
         }
 
@@ -282,18 +280,14 @@ export function useCommits({
         if (data?.owner?.repository?.__typename === 'NotFoundError') {
           return rejectNetworkError({
             errorName: 'Not Found Error',
-            errorDetails: {
-              callingFn: 'useCommits',
-            },
+            errorDetails: { callingFn },
           })
         }
 
         if (data?.owner?.repository?.__typename === 'OwnerNotActivatedError') {
           return rejectNetworkError({
             errorName: 'Owner Not Activated',
-            errorDetails: {
-              callingFn: 'useCommits',
-            },
+            errorDetails: { callingFn },
             data: {
               detail: (
                 <p>

--- a/src/services/comparison/useComparisonForCommitAndParent/useComparisonForCommitAndParent.tsx
+++ b/src/services/comparison/useComparisonForCommitAndParent/useComparisonForCommitAndParent.tsx
@@ -150,6 +150,7 @@ export function useComparisonForCommitAndParent({
           filters,
         },
       }).then((res) => {
+        const callingFn = 'useComparisonForCommitAndParent'
         const parsedRes = ComparisonForCommitAndParentSchema.safeParse(
           res?.data
         )
@@ -157,10 +158,7 @@ export function useComparisonForCommitAndParent({
         if (!parsedRes.success) {
           return rejectNetworkError({
             errorName: 'Parsing Error',
-            errorDetails: {
-              callingFn: 'useComparisonForCommitAndParent',
-              error: parsedRes.error,
-            },
+            errorDetails: { callingFn, error: parsedRes.error },
           })
         }
 
@@ -169,18 +167,14 @@ export function useComparisonForCommitAndParent({
         if (data?.owner?.repository?.__typename === 'NotFoundError') {
           return rejectNetworkError({
             errorName: 'Not Found Error',
-            errorDetails: {
-              callingFn: 'useComparisonForCommitAndParent',
-            },
+            errorDetails: { callingFn },
           })
         }
 
         if (data?.owner?.repository?.__typename === 'OwnerNotActivatedError') {
           return rejectNetworkError({
             errorName: 'Owner Not Activated',
-            errorDetails: {
-              callingFn: 'useComparisonForCommitAndParent',
-            },
+            errorDetails: { callingFn },
             data: {
               detail: (
                 <p>

--- a/src/services/config/LoginProvidersQueryOpts.ts
+++ b/src/services/config/LoginProvidersQueryOpts.ts
@@ -40,15 +40,13 @@ export const LoginProvidersQueryOpts = () => {
         signal,
         query,
       }).then((res) => {
+        const callingFn = 'LoginProvidersQueryOpts'
         const parsedRes = GetLoginProvidersSchema.safeParse(res?.data)
 
         if (!parsedRes.success) {
           return rejectNetworkError({
             errorName: 'Parsing Error',
-            errorDetails: {
-              callingFn: 'LoginProvidersQueryOpts',
-              error: parsedRes.error,
-            },
+            errorDetails: { callingFn, error: parsedRes.error },
           })
         }
 

--- a/src/services/config/SyncProvidersQueryOpts.ts
+++ b/src/services/config/SyncProvidersQueryOpts.ts
@@ -39,15 +39,13 @@ export const SyncProvidersQueryOpts = () => {
         signal,
         query,
       }).then((res) => {
+        const callingFn = 'SyncProvidersQueryOpts'
         const parsedRes = GetSyncProvidersSchema.safeParse(res?.data)
 
         if (!parsedRes.success) {
           return rejectNetworkError({
             errorName: 'Parsing Error',
-            errorDetails: {
-              callingFn: 'SyncProvidersQueryOpts',
-              error: parsedRes.error,
-            },
+            errorDetails: { callingFn, error: parsedRes.error },
           })
         }
 

--- a/src/services/events/hooks.tsx
+++ b/src/services/events/hooks.tsx
@@ -89,15 +89,13 @@ export const OwnerContextQueryOpts = ({
           owner,
         },
       }).then((res) => {
+        const callingFn = 'OwnerContextQueryOpts'
         const parsedRes = OwnerContextSchema.safeParse(res.data)
 
         if (!parsedRes.success) {
           return rejectNetworkError({
             errorName: 'Parsing Error',
-            errorDetails: {
-              callingFn: 'OwnerContextQueryOpts',
-              error: parsedRes.error,
-            },
+            errorDetails: { callingFn, error: parsedRes.error },
           })
         }
 
@@ -172,22 +170,20 @@ export const RepoContextQueryOpts = ({
           repo,
         },
       }).then((res) => {
+        const callingFn = 'RepoContextQueryOpts'
         const parsedRes = RepoContextSchema.safeParse(res.data)
 
         if (!parsedRes.success) {
           return rejectNetworkError({
             errorName: 'Parsing Error',
-            errorDetails: {
-              callingFn: 'RepoContextQueryOpts',
-              error: parsedRes.error,
-            },
+            errorDetails: { callingFn, error: parsedRes.error },
           })
         }
 
         if (parsedRes.data?.owner?.repository?.__typename === 'NotFoundError') {
           return rejectNetworkError({
             errorName: 'Not Found Error',
-            errorDetails: { callingFn: 'RepoContextQueryOpts' },
+            errorDetails: { callingFn },
           })
         }
 
@@ -197,7 +193,7 @@ export const RepoContextQueryOpts = ({
         ) {
           return rejectNetworkError({
             errorName: 'Owner Not Activated',
-            errorDetails: { callingFn: 'RepoContextQueryOpts' },
+            errorDetails: { callingFn },
             data: {
               detail: (
                 <p>

--- a/src/services/orgUploadToken/useOrgUploadToken.ts
+++ b/src/services/orgUploadToken/useOrgUploadToken.ts
@@ -35,15 +35,13 @@ export const useOrgUploadToken = ({ provider, owner }: UseOrgUploadTokenArgs) =>
           owner,
         },
       }).then((res) => {
+        const callingFn = 'useOrgUploadToken'
         const parsedRes = RequestSchema.safeParse(res?.data)
 
         if (!parsedRes.success) {
           return rejectNetworkError({
             errorName: 'Parsing Error',
-            errorDetails: {
-              callingFn: 'useOrgUploadToken',
-              error: parsedRes.error,
-            },
+            errorDetails: { callingFn, error: parsedRes.error },
           })
         }
 

--- a/src/services/orgUploadToken/useRegenerateOrgUploadToken.tsx
+++ b/src/services/orgUploadToken/useRegenerateOrgUploadToken.tsx
@@ -65,14 +65,13 @@ export function useRegenerateOrgUploadToken({
         variables: { input: { owner } },
         mutationPath: 'RegenerateOrgUploadToken',
       }).then(({ data }) => {
+        const callingFn = 'useRegenerateOrgUploadToken'
         const parsedRes = ResponseSchema.safeParse(data)
+
         if (!parsedRes.success) {
           return rejectNetworkError({
             errorName: 'Parsing Error',
-            errorDetails: {
-              callingFn: 'useRegenerateOrgUploadToken',
-              error: parsedRes.error,
-            },
+            errorDetails: { callingFn, error: parsedRes.error },
           })
         }
 

--- a/src/services/pathContents/branch/dir/usePrefetchBranchDirEntry.tsx
+++ b/src/services/pathContents/branch/dir/usePrefetchBranchDirEntry.tsx
@@ -150,15 +150,13 @@ export function usePrefetchBranchDirEntry({
             first: 20,
           },
         }).then((res) => {
+          const callingFn = 'usePrefetchBranchDirEntry'
           const parsedRes = BranchContentsSchema.safeParse(res?.data)
 
           if (!parsedRes.success) {
             return rejectNetworkError({
               errorName: 'Parsing Error',
-              errorDetails: {
-                callingFn: 'usePrefetchBranchDirEntry',
-                error: parsedRes.error,
-              },
+              errorDetails: { callingFn, error: parsedRes.error },
             })
           }
 
@@ -167,9 +165,7 @@ export function usePrefetchBranchDirEntry({
           if (data?.owner?.repository?.__typename === 'NotFoundError') {
             return rejectNetworkError({
               errorName: 'Not Found Error',
-              errorDetails: {
-                callingFn: 'usePrefetchBranchDirEntry',
-              },
+              errorDetails: { callingFn },
             })
           }
 
@@ -178,9 +174,7 @@ export function usePrefetchBranchDirEntry({
           ) {
             return rejectNetworkError({
               errorName: 'Owner Not Activated',
-              errorDetails: {
-                callingFn: 'usePrefetchBranchDirEntry',
-              },
+              errorDetails: { callingFn },
               data: {
                 detail: (
                   <p>

--- a/src/services/pathContents/branch/dir/useRepoBranchContents.tsx
+++ b/src/services/pathContents/branch/dir/useRepoBranchContents.tsx
@@ -142,15 +142,13 @@ export function useRepoBranchContents({
             after: pageParam,
           },
         }).then((res) => {
+          const callingFn = 'useRepoBranchContents'
           const parsedRes = BranchContentsSchema.safeParse(res?.data)
 
           if (!parsedRes.success) {
             return rejectNetworkError({
               errorName: 'Parsing Error',
-              errorDetails: {
-                callingFn: 'useRepoBranchContents',
-                error: parsedRes.error,
-              },
+              errorDetails: { callingFn, error: parsedRes.error },
             })
           }
 
@@ -159,9 +157,7 @@ export function useRepoBranchContents({
           if (data?.owner?.repository?.__typename === 'NotFoundError') {
             return rejectNetworkError({
               errorName: 'Not Found Error',
-              errorDetails: {
-                callingFn: 'useRepoBranchContents',
-              },
+              errorDetails: { callingFn },
             })
           }
 
@@ -170,9 +166,7 @@ export function useRepoBranchContents({
           ) {
             return rejectNetworkError({
               errorName: 'Owner Not Activated',
-              errorDetails: {
-                callingFn: 'useRepoBranchContents',
-              },
+              errorDetails: { callingFn },
               data: {
                 detail: (
                   <p>

--- a/src/services/pathContents/commit/dir/usePrefetchCommitDirEntry.tsx
+++ b/src/services/pathContents/commit/dir/usePrefetchCommitDirEntry.tsx
@@ -57,15 +57,13 @@ export function usePrefetchCommitDirEntry({
             filters,
           },
         }).then((res) => {
+          const callingFn = 'usePrefetchCommitDirEntry'
           const parsedRes = RequestSchema.safeParse(res?.data)
 
           if (!parsedRes.success) {
             return rejectNetworkError({
               errorName: 'Parsing Error',
-              errorDetails: {
-                callingFn: 'usePrefetchCommitDirEntry',
-                error: parsedRes.error,
-              },
+              errorDetails: { callingFn, error: parsedRes.error },
             })
           }
 
@@ -74,9 +72,7 @@ export function usePrefetchCommitDirEntry({
           if (data?.owner?.repository?.__typename === 'NotFoundError') {
             return rejectNetworkError({
               errorName: 'Not Found Error',
-              errorDetails: {
-                callingFn: 'usePrefetchCommitDirEntry',
-              },
+              errorDetails: { callingFn },
             })
           }
 
@@ -85,9 +81,7 @@ export function usePrefetchCommitDirEntry({
           ) {
             return rejectNetworkError({
               errorName: 'Owner Not Activated',
-              errorDetails: {
-                callingFn: 'usePrefetchCommitDirEntry',
-              },
+              errorDetails: { callingFn },
               data: {
                 detail: (
                   <p>

--- a/src/services/pathContents/commit/dir/useRepoCommitContents.tsx
+++ b/src/services/pathContents/commit/dir/useRepoCommitContents.tsx
@@ -52,14 +52,13 @@ export const useRepoCommitContents = ({
           filters,
         },
       }).then((res) => {
+        const callingFn = 'useRepoCommitContents'
         const parsedRes = RequestSchema.safeParse(res?.data)
+
         if (!parsedRes.success) {
           return rejectNetworkError({
             errorName: 'Parsing Error',
-            errorDetails: {
-              callingFn: 'useRepoCommitContents',
-              error: parsedRes.error,
-            },
+            errorDetails: { callingFn, error: parsedRes.error },
           })
         }
         const data = parsedRes.data
@@ -67,18 +66,14 @@ export const useRepoCommitContents = ({
         if (data?.owner?.repository?.__typename === 'NotFoundError') {
           return rejectNetworkError({
             errorName: 'Not Found Error',
-            errorDetails: {
-              callingFn: 'useRepoCommitContents',
-            },
+            errorDetails: { callingFn },
           })
         }
 
         if (data?.owner?.repository?.__typename === 'OwnerNotActivatedError') {
           return rejectNetworkError({
             errorName: 'Owner Not Activated',
-            errorDetails: {
-              callingFn: 'useRepoCommitContents',
-            },
+            errorDetails: { callingFn },
             data: {
               detail: (
                 <p>

--- a/src/services/pathContents/commit/file/usePrefetchCommitFileEntry.tsx
+++ b/src/services/pathContents/commit/file/usePrefetchCommitFileEntry.tsx
@@ -63,15 +63,13 @@ export function usePrefetchCommitFileEntry({
             components,
           },
         }).then((res) => {
+          const callingFn = 'usePrefetchCommitFileEntry'
           const parsedRes = PathContentsRequestSchema.safeParse(res?.data)
 
           if (!parsedRes.success) {
             return rejectNetworkError({
               errorName: 'Parsing Error',
-              errorDetails: {
-                callingFn: 'usePrefetchCommitFileEntry',
-                error: parsedRes.error,
-              },
+              errorDetails: { callingFn, error: parsedRes.error },
             })
           }
 
@@ -80,9 +78,7 @@ export function usePrefetchCommitFileEntry({
           if (data?.owner?.repository?.__typename === 'NotFoundError') {
             return rejectNetworkError({
               errorName: 'Not Found Error',
-              errorDetails: {
-                callingFn: 'usePrefetchCommitFileEntry',
-              },
+              errorDetails: { callingFn },
             })
           }
 
@@ -91,9 +87,7 @@ export function usePrefetchCommitFileEntry({
           ) {
             return rejectNetworkError({
               errorName: 'Owner Not Activated',
-              errorDetails: {
-                callingFn: 'usePrefetchCommitFileEntry',
-              },
+              errorDetails: { callingFn },
               data: {
                 detail: (
                   <p>

--- a/src/services/pathContents/pull/dir/usePrefetchPullDirEntry.tsx
+++ b/src/services/pathContents/pull/dir/usePrefetchPullDirEntry.tsx
@@ -74,15 +74,13 @@ export function usePrefetchPullDirEntry({
             filters,
           },
         }).then((res) => {
+          const callingFn = 'usePrefetchPullDirEntry'
           const parsedRes = RequestSchema.safeParse(res?.data)
 
           if (!parsedRes.success) {
             return rejectNetworkError({
               errorName: 'Parsing Error',
-              errorDetails: {
-                callingFn: 'usePrefetchPullDirEntry',
-                error: parsedRes.error,
-              },
+              errorDetails: { callingFn, error: parsedRes.error },
             })
           }
 
@@ -91,7 +89,7 @@ export function usePrefetchPullDirEntry({
           if (data?.owner?.repository?.__typename === 'NotFoundError') {
             return rejectNetworkError({
               errorName: 'Not Found Error',
-              errorDetails: { callingFn: 'usePrefetchPullDirEntry' },
+              errorDetails: { callingFn },
             })
           }
 
@@ -100,7 +98,7 @@ export function usePrefetchPullDirEntry({
           ) {
             return rejectNetworkError({
               errorName: 'Owner Not Activated',
-              errorDetails: { callingFn: 'usePrefetchPullDirEntry' },
+              errorDetails: { callingFn },
               data: {
                 detail: (
                   <p>

--- a/src/services/pathContents/pull/dir/useRepoPullContents.tsx
+++ b/src/services/pathContents/pull/dir/useRepoPullContents.tsx
@@ -70,15 +70,13 @@ export function useRepoPullContents({
           filters,
         },
       }).then((res) => {
+        const callingFn = 'useRepoPullContents'
         const parsedRes = RequestSchema.safeParse(res?.data)
 
         if (!parsedRes.success) {
           return rejectNetworkError({
             errorName: 'Parsing Error',
-            errorDetails: {
-              callingFn: 'useRepoPullContents',
-              error: parsedRes.error,
-            },
+            errorDetails: { callingFn, error: parsedRes.error },
           })
         }
 
@@ -87,14 +85,14 @@ export function useRepoPullContents({
         if (data?.owner?.repository?.__typename === 'NotFoundError') {
           return rejectNetworkError({
             errorName: 'Not Found Error',
-            errorDetails: { callingFn: 'useRepoPullContents' },
+            errorDetails: { callingFn },
           })
         }
 
         if (data?.owner?.repository?.__typename === 'OwnerNotActivatedError') {
           return rejectNetworkError({
             errorName: 'Owner Not Activated',
-            errorDetails: { callingFn: 'useRepoPullContents' },
+            errorDetails: { callingFn },
             data: {
               detail: (
                 <p>

--- a/src/services/pathContents/pull/file/usePrefetchPullFileEntry.tsx
+++ b/src/services/pathContents/pull/file/usePrefetchPullFileEntry.tsx
@@ -48,15 +48,13 @@ export function usePrefetchPullFileEntry({
             path,
           },
         }).then((res) => {
+          const callingFn = 'usePrefetchPullFileEntry'
           const parsedRes = PathContentsRequestSchema.safeParse(res?.data)
 
           if (!parsedRes.success) {
             return rejectNetworkError({
               errorName: 'Parsing Error',
-              errorDetails: {
-                callingFn: 'usePrefetchPullFileEntry',
-                error: parsedRes.error,
-              },
+              errorDetails: { callingFn, error: parsedRes.error },
             })
           }
 
@@ -65,7 +63,7 @@ export function usePrefetchPullFileEntry({
           if (data?.owner?.repository?.__typename === 'NotFoundError') {
             return rejectNetworkError({
               errorName: 'Not Found Error',
-              errorDetails: { callingFn: 'usePrefetchPullFileEntry' },
+              errorDetails: { callingFn },
             })
           }
 
@@ -74,7 +72,7 @@ export function usePrefetchPullFileEntry({
           ) {
             return rejectNetworkError({
               errorName: 'Owner Not Activated',
-              errorDetails: { callingFn: 'usePrefetchPullFileEntry' },
+              errorDetails: { callingFn },
               data: {
                 detail: (
                   <p>

--- a/src/services/pathContents/useFileWithMainCoverage.tsx
+++ b/src/services/pathContents/useFileWithMainCoverage.tsx
@@ -54,15 +54,13 @@ export function useFileWithMainCoverage({
           components,
         },
       }).then((res) => {
+        const callingFn = 'useFileWithMainCoverage'
         const parsedData = PathContentsRequestSchema.safeParse(res?.data)
 
         if (!parsedData.success) {
           return rejectNetworkError({
             errorName: 'Parsing Error',
-            errorDetails: {
-              callingFn: 'useFileWithMainCoverage',
-              error: parsedData.error,
-            },
+            errorDetails: { callingFn, error: parsedData.error },
           })
         }
 
@@ -71,18 +69,14 @@ export function useFileWithMainCoverage({
         if (data?.owner?.repository?.__typename === 'NotFoundError') {
           return rejectNetworkError({
             errorName: 'Not Found Error',
-            errorDetails: {
-              callingFn: 'useFileWithMainCoverage',
-            },
+            errorDetails: { callingFn },
           })
         }
 
         if (data?.owner?.repository?.__typename === 'OwnerNotActivatedError') {
           return rejectNetworkError({
             errorName: 'Owner Not Activated',
-            errorDetails: {
-              callingFn: 'useFileWithMainCoverage',
-            },
+            errorDetails: { callingFn },
             data: {
               detail: (
                 <p>

--- a/src/services/pull/usePrefetchSingleFileComp.tsx
+++ b/src/services/pull/usePrefetchSingleFileComp.tsx
@@ -112,15 +112,13 @@ export function usePrefetchSingleFileComp({
             filters,
           },
         }).then((res) => {
+          const callingFn = 'usePrefetchSingleFileComp'
           const parsedData = RequestSchema.safeParse(res?.data)
 
           if (!parsedData.success) {
             return rejectNetworkError({
               errorName: 'Parsing Error',
-              errorDetails: {
-                callingFn: 'usePrefetchSingleFileComp',
-                error: parsedData.error,
-              },
+              errorDetails: { callingFn, error: parsedData.error },
             })
           }
 
@@ -129,7 +127,7 @@ export function usePrefetchSingleFileComp({
           if (data?.owner?.repository?.__typename === 'NotFoundError') {
             return rejectNetworkError({
               errorName: 'Not Found Error',
-              errorDetails: { callingFn: 'usePrefetchSingleFileComp' },
+              errorDetails: { callingFn },
             })
           }
 
@@ -138,7 +136,7 @@ export function usePrefetchSingleFileComp({
           ) {
             return rejectNetworkError({
               errorName: 'Owner Not Activated',
-              errorDetails: { callingFn: 'usePrefetchSingleFileComp' },
+              errorDetails: { callingFn },
               data: {
                 detail: (
                   <p>

--- a/src/services/pull/usePull.tsx
+++ b/src/services/pull/usePull.tsx
@@ -317,15 +317,13 @@ export function usePull({
           filters,
         },
       }).then((res) => {
+        const callingFn = 'usePull'
         const parsedRes = RequestSchema.safeParse(res?.data)
 
         if (!parsedRes.success) {
           return rejectNetworkError({
             errorName: 'Parsing Error',
-            errorDetails: {
-              callingFn: 'usePull',
-              error: parsedRes.error,
-            },
+            errorDetails: { callingFn, error: parsedRes.error },
           })
         }
 
@@ -334,14 +332,14 @@ export function usePull({
         if (data?.owner?.repository?.__typename === 'NotFoundError') {
           return rejectNetworkError({
             errorName: 'Not Found Error',
-            errorDetails: { callingFn: 'usePull' },
+            errorDetails: { callingFn },
           })
         }
 
         if (data?.owner?.repository?.__typename === 'OwnerNotActivatedError') {
           return rejectNetworkError({
             errorName: 'Owner Not Activated',
-            errorDetails: { callingFn: 'usePull' },
+            errorDetails: { callingFn },
             data: {
               detail: (
                 <p>

--- a/src/services/pull/usePullBADropdownSummary.tsx
+++ b/src/services/pull/usePullBADropdownSummary.tsx
@@ -140,15 +140,13 @@ export function usePullBADropdownSummary({
           pullId,
         },
       }).then((res) => {
+        const callingFn = 'usePullBADropdownSummary'
         const parsedRes = RequestSchema.safeParse(res?.data)
 
         if (!parsedRes.success) {
           return rejectNetworkError({
             errorName: 'Parsing Error',
-            errorDetails: {
-              callingFn: 'usePullBADropdownSummary',
-              error: parsedRes.error,
-            },
+            errorDetails: { callingFn, error: parsedRes.error },
           })
         }
 
@@ -157,14 +155,14 @@ export function usePullBADropdownSummary({
         if (data?.owner?.repository?.__typename === 'NotFoundError') {
           return rejectNetworkError({
             errorName: 'Not Found Error',
-            errorDetails: { callingFn: 'usePullBADropdownSummary' },
+            errorDetails: { callingFn },
           })
         }
 
         if (data?.owner?.repository?.__typename === 'OwnerNotActivatedError') {
           return rejectNetworkError({
             errorName: 'Owner Not Activated',
-            errorDetails: { callingFn: 'usePullBADropdownSummary' },
+            errorDetails: { callingFn },
             data: {
               detail: (
                 <p>

--- a/src/services/pull/usePullBundleComparisonList.tsx
+++ b/src/services/pull/usePullBundleComparisonList.tsx
@@ -158,15 +158,13 @@ export function usePullBundleComparisonList({
           pullId,
         },
       }).then((res) => {
+        const callingFn = 'usePullBundleComparisonList'
         const parsedRes = RequestSchema.safeParse(res?.data)
 
         if (!parsedRes.success) {
           return rejectNetworkError({
             errorName: 'Parsing Error',
-            errorDetails: {
-              callingFn: 'usePullBundleComparisonList',
-              error: parsedRes.error,
-            },
+            errorDetails: { callingFn, error: parsedRes.error },
           })
         }
 
@@ -175,14 +173,14 @@ export function usePullBundleComparisonList({
         if (data?.owner?.repository?.__typename === 'NotFoundError') {
           return rejectNetworkError({
             errorName: 'Not Found Error',
-            errorDetails: { callingFn: 'usePullBundleComparisonList' },
+            errorDetails: { callingFn },
           })
         }
 
         if (data?.owner?.repository?.__typename === 'OwnerNotActivatedError') {
           return rejectNetworkError({
             errorName: 'Owner Not Activated',
-            errorDetails: { callingFn: 'usePullBundleComparisonList' },
+            errorDetails: { callingFn },
             data: {
               detail: (
                 <p>

--- a/src/services/pull/usePullBundleHeadList.tsx
+++ b/src/services/pull/usePullBundleHeadList.tsx
@@ -129,15 +129,13 @@ export function usePullBundleHeadList({
           pullId,
         },
       }).then((res) => {
+        const callingFn = 'usePullBundleHeadList'
         const parsedRes = RequestSchema.safeParse(res?.data)
 
         if (!parsedRes.success) {
           return rejectNetworkError({
             errorName: 'Parsing Error',
-            errorDetails: {
-              callingFn: 'usePullBundleHeadList',
-              error: parsedRes.error,
-            },
+            errorDetails: { callingFn, error: parsedRes.error },
           })
         }
 
@@ -146,14 +144,14 @@ export function usePullBundleHeadList({
         if (data?.owner?.repository?.__typename === 'NotFoundError') {
           return rejectNetworkError({
             errorName: 'Not Found Error',
-            errorDetails: { callingFn: 'usePullBundleHeadList' },
+            errorDetails: { callingFn },
           })
         }
 
         if (data?.owner?.repository?.__typename === 'OwnerNotActivatedError') {
           return rejectNetworkError({
             errorName: 'Owner Not Activated',
-            errorDetails: { callingFn: 'usePullBundleHeadList' },
+            errorDetails: { callingFn },
             data: {
               detail: (
                 <p>

--- a/src/services/pull/usePullCompareTotalsTeam.tsx
+++ b/src/services/pull/usePullCompareTotalsTeam.tsx
@@ -182,15 +182,13 @@ export function usePullCompareTotalsTeam({
           filters,
         },
       }).then((res) => {
+        const callingFn = 'usePullCompareTotalsTeam'
         const parsedRes = RequestSchema.safeParse(res?.data)
 
         if (!parsedRes.success) {
           return rejectNetworkError({
             errorName: 'Parsing Error',
-            errorDetails: {
-              callingFn: 'usePullCompareTotalsTeam',
-              error: parsedRes.error,
-            },
+            errorDetails: { callingFn, error: parsedRes.error },
           })
         }
 
@@ -199,14 +197,14 @@ export function usePullCompareTotalsTeam({
         if (data?.owner?.repository?.__typename === 'NotFoundError') {
           return rejectNetworkError({
             errorName: 'Not Found Error',
-            errorDetails: { callingFn: 'usePullCompareTotalsTeam' },
+            errorDetails: { callingFn },
           })
         }
 
         if (data?.owner?.repository?.__typename === 'OwnerNotActivatedError') {
           return rejectNetworkError({
             errorName: 'Owner Not Activated',
-            errorDetails: { callingFn: 'usePullCompareTotalsTeam' },
+            errorDetails: { callingFn },
             data: {
               detail: (
                 <p>

--- a/src/services/pull/usePullComponents.tsx
+++ b/src/services/pull/usePullComponents.tsx
@@ -154,15 +154,13 @@ export function usePullComponents({
           pullId: parseInt(pullId, 10),
         },
       }).then((res) => {
+        const callingFn = 'usePullComponents'
         const parsedData = PullComponentsSchema.safeParse(res?.data)
 
         if (!parsedData.success) {
           return rejectNetworkError({
             errorName: 'Parsing Error',
-            errorDetails: {
-              callingFn: 'usePullComponents',
-              error: parsedData.error,
-            },
+            errorDetails: { callingFn, error: parsedData.error },
           })
         }
 
@@ -171,14 +169,14 @@ export function usePullComponents({
         if (data?.owner?.repository?.__typename === 'NotFoundError') {
           return rejectNetworkError({
             errorName: 'Not Found Error',
-            errorDetails: { callingFn: 'usePullComponents' },
+            errorDetails: { callingFn },
           })
         }
 
         if (data?.owner?.repository?.__typename === 'OwnerNotActivatedError') {
           return rejectNetworkError({
             errorName: 'Owner Not Activated',
-            errorDetails: { callingFn: 'usePullComponents' },
+            errorDetails: { callingFn },
             data: {
               detail: (
                 <p>

--- a/src/services/pull/usePullCoverageDropdownSummary.tsx
+++ b/src/services/pull/usePullCoverageDropdownSummary.tsx
@@ -126,15 +126,13 @@ export function usePullCoverageDropdownSummary({
         signal,
         variables: { owner, repo, pullId },
       }).then((res) => {
+        const callingFn = 'usePullCoverageDropdownSummary'
         const parsedRes = RequestSchema.safeParse(res?.data)
 
         if (!parsedRes.success) {
           return rejectNetworkError({
             errorName: 'Parsing Error',
-            errorDetails: {
-              callingFn: 'usePullCoverageDropdownSummary',
-              error: parsedRes.error,
-            },
+            errorDetails: { callingFn, error: parsedRes.error },
           })
         }
 
@@ -143,14 +141,14 @@ export function usePullCoverageDropdownSummary({
         if (data?.owner?.repository?.__typename === 'NotFoundError') {
           return rejectNetworkError({
             errorName: 'Not Found Error',
-            errorDetails: { callingFn: 'usePullCoverageDropdownSummary' },
+            errorDetails: { callingFn },
           })
         }
 
         if (data?.owner?.repository?.__typename === 'OwnerNotActivatedError') {
           return rejectNetworkError({
             errorName: 'Owner Not Activated',
-            errorDetails: { callingFn: 'usePullCoverageDropdownSummary' },
+            errorDetails: { callingFn },
             data: {
               detail: (
                 <p>

--- a/src/services/pull/usePullTeam.tsx
+++ b/src/services/pull/usePullTeam.tsx
@@ -203,12 +203,13 @@ export function usePullTeam({
           filters,
         },
       }).then((res) => {
+        const callingFn = 'usePullTeam'
         const parsedRes = RequestSchema.safeParse(res?.data)
 
         if (!parsedRes.success) {
           return rejectNetworkError({
             errorName: 'Parsing Error',
-            errorDetails: { callingFn: 'usePullTeam', error: parsedRes.error },
+            errorDetails: { callingFn, error: parsedRes.error },
           })
         }
 
@@ -217,14 +218,14 @@ export function usePullTeam({
         if (data?.owner?.repository?.__typename === 'NotFoundError') {
           return rejectNetworkError({
             errorName: 'Not Found Error',
-            errorDetails: { callingFn: 'usePullTeam' },
+            errorDetails: { callingFn },
           })
         }
 
         if (data?.owner?.repository?.__typename === 'OwnerNotActivatedError') {
           return rejectNetworkError({
             errorName: 'Owner Not Activated',
-            errorDetails: { callingFn: 'usePullTeam' },
+            errorDetails: { callingFn },
             data: {
               detail: (
                 <p>

--- a/src/services/pull/useSingularImpactedFileComparison.tsx
+++ b/src/services/pull/useSingularImpactedFileComparison.tsx
@@ -120,15 +120,13 @@ export function useSingularImpactedFileComparison({
           filters,
         },
       }).then((res) => {
+        const callingFn = 'useSingularImpactedFileComparison'
         const parsedRes = RepoSchema.safeParse(res?.data)
 
         if (!parsedRes.success) {
           return rejectNetworkError({
             errorName: 'Parsing Error',
-            errorDetails: {
-              callingFn: 'useSingularImpactedFileComparison',
-              error: parsedRes.error,
-            },
+            errorDetails: { callingFn, error: parsedRes.error },
           })
         }
 
@@ -137,14 +135,14 @@ export function useSingularImpactedFileComparison({
         if (data?.owner?.repository?.__typename === 'NotFoundError') {
           return rejectNetworkError({
             errorName: 'Not Found Error',
-            errorDetails: { callingFn: 'useSingularImpactedFileComparison' },
+            errorDetails: { callingFn },
           })
         }
 
         if (data?.owner?.repository?.__typename === 'OwnerNotActivatedError') {
           return rejectNetworkError({
             errorName: 'Owner Not Activated',
-            errorDetails: { callingFn: 'useSingularImpactedFileComparison' },
+            errorDetails: { callingFn },
             data: {
               detail: (
                 <p>

--- a/src/services/pulls/usePulls.tsx
+++ b/src/services/pulls/usePulls.tsx
@@ -267,12 +267,13 @@ export function usePulls({
           after: pageParam,
         },
       }).then((res) => {
+        const callingFn = 'usePulls'
         const parsedData = GetPullsSchema.safeParse(res?.data)
 
         if (!parsedData.success) {
           return rejectNetworkError({
             errorName: 'Parsing Error',
-            errorDetails: { callingFn: 'usePulls', error: parsedData.error },
+            errorDetails: { callingFn, error: parsedData.error },
           })
         }
 
@@ -281,14 +282,14 @@ export function usePulls({
         if (data?.owner?.repository?.__typename === 'NotFoundError') {
           return rejectNetworkError({
             errorName: 'Not Found Error',
-            errorDetails: { callingFn: 'usePulls' },
+            errorDetails: { callingFn },
           })
         }
 
         if (data?.owner?.repository?.__typename === 'OwnerNotActivatedError') {
           return rejectNetworkError({
             errorName: 'Owner Not Activated',
-            errorDetails: { callingFn: 'usePulls' },
+            errorDetails: { callingFn },
             data: {
               detail: (
                 <p>

--- a/src/services/repo/useActivateMeasurements.tsx
+++ b/src/services/repo/useActivateMeasurements.tsx
@@ -78,14 +78,13 @@ export function useActivateMeasurements({
       })
     },
     onSuccess: ({ data }) => {
+      const callingFn = 'useActivateMeasurements'
       const parsedData = ResponseSchema.safeParse(data)
+
       if (!parsedData.success) {
         return rejectNetworkError({
           errorName: 'Parsing Error',
-          errorDetails: {
-            callingFn: 'useActivateMeasurements',
-            error: parsedData.error,
-          },
+          errorDetails: { callingFn, error: parsedData.error },
         })
       }
 

--- a/src/services/repo/useComponentsBackfilled.tsx
+++ b/src/services/repo/useComponentsBackfilled.tsx
@@ -75,6 +75,7 @@ export function useComponentsBackfilled() {
           repo,
         },
       }).then((res) => {
+        const callingFn = 'useComponentsBackfilled'
         const parsedData = BackfillComponentsMembershipSchema.safeParse(
           res?.data
         )
@@ -82,10 +83,7 @@ export function useComponentsBackfilled() {
         if (!parsedData.success) {
           return rejectNetworkError({
             errorName: 'Parsing Error',
-            errorDetails: {
-              callingFn: 'useComponentsBackfilled',
-              error: parsedData.error,
-            },
+            errorDetails: { callingFn, error: parsedData.error },
           })
         }
 
@@ -94,14 +92,14 @@ export function useComponentsBackfilled() {
         if (data?.owner?.repository?.__typename === 'NotFoundError') {
           return rejectNetworkError({
             errorName: 'Not Found Error',
-            errorDetails: { callingFn: 'useComponentsBackfilled' },
+            errorDetails: { callingFn },
           })
         }
 
         if (data?.owner?.repository?.__typename === 'OwnerNotActivatedError') {
           return rejectNetworkError({
             errorName: 'Owner Not Activated',
-            errorDetails: { callingFn: 'useComponentsBackfilled' },
+            errorDetails: { callingFn },
             data: {
               detail: (
                 <p>

--- a/src/services/repo/useRepo.tsx
+++ b/src/services/repo/useRepo.tsx
@@ -89,15 +89,13 @@ export function useRepo({ provider, owner, repo, opts = {} }: UseRepoArgs) {
           repo,
         },
       }).then((res) => {
+        const callingFn = 'useRepo'
         const parsedRes = RepoSchema.safeParse(res?.data)
 
         if (!parsedRes.success) {
           return rejectNetworkError({
             errorName: 'Parsing Error',
-            errorDetails: {
-              callingFn: 'useRepo',
-              error: parsedRes.error,
-            },
+            errorDetails: { callingFn, error: parsedRes.error },
           })
         }
 
@@ -106,7 +104,7 @@ export function useRepo({ provider, owner, repo, opts = {} }: UseRepoArgs) {
         if (data?.owner?.repository?.__typename === 'NotFoundError') {
           return rejectNetworkError({
             errorName: 'Not Found Error',
-            errorDetails: { callingFn: 'useRepo' },
+            errorDetails: { callingFn },
           })
         }
 

--- a/src/services/repo/useRepoBackfilled.tsx
+++ b/src/services/repo/useRepoBackfilled.tsx
@@ -87,15 +87,13 @@ export function useRepoBackfilled() {
           repo,
         },
       }).then((res) => {
+        const callingFn = 'useRepoBackfilled'
         const parsedRes = RepoBackfilledSchema.safeParse(res?.data)
 
         if (!parsedRes.success) {
           return rejectNetworkError({
             errorName: 'Parsing Error',
-            errorDetails: {
-              callingFn: 'useRepoBackfilled',
-              error: parsedRes.error,
-            },
+            errorDetails: { callingFn, error: parsedRes.error },
           })
         }
 
@@ -104,14 +102,14 @@ export function useRepoBackfilled() {
         if (data?.owner?.repository?.__typename === 'NotFoundError') {
           return rejectNetworkError({
             errorName: 'Not Found Error',
-            errorDetails: { callingFn: 'useRepoBackfilled' },
+            errorDetails: { callingFn },
           })
         }
 
         if (data?.owner?.repository?.__typename === 'OwnerNotActivatedError') {
           return rejectNetworkError({
             errorName: 'Owner Not Activated',
-            errorDetails: { callingFn: 'useRepoBackfilled' },
+            errorDetails: { callingFn },
             data: {
               detail: (
                 <p>

--- a/src/services/repo/useRepoComponents.test.tsx
+++ b/src/services/repo/useRepoComponents.test.tsx
@@ -168,7 +168,7 @@ describe('ComponentMeasurements', () => {
       await waitFor(() =>
         expect(result.current.error).toEqual(
           expect.objectContaining({
-            dev: 'useRepoComponentsArgs - Parsing Error',
+            dev: 'useRepoComponents - Parsing Error',
             status: 400,
           })
         )
@@ -201,7 +201,7 @@ describe('ComponentMeasurements', () => {
       await waitFor(() =>
         expect(result.current.error).toEqual(
           expect.objectContaining({
-            dev: 'useRepoComponentsArgs - Not Found Error',
+            dev: 'useRepoComponents - Not Found Error',
             status: 404,
           })
         )
@@ -234,7 +234,7 @@ describe('ComponentMeasurements', () => {
       await waitFor(() =>
         expect(result.current.error).toEqual(
           expect.objectContaining({
-            dev: 'useRepoComponentsArgs - Owner Not Activated',
+            dev: 'useRepoComponents - Owner Not Activated',
             status: 403,
           })
         )

--- a/src/services/repo/useRepoComponents.tsx
+++ b/src/services/repo/useRepoComponents.tsx
@@ -144,15 +144,13 @@ export function useRepoComponents({
           branch,
         },
       }).then((res) => {
+        const callingFn = 'useRepoComponents'
         const parsedRes = RequestSchema.safeParse(res?.data)
 
         if (!parsedRes.success) {
           return rejectNetworkError({
             errorName: 'Parsing Error',
-            errorDetails: {
-              callingFn: 'useRepoComponentsArgs',
-              error: parsedRes.error,
-            },
+            errorDetails: { callingFn, error: parsedRes.error },
           })
         }
 
@@ -161,14 +159,14 @@ export function useRepoComponents({
         if (data?.owner?.repository?.__typename === 'NotFoundError') {
           return rejectNetworkError({
             errorName: 'Not Found Error',
-            errorDetails: { callingFn: 'useRepoComponentsArgs' },
+            errorDetails: { callingFn },
           })
         }
 
         if (data?.owner?.repository?.__typename === 'OwnerNotActivatedError') {
           return rejectNetworkError({
             errorName: 'Owner Not Activated',
-            errorDetails: { callingFn: 'useRepoComponentsArgs' },
+            errorDetails: { callingFn },
             data: {
               detail: (
                 <p>

--- a/src/services/repo/useRepoComponentsSelect.tsx
+++ b/src/services/repo/useRepoComponentsSelect.tsx
@@ -98,15 +98,13 @@ export function useRepoComponentsSelect({
           termId,
         },
       }).then((res) => {
+        const callingFn = 'useRepoComponentsSelect'
         const parsedData = RequestSchema.safeParse(res?.data)
 
         if (!parsedData.success) {
           return rejectNetworkError({
             errorName: 'Parsing Error',
-            errorDetails: {
-              callingFn: 'useRepoComponentsSelect',
-              error: parsedData.error,
-            },
+            errorDetails: { callingFn, error: parsedData.error },
           })
         }
 
@@ -115,18 +113,14 @@ export function useRepoComponentsSelect({
         if (data?.owner?.repository?.__typename === 'NotFoundError') {
           return rejectNetworkError({
             errorName: 'Not Found Error',
-            errorDetails: {
-              callingFn: 'useRepoComponentsSelect',
-            },
+            errorDetails: { callingFn },
           })
         }
 
         if (data?.owner?.repository?.__typename === 'OwnerNotActivatedError') {
           return rejectNetworkError({
             errorName: 'Owner Not Activated',
-            errorDetails: {
-              callingFn: 'useRepoComponentsSelect',
-            },
+            errorDetails: { callingFn },
             data: {
               detail: (
                 <p>

--- a/src/services/repo/useRepoConfig.tsx
+++ b/src/services/repo/useRepoConfig.tsx
@@ -94,15 +94,13 @@ export const useRepoConfig = ({
           repo,
         },
       }).then((res) => {
+        const callingFn = 'useRepoConfig'
         const parsedRes = UseRepoConfigSchema.safeParse(res?.data)
 
         if (!parsedRes.success) {
           return rejectNetworkError({
             errorName: 'Parsing Error',
-            errorDetails: {
-              callingFn: 'useRepoConfig',
-              error: parsedRes.error,
-            },
+            errorDetails: { callingFn, error: parsedRes.error },
           })
         }
 
@@ -111,18 +109,14 @@ export const useRepoConfig = ({
         if (data?.owner?.repository?.__typename === 'NotFoundError') {
           return rejectNetworkError({
             errorName: 'Not Found Error',
-            errorDetails: {
-              callingFn: 'useRepoConfig',
-            },
+            errorDetails: { callingFn },
           })
         }
 
         if (data?.owner?.repository?.__typename === 'OwnerNotActivatedError') {
           return rejectNetworkError({
             errorName: 'Owner Not Activated',
-            errorDetails: {
-              callingFn: 'useRepoConfig',
-            },
+            errorDetails: { callingFn },
             data: {
               detail: (
                 <p>

--- a/src/services/repo/useRepoCoverage.tsx
+++ b/src/services/repo/useRepoCoverage.tsx
@@ -110,15 +110,13 @@ export function useRepoCoverage({
           branch,
         },
       }).then((res) => {
+        const callingFn = 'useRepoCoverage'
         const parsedRes = ResponseSchema.safeParse(res?.data)
 
         if (!parsedRes.success) {
           return rejectNetworkError({
             errorName: 'Parsing Error',
-            errorDetails: {
-              callingFn: 'useRepoCoverage',
-              error: parsedRes.error,
-            },
+            errorDetails: { callingFn, error: parsedRes.error },
           })
         }
 
@@ -127,18 +125,14 @@ export function useRepoCoverage({
         if (data?.owner?.repository?.__typename === 'NotFoundError') {
           return rejectNetworkError({
             errorName: 'Not Found Error',
-            errorDetails: {
-              callingFn: 'useRepoCoverage',
-            },
+            errorDetails: { callingFn },
           })
         }
 
         if (data?.owner?.repository?.__typename === 'OwnerNotActivatedError') {
           return rejectNetworkError({
             errorName: 'Owner Not Activated',
-            errorDetails: {
-              callingFn: 'useRepoCoverage',
-            },
+            errorDetails: { callingFn },
             data: {
               detail: (
                 <p>

--- a/src/services/repo/useRepoFlags.tsx
+++ b/src/services/repo/useRepoFlags.tsx
@@ -159,15 +159,13 @@ export function useRepoFlags({
           after,
         },
       }).then((res) => {
+        const callingFn = 'useRepoFlags'
         const parsedRes = RequestSchema.safeParse(res?.data)
 
         if (!parsedRes.success) {
           return rejectNetworkError({
             errorName: 'Parsing Error',
-            errorDetails: {
-              callingFn: 'useRepoFlags',
-              error: parsedRes.error,
-            },
+            errorDetails: { callingFn, error: parsedRes.error },
           })
         }
 
@@ -176,18 +174,14 @@ export function useRepoFlags({
         if (data?.owner?.repository?.__typename === 'NotFoundError') {
           return rejectNetworkError({
             errorName: 'Not Found Error',
-            errorDetails: {
-              callingFn: 'useRepoFlags',
-            },
+            errorDetails: { callingFn },
           })
         }
 
         if (data?.owner?.repository?.__typename === 'OwnerNotActivatedError') {
           return rejectNetworkError({
             errorName: 'Owner Not Activated',
-            errorDetails: {
-              callingFn: 'useRepoFlags',
-            },
+            errorDetails: { callingFn },
             data: {
               detail: (
                 <p>

--- a/src/services/repo/useRepoFlagsSelect.tsx
+++ b/src/services/repo/useRepoFlagsSelect.tsx
@@ -117,15 +117,13 @@ function fetchRepoFlags({
       after,
     },
   }).then((res) => {
+    const callingFn = 'fetchRepoFlags'
     const parsedRes = FetchRepoFlagsSchema.safeParse(res?.data)
 
     if (!parsedRes.success) {
       return rejectNetworkError({
         errorName: 'Parsing Error',
-        errorDetails: {
-          callingFn: 'fetchRepoFlags',
-          error: parsedRes.error,
-        },
+        errorDetails: { callingFn, error: parsedRes.error },
       })
     }
 
@@ -134,18 +132,14 @@ function fetchRepoFlags({
     if (data?.owner?.repository?.__typename === 'NotFoundError') {
       return rejectNetworkError({
         errorName: 'Not Found Error',
-        errorDetails: {
-          callingFn: 'fetchRepoFlags',
-        },
+        errorDetails: { callingFn },
       })
     }
 
     if (data?.owner?.repository?.__typename === 'OwnerNotActivatedError') {
       return rejectNetworkError({
         errorName: 'Owner Not Activated',
-        errorDetails: {
-          callingFn: 'fetchRepoFlags',
-        },
+        errorDetails: { callingFn },
         data: {
           detail: (
             <p>
@@ -295,15 +289,13 @@ function fetchRepoFlagsForPull({
       pullId: parseInt(pullId, 10),
     },
   }).then((res) => {
+    const callingFn = 'fetchRepoFlagsForPull'
     const parsedRes = FetchRepoFlagsForPullSchema.safeParse(res?.data)
 
     if (!parsedRes.success) {
       return rejectNetworkError({
         errorName: 'Parsing Error',
-        errorDetails: {
-          callingFn: 'fetchRepoFlagsForPull',
-          error: parsedRes.error,
-        },
+        errorDetails: { callingFn, error: parsedRes.error },
       })
     }
 
@@ -311,18 +303,14 @@ function fetchRepoFlagsForPull({
     if (data?.owner?.repository?.__typename === 'NotFoundError') {
       return rejectNetworkError({
         errorName: 'Not Found Error',
-        errorDetails: {
-          callingFn: 'fetchRepoFlagsForPull',
-        },
+        errorDetails: { callingFn },
       })
     }
 
     if (data?.owner?.repository?.__typename === 'OwnerNotActivatedError') {
       return rejectNetworkError({
         errorName: 'Owner Not Activated',
-        errorDetails: {
-          callingFn: 'fetchRepoFlagsForPull',
-        },
+        errorDetails: { callingFn },
         data: {
           detail: (
             <p>

--- a/src/services/repo/useRepoOverview.tsx
+++ b/src/services/repo/useRepoOverview.tsx
@@ -82,15 +82,13 @@ export function useRepoOverview({
           repo,
         },
       }).then((res) => {
+        const callingFn = 'useRepoOverview'
         const parsedData = RequestSchema.safeParse(res?.data)
 
         if (!parsedData.success) {
           return rejectNetworkError({
             errorName: 'Parsing Error',
-            errorDetails: {
-              callingFn: 'useRepoOverview',
-              error: parsedData.error,
-            },
+            errorDetails: { callingFn, error: parsedData.error },
           })
         }
 
@@ -99,9 +97,7 @@ export function useRepoOverview({
         if (data?.owner?.repository?.__typename === 'NotFoundError') {
           return rejectNetworkError({
             errorName: 'Not Found Error',
-            errorDetails: {
-              callingFn: 'useRepoOverview',
-            },
+            errorDetails: { callingFn },
           })
         }
 

--- a/src/services/repo/useRepoRateLimitStatus.tsx
+++ b/src/services/repo/useRepoRateLimitStatus.tsx
@@ -66,14 +66,13 @@ export function useRepoRateLimitStatus({
           repo,
         },
       }).then((res) => {
+        const callingFn = 'useRepoRateLimitStatus'
         const parsedData = RequestSchema.safeParse(res?.data)
+
         if (!parsedData.success) {
           return rejectNetworkError({
             errorName: 'Parsing Error',
-            errorDetails: {
-              callingFn: 'useRepoRateLimitStatus',
-              error: parsedData.error,
-            },
+            errorDetails: { callingFn, error: parsedData.error },
           })
         }
 
@@ -82,9 +81,7 @@ export function useRepoRateLimitStatus({
         if (data?.owner?.repository?.__typename === 'NotFoundError') {
           return rejectNetworkError({
             errorName: 'Not Found Error',
-            errorDetails: {
-              callingFn: 'useRepoRateLimitStatus',
-            },
+            errorDetails: { callingFn },
           })
         }
 

--- a/src/services/repo/useRepoSettings.tsx
+++ b/src/services/repo/useRepoSettings.tsx
@@ -87,15 +87,13 @@ export function useRepoSettings() {
           repo,
         },
       }).then((res) => {
+        const callingFn = 'useRepoSettings'
         const parsedRes = RequestSchema.safeParse(res?.data)
 
         if (!parsedRes.success) {
           return rejectNetworkError({
             errorName: 'Parsing Error',
-            errorDetails: {
-              callingFn: 'useRepoSettings',
-              error: parsedRes.error,
-            },
+            errorDetails: { callingFn, error: parsedRes.error },
           })
         }
 
@@ -104,18 +102,14 @@ export function useRepoSettings() {
         if (data?.owner?.repository?.__typename === 'NotFoundError') {
           return rejectNetworkError({
             errorName: 'Not Found Error',
-            errorDetails: {
-              callingFn: 'useRepoSettings',
-            },
+            errorDetails: { callingFn },
           })
         }
 
         if (data?.owner?.repository?.__typename === 'OwnerNotActivatedError') {
           return rejectNetworkError({
             errorName: 'Owner Not Activated',
-            errorDetails: {
-              callingFn: 'useRepoSettings',
-            },
+            errorDetails: { callingFn },
             data: {
               detail: (
                 <p>

--- a/src/services/repo/useRepoSettingsTeam.tsx
+++ b/src/services/repo/useRepoSettingsTeam.tsx
@@ -81,15 +81,13 @@ export function useRepoSettingsTeam() {
           repo,
         },
       }).then((res) => {
+        const callingFn = 'useRepoSettingsTeam'
         const parsedRes = RequestSchema.safeParse(res?.data)
 
         if (!parsedRes.success) {
           return rejectNetworkError({
             errorName: 'Parsing Error',
-            errorDetails: {
-              callingFn: 'useRepoSettingsTeam',
-              error: parsedRes.error,
-            },
+            errorDetails: { callingFn, error: parsedRes.error },
           })
         }
 
@@ -98,9 +96,7 @@ export function useRepoSettingsTeam() {
         if (data?.owner?.repository?.__typename === 'NotFoundError') {
           return rejectNetworkError({
             errorName: 'Not Found Error',
-            errorDetails: {
-              callingFn: 'useRepoSettingsTeam',
-            },
+            errorDetails: { callingFn },
           })
         }
 

--- a/src/services/repos/ReposQueryOpts.tsx
+++ b/src/services/repos/ReposQueryOpts.tsx
@@ -151,14 +151,13 @@ function ReposQueryOpts({
           after,
         },
       }).then((res) => {
+        const callingFn = 'ReposQueryOpts'
         const parsedRes = RequestSchema.safeParse(res?.data)
+
         if (!parsedRes.success) {
           return rejectNetworkError({
             errorName: 'Parsing Error',
-            errorDetails: {
-              callingFn: 'ReposQueryOpts',
-              error: parsedRes.error,
-            },
+            errorDetails: { callingFn, error: parsedRes.error },
           })
         }
 

--- a/src/services/repos/ReposTeamQueryOpts.tsx
+++ b/src/services/repos/ReposTeamQueryOpts.tsx
@@ -141,15 +141,13 @@ function ReposTeamQueryOpts({
           after,
         },
       }).then((res) => {
+        const callingFn = 'ReposTeamQueryOpts'
         const parsedRes = RequestSchema.safeParse(res?.data)
 
         if (!parsedRes.success) {
           return rejectNetworkError({
             errorName: 'Parsing Error',
-            errorDetails: {
-              callingFn: 'ReposTeamQueryOpts',
-              error: parsedRes.error,
-            },
+            errorDetails: { callingFn, error: parsedRes.error },
           })
         }
 

--- a/src/services/selfHosted/SelfHostedCurrentUserQueryOpts.ts
+++ b/src/services/selfHosted/SelfHostedCurrentUserQueryOpts.ts
@@ -26,15 +26,13 @@ export const SelfHostedCurrentUserQueryOpts = ({
     queryKey: ['SelfHostedCurrentUser', provider],
     queryFn: ({ signal }) =>
       Api.get({ provider, path: '/users/current', signal }).then((res) => {
+        const callingFn = 'SelfHostedCurrentUserQueryOpts'
         const parsedData = SelfHostedCurrentUserSchema.safeParse(res)
 
         if (!parsedData.success) {
           return rejectNetworkError({
             errorName: 'Parsing Error',
-            errorDetails: {
-              callingFn: 'SelfHostedCurrentUserQueryOpts',
-              error: parsedData.error,
-            },
+            errorDetails: { callingFn, error: parsedData.error },
           })
         }
         return parsedData.data

--- a/src/services/selfHosted/SelfHostedHasAdminsQueryOpts.ts
+++ b/src/services/selfHosted/SelfHostedHasAdminsQueryOpts.ts
@@ -31,15 +31,13 @@ export const SelfHostedHasAdminsQueryOpts = ({
         provider,
         query,
       }).then((res) => {
+        const callingFn = 'SelfHostedHasAdminsQueryOpts'
         const parsedRes = HasAdminsSchema.safeParse(res?.data)
 
         if (!parsedRes.success) {
           return rejectNetworkError({
             errorName: 'Parsing Error',
-            errorDetails: {
-              callingFn: 'SelfHostedHasAdminsQueryOpts',
-              error: parsedRes.error,
-            },
+            errorDetails: { callingFn, error: parsedRes.error },
           })
         }
 

--- a/src/services/selfHosted/SelfHostedSeatsAndLicenseQueryOpts.ts
+++ b/src/services/selfHosted/SelfHostedSeatsAndLicenseQueryOpts.ts
@@ -45,15 +45,13 @@ export const SelfHostedSeatsAndLicenseQueryOpts = ({
         query,
         signal,
       }).then((res) => {
+        const callingFn = 'SelfHostedSeatsAndLicenseQueryOpts'
         const parsedRes = SelfHostedSeatsAndLicenseSchema.safeParse(res?.data)
 
         if (!parsedRes.success) {
           return rejectNetworkError({
             errorName: 'Parsing Error',
-            errorDetails: {
-              callingFn: 'SelfHostedSeatsAndLicenseQueryOpts',
-              error: parsedRes.error,
-            },
+            errorDetails: { callingFn, error: parsedRes.error },
           })
         }
 

--- a/src/services/selfHosted/SelfHostedSeatsConfigQueryOpts.ts
+++ b/src/services/selfHosted/SelfHostedSeatsConfigQueryOpts.ts
@@ -34,15 +34,13 @@ export const SelfHostedSeatsConfigQueryOpts = ({
     queryKey: ['Seats', provider],
     queryFn: ({ signal }) =>
       Api.graphql({ provider, query, signal }).then((res) => {
+        const callingFn = 'SelfHostedSeatsConfigQueryOpts'
         const parsedRes = SeatsSchema.safeParse(res?.data)
 
         if (!parsedRes.success) {
           return rejectNetworkError({
             errorName: 'Parsing Error',
-            errorDetails: {
-              callingFn: 'SelfHostedSeatsConfigQueryOpts',
-              error: parsedRes.error,
-            },
+            errorDetails: { callingFn, error: parsedRes.error },
           })
         }
 

--- a/src/services/selfHosted/SelfHostedSettingsQueryOpts.tsx
+++ b/src/services/selfHosted/SelfHostedSettingsQueryOpts.tsx
@@ -38,15 +38,13 @@ export const SelfHostedSettingsQueryOpts = ({
           provider,
         },
       }).then((res) => {
+        const callingFn = 'SelfHostedSettingsQueryOpts'
         const parsedData = RequestSchema.safeParse(res?.data)
 
         if (!parsedData.success) {
           return rejectNetworkError({
             errorName: 'Parsing Error',
-            errorDetails: {
-              callingFn: 'SelfHostedSettingsQueryOpts',
-              error: parsedData.error,
-            },
+            errorDetails: { callingFn, error: parsedData.error },
           })
         }
 

--- a/src/services/selfHosted/SelfHostedUserListQueryOpts.ts
+++ b/src/services/selfHosted/SelfHostedUserListQueryOpts.ts
@@ -47,15 +47,13 @@ export const SelfHostedUserListQueryOpts = ({
           page: pageParam,
         },
       }).then((res) => {
+        const callingFn = 'SelfHostedUserListQueryOpts'
         const parsedData = RequestSchema.safeParse(res)
 
         if (!parsedData.success) {
           return rejectNetworkError({
             errorName: 'Parsing Error',
-            errorDetails: {
-              callingFn: 'SelfHostedUserListQueryOpts',
-              error: parsedData.error,
-            },
+            errorDetails: { callingFn, error: parsedData.error },
           })
         }
 

--- a/src/services/uploadTokenRequired/useUploadTokenRequired.tsx
+++ b/src/services/uploadTokenRequired/useUploadTokenRequired.tsx
@@ -44,15 +44,13 @@ export const useUploadTokenRequired = ({
           owner,
         },
       }).then((res) => {
+        const callingFn = 'useUploadTokenRequired'
         const parsedRes = RequestSchema.safeParse(res?.data)
 
         if (!parsedRes.success) {
           return rejectNetworkError({
             errorName: 'Parsing Error',
-            errorDetails: {
-              callingFn: 'useUploadTokenRequired',
-              error: parsedRes.error,
-            },
+            errorDetails: { callingFn, error: parsedRes.error },
           })
         }
 

--- a/src/services/useIsTeamPlan/useIsTeamPlan.ts
+++ b/src/services/useIsTeamPlan/useIsTeamPlan.ts
@@ -41,15 +41,13 @@ export const useIsTeamPlan = ({ provider, owner }: UseIsTeamPlanArgs) =>
           owner,
         },
       }).then((res) => {
+        const callingFn = 'useIsTeamPlan'
         const parsedRes = PlanSchema.safeParse(res?.data)
 
         if (!parsedRes.success) {
           return rejectNetworkError({
             errorName: 'Parsing Error',
-            errorDetails: {
-              callingFn: 'useIsTeamPlan',
-              error: parsedRes.error,
-            },
+            errorDetails: { callingFn, error: parsedRes.error },
           })
         }
 

--- a/src/services/user/useInternalUser.ts
+++ b/src/services/user/useInternalUser.ts
@@ -52,15 +52,13 @@ export const useInternalUser = (opts: UseInternalUserArgs) =>
         return {} as InternalUserData
       }
 
+      const callingFn = 'useInternalUser'
       const parsedData = InternalUserSchema.safeParse(response)
 
       if (!parsedData.success) {
         return rejectNetworkError({
           errorName: 'Parsing Error',
-          errorDetails: {
-            callingFn: 'useInternalUser',
-            error: parsedData.error,
-          },
+          errorDetails: { callingFn, error: parsedData.error },
         })
       }
 

--- a/src/services/user/useOwner.ts
+++ b/src/services/user/useOwner.ts
@@ -63,15 +63,13 @@ export function useOwner({
         variables,
         signal,
       }).then((res) => {
+        const callingFn = 'useOwner'
         const parsedRes = RequestSchema.safeParse(res?.data)
 
         if (!parsedRes.success) {
           return rejectNetworkError({
             errorName: 'Parsing Error',
-            errorDetails: {
-              callingFn: 'useOwner',
-              error: parsedRes.error,
-            },
+            errorDetails: { callingFn, error: parsedRes.error },
           })
         }
 

--- a/src/services/user/useUpdateProfile.ts
+++ b/src/services/user/useUpdateProfile.ts
@@ -132,14 +132,13 @@ export function useUpdateProfile({ provider }: { provider: string }) {
           },
         },
       }).then((res) => {
+        const callingFn = 'useUpdateProfile'
         const parsedData = UpdateProfileResponseSchema.safeParse(res.data)
+
         if (!parsedData.success) {
           return rejectNetworkError({
             errorName: 'Parsing Error',
-            errorDetails: {
-              callingFn: 'useUpdateProfile',
-              error: parsedData.error,
-            },
+            errorDetails: { callingFn, error: parsedData.error },
           })
         }
         return parsedData.data.updateProfile?.me


### PR DESCRIPTION
# Description

This PR updates all updated calls to the new `rejectNetworkError` helper to use a shared const for the `callingFn` value. 

From this [suggestion](https://github.com/codecov/gazebo/pull/3768#discussion_r1968535926).

Ticket: codecov/engineering-team#3329

# Notable Changes

-  Update `rejectNetworkError` calls to use a shared