### PR TITLE
ref: Render only two levels of the sunburst

### DIFF
--- a/src/pages/RepoPage/CoverageTab/OverviewTab/subroute/Sunburst/Sunburst.jsx
+++ b/src/pages/RepoPage/CoverageTab/OverviewTab/subroute/Sunburst/Sunburst.jsx
@@ -37,7 +37,6 @@ function Sunburst() {
     <>
       <SunburstChart
         data={data}
-        svgFontSize="24px"
         svgRenderSize={930}
         selector={(data) => data?.coverage}
         onHover={({ path, type }) => setCurrentPath({ path, type })}

--- a/src/ui/SunburstChart/SunburstChart.jsx
+++ b/src/ui/SunburstChart/SunburstChart.jsx
@@ -1,14 +1,12 @@
 import * as Sentry from '@sentry/react'
-import { interpolate } from 'd3-interpolate'
 import { scaleSequential } from 'd3-scale'
 import { select } from 'd3-selection'
 import { arc } from 'd3-shape'
-import { transition } from 'd3-transition' // Kinda odd d3 behavior seems to need to imported but not directly referenced.
 import PropTypes from 'prop-types'
 import { useLayoutEffect, useRef, useState } from 'react'
 
 // Modification of https://observablehq.com/@d3/zoomable-sunburst
-import { arcVisible, colorRange, formatData, partitionFn } from './utils'
+import { colorRange, formatData, partitionFn } from './utils'
 
 function SunburstChart({
   data,
@@ -16,7 +14,6 @@ function SunburstChart({
   onHover = () => {},
   selector = ({ value }) => value,
   svgRenderSize = 932,
-  svgFontSize = '16px',
   colorDomainMin = 0,
   colorDomainMax = 100,
 }) {
@@ -32,11 +29,10 @@ function SunburstChart({
    */
 
   // this state stores the root node of the sunburst chart
-  const [{ root, pathIndex }] = useState(() =>
+  const [root] = useState(() =>
     Sentry.startSpan({ name: 'SunburstChart.createRoot' }, () => {
       // go through the data and add `value` to each node
       const stack = [data]
-      const pathIndex = new Map()
 
       // create a new root node with the value of the root node
       const result = { ...data, value: selectorHandler.current(data) }
@@ -73,19 +69,13 @@ function SunburstChart({
 
       const root = partitionFn(result).each((d) => (d.current = d))
 
-      root.each((d) => {
-        // only add to pathIndex if the node has children as it represents a folder
-        if (d?.children) {
-          pathIndex.set(d.data.fullPath, d)
-        }
-      })
-
       // partition the data and add the `current` property to each node
-      return { root, pathIndex }
+      return root
     })
   )
 
   const [selectedNode, setSelectedNode] = useState(root)
+  const [forceUpdate, setForceUpdate] = useState(false)
 
   // In this case D3 is handling rendering not React, so useLayoutEffect is used to handle rendering
   // and changes outside of the React lifecycle.
@@ -130,208 +120,243 @@ function SunburstChart({
       .append('g')
       .attr('transform', `translate(${width / 2},${width / 2})`)
 
-    // Renders an arc per data point in the correct location. (Pieces of the circle that add up to a circular graph)
-    const path = Sentry.startSpan({ name: 'SunburstChart.renderArcs' }, () =>
-      g
+    function renderArcs() {
+      // Renders an arc per data point in the correct location. (Pieces of the circle that add up to a circular graph)
+      console.debug('renderArcs', selectedNode)
+      const path = g
         .append('g')
         .selectAll('path')
-        .data(root.descendants().slice(1))
+        .data(
+          selectedNode
+            .descendants()
+            .slice(1)
+            .filter((d) => d.depth <= selectedNode.depth + 2)
+        )
         .join('path')
         .attr('fill', (d) => color(d?.data?.value || 0))
         // If data point is a file fade the background color a bit.
-        .attr('fill-opacity', (d) =>
-          arcVisible(d.current) ? (d.children ? 1 : 0.6) : 0
-        )
-        .attr('pointer-events', (d) =>
-          arcVisible(d.current) ? 'auto' : 'none'
-        )
+        .attr('fill-opacity', (d) => (d.children ? 1 : 0.6))
+        .attr('pointer-events', () => 'auto')
         .attr('d', (d) => drawArc(d.current))
-    )
 
-    // Events for folders
-    path
-      .filter((d) => d.children)
-      .style('cursor', 'pointer')
-      .on('click', clickedFolder)
-      .on('mouseover', hoveredFolder)
-      .on('mouseout', mouseout)
+      // Events for folders
+      path
+        .filter((d) => d.children)
+        .style('cursor', 'pointer')
+        .on('click', clickedFolder)
+        .on('mouseover', hoveredFolder)
+        .on('mouseout', mouseout)
 
-    // Events for file
-    path
-      .filter((d) => !d.children)
-      .style('cursor', 'pointer')
-      .on('click', clickedFile)
-      .on('mouseover', hoveredFile)
+      // Events for file
+      path
+        .filter((d) => !d.children)
+        .style('cursor', 'pointer')
+        .on('click', clickedFile)
+        .on('mouseover', hoveredFile)
 
-    // Create a11y label / mouse hover tooltip
-    const formatTitle = (d) => {
-      const coverage = formatData(d.data.value)
-      const filePath = d
-        .ancestors()
-        .map((d) => d.data.name)
-        .reverse()
-        .join('/')
+      // Create a11y label / mouse hover tooltip
+      const formatTitle = (d) => {
+        const coverage = formatData(d.data.value)
+        const filePath = d
+          .ancestors()
+          .map((d) => d.data.name)
+          .reverse()
+          .join('/')
 
-      return `${filePath}\n${coverage}% coverage`
-    }
-
-    path.append('title').text((d) => formatTitle(d))
-
-    // White circle in the middle. Act's as a "back"
-    const parent = g
-      .append('circle')
-      .datum(root)
-      .attr('r', radius)
-      .attr('fill', 'none')
-      .attr('pointer-events', 'all')
-      .attr('cursor', 'pointer')
-      .on('click', clickedFolder)
-      .on('mouseover', hoveredRoot)
-
-    const backText = g
-      .append('text')
-      .datum(root)
-      .text('..')
-      .attr('fill-opacity', 0)
-      .attr('text-anchor', 'middle')
-      .attr('class', 'text-7xl fill-ds-gray-quinary')
-      .attr('cursor', 'pointer')
-      .on('click', clickedFolder)
-      .on('mouseover', hoveredRoot)
-
-    function clickedFolder(_event, p) {
-      reactClickCallback({ target: p, type: 'folder' })
-      changeLocation(p)
-    }
-
-    function clickedFile(_event, p) {
-      reactClickCallback({ target: p, type: 'file' })
-    }
-
-    function hoveredRoot(_event, p) {
-      if (previous) {
-        reactHoverCallback({ target: previous, type: 'folder' })
-        return
+        return `${filePath}\n${coverage}% coverage`
       }
-      reactHoverCallback({ target: p, type: 'folder' })
-    }
 
-    function hoveredFolder(_event, p) {
-      select(this).attr('fill-opacity', 0.6)
-      reactHoverCallback({ target: p, type: 'folder' })
-    }
+      path.append('title').text((d) => formatTitle(d))
 
-    function hoveredFile(_event, p) {
-      select(this).attr('fill-opacity', 0.6)
-      reactHoverCallback({ target: p, type: 'file' })
-    }
+      // White circle in the middle. Act's as a "back"
+      g.append('circle')
+        .datum(selectedNode.parent)
+        .attr('r', radius)
+        .attr('fill', 'none')
+        .attr('pointer-events', 'all')
+        .attr('cursor', 'pointer')
+        .on('click', clickedFolder)
+        .on('mouseover', hoveredRoot)
 
-    function mouseout(_event, _p) {
-      select(this).attr('fill-opacity', 1)
-    }
+      g.append('text')
+        .datum(selectedNode.parent)
+        .text('..')
+        .attr('fill-opacity', (d) => {
+          // if the parent exists, show the text
+          return d ? 1 : 0
+        })
+        .attr('text-anchor', 'middle')
+        .attr('class', 'text-7xl fill-ds-gray-quinary')
+        .attr('cursor', 'pointer')
+        .on('click', clickedFolder)
+        .on('mouseover', hoveredRoot)
 
-    function reactClickCallback({ target, type }) {
-      // Create a string from the root data down to the current item
-      const filePath = target
-        .ancestors()
-        .map((d) => d.data.name)
-        .slice(0, -1)
-        .reverse()
-        .join('/')
+      function clickedFolder(_event, p) {
+        reactClickCallback({ target: p, type: 'folder' })
+        changeLocation(p)
+      }
 
-      // callback to parent component with a path, the data node, and raw d3 data
-      // (just in case we need it for the second iteration to listen to location changes and direct to the correct folder.)
-      clickHandler.current({ path: filePath, data: target.data, target, type })
-    }
+      function clickedFile(_event, p) {
+        reactClickCallback({ target: p, type: 'file' })
+      }
 
-    function reactHoverCallback({ target, type }) {
-      // Create a string from the root data down to the current item
-      const filePath = target
-        .ancestors()
-        .map((d) => d.data.name)
-        .slice(0, -1)
-        .reverse()
-        .join('/')
+      function hoveredRoot(_event, p) {
+        if (previous) {
+          reactHoverCallback({ target: previous, type: 'folder' })
+          return
+        }
+        reactHoverCallback({ target: p, type: 'folder' })
+      }
 
-      // callback to parent component with a path, the data node, and raw d3 data
-      // (just in case we need it for the second iteration to listen to location changes and direct to the correct folder.)
-      hoverHandler.current({ path: filePath, data: target.data, target, type })
-    }
+      function hoveredFolder(_event, p) {
+        select(this).attr('fill-opacity', 0.6)
+        reactHoverCallback({ target: p, type: 'folder' })
+      }
 
-    function changeLocation(p) {
-      // Because you can move two layers at a time previous !== parent
-      previous = p
-      const selected = p.parent || root
-      const t = transition(g).duration(750)
+      function hoveredFile(_event, p) {
+        select(this).attr('fill-opacity', 0.6)
+        reactHoverCallback({ target: p, type: 'file' })
+      }
 
-      handleArcsUpdate({ current: p, selected, transition: t })
-      handleTextUpdate({ current: p, selected, transition: t })
-    }
+      function mouseout(_event, _p) {
+        select(this).attr('fill-opacity', 1)
+      }
 
-    const handleArcsUpdate = ({ current, selected, transition }) =>
-      Sentry.startSpan({ name: 'SunburstChart.handleArcsUpdate' }, () => {
-        parent.datum(selected)
+      function reactClickCallback({ target, type }) {
+        if (target?.ancestors) {
+          // Create a string from the root data down to the current item
+          const filePath = target
+            .ancestors()
+            .map((d) => d.data.name)
+            .slice(0, -1)
+            .reverse()
+            .join('/')
 
-        // Handle animating in/out of a folder
-        Sentry.startSpan({ name: 'SunburstChart.calculateCoordinates' }, () => {
-          root.each((d) => {
-            // determine x0 and y0
-            const x0Min = Math.min(
-              1,
-              (d.x0 - current.x0) / (current.x1 - current.x0)
-            )
-            const x0 = Math.max(0, x0Min) * 2 * Math.PI
-            const y0 = Math.max(0, d.y0 - current.depth)
-
-            // determine x1 and y1
-            const x1Min = Math.min(
-              1,
-              (d.x1 - current.x0) / (current.x1 - current.x0)
-            )
-            const x1 = Math.max(0, x1Min) * 2 * Math.PI
-            const y1 = Math.max(0, d.y1 - current.depth)
-
-            d.target = { x0, y0, x1, y1 }
+          // callback to parent component with a path, the data node, and raw d3 data
+          // (just in case we need it for the second iteration to listen to location changes and direct to the correct folder.)
+          clickHandler.current({
+            path: filePath,
+            data: target.data,
+            target,
+            type,
           })
-        })
-
-        // Transition the data on all arcs, even the ones that aren’t visible,
-        // so that if this transition is interrupted, entering arcs will start
-        // the next transition from the desired position.
-        Sentry.startSpan({ name: 'SunburstChart.transitionArcs' }, () => {
-          path
-            .transition(transition)
-            .tween('data', (d) => {
-              const i = interpolate(d.current, d.target)
-              return (t) => (d.current = i(t))
-            })
-            .filter(function (d) {
-              return +this.getAttribute('fill-opacity') || arcVisible(d.target)
-            })
-            .attr('fill-opacity', (d) =>
-              arcVisible(d.target) ? (d.children ? 1 : 0.6) : 0
-            )
-            .attr('pointer-events', (d) =>
-              arcVisible(d.target) ? 'auto' : 'none'
-            )
-            .attrTween('d', (d) => () => drawArc(d.current))
-        })
-      })
-
-    function handleTextUpdate({ current, selected, transition }) {
-      backText.datum(selected)
-
-      // Only show back if not on root
-      if (current.parent) {
-        backText.transition(transition).attr('fill-opacity', 1)
-      } else {
-        backText.transition(transition).attr('fill-opacity', 0)
+        }
       }
+
+      function reactHoverCallback({ target, type }) {
+        if (target?.ancestors) {
+          // Create a string from the root data down to the current item
+          const filePath = target
+            .ancestors()
+            .map((d) => d.data.name)
+            .slice(0, -1)
+            .reverse()
+            .join('/')
+
+          // callback to parent component with a path, the data node, and raw d3 data
+          // (just in case we need it for the second iteration to listen to location changes and direct to the correct folder.)
+          hoverHandler.current({
+            path: filePath,
+            data: target.data,
+            target,
+            type,
+          })
+        }
+      }
+
+      function changeLocation(p) {
+        // Because you can move two layers at a time previous !== parent
+        previous = p
+        // const selected = p.parent || root
+        // const t = transition(g).duration(750)
+
+        if (p) {
+          // Update the selected node
+          setSelectedNode(
+            p.each((d) => {
+              // determine x0 and y0
+              const x0Min = Math.min(1, (d.x0 - p.x0) / (p.x1 - p.x0))
+              const x0 = Math.max(0, x0Min) * 2 * Math.PI
+              const y0 = Math.max(0, d.y0 - p.depth)
+
+              // determine x1 and y1
+              const x1Min = Math.min(1, (d.x1 - p.x0) / (p.x1 - p.x0))
+              const x1 = Math.max(0, x1Min) * 2 * Math.PI
+              const y1 = Math.max(0, d.y1 - p.depth)
+
+              d.current = { x0, y0, x1, y1 }
+            })
+          )
+          setForceUpdate(!forceUpdate)
+        }
+
+        // handleTextUpdate({ current: p, selected, transition: t })
+      }
+
+      // function handleArcsUpdate({ current, selected, transition }) {
+      //   parent.datum(selected)
+
+      //   // Handle animating in/out of a folder
+      //   root.each((d) => {
+      //     // determine x0 and y0
+      //     const x0Min = Math.min(
+      //       1,
+      //       (d.x0 - current.x0) / (current.x1 - current.x0)
+      //     )
+      //     const x0 = Math.max(0, x0Min) * 2 * Math.PI
+      //     const y0 = Math.max(0, d.y0 - current.depth)
+
+      //     // determine x1 and y1
+      //     const x1Min = Math.min(
+      //       1,
+      //       (d.x1 - current.x0) / (current.x1 - current.x0)
+      //     )
+      //     const x1 = Math.max(0, x1Min) * 2 * Math.PI
+      //     const y1 = Math.max(0, d.y1 - current.depth)
+
+      //     d.target = { x0, y0, x1, y1 }
+      //   })
+
+      // // Transition the data on all arcs, even the ones that aren’t visible,
+      // // so that if this transition is interrupted, entering arcs will start
+      // // the next transition from the desired position.
+      // path
+      //   .transition(transition)
+      //   .tween('data', (d) => {
+      //     const i = interpolate(d.current, d.target)
+      //     return (t) => (d.current = i(t))
+      //   })
+      //   .filter(function (d) {
+      //     return +this.getAttribute('fill-opacity') || arcVisible(d.target)
+      //   })
+      //   .attr('fill-opacity', (d) =>
+      //     arcVisible(d.target) ? (d.children ? 1 : 0.6) : 0
+      //   )
+      //   .attr('pointer-events', (d) =>
+      //     arcVisible(d.target) ? 'auto' : 'none'
+      //   )
+      //   .attrTween('d', (d) => () => drawArc(d.current))
+      // }
+
+      // function handleTextUpdate({ current, selected, transition }) {
+      //   backText.datum(selected)
+
+      //   // Only show back if not on root
+      //   if (current.parent) {
+      //     backText.transition(transition).attr('fill-opacity', 1)
+      //   } else {
+      //     backText.transition(transition).attr('fill-opacity', 0)
+      //   }
+      // }
     }
+
+    renderArcs()
 
     // On cleanup remove the root DOM generated by D3
-    return () => g.remove()
-  }, [colorDomainMax, colorDomainMin, data, root, svgFontSize, svgRenderSize])
+    return () => {
+      g.remove()
+    }
+  }, [colorDomainMax, colorDomainMin, forceUpdate, selectedNode, svgRenderSize])
 
   return (
     <svg
@@ -365,7 +390,6 @@ SunburstChart.propTypes = {
   onClick: PropTypes.func,
   onHover: PropTypes.func,
   svgRenderSize: PropTypes.number,
-  svgFontSize: PropTypes.string,
   colorDomainMin: PropTypes.number,
   colorDomainMax: PropTypes.number,
 }

--- a/src/ui/SunburstChart/SunburstChart.jsx
+++ b/src/ui/SunburstChart/SunburstChart.jsx
@@ -67,25 +67,29 @@ function SunburstChart({
     const radius = width / 6
 
     // Creates a function for creating arcs representing files and folders.
-    const createDrawArcFunction = (parentSpan) =>
-      Sentry.startSpan({ name: 'SunburstChart.drawArc', parentSpan }, () =>
-        arc()
-          .startAngle((d) => d.x0)
-          .endAngle((d) => d.x1)
-          .padAngle((d) => Math.min((d.x1 - d.x0) / 2, 0.005))
-          .padRadius(radius * 1.5)
-          .innerRadius((d) => d.y0 * radius)
-          .outerRadius((d) => Math.max(d.y0 * radius, d.y1 * radius - 1))
+    function createDrawArcFunction(parentSpan) {
+      return Sentry.startSpan(
+        { name: 'SunburstChart.drawArc', parentSpan },
+        () =>
+          arc()
+            .startAngle((d) => d.x0)
+            .endAngle((d) => d.x1)
+            .padAngle((d) => Math.min((d.x1 - d.x0) / 2, 0.005))
+            .padRadius(radius * 1.5)
+            .innerRadius((d) => d.y0 * radius)
+            .outerRadius((d) => Math.max(d.y0 * radius, d.y1 * radius - 1))
       )
+    }
     // A color function you can pass a number from 0-100 to and get a color back from the specified color range
     // Ex color(10.4)
-    const createColorFunction = (parentSpan) =>
-      Sentry.startSpan({ name: 'SunburstChart.color', parentSpan }, () =>
+    function createColorFunction(parentSpan) {
+      return Sentry.startSpan({ name: 'SunburstChart.color', parentSpan }, () =>
         scaleSequential()
           .domain([colorDomainMin, colorDomainMax])
           .interpolator(colorRange)
           .clamp(true)
       )
+    }
 
     // Tracks previous location for rendering .. in the breadcrumb.
     let previous
@@ -98,185 +102,192 @@ function SunburstChart({
       .append('g')
       .attr('transform', `translate(${width / 2},${width / 2})`)
 
-    const renderSunburst = Sentry.startSpan(
-      { name: 'SunburstChart.renderSunburst' },
-      (renderSunburstSpan) => {
-        const drawArc = createDrawArcFunction(renderSunburstSpan)
-        const color = createColorFunction(renderSunburstSpan)
-        const nodesToRender = selectedNode
-          .descendants()
-          .slice(1)
-          .filter((d) => d.depth <= selectedNode.depth + 2)
+    function renderSunburst() {
+      Sentry.startSpan(
+        { name: 'SunburstChart.renderSunburst' },
+        (renderSunburstSpan) => {
+          const drawArc = createDrawArcFunction(renderSunburstSpan)
+          const color = createColorFunction(renderSunburstSpan)
+          const nodesToRender = selectedNode
+            .descendants()
+            .slice(1)
+            .filter((d) => d.depth <= selectedNode.depth + 2)
 
-        // Renders an arc per data point in the correct location. (Pieces of the circle that add up to a circular graph)
-        const path = Sentry.startSpan(
-          { name: 'SunburstChart.renderArcs', parentSpan: renderSunburstSpan },
-          () =>
-            g
-              .append('g')
-              .selectAll('path')
-              .data(nodesToRender)
-              .join('path')
-              .attr('fill', (d) => color(d?.data?.value || 0))
-              // If data point is a file fade the background color a bit.
-              .attr('fill-opacity', (d) => (d.children ? 1 : 0.6))
-              .attr('pointer-events', () => 'auto')
-              .attr('d', (d) => drawArc(d.current))
-        )
-        // Events for folders
-        path
-          .filter((d) => d.children)
-          .style('cursor', 'pointer')
-          .on('click', clickedFolder)
-          .on('mouseover', function (_event, p) {
-            select(this).attr('fill-opacity', 0.6)
-            reactHoverCallback({ target: p, type: 'folder' })
-          })
-          .on('mouseout', function (_event, _node) {
-            select(this).attr('fill-opacity', 1)
-          })
+          // Renders an arc per data point in the correct location. (Pieces of the circle that add up to a circular graph)
+          const path = Sentry.startSpan(
+            {
+              name: 'SunburstChart.renderArcs',
+              parentSpan: renderSunburstSpan,
+            },
+            () =>
+              g
+                .append('g')
+                .selectAll('path')
+                .data(nodesToRender)
+                .join('path')
+                .attr('fill', (d) => color(d?.data?.value || 0))
+                // If data point is a file fade the background color a bit.
+                .attr('fill-opacity', (d) => (d.children ? 1 : 0.6))
+                .attr('pointer-events', () => 'auto')
+                .attr('d', (d) => drawArc(d.current))
+          )
+          // Events for folders
+          path
+            .filter((d) => d.children)
+            .style('cursor', 'pointer')
+            .on('click', clickedFolder)
+            .on('mouseover', function (_event, p) {
+              select(this).attr('fill-opacity', 0.6)
+              reactHoverCallback({ target: p, type: 'folder' })
+            })
+            .on('mouseout', function (_event, _node) {
+              select(this).attr('fill-opacity', 1)
+            })
 
-        // Events for file
-        path
-          .filter((d) => !d.children)
-          .style('cursor', 'pointer')
-          .on('click', function (_event, node) {
-            reactClickCallback({ target: node, type: 'file' })
-          })
-          .on('mouseover', function (_event, node) {
-            select(this).attr('fill-opacity', 0.6)
-            reactHoverCallback({ target: node, type: 'file' })
-          })
+          // Events for file
+          path
+            .filter((d) => !d.children)
+            .style('cursor', 'pointer')
+            .on('click', function (_event, node) {
+              reactClickCallback({ target: node, type: 'file' })
+            })
+            .on('mouseover', function (_event, node) {
+              select(this).attr('fill-opacity', 0.6)
+              reactHoverCallback({ target: node, type: 'file' })
+            })
 
-        // Create a11y label / mouse hover tooltip
-        const formatTitle = (d) => {
-          const coverage = formatData(d.data.value)
-          const filePath = d
-            .ancestors()
-            .map((d) => d.data.name)
-            .reverse()
-            .join('/')
-
-          return `${filePath}\n${coverage}% coverage`
-        }
-
-        path.append('title').text((d) => formatTitle(d))
-
-        // White circle in the middle. Act's as a "back"
-        g.append('circle')
-          .datum(selectedNode.parent)
-          .attr('r', radius)
-          .attr('class', 'fill-none')
-          .attr('fill', 'none')
-          .attr('pointer-events', 'all')
-          .attr('cursor', (d) => (d ? 'pointer' : 'default'))
-          .on('click', clickedFolder)
-          .on('mouseover', hoveredRoot)
-
-        g.append('text')
-          .datum(selectedNode.parent)
-          .text('..')
-          // if the parent exists (i.e. not root), show the text
-          .attr('fill-opacity', (d) => (d ? 1 : 0))
-          .attr('text-anchor', 'middle')
-          .attr('class', 'text-7xl fill-ds-gray-quinary select-none')
-          .attr('cursor', 'pointer')
-          .on('click', clickedFolder)
-          .on('mouseover', hoveredRoot)
-
-        function clickedFolder(_event, node) {
-          reactClickCallback({ target: node, type: 'folder' })
-          changeLocation(node)
-        }
-
-        function hoveredRoot(_event, node) {
-          if (previous) {
-            reactHoverCallback({ target: previous, type: 'folder' })
-            return
-          }
-          reactHoverCallback({ target: node, type: 'folder' })
-        }
-
-        function reactClickCallback({ target, type }) {
-          if (target?.ancestors) {
-            // Create a string from the root data down to the current item
-            const filePath = target
+          // Create a11y label / mouse hover tooltip
+          const formatTitle = (d) => {
+            const coverage = formatData(d.data.value)
+            const filePath = d
               .ancestors()
               .map((d) => d.data.name)
-              .slice(0, -1)
               .reverse()
               .join('/')
 
-            // callback to parent component with a path, the data node, and raw d3 data
-            // (just in case we need it for the second iteration to listen to location changes and direct to the correct folder.)
-            clickHandler.current({
-              path: filePath,
-              data: target.data,
-              target,
-              type,
-            })
+            return `${filePath}\n${coverage}% coverage`
           }
-        }
 
-        function reactHoverCallback({ target, type }) {
-          if (target?.ancestors) {
-            // Create a string from the root data down to the current item
-            const filePath = target
-              .ancestors()
-              .map((d) => d.data.name)
-              .slice(0, -1)
-              .reverse()
-              .join('/')
+          path.append('title').text((d) => formatTitle(d))
 
-            // callback to parent component with a path, the data node, and raw d3 data
-            // (just in case we need it for the second iteration to listen to location changes and direct to the correct folder.)
-            hoverHandler.current({
-              path: filePath,
-              data: target.data,
-              target,
-              type,
-            })
+          // White circle in the middle. Act's as a "back"
+          g.append('circle')
+            .datum(selectedNode.parent)
+            .attr('r', radius)
+            .attr('class', 'fill-none')
+            .attr('fill', 'none')
+            .attr('pointer-events', 'all')
+            .attr('cursor', (d) => (d ? 'pointer' : 'default'))
+            .on('click', clickedFolder)
+            .on('mouseover', hoveredRoot)
+
+          g.append('text')
+            .datum(selectedNode.parent)
+            .text('..')
+            // if the parent exists (i.e. not root), show the text
+            .attr('fill-opacity', (d) => (d ? 1 : 0))
+            .attr('text-anchor', 'middle')
+            .attr('class', 'text-7xl fill-ds-gray-quinary select-none')
+            .attr('cursor', 'pointer')
+            .on('click', clickedFolder)
+            .on('mouseover', hoveredRoot)
+
+          function clickedFolder(_event, node) {
+            reactClickCallback({ target: node, type: 'folder' })
+            changeLocation(node)
           }
-        }
 
-        const changeLocation = Sentry.startSpan(
-          {
-            name: 'SunburstChart.handleArcsUpdate',
-            parentSpan: renderSunburstSpan,
-          },
-          (node) => {
-            // Because you can move two layers at a time previous !== parent
-            previous = node
+          function hoveredRoot(_event, node) {
+            if (previous) {
+              reactHoverCallback({ target: previous, type: 'folder' })
+              return
+            }
+            reactHoverCallback({ target: node, type: 'folder' })
+          }
 
-            if (node) {
-              // Update the selected node
-              setSelectedNode(
-                node.each((d) => {
-                  // determine x0 and y0
-                  const x0Min = Math.min(
-                    1,
-                    (d.x0 - node.x0) / (node.x1 - node.x0)
-                  )
-                  const x0 = Math.max(0, x0Min) * 2 * Math.PI
-                  const y0 = Math.max(0, d.y0 - node.depth)
+          function reactClickCallback({ target, type }) {
+            if (target?.ancestors) {
+              // Create a string from the root data down to the current item
+              const filePath = target
+                .ancestors()
+                .map((d) => d.data.name)
+                .slice(0, -1)
+                .reverse()
+                .join('/')
 
-                  // determine x1 and y1
-                  const x1Min = Math.min(
-                    1,
-                    (d.x1 - node.x0) / (node.x1 - node.x0)
-                  )
-                  const x1 = Math.max(0, x1Min) * 2 * Math.PI
-                  const y1 = Math.max(0, d.y1 - node.depth)
-
-                  // update the cords for the node
-                  d.current = { x0, y0, x1, y1 }
-                })
-              )
+              // callback to parent component with a path, the data node, and raw d3 data
+              // (just in case we need it for the second iteration to listen to location changes and direct to the correct folder.)
+              clickHandler.current({
+                path: filePath,
+                data: target.data,
+                target,
+                type,
+              })
             }
           }
-        )
-      }
-    )
+
+          function reactHoverCallback({ target, type }) {
+            if (target?.ancestors) {
+              // Create a string from the root data down to the current item
+              const filePath = target
+                .ancestors()
+                .map((d) => d.data.name)
+                .slice(0, -1)
+                .reverse()
+                .join('/')
+
+              // callback to parent component with a path, the data node, and raw d3 data
+              // (just in case we need it for the second iteration to listen to location changes and direct to the correct folder.)
+              hoverHandler.current({
+                path: filePath,
+                data: target.data,
+                target,
+                type,
+              })
+            }
+          }
+
+          function changeLocation(node) {
+            Sentry.startSpan(
+              {
+                name: 'SunburstChart.handleArcsUpdate',
+                parentSpan: renderSunburstSpan,
+              },
+              () => {
+                // Because you can move two layers at a time previous !== parent
+                previous = node
+
+                if (node) {
+                  // Update the selected node
+                  setSelectedNode(
+                    node.each((d) => {
+                      // determine x0 and y0
+                      const x0Min = Math.min(
+                        1,
+                        (d.x0 - node.x0) / (node.x1 - node.x0)
+                      )
+                      const x0 = Math.max(0, x0Min) * 2 * Math.PI
+                      const y0 = Math.max(0, d.y0 - node.depth)
+
+                      // determine x1 and y1
+                      const x1Min = Math.min(
+                        1,
+                        (d.x1 - node.x0) / (node.x1 - node.x0)
+                      )
+                      const x1 = Math.max(0, x1Min) * 2 * Math.PI
+                      const y1 = Math.max(0, d.y1 - node.depth)
+
+                      // update the cords for the node
+                      d.current = { x0, y0, x1, y1 }
+                    })
+                  )
+                }
+              }
+            )
+          }
+        }
+      )
+    }
 
     renderSunburst()
 

--- a/src/ui/SunburstChart/SunburstChart.jsx
+++ b/src/ui/SunburstChart/SunburstChart.jsx
@@ -45,10 +45,10 @@ function SunburstChart({
         if (Array.isArray(node.children)) {
           node.children.forEach((child) => stack.push(child))
         }
-
-        // partition the data and add the `current` property to each node
-        return partitionFn(result).each((d) => (d.current = d))
       }
+
+      // partition the data and add the `current` property to each node
+      return partitionFn(result).each((d) => (d.current = d))
     })
   )
 
@@ -68,25 +68,24 @@ function SunburstChart({
 
     // Creates a function for creating arcs representing files and folders.
     const createDrawArcFunction = (parentSpan) =>
-      Sentry.startSpan({ name: 'SunburstChart.drawArc', parentSpan }, () => {
-        return arc()
+      Sentry.startSpan({ name: 'SunburstChart.drawArc', parentSpan }, () =>
+        arc()
           .startAngle((d) => d.x0)
           .endAngle((d) => d.x1)
           .padAngle((d) => Math.min((d.x1 - d.x0) / 2, 0.005))
           .padRadius(radius * 1.5)
           .innerRadius((d) => d.y0 * radius)
           .outerRadius((d) => Math.max(d.y0 * radius, d.y1 * radius - 1))
-      })
-
+      )
     // A color function you can pass a number from 0-100 to and get a color back from the specified color range
     // Ex color(10.4)
     const createColorFunction = (parentSpan) =>
-      Sentry.startSpan({ name: 'SunburstChart.color', parentSpan }, () => {
-        return scaleSequential()
+      Sentry.startSpan({ name: 'SunburstChart.color', parentSpan }, () =>
+        scaleSequential()
           .domain([colorDomainMin, colorDomainMax])
           .interpolator(colorRange)
           .clamp(true)
-      })
+      )
 
     // Tracks previous location for rendering .. in the breadcrumb.
     let previous
@@ -99,192 +98,185 @@ function SunburstChart({
       .append('g')
       .attr('transform', `translate(${width / 2},${width / 2})`)
 
-    const renderSunburst = () =>
-      Sentry.startSpan(
-        { name: 'SunburstChart.renderSunburst' },
-        (renderSunburstSpan) => {
-          const nodesToRender = selectedNode
-            .descendants()
-            .slice(1)
-            .filter((d) => d.depth <= selectedNode.depth + 2)
+    const renderSunburst = Sentry.startSpan(
+      { name: 'SunburstChart.renderSunburst' },
+      (renderSunburstSpan) => {
+        const drawArc = createDrawArcFunction(renderSunburstSpan)
+        const color = createColorFunction(renderSunburstSpan)
+        const nodesToRender = selectedNode
+          .descendants()
+          .slice(1)
+          .filter((d) => d.depth <= selectedNode.depth + 2)
 
-          const drawArc = createDrawArcFunction(renderSunburstSpan)
-          const color = createColorFunction(renderSunburstSpan)
+        // Renders an arc per data point in the correct location. (Pieces of the circle that add up to a circular graph)
+        const path = Sentry.startSpan(
+          { name: 'SunburstChart.renderArcs', parentSpan: renderSunburstSpan },
+          () =>
+            g
+              .append('g')
+              .selectAll('path')
+              .data(nodesToRender)
+              .join('path')
+              .attr('fill', (d) => color(d?.data?.value || 0))
+              // If data point is a file fade the background color a bit.
+              .attr('fill-opacity', (d) => (d.children ? 1 : 0.6))
+              .attr('pointer-events', () => 'auto')
+              .attr('d', (d) => drawArc(d.current))
+        )
+        // Events for folders
+        path
+          .filter((d) => d.children)
+          .style('cursor', 'pointer')
+          .on('click', clickedFolder)
+          .on('mouseover', function (_event, p) {
+            select(this).attr('fill-opacity', 0.6)
+            reactHoverCallback({ target: p, type: 'folder' })
+          })
+          .on('mouseout', function (_event, _node) {
+            select(this).attr('fill-opacity', 1)
+          })
 
-          // Renders an arc per data point in the correct location. (Pieces of the circle that add up to a circular graph)
-          const path = Sentry.startSpan(
-            {
-              name: 'SunburstChart.renderArcs',
-              parentSpan: renderSunburstSpan,
-            },
-            () =>
-              g
-                .append('g')
-                .selectAll('path')
-                .data(nodesToRender)
-                .join('path')
-                .attr('fill', (d) => color(d?.data?.value || 0))
-                // If data point is a file fade the background color a bit.
-                .attr('fill-opacity', (d) => (d.children ? 1 : 0.6))
-                .attr('pointer-events', () => 'auto')
-                .attr('d', (d) => drawArc(d.current))
-          )
+        // Events for file
+        path
+          .filter((d) => !d.children)
+          .style('cursor', 'pointer')
+          .on('click', function (_event, node) {
+            reactClickCallback({ target: node, type: 'file' })
+          })
+          .on('mouseover', function (_event, node) {
+            select(this).attr('fill-opacity', 0.6)
+            reactHoverCallback({ target: node, type: 'file' })
+          })
 
-          // Events for folders
-          path
-            .filter((d) => d.children)
-            .style('cursor', 'pointer')
-            .on('click', clickedFolder)
-            .on('mouseover', function (_event, p) {
-              select(this).attr('fill-opacity', 0.6)
-              reactHoverCallback({ target: p, type: 'folder' })
-            })
-            .on('mouseout', function (_event, _node) {
-              select(this).attr('fill-opacity', 1)
-            })
+        // Create a11y label / mouse hover tooltip
+        const formatTitle = (d) => {
+          const coverage = formatData(d.data.value)
+          const filePath = d
+            .ancestors()
+            .map((d) => d.data.name)
+            .reverse()
+            .join('/')
 
-          // Events for file
-          path
-            .filter((d) => !d.children)
-            .style('cursor', 'pointer')
-            .on('click', function (_event, node) {
-              reactClickCallback({ target: node, type: 'file' })
-            })
-            .on('mouseover', function (_event, node) {
-              select(this).attr('fill-opacity', 0.6)
-              reactHoverCallback({ target: node, type: 'file' })
-            })
+          return `${filePath}\n${coverage}% coverage`
+        }
 
-          // Create a11y label / mouse hover tooltip
-          const formatTitle = (d) => {
-            const coverage = formatData(d.data.value)
-            const filePath = d
+        path.append('title').text((d) => formatTitle(d))
+
+        // White circle in the middle. Act's as a "back"
+        g.append('circle')
+          .datum(selectedNode.parent)
+          .attr('r', radius)
+          .attr('class', 'fill-none')
+          .attr('fill', 'none')
+          .attr('pointer-events', 'all')
+          .attr('cursor', (d) => (d ? 'pointer' : 'default'))
+          .on('click', clickedFolder)
+          .on('mouseover', hoveredRoot)
+
+        g.append('text')
+          .datum(selectedNode.parent)
+          .text('..')
+          // if the parent exists (i.e. not root), show the text
+          .attr('fill-opacity', (d) => (d ? 1 : 0))
+          .attr('text-anchor', 'middle')
+          .attr('class', 'text-7xl fill-ds-gray-quinary select-none')
+          .attr('cursor', 'pointer')
+          .on('click', clickedFolder)
+          .on('mouseover', hoveredRoot)
+
+        function clickedFolder(_event, node) {
+          reactClickCallback({ target: node, type: 'folder' })
+          changeLocation(node)
+        }
+
+        function hoveredRoot(_event, node) {
+          if (previous) {
+            reactHoverCallback({ target: previous, type: 'folder' })
+            return
+          }
+          reactHoverCallback({ target: node, type: 'folder' })
+        }
+
+        function reactClickCallback({ target, type }) {
+          if (target?.ancestors) {
+            // Create a string from the root data down to the current item
+            const filePath = target
               .ancestors()
               .map((d) => d.data.name)
+              .slice(0, -1)
               .reverse()
               .join('/')
 
-            return `${filePath}\n${coverage}% coverage`
+            // callback to parent component with a path, the data node, and raw d3 data
+            // (just in case we need it for the second iteration to listen to location changes and direct to the correct folder.)
+            clickHandler.current({
+              path: filePath,
+              data: target.data,
+              target,
+              type,
+            })
           }
-
-          path.append('title').text((d) => formatTitle(d))
-
-          // White circle in the middle. Act's as a "back"
-          g.append('circle')
-            .datum(selectedNode.parent)
-            .attr('r', radius)
-            .attr('class', 'fill-none')
-            .attr('fill', 'none')
-            .attr('pointer-events', 'all')
-            .attr('cursor', (d) => (d ? 'pointer' : 'default'))
-            .on('click', clickedFolder)
-            .on('mouseover', hoveredRoot)
-
-          g.append('text')
-            .datum(selectedNode.parent)
-            .text('..')
-            // if the parent exists (i.e. not root), show the text
-            .attr('fill-opacity', (d) => (d ? 1 : 0))
-            .attr('text-anchor', 'middle')
-            .attr('class', 'text-7xl fill-ds-gray-quinary select-none')
-            .attr('cursor', 'pointer')
-            .on('click', clickedFolder)
-            .on('mouseover', hoveredRoot)
-
-          function clickedFolder(_event, node) {
-            reactClickCallback({ target: node, type: 'folder' })
-            changeLocation(node)
-          }
-
-          function hoveredRoot(_event, node) {
-            if (previous) {
-              reactHoverCallback({ target: previous, type: 'folder' })
-              return
-            }
-            reactHoverCallback({ target: node, type: 'folder' })
-          }
-
-          function reactClickCallback({ target, type }) {
-            if (target?.ancestors) {
-              // Create a string from the root data down to the current item
-              const filePath = target
-                .ancestors()
-                .map((d) => d.data.name)
-                .slice(0, -1)
-                .reverse()
-                .join('/')
-
-              // callback to parent component with a path, the data node, and raw d3 data
-              // (just in case we need it for the second iteration to listen to location changes and direct to the correct folder.)
-              clickHandler.current({
-                path: filePath,
-                data: target.data,
-                target,
-                type,
-              })
-            }
-          }
-
-          function reactHoverCallback({ target, type }) {
-            if (target?.ancestors) {
-              // Create a string from the root data down to the current item
-              const filePath = target
-                .ancestors()
-                .map((d) => d.data.name)
-                .slice(0, -1)
-                .reverse()
-                .join('/')
-
-              // callback to parent component with a path, the data node, and raw d3 data
-              // (just in case we need it for the second iteration to listen to location changes and direct to the correct folder.)
-              hoverHandler.current({
-                path: filePath,
-                data: target.data,
-                target,
-                type,
-              })
-            }
-          }
-
-          const changeLocation = (node) =>
-            Sentry.startSpan(
-              {
-                name: 'SunburstChart.changeLocation',
-                parentSpan: renderSunburstSpan,
-              },
-              () => {
-                // Because you can move two layers at a time previous !== parent
-                previous = node
-
-                if (node) {
-                  // Update the selected node
-                  setSelectedNode(
-                    node.each((d) => {
-                      // determine x0 and y0
-                      const x0Min = Math.min(
-                        1,
-                        (d.x0 - node.x0) / (node.x1 - node.x0)
-                      )
-                      const x0 = Math.max(0, x0Min) * 2 * Math.PI
-                      const y0 = Math.max(0, d.y0 - node.depth)
-
-                      // determine x1 and y1
-                      const x1Min = Math.min(
-                        1,
-                        (d.x1 - node.x0) / (node.x1 - node.x0)
-                      )
-                      const x1 = Math.max(0, x1Min) * 2 * Math.PI
-                      const y1 = Math.max(0, d.y1 - node.depth)
-
-                      // update the cords for the node
-                      d.current = { x0, y0, x1, y1 }
-                    })
-                  )
-                }
-              }
-            )
         }
-      )
+
+        function reactHoverCallback({ target, type }) {
+          if (target?.ancestors) {
+            // Create a string from the root data down to the current item
+            const filePath = target
+              .ancestors()
+              .map((d) => d.data.name)
+              .slice(0, -1)
+              .reverse()
+              .join('/')
+
+            // callback to parent component with a path, the data node, and raw d3 data
+            // (just in case we need it for the second iteration to listen to location changes and direct to the correct folder.)
+            hoverHandler.current({
+              path: filePath,
+              data: target.data,
+              target,
+              type,
+            })
+          }
+        }
+
+        const changeLocation = Sentry.startSpan(
+          {
+            name: 'SunburstChart.handleArcsUpdate',
+            parentSpan: renderSunburstSpan,
+          },
+          (node) => {
+            // Because you can move two layers at a time previous !== parent
+            previous = node
+
+            if (node) {
+              // Update the selected node
+              setSelectedNode(
+                node.each((d) => {
+                  // determine x0 and y0
+                  const x0Min = Math.min(
+                    1,
+                    (d.x0 - node.x0) / (node.x1 - node.x0)
+                  )
+                  const x0 = Math.max(0, x0Min) * 2 * Math.PI
+                  const y0 = Math.max(0, d.y0 - node.depth)
+
+                  // determine x1 and y1
+                  const x1Min = Math.min(
+                    1,
+                    (d.x1 - node.x0) / (node.x1 - node.x0)
+                  )
+                  const x1 = Math.max(0, x1Min) * 2 * Math.PI
+                  const y1 = Math.max(0, d.y1 - node.depth)
+
+                  // update the cords for the node
+                  d.current = { x0, y0, x1, y1 }
+                })
+              )
+            }
+          }
+        )
+      }
+    )
 
     renderSunburst()
 

--- a/src/ui/SunburstChart/SunburstChart.jsx
+++ b/src/ui/SunburstChart/SunburstChart.jsx
@@ -67,24 +67,26 @@ function SunburstChart({
     const radius = width / 6
 
     // Creates a function for creating arcs representing files and folders.
-    const drawArc = Sentry.startSpan({ name: 'SunburstChart.drawArc' }, () => {
-      return arc()
-        .startAngle((d) => d.x0)
-        .endAngle((d) => d.x1)
-        .padAngle((d) => Math.min((d.x1 - d.x0) / 2, 0.005))
-        .padRadius(radius * 1.5)
-        .innerRadius((d) => d.y0 * radius)
-        .outerRadius((d) => Math.max(d.y0 * radius, d.y1 * radius - 1))
-    })
+    const createDrawArcFunction = (parentSpan) =>
+      Sentry.startSpan({ name: 'SunburstChart.drawArc', parentSpan }, () => {
+        return arc()
+          .startAngle((d) => d.x0)
+          .endAngle((d) => d.x1)
+          .padAngle((d) => Math.min((d.x1 - d.x0) / 2, 0.005))
+          .padRadius(radius * 1.5)
+          .innerRadius((d) => d.y0 * radius)
+          .outerRadius((d) => Math.max(d.y0 * radius, d.y1 * radius - 1))
+      })
 
     // A color function you can pass a number from 0-100 to and get a color back from the specified color range
     // Ex color(10.4)
-    const color = Sentry.startSpan({ name: 'SunburstChart.color' }, () => {
-      return scaleSequential()
-        .domain([colorDomainMin, colorDomainMax])
-        .interpolator(colorRange)
-        .clamp(true)
-    })
+    const createColorFunction = (parentSpan) =>
+      Sentry.startSpan({ name: 'SunburstChart.color', parentSpan }, () => {
+        return scaleSequential()
+          .domain([colorDomainMin, colorDomainMax])
+          .interpolator(colorRange)
+          .clamp(true)
+      })
 
     // Tracks previous location for rendering .. in the breadcrumb.
     let previous
@@ -97,167 +99,194 @@ function SunburstChart({
       .append('g')
       .attr('transform', `translate(${width / 2},${width / 2})`)
 
-    function renderArcs() {
-      const nodesToRender = selectedNode
-        .descendants()
-        .slice(1)
-        .filter((d) => d.depth <= selectedNode.depth + 2)
+    const renderSunburst = () =>
+      Sentry.startSpan(
+        { name: 'SunburstChart.renderSunburst' },
+        (renderSunburstSpan) => {
+          const nodesToRender = selectedNode
+            .descendants()
+            .slice(1)
+            .filter((d) => d.depth <= selectedNode.depth + 2)
 
-      // Renders an arc per data point in the correct location. (Pieces of the circle that add up to a circular graph)
-      const path = g
-        .append('g')
-        .selectAll('path')
-        .data(nodesToRender)
-        .join('path')
-        .attr('fill', (d) => color(d?.data?.value || 0))
-        // If data point is a file fade the background color a bit.
-        .attr('fill-opacity', (d) => (d.children ? 1 : 0.6))
-        .attr('pointer-events', () => 'auto')
-        .attr('d', (d) => drawArc(d.current))
+          const drawArc = createDrawArcFunction(renderSunburstSpan)
+          const color = createColorFunction(renderSunburstSpan)
 
-      // Events for folders
-      path
-        .filter((d) => d.children)
-        .style('cursor', 'pointer')
-        .on('click', clickedFolder)
-        .on('mouseover', function (_event, p) {
-          select(this).attr('fill-opacity', 0.6)
-          reactHoverCallback({ target: p, type: 'folder' })
-        })
-        .on('mouseout', function (_event, _node) {
-          select(this).attr('fill-opacity', 1)
-        })
-
-      // Events for file
-      path
-        .filter((d) => !d.children)
-        .style('cursor', 'pointer')
-        .on('click', function (_event, node) {
-          reactClickCallback({ target: node, type: 'file' })
-        })
-        .on('mouseover', function (_event, node) {
-          select(this).attr('fill-opacity', 0.6)
-          reactHoverCallback({ target: node, type: 'file' })
-        })
-
-      // Create a11y label / mouse hover tooltip
-      const formatTitle = (d) => {
-        const coverage = formatData(d.data.value)
-        const filePath = d
-          .ancestors()
-          .map((d) => d.data.name)
-          .reverse()
-          .join('/')
-
-        return `${filePath}\n${coverage}% coverage`
-      }
-
-      path.append('title').text((d) => formatTitle(d))
-
-      // White circle in the middle. Act's as a "back"
-      g.append('circle')
-        .datum(selectedNode.parent)
-        .attr('r', radius)
-        .attr('class', 'fill-none')
-        .attr('fill', 'none')
-        .attr('pointer-events', 'all')
-        .attr('cursor', (d) => (d ? 'pointer' : 'default'))
-        .on('click', clickedFolder)
-        .on('mouseover', hoveredRoot)
-
-      g.append('text')
-        .datum(selectedNode.parent)
-        .text('..')
-        // if the parent exists (i.e. not root), show the text
-        .attr('fill-opacity', (d) => (d ? 1 : 0))
-        .attr('text-anchor', 'middle')
-        .attr('class', 'text-7xl fill-ds-gray-quinary select-none')
-        .attr('cursor', 'pointer')
-        .on('click', clickedFolder)
-        .on('mouseover', hoveredRoot)
-
-      function clickedFolder(_event, node) {
-        reactClickCallback({ target: node, type: 'folder' })
-        changeLocation(node)
-      }
-
-      function hoveredRoot(_event, node) {
-        if (previous) {
-          reactHoverCallback({ target: previous, type: 'folder' })
-          return
-        }
-        reactHoverCallback({ target: node, type: 'folder' })
-      }
-
-      function reactClickCallback({ target, type }) {
-        if (target?.ancestors) {
-          // Create a string from the root data down to the current item
-          const filePath = target
-            .ancestors()
-            .map((d) => d.data.name)
-            .slice(0, -1)
-            .reverse()
-            .join('/')
-
-          // callback to parent component with a path, the data node, and raw d3 data
-          // (just in case we need it for the second iteration to listen to location changes and direct to the correct folder.)
-          clickHandler.current({
-            path: filePath,
-            data: target.data,
-            target,
-            type,
-          })
-        }
-      }
-
-      function reactHoverCallback({ target, type }) {
-        if (target?.ancestors) {
-          // Create a string from the root data down to the current item
-          const filePath = target
-            .ancestors()
-            .map((d) => d.data.name)
-            .slice(0, -1)
-            .reverse()
-            .join('/')
-
-          // callback to parent component with a path, the data node, and raw d3 data
-          // (just in case we need it for the second iteration to listen to location changes and direct to the correct folder.)
-          hoverHandler.current({
-            path: filePath,
-            data: target.data,
-            target,
-            type,
-          })
-        }
-      }
-
-      function changeLocation(node) {
-        // Because you can move two layers at a time previous !== parent
-        previous = node
-
-        if (node) {
-          // Update the selected node
-          setSelectedNode(
-            node.each((d) => {
-              // determine x0 and y0
-              const x0Min = Math.min(1, (d.x0 - node.x0) / (node.x1 - node.x0))
-              const x0 = Math.max(0, x0Min) * 2 * Math.PI
-              const y0 = Math.max(0, d.y0 - node.depth)
-
-              // determine x1 and y1
-              const x1Min = Math.min(1, (d.x1 - node.x0) / (node.x1 - node.x0))
-              const x1 = Math.max(0, x1Min) * 2 * Math.PI
-              const y1 = Math.max(0, d.y1 - node.depth)
-
-              // update the cords for the node
-              d.current = { x0, y0, x1, y1 }
-            })
+          // Renders an arc per data point in the correct location. (Pieces of the circle that add up to a circular graph)
+          const path = Sentry.startSpan(
+            {
+              name: 'SunburstChart.renderArcs',
+              parentSpan: renderSunburstSpan,
+            },
+            () =>
+              g
+                .append('g')
+                .selectAll('path')
+                .data(nodesToRender)
+                .join('path')
+                .attr('fill', (d) => color(d?.data?.value || 0))
+                // If data point is a file fade the background color a bit.
+                .attr('fill-opacity', (d) => (d.children ? 1 : 0.6))
+                .attr('pointer-events', () => 'auto')
+                .attr('d', (d) => drawArc(d.current))
           )
-        }
-      }
-    }
 
-    renderArcs()
+          // Events for folders
+          path
+            .filter((d) => d.children)
+            .style('cursor', 'pointer')
+            .on('click', clickedFolder)
+            .on('mouseover', function (_event, p) {
+              select(this).attr('fill-opacity', 0.6)
+              reactHoverCallback({ target: p, type: 'folder' })
+            })
+            .on('mouseout', function (_event, _node) {
+              select(this).attr('fill-opacity', 1)
+            })
+
+          // Events for file
+          path
+            .filter((d) => !d.children)
+            .style('cursor', 'pointer')
+            .on('click', function (_event, node) {
+              reactClickCallback({ target: node, type: 'file' })
+            })
+            .on('mouseover', function (_event, node) {
+              select(this).attr('fill-opacity', 0.6)
+              reactHoverCallback({ target: node, type: 'file' })
+            })
+
+          // Create a11y label / mouse hover tooltip
+          const formatTitle = (d) => {
+            const coverage = formatData(d.data.value)
+            const filePath = d
+              .ancestors()
+              .map((d) => d.data.name)
+              .reverse()
+              .join('/')
+
+            return `${filePath}\n${coverage}% coverage`
+          }
+
+          path.append('title').text((d) => formatTitle(d))
+
+          // White circle in the middle. Act's as a "back"
+          g.append('circle')
+            .datum(selectedNode.parent)
+            .attr('r', radius)
+            .attr('class', 'fill-none')
+            .attr('fill', 'none')
+            .attr('pointer-events', 'all')
+            .attr('cursor', (d) => (d ? 'pointer' : 'default'))
+            .on('click', clickedFolder)
+            .on('mouseover', hoveredRoot)
+
+          g.append('text')
+            .datum(selectedNode.parent)
+            .text('..')
+            // if the parent exists (i.e. not root), show the text
+            .attr('fill-opacity', (d) => (d ? 1 : 0))
+            .attr('text-anchor', 'middle')
+            .attr('class', 'text-7xl fill-ds-gray-quinary select-none')
+            .attr('cursor', 'pointer')
+            .on('click', clickedFolder)
+            .on('mouseover', hoveredRoot)
+
+          function clickedFolder(_event, node) {
+            reactClickCallback({ target: node, type: 'folder' })
+            changeLocation(node)
+          }
+
+          function hoveredRoot(_event, node) {
+            if (previous) {
+              reactHoverCallback({ target: previous, type: 'folder' })
+              return
+            }
+            reactHoverCallback({ target: node, type: 'folder' })
+          }
+
+          function reactClickCallback({ target, type }) {
+            if (target?.ancestors) {
+              // Create a string from the root data down to the current item
+              const filePath = target
+                .ancestors()
+                .map((d) => d.data.name)
+                .slice(0, -1)
+                .reverse()
+                .join('/')
+
+              // callback to parent component with a path, the data node, and raw d3 data
+              // (just in case we need it for the second iteration to listen to location changes and direct to the correct folder.)
+              clickHandler.current({
+                path: filePath,
+                data: target.data,
+                target,
+                type,
+              })
+            }
+          }
+
+          function reactHoverCallback({ target, type }) {
+            if (target?.ancestors) {
+              // Create a string from the root data down to the current item
+              const filePath = target
+                .ancestors()
+                .map((d) => d.data.name)
+                .slice(0, -1)
+                .reverse()
+                .join('/')
+
+              // callback to parent component with a path, the data node, and raw d3 data
+              // (just in case we need it for the second iteration to listen to location changes and direct to the correct folder.)
+              hoverHandler.current({
+                path: filePath,
+                data: target.data,
+                target,
+                type,
+              })
+            }
+          }
+
+          const changeLocation = (node) =>
+            Sentry.startSpan(
+              {
+                name: 'SunburstChart.changeLocation',
+                parentSpan: renderSunburstSpan,
+              },
+              () => {
+                // Because you can move two layers at a time previous !== parent
+                previous = node
+
+                if (node) {
+                  // Update the selected node
+                  setSelectedNode(
+                    node.each((d) => {
+                      // determine x0 and y0
+                      const x0Min = Math.min(
+                        1,
+                        (d.x0 - node.x0) / (node.x1 - node.x0)
+                      )
+                      const x0 = Math.max(0, x0Min) * 2 * Math.PI
+                      const y0 = Math.max(0, d.y0 - node.depth)
+
+                      // determine x1 and y1
+                      const x1Min = Math.min(
+                        1,
+                        (d.x1 - node.x0) / (node.x1 - node.x0)
+                      )
+                      const x1 = Math.max(0, x1Min) * 2 * Math.PI
+                      const y1 = Math.max(0, d.y1 - node.depth)
+
+                      // update the cords for the node
+                      d.current = { x0, y0, x1, y1 }
+                    })
+                  )
+                }
+              }
+            )
+        }
+      )
+
+    renderSunburst()
 
     return () => {
       // On cleanup remove the root DOM generated by D3


### PR DESCRIPTION
# Description

The goal of this PR is to optimize the sunbursts performance overall and reduce the lagginess when viewing the coverage overview page. This was accomplished by changing the way that we render the sunburst. Previously we would render the entire tree structure of the repo, hiding elements that weren't currently visible. This lead to many performance issues as we were creating two elements per file in a repo. When users interacted with the sunburst, under the hood it was actually D3 updating the elements attributes overtime "animating" the transition.

With this refactor we have changed our rendering strategy, and how users interact with the sunburst:

**Initial render:**
1. Process and set root node
2. Set the root node as the selected node
3. Run effect
    1. Call `renderArcs`
        1.  Determine nodes to render
        2. Render two levels of arcs
        3. Set events for folders and files
        4. Format and append title
        5. Setup back circle and back text (i.e. `..`)
        6. Setup click event handlers

**On Click**
1. User clicks on a folder
    1. Update coordinates for selected node (i.e. directory)
    2. Set selected node to the clicked node with updated coordinates
2. Re-run effect
    1. Call `renderArcs`

One regression of this change is the removal of the animation with the sunburst, as the change to the render process doesn't support this. We may explore some potential solutions for bringing this back down the road, however for the time being we will be leaving it as is.

Closes: codecov/engineering-team#3382

# Notable Changes

- Remove work that is not required for processing initial dataset
- Move to storing selected node to React state
    - When user clicks on directory, set as selected node 
- Move D3 drawing into a render function