### PR TITLE
fix: Remove redundant call - coverage file

### DIFF
--- a/src/ui/FileViewer/ToggleHeader/Title/Title.tsx
+++ b/src/ui/FileViewer/ToggleHeader/Title/Title.tsx
@@ -72,7 +72,7 @@ export const TitleFlags = ({ commitDetailView = false }: TitleFlagsProps) => {
     hasNextPage: flagsHasNextPage,
     fetchNextPage: flagsFetchNextPage,
   } = useRepoFlagsSelect({
-    filters: { term: flagSearch },
+    filters: { term: flagSearch || undefined },
     options: {
       suspense: false,
       enabled: flagsMeasurementsActive && !noFlagsPresent && isTimescaleEnabled,


### PR DESCRIPTION
Remove the redundant call to the flags api. Was formerly calling with `filters: {term: ""}` and also `filters: {}` so reduce it down to 1 call. These behave same on the [api side](https://github.com/codecov/codecov-api/blob/795e37f5bb45e311b351af47442f9cad2cdb1afb/graphql_api/actions/flags.py#L27) so that's no issue.
Closes https://github.com/codecov/engineering-team/issues/3529