### PR TITLE
fix: Handle segments ProviderError

### DIFF
--- a/src/pages/CommitDetailPage/CommitCoverage/routes/FilesChangedTab/shared/CommitFileDiff/CommitFileDiff.test.tsx
+++ b/src/pages/CommitDetailPage/CommitCoverage/routes/FilesChangedTab/shared/CommitFileDiff/CommitFileDiff.test.tsx
@@ -412,7 +412,7 @@ describe('CommitFileDiff', () => {
         render(<CommitFileDiff path={'flag1/file.js'} />, { wrapper })
 
         const errorMessage = await screen.findByText(
-          /There was a problem getting the source code from your provider. Unable to show line by line coverage/i
+          /There was a problem getting the source code from your provider by path for/i
         )
         expect(errorMessage).toBeInTheDocument()
       })

--- a/src/pages/CommitDetailPage/CommitCoverage/routes/FilesChangedTab/shared/CommitFileDiff/CommitFileDiff.tsx
+++ b/src/pages/CommitDetailPage/CommitCoverage/routes/FilesChangedTab/shared/CommitFileDiff/CommitFileDiff.tsx
@@ -171,11 +171,24 @@ function CommitFileDiff({ path }: CommitFileDiffProps) {
     opts: { enabled: !!path },
   })
 
-  if (!comparisonData || !comparisonData?.impactedFile || !path) {
+  const hadErrorFetchingFileFromProvider =
+    comparisonData?.impactedFile?.segments?.__typename === 'ProviderError' ||
+    comparisonData?.impactedFile?.segments?.__typename === 'UnknownPath'
+
+  if (
+    !comparisonData ||
+    !comparisonData?.impactedFile ||
+    !path ||
+    hadErrorFetchingFileFromProvider
+  ) {
     return <ErrorDisplayMessage />
   }
 
-  return <DiffRenderer impactedFile={comparisonData.impactedFile} path={path} />
+  // since above we've handled when segments is of one of the other union types,
+  // we can safely assert that it's of type SegmentComparisons now
+  const impactedFile = comparisonData.impactedFile as ImpactedFileType
+
+  return <DiffRenderer impactedFile={impactedFile} path={path} />
 }
 
 export default CommitFileDiff

--- a/src/pages/CommitDetailPage/CommitCoverage/routes/FilesChangedTab/shared/CommitFileDiff/CommitFileDiff.tsx
+++ b/src/pages/CommitDetailPage/CommitCoverage/routes/FilesChangedTab/shared/CommitFileDiff/CommitFileDiff.tsx
@@ -147,6 +147,37 @@ function ErrorDisplayMessage() {
   )
 }
 
+function UnknownPathErrorDisplayMessage({ path }: { path: string }) {
+  const location = useLocation()
+
+  return (
+    <p className="border border-solid border-ds-gray-tertiary p-4">
+      There was a problem getting the source code from your provider by path
+      for: <strong>{path}</strong>. Unable to show line by line coverage.
+      <br />
+      <span>
+        If you continue to experience this issue, please try{' '}
+        <A
+          to={{ pageName: 'login', options: { to: location.pathname } }}
+          hook={undefined}
+          isExternal={undefined}
+        >
+          logging in
+        </A>{' '}
+        again to refresh your credentials. Otherwise, please visit our{' '}
+        <A
+          to={{ pageName: 'pathFixing', options: { to: location.pathname } }}
+          hook={undefined}
+          isExternal={undefined}
+        >
+          Path Fixing
+        </A>{' '}
+        documentation for troubleshooting tips.
+      </span>
+    </p>
+  )
+}
+
 interface URLParams {
   provider: string
   owner: string
@@ -171,24 +202,28 @@ function CommitFileDiff({ path }: CommitFileDiffProps) {
     opts: { enabled: !!path },
   })
 
-  const hadErrorFetchingFileFromProvider =
-    comparisonData?.impactedFile?.segments?.__typename === 'ProviderError' ||
-    comparisonData?.impactedFile?.segments?.__typename === 'UnknownPath'
+  const segments = comparisonData?.impactedFile?.segments
 
   if (
     !comparisonData ||
     !comparisonData?.impactedFile ||
     !path ||
-    hadErrorFetchingFileFromProvider
+    !segments ||
+    segments?.__typename === 'ProviderError'
   ) {
     return <ErrorDisplayMessage />
   }
 
