### PR TITLE
fix: Change header text for components

### DIFF
--- a/src/pages/RepoPage/CoverageTab/ComponentsTab/subroute/ComponentsTable/ComponentsTable.test.tsx
+++ b/src/pages/RepoPage/CoverageTab/ComponentsTab/subroute/ComponentsTable/ComponentsTable.test.tsx
@@ -197,7 +197,7 @@ describe('ComponentsTable', () => {
       const components = await screen.findByText('Components')
       expect(components).toBeInTheDocument()
 
-      const coverage = await screen.findByText('Coverage %')
+      const coverage = await screen.findByText('Last aggregated coverage %')
       expect(coverage).toBeInTheDocument()
 
       const trend = await screen.findByText('Historical Trend')

--- a/src/pages/RepoPage/CoverageTab/ComponentsTab/subroute/ComponentsTable/ComponentsTable.tsx
+++ b/src/pages/RepoPage/CoverageTab/ComponentsTab/subroute/ComponentsTable/ComponentsTable.tsx
@@ -87,7 +87,7 @@ const columns = [
     cell: ({ renderValue }) => renderValue(),
   }),
   columnHelper.accessor('coverage', {
-    header: () => 'Coverage %',
+    header: () => 'Last aggregated coverage %',
     cell: ({ renderValue }) => renderValue(),
   }),
   columnHelper.accessor('trend', {


### PR DESCRIPTION
Changes from "Coverage %" to "Last aggregated coverage %" in the Components tab to better communicate intent to user.

Closes https://github.com/codecov/engineering-team/issues/3460

<img width="997" alt="Screenshot 2025-04-07 at 2 28 14 PM" src="https://github.com/user-attachments/assets/e24e2b91-e1e5-435e-9dd0-ddca2b6d2c92" />
