### PR TITLE
fix(docs): fix indentation with github actions setup

### DIFF
--- a/src/pages/RepoPage/CoverageOnboarding/GitHubActions/WorkflowYMLStep.tsx
+++ b/src/pages/RepoPage/CoverageOnboarding/GitHubActions/WorkflowYMLStep.tsx
@@ -33,15 +33,17 @@ function WorkflowYMLStep({
     owner,
   })
 
-  const workflowYMLConfig = `- name: Upload coverage reports to Codecov
-    uses: codecov/codecov-action@v5
-    with:
-      token: \${{ secrets.CODECOV_TOKEN }}${
-        orgUploadToken
-          ? `
-      slug: ${owner}/${repo}`
-          : ''
-      }`
+  // prettier-ignore
+  const actionString =
+  `- name: Upload coverage reports to Codecov
+  uses: codecov/codecov-action@v4.0.1
+  with:
+    token: \${{ secrets.CODECOV_TOKEN }}${
+      orgUploadToken
+        ? `
+    slug: ${owner}/${repo}`
+        : ''
+  }`
 
   return (
     <div>


### PR DESCRIPTION
# Description

There is a syntax error in the GitHub action formatting YAML example for uploading coverage results.

This previously was reported and fixed in #2927, but [a refactor](https://github.com/codecov/gazebo/commit/400d72491e5c418ee8477f69e72f9552a02f1abc#diff-27f2f3af863e5d996d600b2ba5429a5a6f637f644423e36fbdb61fb3aea0b37cR45) reintroduced the issue

# Code Example

N/A

# Notable Changes

Change the format and exclude from prettier

# Screenshots

When setting up coverage for a new repo:

![github yaml](https://github.com/user-attachments/assets/cac4345a-da74-4384-8228-53b28c52e090)

As expected this is invalid YAML:

![invalid ci yaml](https://github.com/user-attachments/assets/252cbe70-785e-4cbe-9600-6f75cdd6c8fb)

# Link to Sample Entry

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.