### PR TITLE
chore: Update base docker images to alpine3.21

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -11,18 +11,18 @@ RUN             mkdir uploader && \
   mkdir uploader/windows
 
 WORKDIR         /tmp/uploader
-RUN             curl -s -o linux/codecov https://uploader.codecov.io/latest/linux/codecov 
-RUN             curl -s -o linux/codecov.SHA256SUM https://uploader.codecov.io/latest/linux/codecov.SHA256SUM 
-RUN             curl -s -o linux/codecov.SHA256SUM.sig https://uploader.codecov.io/latest/linux/codecov.SHA256SUM.sig 
-RUN             curl -s -o alpine/codecov https://uploader.codecov.io/latest/alpine/codecov 
-RUN             curl -s -o alpine/codecov.SHA256SUM https://uploader.codecov.io/latest/alpine/codecov.SHA256SUM 
-RUN             curl -s -o alpine/codecov.SHA256SUM.sig https://uploader.codecov.io/latest/alpine/codecov.SHA256SUM.sig 
-RUN             curl -s -o macos/codecov https://uploader.codecov.io/latest/macos/codecov 
-RUN             curl -s -o macos/codecov.SHA256SUM https://uploader.codecov.io/latest/macos/codecov.SHA256SUM 
-RUN             curl -s -o macos/codecov.SHA256SUM.sig https://uploader.codecov.io/latest/macos/codecov.SHA256SUM.sig 
-RUN             curl -s -o windows/codecov.exe https://uploader.codecov.io/latest/windows/codecov.exe 
-RUN             curl -s -o windows/codecov.exe.SHA256SUM https://uploader.codecov.io/latest/windows/codecov.exe.SHA256SUM 
-RUN             curl -s -o windows/codecov.exe.SHA256SUM.sig https://uploader.codecov.io/latest/windows/codecov.exe.SHA256SUM.sig
+RUN             curl -s -o linux/codecov https://uploader.codecov.io/latest/linux/codecov && \
+  curl -s -o linux/codecov.SHA256SUM https://uploader.codecov.io/latest/linux/codecov.SHA256SUM && \
+  curl -s -o linux/codecov.SHA256SUM.sig https://uploader.codecov.io/latest/linux/codecov.SHA256SUM.sig && \
+  curl -s -o alpine/codecov https://uploader.codecov.io/latest/alpine/codecov && \
+  curl -s -o alpine/codecov.SHA256SUM https://uploader.codecov.io/latest/alpine/codecov.SHA256SUM && \
+  curl -s -o alpine/codecov.SHA256SUM.sig https://uploader.codecov.io/latest/alpine/codecov.SHA256SUM.sig && \
+  curl -s -o macos/codecov https://uploader.codecov.io/latest/macos/codecov && \
+  curl -s -o macos/codecov.SHA256SUM https://uploader.codecov.io/latest/macos/codecov.SHA256SUM && \
+  curl -s -o macos/codecov.SHA256SUM.sig https://uploader.codecov.io/latest/macos/codecov.SHA256SUM.sig && \
+  curl -s -o windows/codecov.exe https://uploader.codecov.io/latest/windows/codecov.exe && \
+  curl -s -o windows/codecov.exe.SHA256SUM https://uploader.codecov.io/latest/windows/codecov.exe.SHA256SUM && \
+  curl -s -o windows/codecov.exe.SHA256SUM.sig https://uploader.codecov.io/latest/windows/codecov.exe.SHA256SUM.sig
 
 # This gpg command is required for the next RUN to work. Something about gpg-agent I'd guess, but this seems to resolve it.
 RUN             gpg --list-keys 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 # syntax = docker/dockerfile:1.3
-FROM            alpine:3.17 as uploader
+FROM            alpine:3.21 as uploader
 USER            root
 WORKDIR         /tmp
 RUN             apk -U add gnupg curl
@@ -11,31 +11,31 @@ RUN             mkdir uploader && \
   mkdir uploader/windows
 
 WORKDIR         /tmp/uploader
