### PR TITLE
feat: add all branches option to TA branch selector

### DIFF
--- a/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/FailedTestsTable/FailedTestsTable.test.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/FailedTestsTable/FailedTestsTable.test.tsx
@@ -24,6 +24,19 @@ vi.mock('../TableHeader/TableHeader', () => ({
   default: () => 'Table Header',
 }))
 
+const mocks = vi.hoisted(() => ({
+  useFlags: vi.fn(() => ({ allBranchesEnabled: false })),
+}))
+
+vi.mock('shared/featureFlags', async () => {
+  const actual = await vi.importActual('shared/featureFlags')
+
+  return {
+    ...actual,
+    useFlags: mocks.useFlags,
+  }
+})
+
 const node1 = {
   updatedAt: '2023-01-01T00:00:00Z',
   name: 'test-1',
@@ -139,7 +152,12 @@ interface SetupArgs {
   isFirstPullRequest?: boolean
 }
 
-describe('FailedTestsTable', () => {
+describe.each([true, false])('FailedTestsTable', (allBranchesEnabled) => {
+  beforeEach(() => {
+    queryClient.clear()
+    mocks.useFlags.mockReturnValue({ allBranchesEnabled })
+  })
+
   function setup({
     noEntries = false,
     planValue = Plans.USERS_ENTERPRISEM,

--- a/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/FailedTestsTable/FailedTestsTable.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/FailedTestsTable/FailedTestsTable.tsx
@@ -14,6 +14,7 @@ import { useInView } from 'react-intersection-observer'
 import { useLocation, useParams } from 'react-router-dom'
 
 import { MeasurementInterval } from 'pages/RepoPage/shared/constants'
+import { ALL_BRANCHES } from 'services/navigation/useNavLinks'
 import { formatTimeToNow } from 'shared/utils/dates'
 import Icon from 'ui/Icon'
 import Spinner from 'ui/Spinner'
@@ -226,7 +227,8 @@ const FailedTestsTable = () => {
     },
   })
 
-  const isDefaultBranch = testData?.defaultBranch === branch
+  const isDefaultBranch =
+    testData?.defaultBranch === branch || ALL_BRANCHES === branch
   const isTeamOrFreePlan = testData?.isTeamPlan || testData?.isFreePlan
   // Only show flake rate column when on default branch for pro / enterprise plans or public repos
   const hideFlakeRate =
@@ -308,7 +310,8 @@ const FailedTestsTable = () => {
         <div className="mt-4 text-center text-ds-gray-quinary">
           <p>No data yet</p>
           <p>
-            To see data for the main branch, merge your PR into the main branch.
+            To see data for the {testData?.defaultBranch} branch, merge your PR
+            into the {testData?.defaultBranch} branch.
           </p>
         </div>
       </div>

--- a/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/MetricsSection/MetricsSection.test.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/MetricsSection/MetricsSection.test.tsx
@@ -12,6 +12,15 @@ import MetricsSection, { historicalTrendToCopy } from './MetricsSection'
 
 import { TestResultsFilterParameter } from '../hooks/useInfiniteTestResults/useInfiniteTestResults'
 
+vi.mock('shared/featureFlags', async () => {
+  const actual = await vi.importActual('shared/featureFlags')
+
+  return {
+    ...actual,
+    useFlags: vi.fn(() => ({ allBranchesEnabled: false })),
+  }
+})
+
 const mockAggResponse = (
   planValue: PlanName = Plans.USERS_ENTERPRISEM,
   isPrivate = false
@@ -148,11 +157,14 @@ describe('MetricsSection', () => {
     })
   })
 
-  describe('when on default branch', () => {
+  describe.each([
+    ['default branch', 'main'],
+    ['all branches', 'All%20branches'],
+  ])('when on %s', (_, encodedBranch) => {
     it('renders subheaders', async () => {
       setup()
       render(<MetricsSection />, {
-        wrapper: wrapper('/gh/owner/repo/tests/main'),
+        wrapper: wrapper(`/gh/owner/repo/tests/${encodedBranch}`),
       })
 
       const runEfficiency = await screen.findByText('Improve CI Run Efficiency')
@@ -164,7 +176,7 @@ describe('MetricsSection', () => {
     it('renders total test runtime card', async () => {
       setup()
       render(<MetricsSection />, {
-        wrapper: wrapper('/gh/owner/repo/tests/main'),
+        wrapper: wrapper(`/gh/owner/repo/tests/${encodedBranch}`),
       })
 
       const title = await screen.findByText('Total test run time')
@@ -182,7 +194,7 @@ describe('MetricsSection', () => {
       it('renders slowest tests card', async () => {
         setup()
         render(<MetricsSection />, {
-          wrapper: wrapper('/gh/owner/repo/tests/main'),
+          wrapper: wrapper(`/gh/owner/repo/tests/${encodedBranch}`),
         })
 
         const title = await screen.findByText('Slowest tests')
@@ -199,7 +211,7 @@ describe('MetricsSection', () => {
       it('can update the location params on button click', async () => {
         const { user } = setup()
         render(<MetricsSection />, {
-          wrapper: wrapper('/gh/owner/repo/tests/main'),
+          wrapper: wrapper(`/gh/owner/repo/tests/${encodedBranch}`),
         })
         const select = await screen.findByText('12')
         expect(select).toBeInTheDocument()
@@ -217,7 +229,7 @@ describe('MetricsSection', () => {
       it('removes the location param on second button click', async () => {
         const { user } = setup()
         render(<MetricsSection />, {
-          wrapper: wrapper('/gh/owner/repo/tests/main'),
+          wrapper: wrapper(`/gh/owner/repo/tests/${encodedBranch}`),
         })
         const select = await screen.findByText('12')
         expect(select).toBeInTheDocument()
@@ -239,7 +251,7 @@ describe('MetricsSection', () => {
       it('renders total flaky tests card', async () => {
         setup()
         render(<MetricsSection />, {
-          wrapper: wrapper('/gh/owner/repo/tests/main'),
+          wrapper: wrapper(`/gh/owner/repo/tests/${encodedBranch}`),
         })
 
         const title = await screen.findByText('Flaky tests')
@@ -256,7 +268,7 @@ describe('MetricsSection', () => {
       it('can update the location params on button click', async () => {
         const { user } = setup()
         render(<MetricsSection />, {
-          wrapper: wrapper('/gh/owner/repo/tests/main'),
+          wrapper: wrapper(`/gh/owner/repo/tests/${encodedBranch}`),
         })
         const select = await screen.findByText(88)
         expect(select).toBeInTheDocument()
@@ -274,7 +286,7 @@ describe('MetricsSection', () => {
       it('removes the location param on second button click', async () => {
         const { user } = setup()
         render(<MetricsSection />, {
-          wrapper: wrapper('/gh/owner/repo/tests/main'),
+          wrapper: wrapper(`/gh/owner/repo/tests/${encodedBranch}`),
         })
         const select = await screen.findByText(88)
         expect(select).toBeInTheDocument()
@@ -313,7 +325,7 @@ describe('MetricsSection', () => {
       it('renders total failures card', async () => {
         setup()
         render(<MetricsSection />, {
-          wrapper: wrapper('/gh/owner/repo/tests/main'),
+          wrapper: wrapper(`/gh/owner/repo/tests/${encodedBranch}`),
         })
 
         const title = await screen.findByText('Cumulative Failures')
@@ -330,7 +342,7 @@ describe('MetricsSection', () => {
       it('can update the location params on button click', async () => {
         const { user } = setup()
         render(<MetricsSection />, {
-          wrapper: wrapper('/gh/owner/repo/tests/main'),
+          wrapper: wrapper(`/gh/owner/repo/tests/${encodedBranch}`),
         })
         const select = await screen.findByText(1)
         expect(select).toBeInTheDocument()
@@ -370,7 +382,7 @@ describe('MetricsSection', () => {
       it('renders total skips card', async () => {
         setup()
         render(<MetricsSection />, {
-          wrapper: wrapper('/gh/owner/repo/tests/main'),
+          wrapper: wrapper(`/gh/owner/repo/tests/${encodedBranch}`),
         })
 
         const title = await screen.findByText('Skipped tests')
@@ -387,7 +399,7 @@ describe('MetricsSection', () => {
       it('can update the location params on button click', async () => {
         const { user } = setup()
         render(<MetricsSection />, {
-          wrapper: wrapper('/gh/owner/repo/tests/main'),
+          wrapper: wrapper(`/gh/owner/repo/tests/${encodedBranch}`),
         })
         const select = await screen.findByText(20)
         expect(select).toBeInTheDocument()
@@ -405,7 +417,7 @@ describe('MetricsSection', () => {
       it('removes the location param on second button click', async () => {
         const { user } = setup()
         render(<MetricsSection />, {
-          wrapper: wrapper('/gh/owner/repo/tests/main'),
+          wrapper: wrapper(`/gh/owner/repo/tests/${encodedBranch}`),
         })
         const select = await screen.findByText(20)
         expect(select).toBeInTheDocument()

--- a/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/MetricsSection/MetricsSection.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/MetricsSection/MetricsSection.tsx
@@ -3,6 +3,7 @@ import { useLocation, useParams } from 'react-router-dom'
 
 import { MeasurementInterval } from 'pages/RepoPage/shared/constants'
 import { useLocationParams } from 'services/navigation/useLocationParams'
+import { ALL_BRANCHES } from 'services/navigation/useNavLinks'
 import { cn } from 'shared/utils/cn'
 import { formatTimeFromSeconds } from 'shared/utils/dates'
 import Badge from 'ui/Badge'
@@ -379,7 +380,10 @@ function MetricsSection() {
   const decodedBranch = getDecodedBranch(branch)
   const selectedBranch = decodedBranch ?? testResults?.defaultBranch ?? ''
 
-  if (selectedBranch !== testResults?.defaultBranch) {
+  if (
+    selectedBranch !== testResults?.defaultBranch &&
+    selectedBranch !== ALL_BRANCHES
+  ) {
     return null
   }
 

--- a/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/SelectorSection/BranchSelector/BranchSelector.test.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/SelectorSection/BranchSelector/BranchSelector.test.tsx
@@ -10,6 +10,7 @@ import BranchSelector from './BranchSelector'
 
 const mocks = vi.hoisted(() => ({
   useIntersection: vi.fn(),
+  useFlags: vi.fn(),
 }))
 
 vi.mock('react-use', async () => {
@@ -17,6 +18,14 @@ vi.mock('react-use', async () => {
   return {
     ...original,
     useIntersection: mocks.useIntersection,
+  }
+})
+
+vi.mock('shared/featureFlags', async () => {
+  const actual = await vi.importActual('shared/featureFlags')
+  return {
+    ...actual,
+    useFlags: mocks.useFlags,
   }
 })
 
@@ -123,6 +132,7 @@ beforeAll(() => {
 })
 
 afterEach(() => {
+  vi.clearAllMocks()
   server.resetHandlers()
 })
 
@@ -151,6 +161,8 @@ describe('BranchSelector', () => {
     const user = userEvent.setup()
     const fetchNextPage = vi.fn()
     const mockSearching = vi.fn()
+
+    mocks.useFlags.mockReturnValue({ allBranchesEnabled: false })
 
     const queryClient = new QueryClient({
       defaultOptions: {
@@ -393,6 +405,221 @@ describe('BranchSelector', () => {
       })
 
       expect(select).toHaveTextContent('Select branch')
+    })
+  })
+})
+
+describe('BranchSelector with All Branches enabled', () => {
+  function setup(
+    {
+      hasNextPage = false,
+      nullOverview = false,
+      nullHead = false,
+    }: SetupArgs = {
+      hasNextPage: false,
+      nullOverview: false,
+      nullHead: false,
+    }
+  ) {
+    const user = userEvent.setup()
+    const fetchNextPage = vi.fn()
+    const mockSearching = vi.fn()
+
+    mocks.useFlags.mockReturnValue({ allBranchesEnabled: true })
+
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: {
+          suspense: true,
+          retry: false,
+        },
+      },
+    })
+
+    server.use(
+      graphql.query('GetRepoOverview', () => {
+        if (nullOverview) {
+          return HttpResponse.json({ data: { owner: null } })
+        }
+
+        return HttpResponse.json({
+          data: {
+            owner: {
+              isCurrentUserActivated: true,
+              repository: mockRepoOverview,
+            },
+          },
+        })
+      }),
+      graphql.query('GetBranch', (info) => {
+        let branch = 'main'
+        if (info.variables?.branch) {
+          branch = info.variables?.branch
+        }
+
+        let mockedBranch = mockBranch(branch)
+        if (nullHead) {
+          mockedBranch = mockBranch(branch, null)
+        }
+
+        return HttpResponse.json({
+          data: {
+            owner: {
+              repository: { __typename: 'Repository', ...mockedBranch },
+            },
+          },
+        })
+      }),
+      graphql.query('GetBranches', (info) => {
+        if (info.variables?.after) {
+          fetchNextPage(info.variables?.after)
+        }
+
+        if (info.variables?.filters?.searchValue === 'main') {
+          return HttpResponse.json({
+            data: { owner: { repository: mockMainBranchSearch } },
+          })
+        }
+
+        if (info.variables?.filters?.searchValue) {
+          mockSearching(info.variables?.filters?.searchValue)
+        }
+
+        return HttpResponse.json({
+          data: { owner: { repository: mockBranches(hasNextPage) } },
+        })
+      })
+    )
+
+    return {
+      fetchNextPage,
+      mockSearching,
+      user,
+      queryClient,
+    }
+  }
+
+  describe('with populated data', () => {
+    it('renders the branch selector', async () => {
+      const { queryClient } = setup()
+      render(<BranchSelector />, {
+        wrapper: wrapper(queryClient),
+      })
+
+      const branchContext = await screen.findByText(/Branch Context/)
+      expect(branchContext).toBeInTheDocument()
+    })
+
+    it('renders default branch as selected branch', async () => {
+      const { queryClient } = setup()
+      render(<BranchSelector />, {
+        wrapper: wrapper(queryClient),
+      })
+
+      const dropDownBtn = await screen.findByText('All branches')
+      expect(dropDownBtn).toBeInTheDocument()
+    })
+  })
+
+  describe('navigating branches', () => {
+    describe('user lands on the page', () => {
+      it('redirects to the default branch', async () => {
+        const { queryClient } = setup()
+        render(<BranchSelector />, {
+          wrapper: wrapper(queryClient),
+        })
+
+        await waitFor(() =>
+          expect(testLocation.pathname).toBe('/gh/codecov/test-repo/tests')
+        )
+      })
+
+      it('does not redirect on Select branch', async () => {
+        const { queryClient } = setup({
+          nullHead: true,
+        })
+        render(<BranchSelector />, {
+          wrapper: wrapper(queryClient),
+        })
+
+        await waitFor(() =>
+          expect(testLocation.pathname).toBe('/gh/codecov/test-repo/tests')
+        )
+      })
+    })
+
+    describe('user selects a branch', () => {
+      it('shows default branch as first option in dropdown', async () => {
+        const { queryClient, user } = setup()
+        render(<BranchSelector />, {
+          wrapper: wrapper(queryClient),
+        })
+
+        const select = await screen.findByRole('button', {
+          name: 'test results branch selector',
+        })
+        await user.click(select)
+
+        const options = screen.getAllByRole('option')
+        expect(options[0]).toHaveTextContent('All branches')
+      })
+
+      it('navigates to the selected branch', async () => {
+        const { user, queryClient } = setup()
+        render(<BranchSelector />, {
+          wrapper: wrapper(queryClient),
+        })
+
+        const select = await screen.findByRole('button', {
+          name: 'test results branch selector',
+        })
+        await user.click(select)
+
+        const branch = await screen.findByText('branch-1')
+        await user.click(branch)
+
+        await waitFor(() =>
+          expect(testLocation.pathname).toBe(
+            '/gh/codecov/test-repo/tests/branch-1'
+          )
+        )
+      })
+    })
+  })
+
+  describe('user searches for branch', () => {
+    it('calls the api with the search value', async () => {
+      const { mockSearching, user, queryClient } = setup()
+      render(<BranchSelector />, {
+        wrapper: wrapper(queryClient),
+      })
+
+      const select = await screen.findByText('All branches')
+      await user.click(select)
+
+      const input = await screen.findByRole('combobox')
+      await user.type(input, 'searching for branch')
+
+      await waitFor(() =>
+        expect(mockSearching).toHaveBeenCalledWith('searching for branch')
+      )
+    })
+  })
+
+  describe('when the branch is not found', () => {
+    it('displays select a branch in the button', async () => {
+      const { queryClient } = setup({
+        nullOverview: true,
+      })
+      render(<BranchSelector />, {
+        wrapper: wrapper(queryClient),
+      })
+
+      const select = await screen.findByRole('button', {
+        name: 'test results branch selector',
+      })
+
+      expect(select).toHaveTextContent('All branches')
     })
   })
 })

--- a/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/SelectorSection/BranchSelector/BranchSelector.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/SelectorSection/BranchSelector/BranchSelector.tsx
@@ -3,8 +3,9 @@ import { useHistory, useParams } from 'react-router-dom'
 
 import { useBranch } from 'services/branches/useBranch'
 import { Branch, useBranches } from 'services/branches/useBranches'
-import { useNavLinks } from 'services/navigation/useNavLinks'
+import { ALL_BRANCHES, useNavLinks } from 'services/navigation/useNavLinks'
 import { useRepoOverview } from 'services/repo'
+import { useFlags } from 'shared/featureFlags'
 import Icon from 'ui/Icon'
 import Select from 'ui/Select'
 
@@ -19,6 +20,10 @@ const getDecodedBranch = (branch?: string) =>
   branch ? decodeURIComponent(branch) : undefined
 
 const BranchSelector = () => {
+  const { allBranchesEnabled: allBranchesEnabledFlag } = useFlags({
+    allBranchesEnabled: false,
+  })
+
   const history = useHistory()
   const { failedTests: failedTestsLink } = useNavLinks()
   const { provider, owner, repo, branch } = useParams<URLParams>()
@@ -46,7 +51,11 @@ const BranchSelector = () => {
   })
 
   const decodedBranch = getDecodedBranch(branch)
-  const selectedBranch = decodedBranch ?? overview?.defaultBranch ?? ''
+  const selectedBranch = allBranchesEnabledFlag
+    ? (decodedBranch ?? ALL_BRANCHES)
+    : (decodedBranch ?? overview?.defaultBranch ?? '')
+
+  console.log('selectedBranch', selectedBranch)
 
   const { data: searchBranchValue } = useBranch({
     provider,
@@ -60,37 +69,76 @@ const BranchSelector = () => {
   })
 
   let selection = searchBranchValue?.branch
-  if (!selection) {
-    selection = {
-      name: 'Select branch',
-      head: null,
-    }
-  }
+  console.log('selection', selection)
 
-  if (
-    selectedBranch === overview?.defaultBranch &&
-    !branch &&
-    selection.head !== null
-  ) {
-    history.push(
-      failedTestsLink.path({ branch: encodeURIComponent(selection?.name) })
-    )
+  if (!allBranchesEnabledFlag) {
+    if (!selection) {
+      selection = {
+        name: 'Select branch',
+        head: null,
+      }
+    }
+
+    if (
+      selectedBranch === overview?.defaultBranch &&
+      !branch &&
+      selection.head !== null
+    ) {
+      history.push(
+        failedTestsLink.path({ branch: encodeURIComponent(selection?.name) })
+      )
+    }
+  } else {
+    if (!selection) {
+      if (branch) {
+        selection = {
+          name: branch,
+          head: null,
+        }
+      } else {
+        selection = {
+          name: 'Select branch',
+          head: null,
+        }
+      }
+    }
+
+    if (!branch) {
+      history.push(
+        failedTestsLink.path({ branch: encodeURIComponent(ALL_BRANCHES) })
+      )
+    }
   }
 
   const sortedBranchList = useMemo(() => {
-    if (!branchList?.branches) return []
+    if (!branchList?.branches?.length) return []
 
-    if (overview?.defaultBranch) {
-      return [
-        // Pins the default branch to the top of the list always, filters it from results otherwise
-        { name: overview.defaultBranch, head: null },
-        ...branchList.branches.filter(
-          (branch) => branch.name !== overview.defaultBranch
-        ),
-      ]
+    if (!allBranchesEnabledFlag) {
+      if (overview?.defaultBranch) {
+        return [
+          // Pins the default branch to the top of the list always, filters it from results otherwise
+          { name: overview.defaultBranch, head: null },
+          ...branchList.branches.filter(
+            (branch) => branch.name !== overview.defaultBranch
+          ),
+        ]
+      }
+      return branchList.branches
+    } else {
+      if (overview?.defaultBranch) {
+        return [
+          // Pins the default branch to the top of the list always, filters it from results otherwise
+          { name: ALL_BRANCHES, head: null },
+          { name: overview.defaultBranch, head: null },
+          ...branchList.branches.filter(
+            (branch) =>
+              branch.name !== overview.defaultBranch &&
+              branch.name !== ALL_BRANCHES
+          ),
+        ]
+      }
     }
-    return branchList.branches
-  }, [overview?.defaultBranch, branchList.branches])
+  }, [overview?.defaultBranch, branchList.branches, allBranchesEnabledFlag])
 
   return (
     <div className="flex w-full flex-col gap-1 px-4 lg:w-64 xl:w-80">

--- a/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/SelectorSection/SelectorSection.test.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/SelectorSection/SelectorSection.test.tsx
@@ -10,6 +10,15 @@ import { ErrorCodeEnum } from 'shared/utils/commit'
 
 import SelectorSection from './SelectorSection'
 
+vi.mock('shared/featureFlags', async () => {
+  const actual = await vi.importActual('shared/featureFlags')
+
+  return {
+    ...actual,
+    useFlags: vi.fn(() => ({ allBranchesEnabled: false })),
+  }
+})
+
 const mockRepoOverview = {
   owner: {
     isCurrentUserActivated: true,
@@ -178,11 +187,14 @@ describe('SelectorSection', () => {
     })
   })
 
-  describe('when on default branch', () => {
+  describe.each([
+    ['default branch', 'main'],
+    ['all branches', 'All%20branches'],
+  ])('when on %s', (_, encodedBranch) => {
     it('has all four selectors', async () => {
       setup()
       render(<SelectorSection />, {
-        wrapper: wrapper('/gh/owner/repo/tests/main'),
+        wrapper: wrapper(`/gh/owner/repo/tests/${encodedBranch}`),
       })
 
       const branchSelector = await screen.findByText('Branch Context')
@@ -198,7 +210,7 @@ describe('SelectorSection', () => {
     it('has 60 day retention link', async () => {
       setup()
       render(<SelectorSection />, {
-        wrapper: wrapper('/gh/owner/repo/tests/main'),
+        wrapper: wrapper(`/gh/owner/repo/tests/${encodedBranch}`),
       })
 
       const link = await screen.findByRole('link')

--- a/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/SelectorSection/SelectorSection.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/SelectorSection/SelectorSection.tsx
@@ -8,6 +8,7 @@ import {
   MeasurementTimeOptions,
 } from 'pages/RepoPage/shared/constants'
 import { useLocationParams } from 'services/navigation/useLocationParams'
+import { ALL_BRANCHES } from 'services/navigation/useNavLinks'
 import { useRepoOverview } from 'services/repo'
 import A from 'ui/A'
 import Icon from 'ui/Icon'
@@ -91,7 +92,8 @@ function SelectorSection() {
   return (
     <div className="flex flex-1 flex-col gap-2 md:flex-row md:justify-between md:gap-0">
       <BranchSelector />
-      {selectedBranch === overview?.defaultBranch ? (
+      {selectedBranch === overview?.defaultBranch ||
+      selectedBranch === ALL_BRANCHES ? (
         <>
           <div className="flex flex-col gap-1 px-4">
             <h3 className="text-sm font-semibold text-ds-gray-octonary">

--- a/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/TableHeader/TableHeader.test.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/TableHeader/TableHeader.test.tsx
@@ -6,6 +6,19 @@ import { MemoryRouter, Route, useLocation } from 'react-router-dom'
 
 import TableHeader from './TableHeader'
 
+const mocks = vi.hoisted(() => ({
+  useFlags: vi.fn(() => ({ allBranchesEnabled: false })),
+}))
+
+vi.mock('shared/featureFlags', async () => {
+  const actual = await vi.importActual('shared/featureFlags')
+
+  return {
+    ...actual,
+    useFlags: mocks.useFlags,
+  }
+})
+
 const queryClient = new QueryClient({
   defaultOptions: { queries: { suspense: true, retry: false } },
 })
@@ -36,9 +49,10 @@ const wrapper: (initialEntries?: string) => React.FC<PropsWithChildren> =
     </QueryClientProvider>
   )
 
-describe('TableHeader', () => {
+describe.each([true, false])('TableHeader', (allBranchesEnabled) => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mocks.useFlags.mockReturnValue({ allBranchesEnabled })
   })
 
   it('renders the TableHeader component', () => {


### PR DESCRIPTION
we want to allow users to not filter by any specific branch and aggregate the results from all branches

we also want to make this the default option when users land on the tests tab from now on

i'm putting this behind a feature flag because the backend is not capable of serving this data yet since it relies on the TA timescale data migration, and there's an equivalent API change that needs to be made for this to work correctly as well

fixed a thing where when users were searching through the branch selector for a specific branch we were still pinning the default branch to the top of the selection

also the all branches view has all the nice stuff that the default branch view has: metrics section, reset to default button, etc.