### PR TITLE
fix: useInfiniteUser schema parsing error

### DIFF
--- a/src/pages/AccountSettings/tabs/Admin/ManageAdminCard/AdminTable/AdminTable.tsx
+++ b/src/pages/AccountSettings/tabs/Admin/ManageAdminCard/AdminTable/AdminTable.tsx
@@ -87,9 +87,7 @@ export default function AdminTable() {
           ordering: getOrderingDirection(sorting),
         },
       },
-      {
-        suspense: false,
-      }
+      { suspense: false }
     )
   const { mutate, isLoading: isUpdatingUser } = useUpdateUser({
     provider,

--- a/src/pages/MembersPage/MembersList/MembersTable/MembersTable.tsx
+++ b/src/pages/MembersPage/MembersList/MembersTable/MembersTable.tsx
@@ -173,9 +173,7 @@ export default function MembersTable({
           ordering: getOrderingDirection(sorting),
         },
       },
-      {
-        suspense: false,
-      }
+      { suspense: false }
     )
 
   useEffect(() => {

--- a/src/services/users/useInfiniteUser.test.tsx
+++ b/src/services/users/useInfiniteUser.test.tsx
@@ -88,8 +88,8 @@ describe('useInfiniteUser', () => {
         { wrapper }
       )
 
-      await waitFor(() => result.current.isFetching)
-      await waitFor(() => !result.current.isFetching)
+      await waitFor(() => result.current.isLoading)
+      await waitFor(() => !result.current.isLoading)
 
       await waitFor(() =>
         expect(result.current.data).toStrictEqual([
@@ -121,13 +121,13 @@ describe('useInfiniteUser', () => {
         { wrapper }
       )
 
-      await waitFor(() => result.current.isFetching)
-      await waitFor(() => !result.current.isFetching)
+      await waitFor(() => result.current.isLoading)
+      await waitFor(() => !result.current.isLoading)
 
       result.current.fetchNextPage()
 
-      await waitFor(() => result.current.isFetching)
-      await waitFor(() => !result.current.isFetching)
+      await waitFor(() => result.current.isLoading)
+      await waitFor(() => !result.current.isLoading)
 
       await waitFor(() =>
         expect(result.current.data).toStrictEqual([

--- a/src/services/users/useInfiniteUser.tsx
+++ b/src/services/users/useInfiniteUser.tsx
@@ -18,13 +18,15 @@ export const MemberSchema = z.object({
 
 export type Member = z.infer<typeof MemberSchema>
 
-export const MemberListSchema = z.object({
-  count: z.number(),
-  next: z.string().nullable(),
-  previous: z.string().nullable(),
-  results: z.array(MemberSchema),
-  totalPages: z.number(),
-})
+export const MemberListSchema = z
+  .object({
+    count: z.number(),
+    next: z.string().nullable(),
+    previous: z.string().nullable(),
+    results: z.array(MemberSchema),
+    totalPages: z.number(),
+  })
+  .nullable()
 
 export type MemberList = z.infer<typeof MemberListSchema>
 
@@ -47,7 +49,15 @@ export const useInfiniteUsers = (
     retry?: boolean
   }
 ) => {
-  const { data, ...rest } = useInfiniteQuery({
+  const {
+    data,
+    error,
+    isLoading,
+    isError,
+    hasNextPage,
+    isFetchingNextPage,
+    fetchNextPage,
+  } = useInfiniteQuery({
     queryKey: ['users', provider, owner, query],
     queryFn: ({ pageParam = 1, signal }) =>
       Api.get({
@@ -75,7 +85,7 @@ export const useInfiniteUsers = (
     select: (data) => {
       return {
         pages: data.pages,
-        results: data.pages.flatMap((page) => page.results),
+        results: data.pages.flatMap((page) => page?.results ?? []),
         pageParams: data.pageParams,
       }
     },
@@ -90,7 +100,15 @@ export const useInfiniteUsers = (
   })
 
   return {
-    data: useMemo(() => data?.pages.flatMap((page) => page.results), [data]),
-    ...rest,
+    data: useMemo(
+      () => data?.pages.flatMap((page) => page?.results ?? []),
+      [data]
+    ),
+    error,
+    isLoading,
+    isError,
+    hasNextPage,
+    isFetchingNextPage,
+    fetchNextPage,
   }
 }


### PR DESCRIPTION
# Description

Should resolve this [Sentry issue](https://codecov.sentry.io/issues/6333058034/?project=5514400&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=issue-stream&sort=date&statsPeriod=14d&stream_index=3) from occurring again.

Ticket: codecov/engineering-team#3385

# Notable Changes

- Make field nullable
- Only extract values that are being used, as this is optimal for reducing the amount of things being tracked by Query, reducing the chance of an extra re-render