### PR TITLE
feat: Update login pageName to include redirect

### DIFF
--- a/src/layouts/Header/components/GuestHeader/GuestHeader.test.tsx
+++ b/src/layouts/Header/components/GuestHeader/GuestHeader.test.tsx
@@ -1,5 +1,6 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { render, screen } from '@testing-library/react'
+import qs from 'qs'
 import React from 'react'
 import { MemoryRouter, Route } from 'react-router-dom'
 
@@ -47,6 +48,7 @@ describe('GuestHeader', () => {
         expect(link).toHaveAttribute('href', 'https://about.codecov.io')
       })
     })
+
     describe('why test code link', () => {
       it('directs user to what is code coverage page', async () => {
         render(<GuestHeader />, {
@@ -61,6 +63,7 @@ describe('GuestHeader', () => {
         )
       })
     })
+
     describe('Get a demo link', () => {
       it('directs user to demo page', async () => {
         render(<GuestHeader />, {
@@ -72,6 +75,7 @@ describe('GuestHeader', () => {
         expect(link).toHaveAttribute('href', 'https://about.codecov.io/demo')
       })
     })
+
     describe('pricing link', () => {
       it('directs user to pricing page', async () => {
         render(<GuestHeader />, {
@@ -83,17 +87,20 @@ describe('GuestHeader', () => {
         expect(link).toHaveAttribute('href', 'https://about.codecov.io/pricing')
       })
     })
+
     describe('login link', () => {
-      it('directs user to login page', async () => {
+      it('directs user to login page with redirect to path', async () => {
         render(<GuestHeader />, {
           wrapper,
         })
 
+        const queryString = qs.stringify({ to: '/gh' })
         const link = await screen.findByTestId('login-link')
         expect(link).toBeInTheDocument()
-        expect(link).toHaveAttribute('href', '/login')
+        expect(link).toHaveAttribute('href', `/login?${queryString}`)
       })
     })
+
     describe('start trial link', () => {
       it('directs user to start trial page', async () => {
         render(<GuestHeader />, {
@@ -128,18 +135,21 @@ describe('GuestHeader', () => {
       const pricing = screen.queryByText('Pricing')
       expect(pricing).not.toBeInTheDocument()
     })
+
     it('does not render start free trial link', () => {
       render(<GuestHeader />, { wrapper })
 
       const startFreeTrial = screen.queryByText('Start Free Trial')
       expect(startFreeTrial).not.toBeInTheDocument()
     })
-    it('renders a login button', () => {
+
+    it('renders a login button with redirect to path', () => {
       render(<GuestHeader />, { wrapper })
 
+      const queryString = qs.stringify({ to: '/gh' })
       const login = screen.queryByText('Login')
       expect(login).toBeInTheDocument()
-      expect(login).toHaveAttribute('href', '/')
+      expect(login).toHaveAttribute('href', `/?${queryString}`)
     })
   })
 })

--- a/src/layouts/Header/components/GuestHeader/GuestHeader.tsx
+++ b/src/layouts/Header/components/GuestHeader/GuestHeader.tsx
@@ -1,3 +1,5 @@
+import { useLocation } from 'react-router'
+
 import config from 'config'
 
 import { CodecovIcon } from 'assets/svg/codecov'
@@ -26,6 +28,7 @@ const LogoButton = () => {
 
 function GuestHeader() {
   const isSelfHosted = config.IS_SELF_HOSTED
+  const location = useLocation()
 
   return (
     <div className="border-b">
@@ -69,7 +72,7 @@ function GuestHeader() {
           <ThemeToggle />
           {isSelfHosted ? (
             <Button
-              to={{ pageName: 'login' }}
+              to={{ pageName: 'login', options: { to: location.pathname } }}
               variant="primary"
               activeClassName="hidden"
               exact={true}
@@ -86,7 +89,7 @@ function GuestHeader() {
               className="mx-2 flex items-center justify-between gap-4 md:mx-0"
             >
               <A
-                to={{ pageName: 'login' }}
+                to={{ pageName: 'login', options: { to: location.pathname } }}
                 variant="guestHeader"
                 activeClassName="hidden"
                 isExternal={false}

--- a/src/pages/CommitDetailPage/CommitCoverage/routes/FilesChangedTab/shared/CommitFileDiff/CommitFileDiff.test.tsx
+++ b/src/pages/CommitDetailPage/CommitCoverage/routes/FilesChangedTab/shared/CommitFileDiff/CommitFileDiff.test.tsx
@@ -6,6 +6,7 @@ import {
 import { render, screen, waitFor, within } from '@testing-library/react'
 import { graphql, HttpResponse } from 'msw'
 import { setupServer } from 'msw/node'
+import qs from 'qs'
 import { Suspense } from 'react'
 import { MemoryRouter, Route } from 'react-router-dom'
 import { type MockInstance } from 'vitest'
@@ -364,13 +365,16 @@ describe('CommitFileDiff', () => {
       expect(errorMessage).toBeInTheDocument()
     })
 
-    it('renders a login link', async () => {
+    it('renders a login link with redirect to path', async () => {
       setup({ impactedFile: null })
       render(<CommitFileDiff path={'random/path'} />, { wrapper })
 
+      const queryString = qs.stringify({
+        to: '/gh/codecov/gazebo/commit/123sha/folder/subfolder/file.js',
+      })
       const link = await screen.findByText(/logging in/)
       expect(link).toBeVisible()
-      expect(link).toHaveAttribute('href', '/login')
+      expect(link).toHaveAttribute('href', `/login?${queryString}`)
     })
   })
 

--- a/src/pages/CommitDetailPage/CommitCoverage/routes/FilesChangedTab/shared/CommitFileDiff/CommitFileDiff.tsx
+++ b/src/pages/CommitDetailPage/CommitCoverage/routes/FilesChangedTab/shared/CommitFileDiff/CommitFileDiff.tsx
@@ -1,6 +1,6 @@
 import { useQuery as useQueryV5 } from '@tanstack/react-queryV5'
 import { Fragment, useMemo } from 'react'
-import { useParams } from 'react-router-dom'
+import { useLocation, useParams } from 'react-router-dom'
 
 import { IgnoredIdsQueryOptions } from 'pages/CommitDetailPage/queries/IgnoredIdsQueryOptions'
 import {
@@ -122,6 +122,8 @@ function DiffRenderer({
 }
 
 function ErrorDisplayMessage() {
+  const location = useLocation()
+
   return (
     <p className="border border-solid border-ds-gray-tertiary p-4">
       There was a problem getting the source code from your provider. Unable to
@@ -132,6 +134,7 @@ function ErrorDisplayMessage() {
         <A
           to={{
             pageName: 'login',
+            options: { to: location.pathname },
           }}
           hook={undefined}
           isExternal={undefined}

--- a/src/pages/CommitDetailPage/CommitCoverage/routes/IndirectChangesTab/IndirectChangesTable/CommitFileDiff/CommitFileDiff.test.tsx
+++ b/src/pages/CommitDetailPage/CommitCoverage/routes/IndirectChangesTab/IndirectChangesTable/CommitFileDiff/CommitFileDiff.test.tsx
@@ -6,6 +6,7 @@ import {
 import { render, screen, waitFor, within } from '@testing-library/react'
 import { graphql, HttpResponse } from 'msw'
 import { setupServer } from 'msw/node'
+import qs from 'qs'
 import { Suspense } from 'react'
 import { MemoryRouter, Route } from 'react-router-dom'
 import { type MockInstance } from 'vitest'
@@ -357,9 +358,12 @@ describe('CommitFileDiff', () => {
       setup({ impactedFile: null })
       render(<CommitFileDiff path={'random/path'} />, { wrapper })
 
+      const queryString = qs.stringify({
+        to: '/gh/codecov/gazebo/commit/123sha/folder/subfolder/file.js',
+      })
       const link = await screen.findByText(/logging in/)
       expect(link).toBeVisible()
-      expect(link).toHaveAttribute('href', '/login')
+      expect(link).toHaveAttribute('href', `/login?${queryString}`)
     })
   })
 

--- a/src/pages/CommitDetailPage/CommitCoverage/routes/IndirectChangesTab/IndirectChangesTable/CommitFileDiff/CommitFileDiff.tsx
+++ b/src/pages/CommitDetailPage/CommitCoverage/routes/IndirectChangesTab/IndirectChangesTable/CommitFileDiff/CommitFileDiff.tsx
@@ -1,7 +1,7 @@
 import { useQuery as useQueryV5 } from '@tanstack/react-queryV5'
 import PropTypes from 'prop-types'
 import { Fragment, useMemo } from 'react'
-import { useParams } from 'react-router-dom'
+import { useLocation, useParams } from 'react-router-dom'
 
 import { IgnoredIdsQueryOptions } from 'pages/CommitDetailPage/queries/IgnoredIdsQueryOptions'
 import {
@@ -123,6 +123,8 @@ function DiffRenderer({
 }
 
 function ErrorDisplayMessage() {
+  const location = useLocation()
+
   return (
     <p className="border border-solid border-ds-gray-tertiary p-4">
       There was a problem getting the source code from your provider. Unable to
@@ -131,9 +133,7 @@ function ErrorDisplayMessage() {
       <span>
         If you continue to experience this issue, please try{' '}
         <A
-          to={{
-            pageName: 'login',
-          }}
+          to={{ pageName: 'login', options: { to: location.pathname } }}
           hook={undefined}
           isExternal={undefined}
         >

--- a/src/pages/PullRequestPage/PullCoverage/routes/FilesChangedTab/FilesChanged/PullFileDiff/PullFileDiff.test.tsx
+++ b/src/pages/PullRequestPage/PullCoverage/routes/FilesChangedTab/FilesChanged/PullFileDiff/PullFileDiff.test.tsx
@@ -2,6 +2,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { render, screen, within } from '@testing-library/react'
 import { graphql, HttpResponse } from 'msw'
 import { setupServer } from 'msw/node'
+import qs from 'qs'
 import { Suspense } from 'react'
 import { MemoryRouter, Route } from 'react-router-dom'
 
@@ -333,13 +334,14 @@ describe('FileDiff', () => {
       expect(errorMessage).toBeInTheDocument()
     })
 
-    it('renders a login link', async () => {
+    it('renders a login link with redirect to path', async () => {
       setup({})
       render(<FileDiff path={undefined} />, { wrapper })
 
+      const queryString = qs.stringify({ to: '/gh/codecov/cool-repo/pull/1' })
       const loginLink = await screen.findByRole('link', { name: /logging in/ })
       expect(loginLink).toBeInTheDocument()
-      expect(loginLink).toHaveAttribute('href', '/login')
+      expect(loginLink).toHaveAttribute('href', `/login?${queryString}`)
     })
   })
 })

--- a/src/pages/PullRequestPage/PullCoverage/routes/FilesChangedTab/FilesChanged/PullFileDiff/PullFileDiff.tsx
+++ b/src/pages/PullRequestPage/PullCoverage/routes/FilesChangedTab/FilesChanged/PullFileDiff/PullFileDiff.tsx
@@ -1,5 +1,5 @@
 import { Fragment, useMemo } from 'react'
-import { useParams } from 'react-router-dom'
+import { useLocation, useParams } from 'react-router-dom'
 
 import { useNavLinks } from 'services/navigation/useNavLinks'
 import {
@@ -112,6 +112,8 @@ function DiffRenderer({
 }
 
 function ErrorDisplayMessage() {
+  const location = useLocation()
+
   return (
     <p className="border border-solid border-ds-gray-tertiary p-4">
       There was a problem getting the source code from your provider. Unable to
@@ -120,9 +122,7 @@ function ErrorDisplayMessage() {
       <span>
         If you continue to experience this issue, please try{' '}
         <A
-          to={{
-            pageName: 'login',
-          }}
+          to={{ pageName: 'login', options: { to: location.pathname } }}
           hook={undefined}
           isExternal={undefined}
         >

--- a/src/pages/PullRequestPage/PullCoverage/routes/IndirectChangesTab/PullFileDiff/PullFileDiff.test.tsx
+++ b/src/pages/PullRequestPage/PullCoverage/routes/IndirectChangesTab/PullFileDiff/PullFileDiff.test.tsx
@@ -2,6 +2,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { render, screen, within } from '@testing-library/react'
 import { graphql, HttpResponse } from 'msw'
 import { setupServer } from 'msw/node'
+import qs from 'qs'
 import { MemoryRouter, Route } from 'react-router-dom'
 
 import PullFileDiff from './PullFileDiff'
@@ -322,13 +323,14 @@ describe('FileDiff', () => {
       expect(errorMessage).toBeInTheDocument()
     })
 
-    it('renders a login link', async () => {
+    it('renders a login link with redirect to path', async () => {
       setup({})
       render(<PullFileDiff path={undefined} />, { wrapper })
 
+      const queryString = qs.stringify({ to: '/gh/codecov/cool-repo/pull/1' })
       const loginLink = await screen.findByRole('link', { name: /logging in/ })
       expect(loginLink).toBeInTheDocument()
-      expect(loginLink).toHaveAttribute('href', '/login')
+      expect(loginLink).toHaveAttribute('href', `/login?${queryString}`)
     })
   })
 })

--- a/src/pages/PullRequestPage/PullCoverage/routes/IndirectChangesTab/PullFileDiff/PullFileDiff.tsx
+++ b/src/pages/PullRequestPage/PullCoverage/routes/IndirectChangesTab/PullFileDiff/PullFileDiff.tsx
@@ -1,5 +1,5 @@
 import { Fragment, useMemo } from 'react'
-import { useParams } from 'react-router-dom'
+import { useLocation, useParams } from 'react-router-dom'
 
 import { useNavLinks } from 'services/navigation/useNavLinks'
 import {
@@ -106,6 +106,8 @@ function DiffRenderer({
 }
 
 function ErrorDisplayMessage() {
+  const location = useLocation()
+
   return (
     <p className="border border-solid border-ds-gray-tertiary p-4">
       There was a problem getting the source code from your provider. Unable to
@@ -114,9 +116,7 @@ function ErrorDisplayMessage() {
       <span>
         If you continue to experience this issue, please try{' '}
         <A
-          to={{
-            pageName: 'login',
-          }}
+          to={{ pageName: 'login', options: { to: location.pathname } }}
           hook={undefined}
           isExternal={undefined}
         >

--- a/src/shared/RawFileViewer/RawFileViewer.test.tsx
+++ b/src/shared/RawFileViewer/RawFileViewer.test.tsx
@@ -2,6 +2,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { render, screen, waitFor } from '@testing-library/react'
 import { graphql, HttpResponse } from 'msw'
 import { setupServer } from 'msw/node'
+import qs from 'qs'
 import { MemoryRouter, Route } from 'react-router-dom'
 
 import RawFileViewer from './RawFileViewer'
@@ -359,14 +360,18 @@ describe('RawFileViewer', () => {
       expect(errorMessage).toBeInTheDocument()
     })
 
-    it('renders a login link', async () => {
+    it('renders a login link with redirect to path', async () => {
       render(
         <RawFileViewer title="The FileViewer" commit="cool-commit-sha" />,
         { wrapper: wrapper() }
       )
+
+      const queryString = qs.stringify({
+        to: '/gh/codecov/cool-repo/blob/branch-name/a/file.js',
+      })
       const link = await screen.findByText(/logging in/)
       expect(link).toBeVisible()
-      expect(link).toHaveAttribute('href', '/login')
+      expect(link).toHaveAttribute('href', `/login?${queryString}`)
     })
   })
 

--- a/src/shared/RawFileViewer/RawFileViewer.tsx
+++ b/src/shared/RawFileViewer/RawFileViewer.tsx
@@ -16,6 +16,7 @@ import Title from 'ui/FileViewer/ToggleHeader/Title'
 import { VirtualFileRenderer } from 'ui/VirtualRenderers'
 
 function ErrorDisplayMessage() {
+  const location = useLocation()
   return (
     <p className="border border-solid border-ds-gray-tertiary p-4">
       There was a problem getting the source code from your provider. Unable to
@@ -24,9 +25,7 @@ function ErrorDisplayMessage() {
       <span>
         If you continue to experience this issue, please try{' '}
         <A
-          to={{
-            pageName: 'login',
-          }}
+          to={{ pageName: 'login', options: { to: location.pathname } }}
           hook={undefined}
           isExternal={undefined}
         >


### PR DESCRIPTION
# Description

This PR updates the various locations in Gazebo where we are using a `pageName: 'login'`, and updating them to include a `to` param of the current location. This will allow us to redirect the user from whatever page they are on after logging in with Codecov, streamlining the process for users to get back to where they were.

Closes: codecov/engineering-team#3452

# Notable Changes

- Update `GuestHeader`, `CommitFileDiff` x 2, `PullFileDiff` x 2, and `RawFileViewer` to include `to` redirect param
- Update tests