-RUN             curl -s -o linux/codecov https://uploader.codecov.io/latest/linux/codecov && \
-  curl -s -o linux/codecov.SHA256SUM https://uploader.codecov.io/latest/linux/codecov.SHA256SUM && \
-  curl -s -o linux/codecov.SHA256SUM.sig https://uploader.codecov.io/latest/linux/codecov.SHA256SUM.sig && \
-  curl -s -o alpine/codecov https://uploader.codecov.io/latest/alpine/codecov && \
-  curl -s -o alpine/codecov.SHA256SUM https://uploader.codecov.io/latest/alpine/codecov.SHA256SUM && \
-  curl -s -o alpine/codecov.SHA256SUM.sig https://uploader.codecov.io/latest/alpine/codecov.SHA256SUM.sig && \
-  curl -s -o macos/codecov https://uploader.codecov.io/latest/macos/codecov && \
-  curl -s -o macos/codecov.SHA256SUM https://uploader.codecov.io/latest/macos/codecov.SHA256SUM && \
-  curl -s -o macos/codecov.SHA256SUM.sig https://uploader.codecov.io/latest/macos/codecov.SHA256SUM.sig && \
-  curl -s -o windows/codecov.exe https://uploader.codecov.io/latest/windows/codecov.exe && \
-  curl -s -o windows/codecov.exe.SHA256SUM https://uploader.codecov.io/latest/windows/codecov.exe.SHA256SUM && \
-  curl -s -o windows/codecov.exe.SHA256SUM.sig https://uploader.codecov.io/latest/windows/codecov.exe.SHA256SUM.sig
+RUN             curl -s -o linux/codecov https://uploader.codecov.io/latest/linux/codecov 
+RUN             curl -s -o linux/codecov.SHA256SUM https://uploader.codecov.io/latest/linux/codecov.SHA256SUM 
+RUN             curl -s -o linux/codecov.SHA256SUM.sig https://uploader.codecov.io/latest/linux/codecov.SHA256SUM.sig 
+RUN             curl -s -o alpine/codecov https://uploader.codecov.io/latest/alpine/codecov 
+RUN             curl -s -o alpine/codecov.SHA256SUM https://uploader.codecov.io/latest/alpine/codecov.SHA256SUM 
+RUN             curl -s -o alpine/codecov.SHA256SUM.sig https://uploader.codecov.io/latest/alpine/codecov.SHA256SUM.sig 
+RUN             curl -s -o macos/codecov https://uploader.codecov.io/latest/macos/codecov 
+RUN             curl -s -o macos/codecov.SHA256SUM https://uploader.codecov.io/latest/macos/codecov.SHA256SUM 
+RUN             curl -s -o macos/codecov.SHA256SUM.sig https://uploader.codecov.io/latest/macos/codecov.SHA256SUM.sig 
+RUN             curl -s -o windows/codecov.exe https://uploader.codecov.io/latest/windows/codecov.exe 
+RUN             curl -s -o windows/codecov.exe.SHA256SUM https://uploader.codecov.io/latest/windows/codecov.exe.SHA256SUM 
+RUN             curl -s -o windows/codecov.exe.SHA256SUM.sig https://uploader.codecov.io/latest/windows/codecov.exe.SHA256SUM.sig
 
-RUN             gpg --verify linux/codecov.SHA256SUM.sig linux/codecov.SHA256SUM && \
-  gpg --verify alpine/codecov.SHA256SUM.sig alpine/codecov.SHA256SUM && \
-  gpg --verify macos/codecov.SHA256SUM.sig macos/codecov.SHA256SUM && \
-  gpg --verify windows/codecov.exe.SHA256SUM.sig windows/codecov.exe.SHA256SUM && \
-  cd linux && sha256sum -c codecov.SHA256SUM && cd .. && \
-  cd alpine && sha256sum -c codecov.SHA256SUM && cd .. && \
-  cd macos && sha256sum -c codecov.SHA256SUM && cd .. && \
-  cd windows && sha256sum -c codecov.exe.SHA256SUM
+RUN             gpg --verify linux/codecov.SHA256SUM.sig linux/codecov.SHA256SUM 
+RUN             gpg --verify alpine/codecov.SHA256SUM.sig alpine/codecov.SHA256SUM 
+RUN             gpg --verify macos/codecov.SHA256SUM.sig macos/codecov.SHA256SUM 
+RUN             gpg --verify windows/codecov.exe.SHA256SUM.sig windows/codecov.exe.SHA256SUM 
+RUN             cd linux && sha256sum -c codecov.SHA256SUM && cd .. 
+RUN             cd alpine && sha256sum -c codecov.SHA256SUM && cd ..
+RUN             cd macos && sha256sum -c codecov.SHA256SUM && cd ..
+RUN             cd windows && sha256sum -c codecov.exe.SHA256SUM
 
 COPY            docker/index.html /tmp/uploader
 
-FROM node:22-alpine3.20 as build
+FROM node:22-alpine3.21 as build
 ARG REACT_APP_ENV_ARG
 ARG REACT_APP_CODECOV_VERSION
 ENV REACT_APP_ENV=$REACT_APP_ENV_ARG
@@ -50,7 +50,7 @@ RUN yarn install
 RUN yarn build && rm -f build/mockServiceWorker.js
 
 
-FROM alpine:3.17
+FROM alpine:3.21
 ARG REACT_APP_CODECOV_VERSION
 ARG ENVIRONMENT
 ARG COMMIT_SHA
@@ -76,12 +76,13 @@ RUN  addgroup -S application \
 
 COPY --chown=codecov:application docker/start-nginx.sh /usr/bin/start-nginx
 
