### PR TITLE
fix: usePullCompareTotalsTeam parsing error

### DIFF
--- a/src/services/pull/usePullCompareTotalsTeam.tsx
+++ b/src/services/pull/usePullCompareTotalsTeam.tsx
@@ -25,7 +25,7 @@ const ImpactedFilesSchema = z.discriminatedUnion('__typename', [
         z.object({
           headName: z.string().nullable(),
           missesCount: z.number(),
-          patchCoverage: CoverageObjSchema,
+          patchCoverage: CoverageObjSchema.nullable(),
         })
       )
       .nullable(),


### PR DESCRIPTION
# Description

This PR updates the Zod schema for usePullCompareTotalsTeam to set the `patchCoverage` field to be nullable

Ticket: codecov/engineering-team#3385

# Notable Changes

- Set `patchCoverage` to be nullable