### PR TITLE
feat: Update signIn paths to append extra redirect

### DIFF
--- a/src/pages/EnterpriseLandingPage/ProviderCard/ProviderCard.test.tsx
+++ b/src/pages/EnterpriseLandingPage/ProviderCard/ProviderCard.test.tsx
@@ -1,148 +1,140 @@
 import { render, screen } from '@testing-library/react'
+import qs from 'qs'
 import { MemoryRouter, Route } from 'react-router-dom'
 
+import config from 'config'
+
+import { EnterpriseLoginProviders } from 'services/config/LoginProvidersQueryOpts'
 import { ThemeContextProvider } from 'shared/ThemeContext'
 import { LoginProvidersEnum } from 'shared/utils/loginProviders'
 
-import ProviderCard, { InternalProviderButton } from './ProviderCard'
+import ProviderCard from './ProviderCard'
 
-const wrapper: React.FC<React.PropsWithChildren> = ({ children }) => (
-  <ThemeContextProvider>
-    <MemoryRouter initialEntries={['/']}>
-      <Route path="/">{children}</Route>
-    </MemoryRouter>
-  </ThemeContextProvider>
-)
+vi.mock('config')
+config.API_URL = 'secret-api-url'
+
+const { location } = window
+beforeEach(() => {
+  Object.defineProperty(window, 'location', {
+    value: { ...location, protocol: 'http:', host: 'secret-api-url' },
+  })
+})
+
+afterEach(() => {
+  Object.defineProperty(window, 'location', { value: location })
+})
+
+const wrapper =
+  (initialEntries = '/'): React.FC<React.PropsWithChildren> =>
+  ({ children }) => (
+    <ThemeContextProvider>
+      <MemoryRouter initialEntries={[initialEntries]}>
+        <Route path="/">{children}</Route>
+      </MemoryRouter>
+    </ThemeContextProvider>
+  )
+
+type LoginProviders = typeof LoginProvidersEnum
+
+type Provider = {
+  [K in keyof LoginProviders]: LoginProviders[K]
+}[keyof LoginProviders]
+
+interface Case {
+  provider: Provider
+  name: string
+  providers: Array<EnterpriseLoginProviders>
+  to: string
+}
+
+const cases: Case[] = [
+  {
+    provider: LoginProvidersEnum.BITBUCKET,
+    name: LoginProvidersEnum.BITBUCKET.name,
+    providers: ['BITBUCKET'],
+    to: '/login/bb',
+  },
+  {
+    provider: LoginProvidersEnum.BITBUCKET,
+    name: LoginProvidersEnum.BITBUCKET.selfHostedName,
+    providers: ['BITBUCKET_SERVER'],
+    to: '/login/bbs',
+  },
+  {
+    provider: LoginProvidersEnum.GITHUB,
+    name: LoginProvidersEnum.GITHUB.name,
+    providers: ['GITHUB'],
+    to: '/login/gh',
+  },
+  {
+    provider: LoginProvidersEnum.GITHUB,
+    name: LoginProvidersEnum.GITHUB.selfHostedName,
+    providers: ['GITHUB_ENTERPRISE'],
+    to: '/login/ghe',
+  },
+  {
+    provider: LoginProvidersEnum.GITLAB,
+    name: LoginProvidersEnum.GITLAB.name,
+    providers: ['GITLAB'],
+    to: '/login/gl',
+  },
+  {
+    provider: LoginProvidersEnum.GITLAB,
+    name: LoginProvidersEnum.GITLAB.selfHostedName,
+    providers: ['GITLAB_ENTERPRISE'],
+    to: '/login/gle',
+  },
+  {
+    provider: LoginProvidersEnum.OKTA,
+    name: LoginProvidersEnum.OKTA.name,
+    providers: ['OKTA'],
+    to: '/login/okta',
+  },
+]
 
 describe('ProviderCard', () => {
-  describe('Bitbucket', () => {
-    describe('when system is configured with Bitbucket', () => {
-      it('renders external login button', () => {
-        render(
-          <ProviderCard
-            provider={LoginProvidersEnum.BITBUCKET}
-            providers={['BITBUCKET']}
-          />,
-          { wrapper }
-        )
+  describe.each(cases)('$name', ({ provider, providers, to, name }) => {
+    describe('when system is configured with $providers.[0]', () => {
+      it('renders the correct login button', () => {
+        render(<ProviderCard provider={provider} providers={providers} />, {
+          wrapper: wrapper(),
+        })
 
         const element = screen.getByRole('link', {
-          name: 'Login via Bitbucket',
+          name: `Login via ${name}`,
         })
         expect(element).toBeInTheDocument()
-        expect(element).toHaveAttribute('href', '/login/bb')
-      })
-
-      it('renders self hosted login link', () => {
-        render(
-          <ProviderCard
-            provider={LoginProvidersEnum.BITBUCKET}
-            providers={['BITBUCKET_SERVER']}
-          />,
-          { wrapper }
-        )
-
-        const element = screen.getByRole('link', {
-          name: 'Login via Bitbucket Server',
-        })
-        expect(element).toBeInTheDocument()
-        expect(element).toHaveAttribute('href', '/login/bbs')
+        expect(element).toHaveAttribute('href', `secret-api-url${to}`)
       })
     })
   })
 
-  describe('GitHub', () => {
-    describe('when system is configured with GitHub', () => {
-      it('renders external login button', () => {
-        render(
-          <ProviderCard
-            provider={LoginProvidersEnum.GITHUB}
-            providers={['GITHUB']}
-          />,
-          { wrapper }
-        )
-
-        const element = screen.getByRole('link', { name: 'Login via GitHub' })
-        expect(element).toBeInTheDocument()
-        expect(element).toHaveAttribute('href', '/login/gh')
-      })
-
-      it('renders self hosted login link', () => {
-        render(
-          <ProviderCard
-            provider={LoginProvidersEnum.GITHUB}
-            providers={['GITHUB_ENTERPRISE']}
-          />,
-          { wrapper }
-        )
-
-        const element = screen.getByRole('link', {
-          name: 'Login via GitHub Enterprise',
-        })
-        expect(element).toBeInTheDocument()
-        expect(element).toHaveAttribute('href', '/login/ghe')
-      })
-    })
-  })
-
-  describe('GitLab', () => {
-    describe('when system is configured with GitLab', () => {
-      it('renders external login button', () => {
-        render(
-          <ProviderCard
-            provider={LoginProvidersEnum.GITLAB}
-            providers={['GITLAB']}
-          />,
-          { wrapper }
-        )
-
-        const element = screen.getByRole('link', { name: 'Login via GitLab' })
-        expect(element).toBeInTheDocument()
-        expect(element).toHaveAttribute('href', '/login/gl')
-      })
-
-      it('renders self hosted login link', () => {
-        render(
-          <ProviderCard
-            provider={LoginProvidersEnum.GITLAB}
-            providers={['GITLAB_ENTERPRISE']}
-          />,
-          { wrapper }
-        )
-
-        const element = screen.getByRole('link', {
-          name: 'Login via GitLab CE/EE',
-        })
-        expect(element).toBeInTheDocument()
-        expect(element).toHaveAttribute('href', '/login/gle')
-      })
-    })
-  })
-
-  describe('Okta', () => {
-    describe('when system is configured with Okta', () => {
-      it('renders external login button', () => {
-        render(
-          <ProviderCard
-            provider={LoginProvidersEnum.OKTA}
-            providers={['OKTA']}
-          />,
-          { wrapper }
-        )
-
-        const element = screen.getByRole('link', { name: 'Login via Okta' })
-        expect(element).toBeInTheDocument()
-        expect(element).toHaveAttribute('href', '/login/okta')
-      })
-    })
-
-    it('InternalProviderButton returns null', () => {
-      const { container } = render(
-        <InternalProviderButton provider={LoginProvidersEnum.OKTA} />,
-        { wrapper }
+  describe('when to param is provided', () => {
+    it('appends redirect param to the login url', () => {
+      const queryString = qs.stringify(
+        { to: '/gh/codecov/gazebo' },
+        { addQueryPrefix: true }
+      )
+      render(
+        <ProviderCard
+          provider={LoginProvidersEnum.BITBUCKET}
+          providers={['BITBUCKET']}
+        />,
+        { wrapper: wrapper(`/login/bb${queryString}`) }
       )
 
-      expect(container).toBeEmptyDOMElement()
+      const redirectURL = qs.stringify(
+        { to: `http://secret-api-url/bb${queryString}` },
+        { addQueryPrefix: true }
+      )
+      const element = screen.getByRole('link', {
+        name: `Login via Bitbucket`,
+      })
+      expect(element).toBeInTheDocument()
+      expect(element).toHaveAttribute(
+        'href',
+        `secret-api-url/login/bb${redirectURL}`
+      )
     })
   })
 })

--- a/src/pages/LoginPage/LoginButton.jsx
+++ b/src/pages/LoginPage/LoginButton.jsx
@@ -1,6 +1,8 @@
 import PropTypes from 'prop-types'
+import qs from 'qs'
 
 import { eventTracker } from 'services/events/events'
+import { useLocationParams } from 'services/navigation/useLocationParams'
 import { useNavLinks } from 'services/navigation/useNavLinks'
 import { Theme, useThemeContext } from 'shared/ThemeContext'
 import {
@@ -13,9 +15,12 @@ function LoginButton({ provider }) {
   const { theme } = useThemeContext()
 
   const isDarkMode = theme === Theme.DARK
-  const to = `${window.location.protocol}//${window.location.host}/${provider}`
   const providerName = loginProviderToName(provider)
   const providerImage = loginProviderImage(provider, isDarkMode)
+
+  const { params } = useLocationParams()
+  const queryString = qs.stringify({ to: params?.to }, { addQueryPrefix: true })
+  const to = `${window.location.protocol}//${window.location.host}/${provider}${queryString}`
 
   return (
     <a

--- a/src/pages/SyncProviderPage/SyncButton.tsx
+++ b/src/pages/SyncProviderPage/SyncButton.tsx
@@ -1,4 +1,7 @@
+import qs from 'qs'
+
 import { eventTracker } from 'services/events/events'
+import { useLocationParams } from 'services/navigation/useLocationParams'
 import { useNavLinks } from 'services/navigation/useNavLinks'
 import { Provider } from 'shared/api/helpers'
 import { loginProviderImage } from 'shared/utils/loginProviders'
@@ -10,8 +13,13 @@ interface SyncButtonProps {
 
 const SyncButton: React.FC<SyncButtonProps> = ({ provider }) => {
   const { signIn } = useNavLinks()
-  const to = `${window.location.protocol}//${window.location.host}/${provider}`
+  const { params } = useLocationParams()
+
   const providerName = providerToName(provider)
+  // @ts-expect-error useLocationParams needs to be typed
+  const queryString = qs.stringify({ to: params?.to }, { addQueryPrefix: true })
+  const to = `${window.location.protocol}//${window.location.host}/${provider}${queryString}`
+
   return (
     <div className="flex h-14 items-center rounded-sm border border-ds-gray-quaternary bg-ds-gray-primary text-left shadow">
       <a


### PR DESCRIPTION
# Description

This PR updates the various uses of `signIn` in Gazebo, that will conditionally append a secondary `to` parameter that will after the user is redirect back to Codecov will redirect the user to that URL.

Closes: codecov/engineering-team#3458

# Notable Changes

- Update `ProviderButton`
- Update `LoginButton`
- Update `SyncButton`
- Update tests