### PR TITLE
feat: Add redirect to App.tsx

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -147,6 +147,7 @@ const mockRepoContext = {
 const queryClient = new QueryClient({
   defaultOptions: { queries: { retry: false } },
 })
+
 const queryClientV5 = new QueryClientV5({
   defaultOptions: { queries: { retry: false } },
 })
@@ -642,20 +643,6 @@ describe('App', () => {
     })
   })
 
-  describe('user has setup action', () => {
-    it(`renders the setup action redirect page`, async () => {
-      mockedUseLocationParams.mockReturnValue({
-        params: { setup_action: 'install' },
-      })
-      setup({ hasLoggedInUser: true, hasSession: true })
-      render(<App />, { wrapper: wrapper(['/gh?setup_action=install']) })
-
-      await waitFor(() => expect(testLocation.pathname).toBe('/gh/codecov'))
-      const page = await screen.findByText(/OwnerPage/i)
-      expect(page).toBeInTheDocument()
-    })
-  })
-
   describe('user has session, not logged in', () => {
     it('redirects to session default', async () => {
       setup({ hasLoggedInUser: false, hasSession: true })
@@ -677,6 +664,39 @@ describe('App', () => {
       await waitFor(() =>
         expect(testLocation.pathname).toBe('/plan/cool-service/cool-guy')
       )
+    })
+  })
+
+  describe('user is logged in', () => {
+    describe('params have setup action', () => {
+      it('renders the setup action redirect page', async () => {
+        mockedUseLocationParams.mockReturnValue({
+          params: { setup_action: 'install' },
+        })
+        setup({ hasLoggedInUser: true, hasSession: true })
+        render(<App />, { wrapper: wrapper(['/gh?setup_action=install']) })
+
+        await waitFor(() => expect(testLocation.pathname).toBe('/gh/codecov'))
+        const page = await screen.findByText(/OwnerPage/i)
+        expect(page).toBeInTheDocument()
+      })
+    })
+
+    describe('params have to param', () => {
+      it('redirects to to param if it exists', async () => {
+        mockedUseLocationParams.mockReturnValue({
+          params: { to: '/gh/codecov/test-app/pull/123' },
+        })
+        setup({ hasLoggedInUser: true, hasSession: true })
+
+        render(<App />, { wrapper: wrapper(['/gh']) })
+
+        await waitFor(() => expect(testLocation.pathname).toBe('/gh'))
+
+        await waitFor(() =>
+          expect(testLocation.pathname).toBe('/gh/codecov/test-app/pull/123')
+        )
+      })
     })
   })
 })

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -697,6 +697,23 @@ describe('App', () => {
           expect(testLocation.pathname).toBe('/gh/codecov/test-app/pull/123')
         )
       })
+
+      it('redirects home if unknown to param', async () => {
+        mockedUseLocationParams
+          // on initial page visit the to param should be set
+          .mockReturnValueOnce({
+            params: { to: '/gh/path/does/not/exist' },
+          })
+          // after redirecting the param should be removed
+          .mockReturnValue({ params: {} })
+        setup({ hasLoggedInUser: true, hasSession: true })
+
+        render(<App />, {
+          wrapper: wrapper(['/gh?to=/gh/path/does/not/exist']),
+        })
+
+        await waitFor(() => expect(testLocation.pathname).toBe('/gh/codecov'))
+      })
     })
   })
 })

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,5 @@
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools'
+import qs from 'qs'
 import { lazy } from 'react'
 import { Toaster } from 'react-hot-toast'
 import { Redirect, Switch, useParams } from 'react-router-dom'
@@ -47,23 +48,36 @@ const HomePageRedirect = () => {
   let redirectURL = '/login'
 
   if (internalUser && internalUser.owners) {
-    redirectURL = `/${internalUser.owners[0]?.service}/${internalUser.owners[0]?.username}`
+    const service = internalUser.owners[0]?.service
+    const username = internalUser.owners[0]?.username
+    redirectURL = `/${service}/${username}`
     if (to === 'plan') {
       redirectURL = '/plan' + redirectURL
     }
   }
 
+  // create a query params object to be added to the redirect URL
+  const queryParams: Record<string, string> = {}
+
+  // only redirect if we have a provider and it's a valid provider and the user is logged in
   if (provider && isProvider(provider) && currentUser) {
+    // set the redirect URL to the owner's default org or the user's username
     const defaultOrg =
       currentUser.owner?.defaultOrgUsername ?? currentUser.user?.username
     redirectURL = `/${provider}/${defaultOrg}`
 
     if (setupAction) {
-      redirectURL += `?setup_action=${setupAction}`
+      // eslint-disable-next-line camelcase
+      queryParams.setup_action = setupAction
+    }
+    // ensure that we only redirect if the user is not setting up the action
+    else if (to) {
+      redirectURL = to
     }
   }
 
-  return <Redirect to={redirectURL} />
+  const queryString = qs.stringify(queryParams)
+  return <Redirect to={`${redirectURL}?${queryString}`} />
 }
 
 const MainAppRoutes = () => (

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -70,8 +70,8 @@ const HomePageRedirect = () => {
       // eslint-disable-next-line camelcase
       queryParams.setup_action = setupAction
     }
-    // ensure that we only redirect if the user is not setting up the action
-    else if (to) {
+    // ensure that we only redirect if the user is not setting up the action and we don't want to redirect if we're already redirecting to the plan page
+    else if (to && to !== 'plan') {
       redirectURL = to
     }
   }


### PR DESCRIPTION
# Description

This PR updates the `HomePageRedirect` functionality to redirect to the `to` parameter to whatever value it is set to, other than `plan`, and will not redirect if the `setup_action` param is set.

Closes codecov/engineering-team#3450

# Notable Changes

- Conditionally redirect in the `HomePageRedirect` if `to` param is set
- Add in tests