### PR TITLE
chore: Silence launchDarkly, sentry console logs

### DIFF
--- a/src/sentry.ts
+++ b/src/sentry.ts
@@ -133,7 +133,7 @@ export const setupSentry = ({
 
   Sentry.init({
     dsn: config.SENTRY_DSN,
-    debug: config.NODE_ENV !== 'production',
+    debug: config.SENTRY_ENVIRONMENT !== 'production',
     environment: config.SENTRY_ENVIRONMENT,
     integrations: [
       // Adds Sentry Replay

--- a/src/shared/featureFlags/featureFlag.ts
+++ b/src/shared/featureFlags/featureFlag.ts
@@ -1,6 +1,7 @@
 /* eslint-disable no-restricted-imports */
 import * as Sentry from '@sentry/react'
 import {
+  basicLogger,
   useLDClient,
   useFlags as useLDFlags,
   withLDProvider,
@@ -20,6 +21,7 @@ export const withFeatureFlagProvider = (Component: React.ComponentType) => {
           // Add in Sentry error handling for LaunchDarkly flags
           Sentry.buildLaunchDarklyFlagUsedHandler(),
         ],
+        logger: basicLogger({ level: 'error' }),
       },
     })(Component)
   }


### PR DESCRIPTION
Reduce the noise in our console in prod by lowering the loglevel for Launch Darkly and Sentry integrations.

