### PR TITLE
perf: Minor extract coverage util perf updates

### DIFF
--- a/src/services/pathContents/useFileWithMainCoverage.tsx
+++ b/src/services/pathContents/useFileWithMainCoverage.tsx
@@ -11,8 +11,14 @@ import {
 } from './constants'
 import { extractCoverageFromResponse } from './utils'
 
-// There's only 1 hook per page table as of Feb 22, 2023. This is a limitation to tailor a table to a particular page. Each "page" should have an independent set of hooks for directory and file entries. Every usePrefetchFile<page name> hook needs to this hook's query and queryKey
-// There should be a coverageForFile + prefetch hook set per page. This function, due to how it's written, acts as 1 hook all pages use, and each file implements it's prefetch function accordingly. This is something that needs to be changed, likely in a subsequent PR, as we're getting rid of the individual line file type layout anyway and doing diff line only
+/* There's only 1 hook per page table as of Feb 22, 2023. This is a limitation to
+tailor a table to a particular page. Each "page" should have an independent set of
+hooks for directory and file entries. Every usePrefetchFile<page name> hook needs to
+this hook's query and queryKey. There should be a coverageForFile + prefetch hook set per page. 
+This function, due to how it's written, acts as 1 hook all pages use, and each file implements 
+it's prefetch function accordingly. This is something that needs to be changed, likely in a 
+subsequent PR, as we're getting rid of the individual line file type layout anyway and 
+doing diff line only */
 
 interface UseFileWithMainCoverageArgs {
   provider: string

--- a/src/services/pathContents/utils.ts
+++ b/src/services/pathContents/utils.ts
@@ -1,33 +1,33 @@
-import keyBy from 'lodash/keyBy'
-import mapValues from 'lodash/mapValues'
-
 import { PathContentsRepositorySchema } from './constants'
 
 export function extractCoverageFromResponse(
   repository: PathContentsRepositorySchema | undefined | null
 ) {
   if (!repository) return null
-  const commit = repository?.commit
-  const branch = repository?.branch?.head
-  const coverageSource = (commit || branch)?.coverageAnalytics
+
+  const commit = repository.commit
+  const branch = repository.branch?.head
+  const coverageSource = commit?.coverageAnalytics || branch?.coverageAnalytics
   const coverageFile = coverageSource?.coverageFile
+
   if (!coverageFile) return null
-  const lineWithCoverage = keyBy(coverageFile?.coverage, 'line')
-  const fileCoverage = mapValues(lineWithCoverage, 'coverage')
+
+  const fileCoverage = Object.fromEntries(
+    coverageFile.coverage?.map((item) => [item?.line, item?.coverage]) || []
+  )
   const coverageTotal = coverageFile?.totals?.percentCovered
   const hashedPath = coverageFile?.hashedPath
 
-  return {
+  const result = {
     content: coverageFile?.content,
     coverage: fileCoverage,
-    totals:
-      typeof coverageTotal !== 'number' || isNaN(coverageTotal)
-        ? 0
-        : coverageTotal,
+    totals: coverageTotal && !Number.isNaN(coverageTotal) ? coverageTotal : 0,
     flagNames: coverageSource?.flagNames ?? [],
     componentNames: coverageSource?.components?.map(({ name }) => name) ?? [],
     ...(hashedPath && { hashedPath }),
   }
+
+  return result
 }
 
 export type PrefetchBranchFileEntryCoverage = ReturnType<


### PR DESCRIPTION
# Description

Just familiarizing myself with the File Explorer code and in the process found a couple minor optimizations we could do.

Namely removing the 2 lodash functions for some JS built-ins. Also potentially a bug fix where we had (commit || branch) which if commit didn't have coverage analytics but branch did would result in an error / premature return when we didn't need to.

# Screenshots
**before**
<img width="732" alt="Screenshot 2025-05-16 at 1 45 02 PM" src="https://github.com/user-attachments/assets/16fefeef-23ac-4422-8197-f56aec881f2a" />

**after**
<img width="736" alt="Screenshot 2025-05-16 at 1 45 52 PM" src="https://github.com/user-attachments/assets/b41d72ff-3ec6-40d6-9834-4cabf4a7ed3e" />


These aren't scientific but yeah this is mostly yak shaving anyway

# Link to Sample Entry

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.