### PR TITLE
fix: Pytest instructions wrong command

### DIFF
--- a/src/pages/RepoPage/CoverageOnboarding/UseFrameworkInstructions.tsx
+++ b/src/pages/RepoPage/CoverageOnboarding/UseFrameworkInstructions.tsx
@@ -94,7 +94,7 @@ jobs:
       },
       Pytest: {
         install: 'pip install pytest pytest-cov',
-        run: 'pytest --cov-branch --cov-report=xml',
+        run: 'pytest --cov --cov-branch --cov-report=xml',
         githubActionsWorkflow: `name: Run tests and upload coverage
 
 on: 
@@ -117,7 +117,7 @@ jobs:
         run: pip install pytest pytest-cov
 
       - name: Run tests
-        run: pytest --cov-branch --cov-report=xml
+        run: pytest --cov --cov-branch --cov-report=xml
 
       - name: Upload results to Codecov
         uses: codecov/codecov-action@v5


### PR DESCRIPTION
Fixes pytest test run command.

I recall testing this worked without `--cov` when I last updated this, but today it seems to not work. I guess my testing was wrong.
