### PR TITLE
fix: useInvoices, usePrefetchBranchDirEntry, BundleTrendQueryOpts, usePullComponents schemas

### DIFF
--- a/src/pages/PullRequestPage/PullCoverage/routes/ComponentsSelector/ComponentsSelector.tsx
+++ b/src/pages/PullRequestPage/PullCoverage/routes/ComponentsSelector/ComponentsSelector.tsx
@@ -25,7 +25,7 @@ function ComponentsSelector() {
   })
 
   const components = useMemo(() => {
-    return data?.pull?.compareWithBase.__typename === 'Comparison'
+    return data?.pull?.compareWithBase?.__typename === 'Comparison'
       ? data?.pull?.compareWithBase?.componentComparisons
       : []
   }, [data])

--- a/src/services/account/useInvoices.ts
+++ b/src/services/account/useInvoices.ts
@@ -61,7 +61,7 @@ const InvoicesSchema = z.array(InvoiceSchema)
 const OwnerInvoiceSchema = z.object({
   owner: z
     .object({
-      invoices: InvoicesSchema,
+      invoices: InvoicesSchema.nullable(),
     })
     .nullable(),
 })

--- a/src/services/bundleAnalysis/BundleTrendDataQueryOpts.tsx
+++ b/src/services/bundleAnalysis/BundleTrendDataQueryOpts.tsx
@@ -51,10 +51,12 @@ const BranchSchema = z.object({
     .object({
       bundleAnalysis: z
         .object({
-          bundleAnalysisReport: z.discriminatedUnion('__typename', [
-            BundleReportSchema,
-            MissingHeadReportSchema,
-          ]),
+          bundleAnalysisReport: z
+            .discriminatedUnion('__typename', [
+              BundleReportSchema,
+              MissingHeadReportSchema,
+            ])
+            .nullable(),
         })
         .nullable(),
     })
@@ -228,7 +230,10 @@ export const BundleTrendDataQueryOpts = ({
           data.owner?.repository?.branch?.head?.bundleAnalysis
             ?.bundleAnalysisReport
 
-        if (bundleReport?.__typename === 'BundleAnalysisReport') {
+        if (
+          bundleReport &&
+          bundleReport?.__typename === 'BundleAnalysisReport'
+        ) {
           return bundleReport?.bundle?.measurements
         }
 

--- a/src/services/pathContents/branch/dir/usePrefetchBranchDirEntry.tsx
+++ b/src/services/pathContents/branch/dir/usePrefetchBranchDirEntry.tsx
@@ -75,13 +75,15 @@ const PathContentsUnionSchema = z.discriminatedUnion('__typename', [
 const RepositorySchema = z.object({
   __typename: z.literal('Repository'),
   repositoryConfig: RepositoryConfigSchema,
-  branch: z.object({
-    head: z
-      .object({
-        deprecatedPathContents: PathContentsUnionSchema.nullish(),
-      })
-      .nullable(),
-  }),
+  branch: z
+    .object({
+      head: z
+        .object({
+          deprecatedPathContents: PathContentsUnionSchema.nullish(),
+        })
+        .nullable(),
+    })
+    .nullable(),
 })
 
 const BranchContentsSchema = z.object({

--- a/src/services/pull/usePullComponents.tsx
+++ b/src/services/pull/usePullComponents.tsx
@@ -69,24 +69,26 @@ const RepositorySchema = z.object({
   __typename: z.literal('Repository'),
   pull: z
     .object({
-      compareWithBase: z.discriminatedUnion('__typename', [
-        z.object({
-          __typename: z.literal('Comparison'),
-          componentComparisons: z
-            .array(
-              z.object({
-                name: z.string(),
-              })
-            )
-            .nullable(),
-        }),
-        FirstPullRequestSchema,
-        MissingBaseCommitSchema,
-        MissingBaseReportSchema,
-        MissingComparisonSchema,
-        MissingHeadCommitSchema,
-        MissingHeadReportSchema,
-      ]),
+      compareWithBase: z
+        .discriminatedUnion('__typename', [
+          z.object({
+            __typename: z.literal('Comparison'),
+            componentComparisons: z
+              .array(
+                z.object({
+                  name: z.string(),
+                })
+              )
+              .nullable(),
+          }),
+          FirstPullRequestSchema,
+          MissingBaseCommitSchema,
+          MissingBaseReportSchema,
+          MissingComparisonSchema,
+          MissingHeadCommitSchema,
+          MissingHeadReportSchema,
+        ])
+        .nullable(),
     })
     .nullable(),
 })
@@ -193,9 +195,7 @@ export function usePullComponents({
           })
         }
 
-        return {
-          pull: data?.owner?.repository?.pull,
-        }
+        return { pull: data?.owner?.repository?.pull }
       }),
     ...options,
   })


### PR DESCRIPTION
# Description

This PR updates the following Zod schemas, to resolve their related Sentry issue:

- `useInvoices` -> [Sentry issue](https://codecov.sentry.io/issues/6393367486/?query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=issue-stream&stream_index=5)
- `usePrefetchBranchDirEntry` -> [Sentry issue](https://codecov.sentry.io/issues/6392066289/?alert_rule_id=15115849&alert_type=issue&notification_uuid=07598a3a-0bc0-4a4a-8923-18b54d42b184&project=5514400&referrer=issue_alert-slack)
- `BundleTrendQueryOpts` -> [Sentry issue](https://codecov.sentry.io/issues/6391712513/?alert_rule_id=15115849&alert_type=issue&notification_uuid=8a1a2e6d-83a8-4cd5-8034-237eeb0c504e&project=5514400&referrer=issue_alert-slack)
- `usePullComponents` -> [Sentry issue](https://codecov.sentry.io/issues/6390577481/?alert_rule_id=15115849&alert_type=issue&notification_uuid=7109b4ba-48b1-4bf0-8abd-23b24930e461&project=5514400&referrer=digest-slack)

Ticket: codecov/engineering-team#3385

# Notable Changes

- Update `useInvoices`, `usePrefetchBranchDirEntry`, `BundleTrendQueryOpts`, `usePullComponents`
- Update `ComponentsSelector` to use optional chaining