### PR TITLE
chore(overwatch): Fix overwatch CI step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -376,7 +376,7 @@ jobs:
           ./overwatch-cli \
             --auth-token ${{ secrets.SENTRY_AUTH_TOKEN }} \
             --organization-slug codecov \
-            javascript --package-manager yarn
+            javascript --package-manager yarn --work-dir src
 
   storybook:
     name: Run storybook

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -376,7 +376,7 @@ jobs:
           ./overwatch-cli \
             --auth-token ${{ secrets.SENTRY_AUTH_TOKEN }} \
             --organization-slug codecov \
-            javascript --package-manager yarn --work-dir src
+            javascript --package-manager yarn --workdir src
 
   storybook:
     name: Run storybook


### PR DESCRIPTION
Overwatch uses a default `.` for working directory if not specified in the flag.
This results in the below command run, which fails in local as well

```
yarn run eslint .                                                                                                                 

Oops! Something went wrong! :(

ESLint: 8.57.1

Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: No "exports" main defined in /Users/suejungshin/dev/codecov/gazebo/node_modules/tsconfck/package.json
Occurred while linting /Users/suejungshin/dev/codecov/gazebo/vite.config.mjs:1
Rule: "import/namespace"
    at exportsNotFound (node:internal/modules/esm/resolve:296:10)
    at packageExportsResolve (node:internal/modules/esm/resolve:586:13)
    at resolveExports (node:internal/modules/cjs/loader:640:36)
    at Function._findPath (node:internal/modules/cjs/loader:748:31)
    at findModulePath (/Users/suejungshin/dev/codecov/gazebo/node_modules/eslint-import-resolver-alias/index.js:99:27)
    at exports.resolve (/Users/suejungshin/dev/codecov/gazebo/node_modules/eslint-import-resolver-alias/index.js:75:10)
```

Actually the full command is below which yields the same result (with some more options passed in, but those options aren't what is causing the issue)
```
yarn run eslint --format json --ignore-pattern "**/dist/**" --ignore-pattern "**/build/**" --ignore-pattern "**/node-modules/**" .

Oops! Something went wrong! :(

ESLint: 8.57.1

Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: No "exports" main defined in /Users/suejungshin/dev/codecov/gazebo/node_modules/tsconfck/package.json
Occurred while linting /Users/suejungshin/dev/codecov/gazebo/vite.config.mjs:1
Rule: "import/namespace"
    at exportsNotFound (node:internal/modules/esm/resolve:296:10)
```
