### PR TITLE
docs: Set fetch-depth to 2 in our GHA examples

### DIFF
--- a/src/pages/RepoPage/CoverageOnboarding/UseFrameworkInstructions.tsx
+++ b/src/pages/RepoPage/CoverageOnboarding/UseFrameworkInstructions.tsx
@@ -32,7 +32,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          fetch-depth: 2
 
       - name: Set up Node
         uses: actions/setup-node@v4
@@ -70,7 +70,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          fetch-depth: 2
 
       - name: Set up Node
         uses: actions/setup-node@v4
@@ -108,7 +108,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          fetch-depth: 2
 
       - name: Set up Python
         uses: actions/setup-python@v4
@@ -146,7 +146,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          fetch-depth: 2
 
       - name: Set up Go
         uses: actions/setup-go@v5

--- a/src/pages/RepoPage/FailedTestsTab/GitHubActions/GitHubActions.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/GitHubActions/GitHubActions.tsx
@@ -37,7 +37,7 @@ const JobsScript = `jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          fetch-depth: 2
       - name: Set up Python 3.11
         uses: actions/setup-python@v3
         with:


### PR DESCRIPTION
This PR sets all fetch-depths to 2 in our example github actions. This is something we say you need to do in our docs, but it wasn't reflected here.
