### PR TITLE
feat: Add rejectNetworkError to calls (part five)

### DIFF
--- a/src/services/user/useMyContexts.test.tsx
+++ b/src/services/user/useMyContexts.test.tsx
@@ -56,10 +56,7 @@ describe('useMyContexts', () => {
             },
             myOrganizations: {
               edges: [{ node: orgList }],
-              pageInfo: {
-                hasNextPage,
-                endCursor,
-              },
+              pageInfo: { hasNextPage, endCursor },
             },
           },
         }
@@ -83,15 +80,9 @@ describe('useMyContexts', () => {
           defaultOrgUsername: null,
         },
         myOrganizations: [
-          {
-            avatarUrl: 'http://127.0.0.1/avatar-url',
-            username: 'org1',
-          },
+          { avatarUrl: 'http://127.0.0.1/avatar-url', username: 'org1' },
         ],
-        pageInfo: {
-          endCursor: 'first',
-          hasNextPage: true,
-        },
+        pageInfo: { endCursor: 'first', hasNextPage: true },
       }
 
       await waitFor(() =>
@@ -111,7 +102,7 @@ describe('useMyContexts', () => {
         consoleSpy.mockRestore()
       })
 
-      it('throws 404 failed to parse', async () => {
+      it('throws 400 failed to parse', async () => {
         console.error = () => {}
         setup({ badResponse: true })
         const { result } = renderHook(() => useMyContexts({ provider: 'gh' }), {
@@ -121,8 +112,8 @@ describe('useMyContexts', () => {
         await waitFor(() =>
           expect(result.current.failureReason).toEqual(
             expect.objectContaining({
-              dev: 'useMyContexts - 404 Failed to parse data',
-              status: 404,
+              dev: 'useMyContexts - Parsing Error',
+              status: 400,
             })
           )
         )
@@ -152,19 +143,10 @@ describe('useMyContexts', () => {
           defaultOrgUsername: null,
         },
         myOrganizations: [
-          {
-            avatarUrl: 'http://127.0.0.1/avatar-url',
-            username: 'org1',
-          },
-          {
-            avatarUrl: 'http://127.0.0.1/avatar-url',
-            username: 'org2',
-          },
+          { avatarUrl: 'http://127.0.0.1/avatar-url', username: 'org1' },
+          { avatarUrl: 'http://127.0.0.1/avatar-url', username: 'org2' },
         ],
-        pageInfo: {
-          endCursor: 'second',
-          hasNextPage: false,
-        },
+        pageInfo: { endCursor: 'second', hasNextPage: false },
       }
 
       await waitFor(() =>

--- a/src/services/user/useMyContexts.ts
+++ b/src/services/user/useMyContexts.ts
@@ -6,7 +6,7 @@ import { useMemo } from 'react'
 import { z } from 'zod'
 
 import Api from 'shared/api'
-import { NetworkErrorObject } from 'shared/api/helpers'
+import { rejectNetworkError } from 'shared/api/rejectNetworkError'
 import { mapEdges } from 'shared/utils/graphql'
 
 const MyContextsSchema = z.object({
@@ -76,14 +76,14 @@ export function useMyContexts({ provider, opts = {} }: UseMyContextsArgs) {
         signal,
         variables: { after: pageParam },
       }).then((res) => {
+        const callingFn = 'useMyContexts'
         const parsedRes = MyContextsSchema.safeParse(res?.data)
 
         if (!parsedRes.success) {
-          return Promise.reject({
-            status: 404,
-            data: {},
-            dev: 'useMyContexts - 404 Failed to parse data',
-          } satisfies NetworkErrorObject)
+          return rejectNetworkError({
+            errorName: 'Parsing Error',
+            errorDetails: { callingFn, error: parsedRes.error },
+          })
         }
 
         return parsedRes?.data

--- a/src/services/user/useOwnerRateLimitStatus.test.tsx
+++ b/src/services/user/useOwnerRateLimitStatus.test.tsx
@@ -78,7 +78,7 @@ describe('useOwnerRateLimitStatus', () => {
       consoleSpy.mockRestore()
     })
 
-    it('throws a 404', async () => {
+    it('throws a 400', async () => {
       setup({ isUnsuccessfulParseError: true })
       const { result } = renderHook(
         () => useOwnerRateLimitStatus({ provider: 'gh' }),
@@ -88,7 +88,8 @@ describe('useOwnerRateLimitStatus', () => {
       await waitFor(() =>
         expect(result.current.error).toEqual(
           expect.objectContaining({
-            status: 404,
+            dev: 'useOwnerRateLimitStatus - Parsing Error',
+            status: 400,
           })
         )
       )

--- a/src/services/user/useOwnerRateLimitStatus.tsx
+++ b/src/services/user/useOwnerRateLimitStatus.tsx
@@ -2,7 +2,7 @@ import { useQuery } from '@tanstack/react-query'
 import { z } from 'zod'
 
 import Api from 'shared/api'
-import { NetworkErrorObject } from 'shared/api/helpers'
+import { rejectNetworkError } from 'shared/api/rejectNetworkError'
 
 export const RequestSchema = z
   .object({
@@ -41,13 +41,14 @@ export function useOwnerRateLimitStatus({
         signal,
         query,
       }).then((res) => {
+        const callingFn = 'useOwnerRateLimitStatus'
         const parsedData = RequestSchema.safeParse(res?.data)
+
         if (!parsedData.success) {
-          return Promise.reject({
-            status: 404,
-            data: {},
-            dev: 'useOwnerRateLimitStatus - 404 NotFoundError',
-          } satisfies NetworkErrorObject)
+          return rejectNetworkError({
+            errorName: 'Parsing Error',
+            errorDetails: { callingFn, error: parsedData.error },
+          })
         }
 
         const data = parsedData.data

--- a/src/services/user/useUser.test.tsx
+++ b/src/services/user/useUser.test.tsx
@@ -134,7 +134,7 @@ describe('useUser', () => {
         consoleSpy.mockRestore()
       })
 
-      it('returns 404 failed to parse', async () => {
+      it('returns 400 failed to parse', async () => {
         setup(badResponse)
         const { result } = renderHook(() => useUser(), {
           wrapper: wrapper(),
@@ -144,9 +144,8 @@ describe('useUser', () => {
         await waitFor(() =>
           expect(result.current.failureReason).toEqual(
             expect.objectContaining({
-              data: {},
-              dev: 'useUser - 404 failed to parse',
-              status: 404,
+              dev: 'useUser - Parsing Error',
+              status: 400,
             })
           )
         )

--- a/src/services/users/useInfiniteUser.test.tsx
+++ b/src/services/users/useInfiniteUser.test.tsx
@@ -186,7 +186,8 @@ describe('useInfiniteUser', () => {
       await waitFor(() =>
         expect(result.current.error).toEqual(
           expect.objectContaining({
-            status: 404,
+            dev: 'useInfiniteUsers - Parsing Error',
+            status: 400,
           })
         )
       )

--- a/src/services/users/useInfiniteUser.tsx
+++ b/src/services/users/useInfiniteUser.tsx
@@ -3,7 +3,7 @@ import { useMemo } from 'react'
 import { z } from 'zod'
 
 import Api from 'shared/api'
-import { NetworkErrorObject } from 'shared/api/helpers'
+import { rejectNetworkError } from 'shared/api/rejectNetworkError'
 
 export const MemberSchema = z.object({
   activated: z.boolean(),
@@ -60,14 +60,14 @@ export const useInfiniteUsers = (
           page: pageParam,
         },
       }).then((res) => {
+        const callingFn = 'useInfiniteUsers'
         const parsedRes = MemberListSchema.safeParse(res)
 
         if (!parsedRes.success) {
-          return Promise.reject({
-            status: 404,
-            data: {},
-            dev: 'useInfiniteUser - 404 failed to parse',
-          } satisfies NetworkErrorObject)
+          return rejectNetworkError({
+            errorName: 'Parsing Error',
+            errorDetails: { callingFn, error: parsedRes.error },
+          })
         }
 
         return parsedRes.data


### PR DESCRIPTION
# Description

This is the last PR updating API calls to use the new `rejectNetworkError` helper function

Ticket: codecov/engineering-team#3329

# Notable Changes

- Update calls to use updated `rejectNetworkError` (see [commits](https://github.com/codecov/gazebo/pull/3771/commits))
- Update tests