### PR TITLE
fix: Table incorrectly sorting first page of results when sorted

### DIFF
--- a/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/FailedTestsTable/FailedTestsTable.tsx
+++ b/src/pages/RepoPage/FailedTestsTab/FailedTestsPage/FailedTestsTable/FailedTestsTable.tsx
@@ -3,7 +3,6 @@ import {
   createColumnHelper,
   flexRender,
   getCoreRowModel,
-  getSortedRowModel,
   SortingState,
   useReactTable,
 } from '@tanstack/react-table'
@@ -288,7 +287,6 @@ const FailedTestsTable = () => {
     },
     onSortingChange: setSorting,
     getCoreRowModel: getCoreRowModel(),
-    getSortedRowModel: getSortedRowModel(),
   })
 
   useEffect(() => {


### PR DESCRIPTION
# Description

This PR aims to fix a bug where the first page of results returned from a sorted column on a table were reversed. Interestingly, the table had the correctly sorted results on the ascending case for Firefox and the descending case for Chrome, but failed in the opposite case for either.

After removing this additional table option somehow everything worked again, so probably some weird interaction reversing reversed results or something with the tanstack table library.

Closes https://github.com/codecov/engineering-team/issues/3583

# Screenshots

**CHROME**
https://github.com/user-attachments/assets/08ae42ea-2faf-4c6e-a8a6-73e76bdcb17f

**FIREFOX**
https://github.com/user-attachments/assets/eaa41615-66fc-46c2-ac9e-3ce8ed9423ed



# Link to Sample Entry

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.