### PR TITLE
fix: Remove duplicate calls to GetBranchCoverageMeasurements

### DIFF
--- a/src/pages/RepoPage/CoverageTab/OverviewTab/hooks/useRepoCoverageTimeseries.ts
+++ b/src/pages/RepoPage/CoverageTab/OverviewTab/hooks/useRepoCoverageTimeseries.ts
@@ -2,7 +2,7 @@ import {
   keepPreviousData,
   useQuery as useQueryV5,
 } from '@tanstack/react-queryV5'
-import { useMemo } from 'react'
+import { useMemo, useRef } from 'react'
 import { useParams } from 'react-router-dom'
 
 import { BranchCoverageMeasurementsQueryOpts } from 'services/charts/BranchCoverageMeasurementsQueryOpts'
@@ -42,15 +42,20 @@ export function useRepoCoverageTimeseries({
     params: { trend?: Trends }
   } = useLocationParams({ trend: Trend.THREE_MONTHS })
 
-  const today = useMemo(() => new Date(), [])
+  const todayRef = useRef(new Date())
+  todayRef.current.setMilliseconds(0)
 
   const queryVars = useMemo(() => {
     const trend = getTrendEnum(params?.trend ?? Trend.THREE_MONTHS)
     const oldestCommit = overview?.oldestCommitAt
       ? new Date(overview?.oldestCommitAt)
       : null
-    return createTimeSeriesQueryVars({ trend, oldestCommit, today })
-  }, [overview?.oldestCommitAt, params?.trend, today])
+    return createTimeSeriesQueryVars({
+      trend,
+      oldestCommit,
+      today: todayRef.current,
+    })
+  }, [overview?.oldestCommitAt, params?.trend])
 
   return useQueryV5({
     ...BranchCoverageMeasurementsQueryOpts({
@@ -59,7 +64,7 @@ export function useRepoCoverageTimeseries({
       repo,
       branch,
       after: queryVars?.after,
-      before: today,
+      before: queryVars?.before,
       interval: queryVars.interval,
     }),
     select: (data) => {

--- a/src/shared/utils/timeseriesCharts.ts
+++ b/src/shared/utils/timeseriesCharts.ts
@@ -155,6 +155,9 @@ export function createTimeSeriesQueryVars({
   oldestCommit: Date | null
 }) {
   let after = calculateTrendDate({ today, trend })
+
+  console.log('today', today)
+  console.log('after', after)
   if (after === null) {
     after = oldestCommit
   }


### PR DESCRIPTION
There is a duplicate call to GetBranchCoverageMeasurements due to milliseconds drift across re-renders when calling new Date(). Remove the milliseconds portion of the date (to the closest second is perfectly fine for this use case of showing the trend with the finest granularity being for the last day). Also uses useRef instead of useMemo in order to in order to guarantee stability across re-renders and component remounts, since useMemo(() => new Date(), []) may still be re-evaluated when the component remounts

<img width="1457" alt="Screenshot 2025-04-17 at 11 25 17 AM" src="https://github.com/user-attachments/assets/eb39fb2d-c55b-4583-ac69-4bc3f71ab8a5" />
