### PR TITLE
fix: Remove the default error for failed tests error banner

### DIFF
--- a/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/FailedTestsErrorBanner/FailedTestsErrorBanner.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/FailedTestsErrorBanner/FailedTestsErrorBanner.tsx
@@ -105,10 +105,7 @@ function FailedTestsErrorBanner() {
   })
 
   const { data } = useTestResultsTestSuites({ branch })
-  const latestUploadError = data?.latestUploadError ?? {
-    errorCode: ErrorCodeEnum.fileNotFoundInStorage,
-    errorMessage: 'File not found',
-  }
+  const latestUploadError = data?.latestUploadError
 
   if (!latestUploadError || branch === overview?.defaultBranch) {
     return null


### PR DESCRIPTION
# Description
We shouldn't have a default error for the banner 

# Link to Sample Entry

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.