### PR TITLE
fix: Various usability tweaks on the members page

### DIFF
--- a/src/pages/MembersPage/MembersActivation/AutoActivate/AutoActivate.jsx
+++ b/src/pages/MembersPage/MembersActivation/AutoActivate/AutoActivate.jsx
@@ -6,15 +6,19 @@ import Toggle from 'ui/Toggle'
 
 function AutoActivate({ planAutoActivate }) {
   const { owner, provider } = useParams()
-  const { mutate: autoActivate } = useAutoActivate({ owner, provider })
+  const { mutate: autoActivate, isLoading } = useAutoActivate({
+    owner,
+    provider,
+  })
 
   return (
-    <div className="flex flex-col gap-2 p-4">
+    <div className="flex flex-col items-start gap-2 p-4">
       <div className="font-semibold">
         <Toggle
           dataMarketing="auto-activate-members"
           onClick={() => autoActivate(!planAutoActivate)}
           value={planAutoActivate}
+          isLoading={isLoading}
           label="Auto-activate members"
         />
       </div>

--- a/src/pages/MembersPage/MembersList/MembersList.jsx
+++ b/src/pages/MembersPage/MembersList/MembersList.jsx
@@ -1,10 +1,7 @@
 import { Suspense, useState } from 'react'
-import { useParams } from 'react-router-dom'
 
-import { usePlanData } from 'services/account/usePlanData'
 import { ApiFilterEnum } from 'services/navigation/normalize'
 import { useLocationParams } from 'services/navigation/useLocationParams'
-import { useUpdateUser } from 'services/users'
 import SearchField from 'ui/SearchField'
 import Select from 'ui/Select'
 import Spinner from 'ui/Spinner'
@@ -26,33 +23,7 @@ const UserManagementClasses = {
   cta: 'w-full truncate',
 }
 
-function useActivateUser({ provider, owner }) {
-  const { mutate, ...rest } = useUpdateUser({
-    provider,
-    owner,
-  })
-
-  function activate(ownerid, activated) {
-    mutate({ targetUserOwnerid: ownerid, activated })
-  }
-
-  return { activate, ...rest }
-}
-
-const handleActivate = (planData, activate, setIsOpen) => (user) => {
-  if (
-    !planData?.plan?.hasSeatsLeft &&
-    !user.activated &&
-    planData?.plan?.isFreePlan
-  ) {
-    setIsOpen(true)
-  } else {
-    activate(user.ownerid, !user.activated)
-  }
-}
-
 function MembersList() {
-  const { owner, provider } = useParams()
   const { params, updateParams } = useLocationParams({
     activated: ApiFilterEnum.none, // Default to no filter on activated
     isAdmin: ApiFilterEnum.none, // Default to no filter on isAdmin
@@ -61,8 +32,6 @@ function MembersList() {
     pageSize: 50, // Default page size
   })
 
-  const { activate } = useActivateUser({ owner, provider })
-  const { data: planData } = usePlanData({ owner, provider })
   const [isOpen, setIsOpen] = useState(false)
 
   return (
@@ -114,7 +83,7 @@ function MembersList() {
         }
       >
         <MembersTable
-          handleActivate={handleActivate(planData, activate, setIsOpen)}
+          openUpgradeModal={() => setIsOpen(true)}
           params={params}
         />
       </Suspense>

--- a/src/pages/MembersPage/MembersList/MembersList.jsx
+++ b/src/pages/MembersPage/MembersList/MembersList.jsx
@@ -7,7 +7,7 @@ import Select from 'ui/Select'
 import Spinner from 'ui/Spinner'
 
 import { ActivatedItems, AdminItems } from './enums'
-import MembersTable from './MembersTable'
+import MembersTable from './MembersTable/MembersTable'
 import UpgradeModal from './UpgradeModal/UpgradeModal'
 
 const UserManagementClasses = {

--- a/src/pages/MembersPage/MembersList/MembersTable/MembersTable.test.tsx
+++ b/src/pages/MembersPage/MembersList/MembersTable/MembersTable.test.tsx
@@ -357,6 +357,10 @@ describe('MembersTable', () => {
           describe('there are no open seats', () => {
             beforeEach(() =>
               setup({
+                mockUserRequest: mockBaseUserRequest({
+                  student: false,
+                  activated: false,
+                }),
                 planName: Plans.USERS_PR_INAPPY,
                 hasSeatsLeft: false,
                 planUserCount: 1,
@@ -367,9 +371,6 @@ describe('MembersTable', () => {
               render(<MembersTable openUpgradeModal={mockOpenUpgradeModal} />, {
                 wrapper: wrapper(),
               })
-
-              await waitFor(() => queryClient.isFetching())
-              await waitFor(() => !queryClient.isFetching())
 
               const toggle = await screen.findByRole('button')
               await waitFor(() => expect(toggle).toBeDisabled())

--- a/src/pages/MembersPage/MembersList/MembersTable/MembersTable.test.tsx
+++ b/src/pages/MembersPage/MembersList/MembersTable/MembersTable.test.tsx
@@ -23,13 +23,18 @@ vi.mock('services/image', async () => {
   }
 })
 
-const mockBaseUserRequest = ({ student = false } = { student: false }) => ({
+const mockBaseUserRequest = (
+  { student, activated }: { student: boolean; activated: boolean } = {
+    student: false,
+    activated: true,
+  }
+) => ({
   count: 2,
   next: null,
   previous: null,
   results: [
     {
-      activated: false,
+      activated,
       isAdmin: false,
       username: 'codecov-user',
       email: 'user@codecov.io',
@@ -41,6 +46,23 @@ const mockBaseUserRequest = ({ student = false } = { student: false }) => ({
   ],
   totalPages: 1,
 })
+
+type MockBaseUserRequest = {
+  count: number
+  next: string | null
+  previous: string | null
+  results: {
+    activated: boolean
+    isAdmin: boolean
+    username: string | null
+    email: string
+    ownerid: number
+    student: boolean
+    name: string
+    lastPullTimestamp: null
+  }[]
+  totalPages: number
+}
 
 const mockedFirstResponse = {
   count: 1,
@@ -117,9 +139,13 @@ afterEach(() => {
 afterAll(() => server.close())
 
 describe('MembersTable', () => {
-  let requestSearchParams
+  let requestSearchParams: any
+  const mockOpenUpgradeModal = vi.fn()
+  const handleActivate = vi.fn()
 
-  const wrapper =
+  const wrapper: (
+    initialEntries?: string[]
+  ) => React.FC<React.PropsWithChildren> =
     (initialEntries = ['/gh/codecov']) =>
     ({ children }) => (
       <QueryClientProvider client={queryClient}>
@@ -129,13 +155,21 @@ describe('MembersTable', () => {
       </QueryClientProvider>
     )
 
+  interface SetupArgs {
+    mockUserRequest?: MockBaseUserRequest
+    usePaginatedRequest?: boolean
+    planName?: (typeof Plans)[keyof typeof Plans]
+    planUserCount?: number
+    hasSeatsLeft?: boolean
+  }
+
   function setup({
-    mockUserRequest = mockBaseUserRequest(false),
+    mockUserRequest = mockBaseUserRequest({ student: false, activated: true }),
     usePaginatedRequest = false,
     planName = Plans.USERS_DEVELOPER,
     planUserCount = 0,
     hasSeatsLeft = false,
-  }) {
+  }: SetupArgs) {
     const user = userEvent.setup()
     mocks.useImage.mockReturnValue({ src: 'mocked-avatar-url' })
     server.use(
@@ -151,6 +185,10 @@ describe('MembersTable', () => {
         }
 
         return HttpResponse.json(mockUserRequest)
+      }),
+      http.patch(`/internal/:provider/:owner/users/:ownerid`, () => {
+        handleActivate()
+        return HttpResponse.json('NICE')
       }),
       graphql.query('GetPlanData', () => {
         return HttpResponse.json({
@@ -184,28 +222,36 @@ describe('MembersTable', () => {
 
     describe('renders table header', () => {
       it('has Username column', async () => {
-        render(<MembersTable />, { wrapper: wrapper() })
+        render(<MembersTable openUpgradeModal={mockOpenUpgradeModal} />, {
+          wrapper: wrapper(),
+        })
 
         const userName = await screen.findByText('Username')
         expect(userName).toBeInTheDocument()
       })
 
       it('has Type column', async () => {
-        render(<MembersTable />, { wrapper: wrapper() })
+        render(<MembersTable openUpgradeModal={mockOpenUpgradeModal} />, {
+          wrapper: wrapper(),
+        })
 
         const type = await screen.findByText('Type')
         expect(type).toBeInTheDocument()
       })
 
       it('has email column', async () => {
-        render(<MembersTable />, { wrapper: wrapper() })
+        render(<MembersTable openUpgradeModal={mockOpenUpgradeModal} />, {
+          wrapper: wrapper(),
+        })
 
         const email = await screen.findByText('Email')
         expect(email).toBeInTheDocument()
       })
 
       it('has Activation status column', async () => {
-        render(<MembersTable />, { wrapper: wrapper() })
+        render(<MembersTable openUpgradeModal={mockOpenUpgradeModal} />, {
+          wrapper: wrapper(),
+        })
 
         const activationStatus = await screen.findByText('Activation status')
         expect(activationStatus).toBeInTheDocument()
@@ -221,7 +267,7 @@ describe('MembersTable', () => {
                 ...mockBaseUserRequest(),
                 results: [
                   {
-                    ...mockBaseUserRequest().results[0],
+                    ...mockBaseUserRequest().results[0]!,
                     name: 'codecov-name',
                   },
                 ],
@@ -230,7 +276,9 @@ describe('MembersTable', () => {
           )
 
           it('renders with name', async () => {
-            render(<MembersTable />, { wrapper: wrapper() })
+            render(<MembersTable openUpgradeModal={mockOpenUpgradeModal} />, {
+              wrapper: wrapper(),
+            })
 
             const name = await screen.findByText('codecov-name')
             expect(name).toBeInTheDocument()
@@ -241,7 +289,9 @@ describe('MembersTable', () => {
           beforeEach(() => setup({}))
 
           it('renders with the username', async () => {
-            render(<MembersTable />, { wrapper: wrapper() })
+            render(<MembersTable openUpgradeModal={mockOpenUpgradeModal} />, {
+              wrapper: wrapper(),
+            })
 
             const userName = await screen.findByText('codecov')
             expect(userName).toBeInTheDocument()
@@ -257,8 +307,8 @@ describe('MembersTable', () => {
                 ...mockBaseUserRequest(),
                 results: [
                   {
-                    ...mockBaseUserRequest().results[0],
-                    is_admin: true,
+                    ...mockBaseUserRequest().results[0]!,
+                    isAdmin: true,
                   },
                 ],
               },
@@ -266,7 +316,9 @@ describe('MembersTable', () => {
           )
 
           it('renders admin', async () => {
-            render(<MembersTable />, { wrapper: wrapper() })
+            render(<MembersTable openUpgradeModal={mockOpenUpgradeModal} />, {
+              wrapper: wrapper(),
+            })
 
             const admin = await screen.findByText('Admin')
             expect(admin).toBeInTheDocument()
@@ -277,7 +329,9 @@ describe('MembersTable', () => {
           beforeEach(() => setup({}))
 
           it('renders Developer', async () => {
-            render(<MembersTable />, { wrapper: wrapper() })
+            render(<MembersTable openUpgradeModal={mockOpenUpgradeModal} />, {
+              wrapper: wrapper(),
+            })
 
             const developer = await screen.findByText('Developer')
             expect(developer).toBeInTheDocument()
@@ -289,7 +343,9 @@ describe('MembersTable', () => {
         beforeEach(() => setup({}))
 
         it('displays users email', async () => {
-          render(<MembersTable />, { wrapper: wrapper() })
+          render(<MembersTable openUpgradeModal={mockOpenUpgradeModal} />, {
+            wrapper: wrapper(),
+          })
 
           const email = await screen.findByText('user@codecov.io')
           expect(email).toBeInTheDocument()
@@ -308,7 +364,9 @@ describe('MembersTable', () => {
             )
 
             it('displays disabled toggle', async () => {
-              render(<MembersTable />, { wrapper: wrapper() })
+              render(<MembersTable openUpgradeModal={mockOpenUpgradeModal} />, {
+                wrapper: wrapper(),
+              })
 
               await waitFor(() => queryClient.isFetching())
               await waitFor(() => !queryClient.isFetching())
@@ -329,7 +387,12 @@ describe('MembersTable', () => {
               )
 
               it('displays enabled toggle', async () => {
-                render(<MembersTable />, { wrapper: wrapper() })
+                render(
+                  <MembersTable openUpgradeModal={mockOpenUpgradeModal} />,
+                  {
+                    wrapper: wrapper(),
+                  }
+                )
 
                 const toggle = await screen.findByRole('button')
                 expect(toggle).not.toBeDisabled()
@@ -347,7 +410,9 @@ describe('MembersTable', () => {
             )
 
             it('renders an non-disabled toggle', async () => {
-              render(<MembersTable />, { wrapper: wrapper() })
+              render(<MembersTable openUpgradeModal={mockOpenUpgradeModal} />, {
+                wrapper: wrapper(),
+              })
 
               const toggle = await screen.findByRole('button')
               expect(toggle).not.toBeDisabled()
@@ -359,46 +424,126 @@ describe('MembersTable', () => {
   })
   describe('user interacts with toggle', () => {
     describe('user is not a student', () => {
-      it('calls handleActivate', async () => {
-        const { user } = setup({})
-        const handleActivate = vi.fn()
-        render(<MembersTable handleActivate={handleActivate} />, {
-          wrapper: wrapper(),
+      describe('and user is not activated', () => {
+        describe('and is free plan with no seats available', () => {
+          it('calls openUpgradeModal', async () => {
+            const { user } = setup({
+              hasSeatsLeft: false,
+              mockUserRequest: mockBaseUserRequest({
+                student: false,
+                activated: false,
+              }),
+            })
+            render(<MembersTable openUpgradeModal={mockOpenUpgradeModal} />, {
+              wrapper: wrapper(),
+            })
+
+            const toggle = await screen.findByRole('button')
+            await user.click(toggle)
+
+            await waitFor(() => expect(mockOpenUpgradeModal).toHaveBeenCalled())
+          })
         })
 
-        const toggle = await screen.findByRole('button')
-        await user.click(toggle)
+        describe('and seats are available', () => {
+          it('calls activate', async () => {
+            const { user } = setup({ hasSeatsLeft: true })
+            render(<MembersTable openUpgradeModal={mockOpenUpgradeModal} />, {
+              wrapper: wrapper(),
+            })
 
-        await waitFor(() =>
-          expect(handleActivate).toHaveBeenCalledWith({
-            activated: false,
-            ownerid: 1,
+            const toggle = await screen.findByRole('button')
+            await user.click(toggle)
+
+            await waitFor(() => expect(handleActivate).toHaveBeenCalled())
           })
-        )
+        })
+      })
+
+      describe('and user is activated', () => {
+        describe('and no seats are available', () => {
+          it('calls activate', async () => {
+            const { user } = setup({
+              mockUserRequest: mockBaseUserRequest({
+                student: false,
+                activated: true,
+              }),
+            })
+            render(<MembersTable openUpgradeModal={mockOpenUpgradeModal} />, {
+              wrapper: wrapper(),
+            })
+
+            const toggle = await screen.findByRole('button')
+            await user.click(toggle)
+
+            await waitFor(() => expect(handleActivate).toHaveBeenCalled())
+          })
+        })
+
+        describe('and seats are available', () => {
+          it('calls activate', async () => {
+            const { user } = setup({
+              mockUserRequest: mockBaseUserRequest({
+                student: false,
+                activated: true,
+              }),
+              hasSeatsLeft: true,
+            })
+            render(<MembersTable openUpgradeModal={mockOpenUpgradeModal} />, {
+              wrapper: wrapper(),
+            })
+
+            const toggle = await screen.findByRole('button')
+            await user.click(toggle)
+
+            await waitFor(() => expect(handleActivate).toHaveBeenCalled())
+          })
+        })
       })
     })
-    describe('user is a student and limit has been reached', () => {
-      it('calls handleActivate', async () => {
-        const { user } = setup({
-          mockUserRequest: mockBaseUserRequest({ student: true }),
-          planName: Plans.USERS_DEVELOPER,
-          planUserCount: 1,
-          hasSeatsLeft: false,
-        })
-        const handleActivate = vi.fn()
-        render(<MembersTable handleActivate={handleActivate} />, {
-          wrapper: wrapper(),
-        })
-
-        const toggle = await screen.findByRole('button')
-        await user.click(toggle)
-
-        await waitFor(() =>
-          expect(handleActivate).toHaveBeenCalledWith({
-            activated: false,
-            ownerid: 1,
+    describe('user is a student', () => {
+      describe('user is not activated', () => {
+        it('calls activate', async () => {
+          const { user } = setup({
+            mockUserRequest: mockBaseUserRequest({
+              student: true,
+              activated: false,
+            }),
+            planName: Plans.USERS_DEVELOPER,
+            planUserCount: 1,
+            hasSeatsLeft: false,
           })
-        )
+          render(<MembersTable openUpgradeModal={mockOpenUpgradeModal} />, {
+            wrapper: wrapper(),
+          })
+
+          const toggle = await screen.findByRole('button')
+          await user.click(toggle)
+
+          await waitFor(() => expect(handleActivate).toHaveBeenCalled())
+        })
+      })
+
+      describe('user is activated', () => {
+        it('calls activate', async () => {
+          const { user } = setup({
+            mockUserRequest: mockBaseUserRequest({
+              student: true,
+              activated: true,
+            }),
+            planName: Plans.USERS_DEVELOPER,
+            planUserCount: 1,
+            hasSeatsLeft: false,
+          })
+          render(<MembersTable openUpgradeModal={mockOpenUpgradeModal} />, {
+            wrapper: wrapper(),
+          })
+
+          const toggle = await screen.findByRole('button')
+          await user.click(toggle)
+
+          await waitFor(() => expect(handleActivate).toHaveBeenCalled())
+        })
       })
     })
   })
@@ -408,7 +553,9 @@ describe('MembersTable', () => {
       describe('setting in asc order', () => {
         it('updates the request params', async () => {
           const { user } = setup({})
-          render(<MembersTable />, { wrapper: wrapper() })
+          render(<MembersTable openUpgradeModal={mockOpenUpgradeModal} />, {
+            wrapper: wrapper(),
+          })
 
           const userName = await screen.findByText('Username')
           await user.click(userName)
@@ -422,7 +569,9 @@ describe('MembersTable', () => {
       describe('setting in desc order', () => {
         it('updates the request params', async () => {
           const { user } = setup({})
-          render(<MembersTable />, { wrapper: wrapper() })
+          render(<MembersTable openUpgradeModal={mockOpenUpgradeModal} />, {
+            wrapper: wrapper(),
+          })
 
           const userName = await screen.findByText('Username')
 
@@ -439,7 +588,9 @@ describe('MembersTable', () => {
       describe('setting in originally order', () => {
         it('removes the request param', async () => {
           const { user } = setup({})
-          render(<MembersTable />, { wrapper: wrapper() })
+          render(<MembersTable openUpgradeModal={mockOpenUpgradeModal} />, {
+            wrapper: wrapper(),
+          })
 
           const userName = await screen.findByText('Username')
 
@@ -457,7 +608,9 @@ describe('MembersTable', () => {
       describe('setting in asc order', () => {
         it('updates the request params', async () => {
           const { user } = setup({})
-          render(<MembersTable />, { wrapper: wrapper() })
+          render(<MembersTable openUpgradeModal={mockOpenUpgradeModal} />, {
+            wrapper: wrapper(),
+          })
 
           const email = await screen.findByText('Email')
 
@@ -473,7 +626,9 @@ describe('MembersTable', () => {
       describe('setting in desc order', () => {
         it('updates the request params', async () => {
           const { user } = setup({})
-          render(<MembersTable />, { wrapper: wrapper() })
+          render(<MembersTable openUpgradeModal={mockOpenUpgradeModal} />, {
+            wrapper: wrapper(),
+          })
 
           const email = await screen.findByText('Email')
           await user.click(email)
@@ -487,7 +642,9 @@ describe('MembersTable', () => {
       describe('setting in originally order', () => {
         it('removes the request param', async () => {
           const { user } = setup({})
-          render(<MembersTable />, { wrapper: wrapper() })
+          render(<MembersTable openUpgradeModal={mockOpenUpgradeModal} />, {
+            wrapper: wrapper(),
+          })
 
           const email = await screen.findByText('Email')
           await user.click(email)
@@ -505,7 +662,9 @@ describe('MembersTable', () => {
       describe('setting in asc order', () => {
         it('updates the request params', async () => {
           const { user } = setup({})
-          render(<MembersTable />, { wrapper: wrapper() })
+          render(<MembersTable openUpgradeModal={mockOpenUpgradeModal} />, {
+            wrapper: wrapper(),
+          })
 
           const activationStatus = await screen.findByText('Activation status')
           await user.click(activationStatus)
@@ -519,7 +678,9 @@ describe('MembersTable', () => {
       describe('setting in desc order', () => {
         it('updates the request params', async () => {
           const { user } = setup({})
-          render(<MembersTable />, { wrapper: wrapper() })
+          render(<MembersTable openUpgradeModal={mockOpenUpgradeModal} />, {
+            wrapper: wrapper(),
+          })
 
           const activationStatus = await screen.findByText('Activation status')
           await user.click(activationStatus)
@@ -534,7 +695,9 @@ describe('MembersTable', () => {
       describe('setting in originally order', () => {
         it('removes the request param', async () => {
           const { user } = setup({})
-          render(<MembersTable />, { wrapper: wrapper() })
+          render(<MembersTable openUpgradeModal={mockOpenUpgradeModal} />, {
+            wrapper: wrapper(),
+          })
 
           const activationStatus = await screen.findByText('Activation status')
           await user.click(activationStatus)
@@ -551,11 +714,13 @@ describe('MembersTable', () => {
 
   describe('triggering isIntersecting', () => {
     beforeEach(() => {
-      setup({ usePaginatedRequest: true, isIntersecting: true })
+      setup({ usePaginatedRequest: true })
     })
 
     it('displays two users', async () => {
-      render(<MembersTable />, { wrapper: wrapper() })
+      render(<MembersTable openUpgradeModal={mockOpenUpgradeModal} />, {
+        wrapper: wrapper(),
+      })
 
       const user1 = await screen.findByText('User 1')
       expect(user1).toBeInTheDocument()
@@ -580,7 +745,7 @@ describe('MembersTable', () => {
             ...mockBaseUserRequest(),
             results: [
               {
-                ...mockBaseUserRequest().results[0],
+                ...mockBaseUserRequest().results[0]!,
                 username: null,
               },
             ],
@@ -589,7 +754,9 @@ describe('MembersTable', () => {
       })
 
       it('uses default author', async () => {
-        render(<MembersTable />, { wrapper: wrapper(['/gl/codecov']) })
+        render(<MembersTable openUpgradeModal={mockOpenUpgradeModal} />, {
+          wrapper: wrapper(),
+        })
 
         const avatar = await screen.findByRole('img')
         await waitFor(() => expect(avatar).toBeInTheDocument())

--- a/src/pages/MembersPage/MembersList/MembersTable/MembersTable.tsx
+++ b/src/pages/MembersPage/MembersList/MembersTable/MembersTable.tsx
@@ -95,11 +95,6 @@ function ActivationStatus({
   })
   const { data: planData } = usePlanData({ owner, provider })
 
-  useEffect(() => {
-    // if real activation status changes, update optimistic status to reflect
-    setOptimisticActivation(activated)
-  }, [activated])
-
   let disabled = false
 
   if (planData?.plan) {

--- a/src/pages/MembersPage/MembersList/MembersTable/MembersTable.tsx
+++ b/src/pages/MembersPage/MembersList/MembersTable/MembersTable.tsx
@@ -109,7 +109,7 @@ function ActivationStatus({
         }
       }}
       isLoading={isLoading}
-      disabled={disabled}
+      disabled={disabled && !activated}
     />
   )
 }

--- a/src/pages/MembersPage/MembersList/MembersTable/index.js
+++ b/src/pages/MembersPage/MembersList/MembersTable/index.js
@@ -1,1 +1,0 @@
-export { default } from './MembersTable'

--- a/src/services/users/useUpdateUser.js
+++ b/src/services/users/useUpdateUser.js
@@ -20,7 +20,7 @@ export function useUpdateUser({ provider, owner, opts = {} }) {
 
       sessionStorage.setItem(
         UPDATE_USERS_TIMEOUT_KEY,
-        setTimeout(() => queryClient.invalidateQueries(['users']), 1000)
+        setTimeout(() => queryClient.invalidateQueries(['users']), 2000) // feels good to me
       )
 
       // Execute passed onSuccess after invalidating queries

--- a/src/services/users/useUpdateUser.js
+++ b/src/services/users/useUpdateUser.js
@@ -21,17 +21,11 @@ export function useUpdateUser({ provider, owner, opts = {} }) {
     // The following cache busts will trigger react-query to retry the api call updating components depending on this data.
     queryClient.invalidateQueries(['users'])
     queryClient.invalidateQueries(['accountDetails'])
-    queryClient.invalidateQueries(['InfiniteUsers'])
     queryClient.invalidateQueries(['GetPlanData'])
   }
 
   return useMutation({
     mutationFn: ({ targetUserOwnerid, ...body }) => {
-      // If the activate user button is clicked multiple times in quick succession, the button loading state can get weird. To solve this we can cancel in-flight refreshes and let this new request trigger the refresh.
-      queryClient.cancelQueries(['users'])
-      queryClient.cancelQueries(['accountDetails'])
-      queryClient.cancelQueries(['InfiniteUsers'])
-      queryClient.cancelQueries(['GetPlanData'])
       const path = patchPathUsers({ provider, owner, targetUserOwnerid })
       return Api.patch({ path, provider, body })
     },

--- a/src/services/users/useUpdateUser.js
+++ b/src/services/users/useUpdateUser.js
@@ -12,16 +12,13 @@ export function useUpdateUser({ provider, owner, opts = {} }) {
 
   const successHandler = (...args) => {
     if (onSuccess) {
+      // The following cache busts will trigger react-query to retry the api call updating components depending on this data.
+      queryClient.invalidateQueries(['accountDetails'])
+      queryClient.invalidateQueries(['GetPlanData'])
+      queryClient.invalidateQueries(['users'])
       // Execute passed onSuccess after invalidating queries
       onSuccess.apply(null, args)
     }
-  }
-
-  const settleHandler = () => {
-    // The following cache busts will trigger react-query to retry the api call updating components depending on this data.
-    queryClient.invalidateQueries(['users'])
-    queryClient.invalidateQueries(['accountDetails'])
-    queryClient.invalidateQueries(['GetPlanData'])
   }
 
   return useMutation({
@@ -30,7 +27,6 @@ export function useUpdateUser({ provider, owner, opts = {} }) {
       return Api.patch({ path, provider, body })
     },
     onSuccess: successHandler,
-    onSettled: settleHandler,
     ...passedOpts,
   })
 }

--- a/src/services/users/useUpdateUser.js
+++ b/src/services/users/useUpdateUser.js
@@ -28,7 +28,10 @@ export function useUpdateUser({ provider, owner, opts = {} }) {
   return useMutation({
     mutationFn: ({ targetUserOwnerid, ...body }) => {
       // If the activate user button is clicked multiple times in quick succession, the button loading state can get weird. To solve this we can cancel in-flight refreshes and let this new request trigger the refresh.
+      queryClient.cancelQueries(['users'])
+      queryClient.cancelQueries(['accountDetails'])
       queryClient.cancelQueries(['InfiniteUsers'])
+      queryClient.cancelQueries(['GetPlanData'])
       const path = patchPathUsers({ provider, owner, targetUserOwnerid })
       return Api.patch({ path, provider, body })
     },

--- a/src/services/users/useUpdateUser.js
+++ b/src/services/users/useUpdateUser.js
@@ -15,6 +15,7 @@ export function useUpdateUser({ provider, owner, opts = {} }) {
     queryClient.invalidateQueries(['users'])
     queryClient.invalidateQueries(['accountDetails'])
     queryClient.invalidateQueries(['InfiniteUsers'])
+    queryClient.invalidateQueries(['GetPlanData'])
 
     if (onSuccess) {
       // Execute passed onSuccess after invalidating queries

--- a/src/services/users/useUpdateUser.js
+++ b/src/services/users/useUpdateUser.js
@@ -11,24 +11,29 @@ export function useUpdateUser({ provider, owner, opts = {} }) {
   const queryClient = useQueryClient()
 
   const successHandler = (...args) => {
-    // The following cache busts will trigger react-query to retry the api call updating components depending on this data.
-    queryClient.invalidateQueries(['users'])
-    queryClient.invalidateQueries(['accountDetails'])
-    queryClient.invalidateQueries(['InfiniteUsers'])
-    queryClient.invalidateQueries(['GetPlanData'])
-
     if (onSuccess) {
       // Execute passed onSuccess after invalidating queries
       onSuccess.apply(null, args)
     }
   }
 
+  const settleHandler = () => {
+    // The following cache busts will trigger react-query to retry the api call updating components depending on this data.
+    queryClient.invalidateQueries(['users'])
+    queryClient.invalidateQueries(['accountDetails'])
+    queryClient.invalidateQueries(['InfiniteUsers'])
+    queryClient.invalidateQueries(['GetPlanData'])
+  }
+
   return useMutation({
     mutationFn: ({ targetUserOwnerid, ...body }) => {
+      // If the activate user button is clicked multiple times in quick succession, the button loading state can get weird. To solve this we can cancel in-flight refreshes and let this new request trigger the refresh.
+      queryClient.cancelQueries(['InfiniteUsers'])
       const path = patchPathUsers({ provider, owner, targetUserOwnerid })
       return Api.patch({ path, provider, body })
     },
     onSuccess: successHandler,
+    onSettled: settleHandler,
     ...passedOpts,
   })
 }


### PR DESCRIPTION
- Adds a spinner to indicate the query is in flight.
- To achieve the spinners on members list I did a refactor that pulls the mutation down into the table component itself. Also gets rid of unnecessary prop drilling.
- Prevents the toggle div from filling the whole card width (whole div is clickable).
- Right aligns toggles in the members list.

Closes https://github.com/codecov/engineering-team/issues/3325