-  // since above we've handled when segments is of one of the other union types,
-  // we can safely assert that it's of type SegmentComparisons now
-  const impactedFile = comparisonData.impactedFile as ImpactedFileType
+  if (segments?.__typename === 'UnknownPath') {
+    return <UnknownPathErrorDisplayMessage path={path} />
+  }
 
-  return <DiffRenderer impactedFile={impactedFile} path={path} />
+  const impactedFileWithSegments = {
+    ...comparisonData.impactedFile,
+    segments,
+  }
+
+  return <DiffRenderer impactedFile={impactedFileWithSegments} path={path} />
 }
 
 export default CommitFileDiff

--- a/src/pages/CommitDetailPage/CommitCoverage/routes/IndirectChangesTab/IndirectChangesTable/CommitFileDiff/CommitFileDiff.test.tsx
+++ b/src/pages/CommitDetailPage/CommitCoverage/routes/IndirectChangesTab/IndirectChangesTable/CommitFileDiff/CommitFileDiff.test.tsx
@@ -115,6 +115,7 @@ const mockImpactedFile = {
   },
   changeCoverage: 0,
   segments: {
+    __typename: 'SegmentComparisons',
     results: [
       {
         header: '-0,0 +1,45',
@@ -364,6 +365,46 @@ describe('CommitFileDiff', () => {
       const link = await screen.findByText(/logging in/)
       expect(link).toBeVisible()
       expect(link).toHaveAttribute('href', `/login?${queryString}`)
+    })
+  })
+
+  describe('when segments union type returned error', () => {
+    describe('when provider error', () => {
+      it('renders a error display message', async () => {
+        const impactedFileWithProviderError = {
+          ...mockImpactedFile,
+          segments: {
+            __typename: 'ProviderError',
+            message: 'Error fetching data from the provider',
+          },
+        }
+        setup({ impactedFile: impactedFileWithProviderError })
+        render(<CommitFileDiff path={'flag1/file.js'} />, { wrapper })
+
+        const errorMessage = await screen.findByText(
+          /There was a problem getting the source code from your provider. Unable to show line by line coverage/i
+        )
+        expect(errorMessage).toBeInTheDocument()
+      })
+    })
+
+    describe('when path error', () => {
+      it('renders a error display message for path error', async () => {
+        const impactedFileWithPathError = {
+          ...mockImpactedFile,
+          segments: {
+            __typename: 'UnknownPath',
+            message: 'Unknown path',
+          },
+        }
+        setup({ impactedFile: impactedFileWithPathError })
+        render(<CommitFileDiff path={'flag1/file.js'} />, { wrapper })
+
+        const errorMessage = await screen.findByText(
+          /There was a problem getting the source code from your provider. Unable to show line by line coverage/i
+        )
+        expect(errorMessage).toBeInTheDocument()
+      })
     })
   })
 

--- a/src/pages/CommitDetailPage/CommitCoverage/routes/IndirectChangesTab/IndirectChangesTable/CommitFileDiff/CommitFileDiff.test.tsx
+++ b/src/pages/CommitDetailPage/CommitCoverage/routes/IndirectChangesTab/IndirectChangesTable/CommitFileDiff/CommitFileDiff.test.tsx
@@ -401,7 +401,7 @@ describe('CommitFileDiff', () => {
         render(<CommitFileDiff path={'flag1/file.js'} />, { wrapper })
 
         const errorMessage = await screen.findByText(
-          /There was a problem getting the source code from your provider. Unable to show line by line coverage/i
+          /There was a problem getting the source code from your provider by path for/i
         )
         expect(errorMessage).toBeInTheDocument()
       })

--- a/src/pages/CommitDetailPage/CommitCoverage/routes/IndirectChangesTab/IndirectChangesTable/CommitFileDiff/CommitFileDiff.tsx
+++ b/src/pages/CommitDetailPage/CommitCoverage/routes/IndirectChangesTab/IndirectChangesTable/CommitFileDiff/CommitFileDiff.tsx
@@ -183,7 +183,11 @@ function CommitFileDiff({ path }: CommitFileDiffProps) {
     return <ErrorDisplayMessage />
   }
 
-  return <DiffRenderer impactedFile={comparisonData.impactedFile} path={path} />
+  // since above we've handled when segments is of one of the other union types,
+  // we can safely assert that it's of type SegmentComparisons now
+  const impactedFile = comparisonData.impactedFile as ImpactedFileType
+
+  return <DiffRenderer impactedFile={impactedFile} path={path} />
 }
 
 CommitFileDiff.propTypes = {

--- a/src/pages/CommitDetailPage/CommitCoverage/routes/IndirectChangesTab/IndirectChangesTable/CommitFileDiff/CommitFileDiff.tsx
+++ b/src/pages/CommitDetailPage/CommitCoverage/routes/IndirectChangesTab/IndirectChangesTable/CommitFileDiff/CommitFileDiff.tsx
@@ -170,7 +170,16 @@ function CommitFileDiff({ path }: CommitFileDiffProps) {
     },
   })
 
