### PR TITLE
[ft] Re-Add test gen copy

### DIFF
--- a/src/pages/CodecovAIPage/CodecovAICommands/CodecovAICommands.tsx
+++ b/src/pages/CodecovAIPage/CodecovAICommands/CodecovAICommands.tsx
@@ -12,8 +12,14 @@ const CodecovAICommands: React.FC = () => {
           <Card.Title size="base">Codecov AI Commands</Card.Title>
         </Card.Header>
         <Card.Content>
-          After installing the app, use this command in your PR comments:
+          After installing the app, use these commands in your PR comments:
           <ul className="mt-2 list-inside list-disc space-y-1">
+            <li>
+              <span className="rounded border border-gray-200 bg-gray-100 px-1 font-semibold">
+                @codecov-ai-reviewer test
+              </span>
+              -- the assistant will generate tests for the PR.
+            </li>
             <li>
               <span className="rounded border border-gray-200 bg-gray-100 px-1 font-semibold">
                 @codecov-ai-reviewer review
@@ -30,6 +36,20 @@ const CodecovAICommands: React.FC = () => {
             generation may take time.
           </p>
         </ExpandableSection.Trigger>
+        <ExpandableSection.Content>
+          Screenshot goes here
+        </ExpandableSection.Content>
+      </ExpandableSection>
+      <ExpandableSection className="-mt-2 border-t-0">
+        <ExpandableSection.Trigger>
+          <p>
+            Here is an example of Codecov AI Test Generator in PR comments.
+            Comment generation may take time.
+          </p>
+        </ExpandableSection.Trigger>
+        <ExpandableSection.Content>
+          Screenshot goes here
+        </ExpandableSection.Content>
         <ExpandableSection.Content className="m-0 p-0">
           <LightDarkImg
             className="size-full object-cover"


### PR DESCRIPTION
The copy was removed since we were using the Github Copilot extension. After some back and forth, we are supporting it via Codecov AI again. 

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.