### PR TITLE
feat: Instrument retry with Sentry spans

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -77,19 +77,20 @@ const queryClientV5 = new QueryClientV5({
     queries: {
       staleTime: QUERY_STALE_TIME,
       refetchOnWindowFocus: false,
-      retry: (failureCount, error) => {
-        // Do not retry if the response status is 429
-        if (
-          typeof error === 'object' &&
-          error !== null &&
-          'status' in error &&
-          error.status === TOO_MANY_REQUESTS_ERROR_CODE
-        ) {
-          return false
-        }
-        // Otherwise, retry up to 3 times
-        return failureCount < 3
-      },
+      retry: (failureCount, error) =>
+        Sentry.startSpan({ name: 'QueryClient V5 Retry' }, () => {
+          // Do not retry if the response status is 429
+          if (
+            typeof error === 'object' &&
+            error !== null &&
+            'status' in error &&
+            error.status === TOO_MANY_REQUESTS_ERROR_CODE
+          ) {
+            return false
+          }
+          // Otherwise, retry up to 3 times
+          return failureCount < 3
+        }),
     },
   },
 })

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -54,19 +54,20 @@ const queryClient = new QueryClient({
       suspense: true,
       staleTime: QUERY_STALE_TIME,
       refetchOnWindowFocus: false,
-      retry: (failureCount, error) => {
-        // Do not retry if the response status is 429
-        if (
-          typeof error === 'object' &&
-          error !== null &&
-          'status' in error &&
-          error.status === TOO_MANY_REQUESTS_ERROR_CODE
-        ) {
-          return false
-        }
-        // Otherwise, retry up to 3 times
-        return failureCount < 3
-      },
+      retry: (failureCount, error) =>
+        Sentry.startSpan({ name: 'QueryClient V4 Retry' }, () => {
+          // Do not retry if the response status is 429
+          if (
+            typeof error === 'object' &&
+            error !== null &&
+            'status' in error &&
+            error.status === TOO_MANY_REQUESTS_ERROR_CODE
+          ) {
+            return false
+          }
+          // Otherwise, retry up to 3 times
+          return failureCount < 3
+        }),
     },
   },
 })


### PR DESCRIPTION
# Description

This PR wraps out retry callbacks with Sentry spans, so we can better determine what the current retry times look like for failing network calls.

Ticket: codecov/engineering-team#3184

# Notable Changes

- Wrap retry callbacks with `Sentry.startSpan`