-RUN chown -R codecov.application /var/www/app && \
-  chown -R codecov.application /run && \
-  chown -R codecov.application /var/lib/nginx && \
-  chown -R codecov.application /var/log/nginx && \
-  chmod +x /usr/bin/start-nginx && \
-  chown codecov.application /etc/nginx/nginx.conf
+RUN chown -R codecov:application /var/www/app 
+RUN chown -R codecov:application /run 
+RUN chown -R codecov:application /var/lib/nginx 
+RUN chown -R codecov:application /var/log/nginx 
+RUN chmod +x /usr/bin/start-nginx 
+RUN chown codecov:application /etc/nginx/nginx.conf
+
 # Switch to use a non-root user from here on
 USER codecov
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -24,14 +24,14 @@ RUN             curl -s -o windows/codecov.exe https://uploader.codecov.io/lates
 RUN             curl -s -o windows/codecov.exe.SHA256SUM https://uploader.codecov.io/latest/windows/codecov.exe.SHA256SUM 
 RUN             curl -s -o windows/codecov.exe.SHA256SUM.sig https://uploader.codecov.io/latest/windows/codecov.exe.SHA256SUM.sig
 
-RUN             gpg --verify linux/codecov.SHA256SUM.sig linux/codecov.SHA256SUM 
-RUN             gpg --verify alpine/codecov.SHA256SUM.sig alpine/codecov.SHA256SUM 
-RUN             gpg --verify macos/codecov.SHA256SUM.sig macos/codecov.SHA256SUM 
-RUN             gpg --verify windows/codecov.exe.SHA256SUM.sig windows/codecov.exe.SHA256SUM 
-RUN             cd linux && sha256sum -c codecov.SHA256SUM && cd .. 
-RUN             cd alpine && sha256sum -c codecov.SHA256SUM && cd ..
-RUN             cd macos && sha256sum -c codecov.SHA256SUM && cd ..
-RUN             cd windows && sha256sum -c codecov.exe.SHA256SUM
+RUN             gpg --verify linux/codecov.SHA256SUM.sig linux/codecov.SHA256SUM
+RUN             gpg --verify alpine/codecov.SHA256SUM.sig alpine/codecov.SHA256SUM && \
+  gpg --verify macos/codecov.SHA256SUM.sig macos/codecov.SHA256SUM && \
+  gpg --verify windows/codecov.exe.SHA256SUM.sig windows/codecov.exe.SHA256SUM && \
+  cd linux && sha256sum -c codecov.SHA256SUM && cd .. && \
+  cd alpine && sha256sum -c codecov.SHA256SUM && cd .. && \
+  cd macos && sha256sum -c codecov.SHA256SUM && cd .. && \
+  cd windows && sha256sum -c codecov.exe.SHA256SUM
 
 COPY            docker/index.html /tmp/uploader
 
@@ -76,13 +76,12 @@ RUN  addgroup -S application \
 
 COPY --chown=codecov:application docker/start-nginx.sh /usr/bin/start-nginx
 
-RUN chown -R codecov:application /var/www/app 
-RUN chown -R codecov:application /run 
-RUN chown -R codecov:application /var/lib/nginx 
-RUN chown -R codecov:application /var/log/nginx 
-RUN chmod +x /usr/bin/start-nginx 
-RUN chown codecov:application /etc/nginx/nginx.conf
-
+RUN chown -R codecov:application /var/www/app && \
+  chown -R codecov:application /run && \
+  chown -R codecov:application /var/lib/nginx && \
+  chown -R codecov:application /var/log/nginx && \
+  chmod +x /usr/bin/start-nginx && \
+  chown codecov:application /etc/nginx/nginx.conf
 # Switch to use a non-root user from here on
 USER codecov
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -24,8 +24,10 @@ RUN             curl -s -o windows/codecov.exe https://uploader.codecov.io/lates
 RUN             curl -s -o windows/codecov.exe.SHA256SUM https://uploader.codecov.io/latest/windows/codecov.exe.SHA256SUM 
 RUN             curl -s -o windows/codecov.exe.SHA256SUM.sig https://uploader.codecov.io/latest/windows/codecov.exe.SHA256SUM.sig
 
-RUN             gpg --verify linux/codecov.SHA256SUM.sig linux/codecov.SHA256SUM
-RUN             gpg --verify alpine/codecov.SHA256SUM.sig alpine/codecov.SHA256SUM && \
+# This gpg command is required for the next RUN to work. Something about gpg-agent I'd guess, but this seems to resolve it.
+RUN             gpg --list-keys 
+RUN             gpg --verify linux/codecov.SHA256SUM.sig linux/codecov.SHA256SUM && \ 
+  gpg --verify alpine/codecov.SHA256SUM.sig alpine/codecov.SHA256SUM && \
   gpg --verify macos/codecov.SHA256SUM.sig macos/codecov.SHA256SUM && \
   gpg --verify windows/codecov.exe.SHA256SUM.sig windows/codecov.exe.SHA256SUM && \
   cd linux && sha256sum -c codecov.SHA256SUM && cd .. && \


### PR DESCRIPTION
Updates base docker images to alpine 3.21

Closes https://github.com/codecov/feedback/issues/705
