### PR TITLE
fix: Remove duplicate calls on coverage overview page

### DIFF
--- a/src/pages/RepoPage/CoverageTab/OverviewTab/subroute/FileExplorer/FileExplorer.jsx
+++ b/src/pages/RepoPage/CoverageTab/OverviewTab/subroute/FileExplorer/FileExplorer.jsx
@@ -18,8 +18,13 @@ function FileExplorer() {
   const { params, updateParams } = useLocationParams(defaultQueryParams)
   const isFileListDisplay = params?.displayType === 'list'
 
+  const defaultInitialSorting = {
+    direction: 'ASC',
+    ordering: 'NAME',
+  }
+
   const { data: branchData, isLoading: branchIsLoading } =
-    useRepoBranchContentsTable()
+    useRepoBranchContentsTable(defaultInitialSorting)
 
   return (
     <div className="flex flex-col gap-4">

--- a/src/pages/RepoPage/CoverageTab/OverviewTab/subroute/FileExplorer/FlagMultiSelect.jsx
+++ b/src/pages/RepoPage/CoverageTab/OverviewTab/subroute/FileExplorer/FlagMultiSelect.jsx
@@ -24,7 +24,7 @@ function FlagMultiSelect() {
   const { provider, owner } = useParams()
   const { params, updateParams } = useLocationParams(defaultQueryParams)
   const [selectedFlags, setSelectedFlags] = useState(params?.flags)
-  const [flagSearch, setFlagSearch] = useState(null)
+  const [flagSearch, setFlagSearch] = useState('')
 
   const { data: isTeamPlan } = useIsTeamPlan({ provider, owner })
   const { data: repoData } = useRepoSettingsTeam()


### PR DESCRIPTION
Remove a couple more duplicate calls on the coverage overview page

* Branch Contents ~400 ms (was called both with and without some default initial ordering - updated so both calls would have the same first call so first page load is faster and can make the extra call if sorting the table)
* Flag Select ~100 ms (was swapping between null and "")

<img width="1159" alt="Screenshot 2025-04-17 at 2 59 21 PM" src="https://github.com/user-attachments/assets/081b05c8-f8d2-41dd-9333-c59c228f76e0" />


Closes https://github.com/codecov/engineering-team/issues/3530