-  if (!comparisonData || !comparisonData?.impactedFile || !path) {
+  const hadErrorFetchingFileFromProvider =
+    comparisonData?.impactedFile?.segments?.__typename === 'ProviderError' ||
+    comparisonData?.impactedFile?.segments?.__typename === 'UnknownPath'
+
+  if (
+    !comparisonData ||
+    !comparisonData?.impactedFile ||
+    !path ||
+    hadErrorFetchingFileFromProvider
+  ) {
     return <ErrorDisplayMessage />
   }
 

--- a/src/services/comparison/constants.ts
+++ b/src/services/comparison/constants.ts
@@ -21,6 +21,7 @@ fragment ComparisonFragment on Comparison {
       changeCoverage
       segments (filters: $filters) {
         ... on SegmentComparisons {
+          __typename
           results {
             header
             hasUnintendedChanges
@@ -36,6 +37,14 @@ fragment ComparisonFragment on Comparison {
               }
             }
           }
+        }
+        ... on ProviderError {
+          __typename
+          message
+        }
+        ... on UnknownPath {
+          __typename
+          message
         }
       }
     }

--- a/src/services/comparison/useComparisonForCommitAndParent/useComparisonForCommitAndParent.test.tsx
+++ b/src/services/comparison/useComparisonForCommitAndParent/useComparisonForCommitAndParent.test.tsx
@@ -29,6 +29,7 @@ const mockImpactedFile = {
   },
   changeCoverage: 0,
   segments: {
+    __typename: 'SegmentComparisons',
     results: [
       {
         header: '-0,0 +1,45',
@@ -193,6 +194,7 @@ describe('useComparisonForCommitAndParent', () => {
               coverage: 100,
             },
             segments: {
+              __typename: 'SegmentComparisons',
               results: [
                 {
                   hasUnintendedChanges: false,

--- a/src/services/comparison/useComparisonForCommitAndParent/useComparisonForCommitAndParent.tsx
+++ b/src/services/comparison/useComparisonForCommitAndParent/useComparisonForCommitAndParent.tsx
@@ -30,27 +30,38 @@ export const ImpactedFileSchema = z.object({
   headCoverage: CoverageObjSchema.nullable(),
   patchCoverage: CoverageObjSchema.nullable(),
   changeCoverage: z.number().nullable(),
-  segments: z.object({
-    results: z.array(
-      z.object({
-        header: z.string(),
-        hasUnintendedChanges: z.boolean(),
-        lines: z.array(
-          z.object({
-            baseNumber: z.string().nullable(),
-            headNumber: z.string().nullable(),
-            baseCoverage: z.string().nullable(),
-            headCoverage: z.string().nullable(),
-            content: z.string().nullable(),
-            coverageInfo: z.object({
-              hitCount: z.number().nullable(),
-              hitUploadIds: z.array(z.number()).nullable(),
-            }),
-          })
-        ),
-      })
-    ),
-  }),
+  segments: z.discriminatedUnion('__typename', [
+    z.object({
+      __typename: z.literal('SegmentComparisons'),
+      results: z.array(
+        z.object({
+          header: z.string(),
+          hasUnintendedChanges: z.boolean(),
+          lines: z.array(
+            z.object({
+              baseNumber: z.string().nullable(),
+              headNumber: z.string().nullable(),
+              baseCoverage: z.string().nullable(),
+              headCoverage: z.string().nullable(),
+              content: z.string().nullable(),
+              coverageInfo: z.object({
+                hitCount: z.number().nullable(),
+                hitUploadIds: z.array(z.number()).nullable(),
+              }),
+            })
+          ),
+        })
+      ),
+    }),
+    z.object({
+      __typename: z.literal('UnknownPath'),
+      message: z.string(),
+    }),
+    z.object({
+      __typename: z.literal('ProviderError'),
+      message: z.string(),
+    }),
+  ]),
 })
 
 export type ImpactedFileType = z.infer<typeof ImpactedFileSchema>

--- a/src/services/comparison/useComparisonForCommitAndParent/useComparisonForCommitAndParent.tsx
+++ b/src/services/comparison/useComparisonForCommitAndParent/useComparisonForCommitAndParent.tsx
@@ -64,7 +64,21 @@ export const ImpactedFileSchema = z.object({
   ]),
 })
 
-export type ImpactedFileType = z.infer<typeof ImpactedFileSchema>
+// segments is a union type of SegmentComparisons, ProviderError, and UnknownPath
+export type ImpactedFileWithSegmentsUnionType = z.infer<
+  typeof ImpactedFileSchema
+>
+
+// guaranteed to have segments (instead of ProviderError or UnknownPath for that union type)
+export type ImpactedFileType = Omit<
+  ImpactedFileWithSegmentsUnionType,
+  'segments'
+> & {
+  segments: Extract<
+    z.infer<typeof ImpactedFileSchema.shape.segments>,
+    { __typename: 'SegmentComparisons' }
+  >
+}
 
 const ComparisonSchema = z.object({
   __typename: z.literal('Comparison'),

--- a/src/services/navigation/useStaticNavLinks.test.tsx
+++ b/src/services/navigation/useStaticNavLinks.test.tsx
@@ -100,6 +100,7 @@ describe('useStaticNavLinks', () => {
       ${links.requireCIPassDocs}             | ${'https://docs.codecov.com/docs/codecovyml-reference#codecovrequire_ci_to_pass'}
       ${links.circleCIEnvVars}               | ${'https://circleci.com/docs/set-environment-variable/#set-an-environment-variable-in-a-project'}
       ${links.testAnalyticsTroubleshooting}  | ${'https://docs.codecov.com/docs/test-analytics#troubleshooting'}
+      ${links.pathFixing}                    | ${'https://docs.codecov.com/docs/fixing-paths'}
     `('static links return path', ({ link, outcome }) => {
       it(`${link.text}: Returns the correct link`, () => {
         expect(link.path()).toBe(outcome)

--- a/src/services/navigation/useStaticNavLinks.ts
+++ b/src/services/navigation/useStaticNavLinks.ts
@@ -537,5 +537,11 @@ export function useStaticNavLinks() {
       isExternalLink: true,
       openNewTab: true,
     },
+    pathFixing: {
+      text: 'Path Fixing',
+      path: () => 'https://docs.codecov.com/docs/fixing-paths',
+      isExternalLink: true,
+      openNewTab: true,
+    },
   }
 }


### PR DESCRIPTION
Handle when segments returns `ProviderError` or `UnknownPath` [here](https://github.com/codecov/codecov-api/blob/18eb985ef8ed3d409421df684e8fb9f6442cec17/graphql_api/types/segment_comparison/segment_comparison.graphql#L11). 

Closes https://github.com/codecov/engineering-team/issues/3485
<img width="734" alt="Screenshot 2025-04-25 at 9 56 49 AM" src="https://github.com/user-attachments/assets/ba3d8323-93b1-472b-9a6c-06ffadf031c4" />
<img width="877" alt="Screenshot 2025-04-25 at 9 57 24 AM" src="https://github.com/user-attachments/assets/752c2331-ff5c-4be4-ac61-02b80b52e5ec" />

