### PR TITLE
fix(ta): seconds to duration function

### DIFF
--- a/src/shared/utils/dates.test.ts
+++ b/src/shared/utils/dates.test.ts
@@ -42,4 +42,16 @@ describe('formatTimeFromSeconds', () => {
   it('returns the correct time format when totalSeconds is less than 1', () => {
     expect(formatTimeFromSeconds(0.5)).toBe('<1s')
   })
+
+  it('returns "N/A" when totalSeconds is negative', () => {
+    expect(formatTimeFromSeconds(-1)).toBe('N/A')
+  })
+
+  it('returns only minutes when totalSeconds is an exact number of minutes', () => {
+    expect(formatTimeFromSeconds(120)).toBe('2m')
+  })
+
+  it('handles float values that round down', () => {
+    expect(formatTimeFromSeconds(59.999)).toBe('59s')
+  })
 })

--- a/src/shared/utils/dates.test.ts
+++ b/src/shared/utils/dates.test.ts
@@ -38,4 +38,8 @@ describe('formatTimeFromSeconds', () => {
   it('returns the correct time format when totalSeconds is a float', () => {
     expect(formatTimeFromSeconds(12901948.144373389)).toBe('149d 7h 52m 28s')
   })
+
+  it('returns the correct time format when totalSeconds is less than 1', () => {
+    expect(formatTimeFromSeconds(0.5)).toBe('<1s')
+  })
 })

--- a/src/shared/utils/dates.test.ts
+++ b/src/shared/utils/dates.test.ts
@@ -34,4 +34,8 @@ describe('formatTimeFromSeconds', () => {
   it('returns the correct time format when totalSeconds is greater than 0', () => {
     expect(formatTimeFromSeconds(3661)).toBe('1h 1m 1s')
   })
+
+  it('returns the correct time format when totalSeconds is a float', () => {
+    expect(formatTimeFromSeconds(12901948.144373389)).toBe('149d 7h 52m 28s')
+  })
 })

--- a/src/shared/utils/dates.ts
+++ b/src/shared/utils/dates.ts
@@ -1,9 +1,4 @@
-import {
-  formatDistanceToNow,
-  fromUnixTime,
-  intervalToDuration,
-  parseISO,
-} from 'date-fns'
+import { formatDistanceToNow, fromUnixTime, parseISO } from 'date-fns'
 
 export function formatTimeToNow(date?: string | number | null) {
   if (!date) return null
@@ -16,19 +11,35 @@ export function formatTimeToNow(date?: string | number | null) {
 }
 
 export const formatTimeFromSeconds = (totalSeconds?: number | null) => {
-  if (totalSeconds === 0) return '0s'
-  if (!totalSeconds) return 'N/A'
+  if (totalSeconds === 0) {
+    return '0s'
+  }
+  if (totalSeconds == null || totalSeconds < 0) {
+    return 'N/A'
+  }
 
-  const duration = intervalToDuration({ start: 0, end: totalSeconds * 1000 })
+  const days = Math.floor(totalSeconds / 86400)
+  const hours = Math.floor((totalSeconds % 86400) / 3600)
+  const minutes = Math.floor((totalSeconds % 3600) / 60)
+  const seconds = Math.floor(totalSeconds % 60)
 
-  const { days, hours, minutes, seconds } = duration
+  const timeParts = []
+  if (days > 0) {
+    timeParts.push(`${days}d`)
+  }
+  if (hours > 0) {
+    timeParts.push(`${hours}h`)
+  }
+  if (minutes > 0) {
+    timeParts.push(`${minutes}m`)
+  }
+  if (seconds > 0) {
+    timeParts.push(`${seconds}s`)
+  }
 
-  return [
-    days ? `${days}d` : '',
-    hours ? `${hours}h` : '',
-    minutes ? `${minutes}m` : '',
-    seconds ? `${seconds}s` : '',
-  ]
-    .filter(Boolean)
-    .join(' ')
+  if (timeParts.length === 0 && totalSeconds > 0) {
+    return '<1s'
+  }
+
+  return timeParts.join(' ')
 }

--- a/src/shared/utils/dates.ts
+++ b/src/shared/utils/dates.ts
@@ -14,14 +14,21 @@ export const formatTimeFromSeconds = (totalSeconds?: number | null) => {
   if (totalSeconds === 0) {
     return '0s'
   }
+
   if (totalSeconds == null || totalSeconds < 0) {
     return 'N/A'
   }
 
-  const days = Math.floor(totalSeconds / 86400)
-  const hours = Math.floor((totalSeconds % 86400) / 3600)
-  const minutes = Math.floor((totalSeconds % 3600) / 60)
-  const seconds = Math.floor(totalSeconds % 60)
+  const SECONDS_PER_DAY = 86400
+  const SECONDS_PER_HOUR = 3600
+  const SECONDS_PER_MINUTE = 60
+
+  const days = Math.floor(totalSeconds / SECONDS_PER_DAY)
+  const hours = Math.floor((totalSeconds % SECONDS_PER_DAY) / SECONDS_PER_HOUR)
+  const minutes = Math.floor(
+    (totalSeconds % SECONDS_PER_HOUR) / SECONDS_PER_MINUTE
+  )
+  const seconds = Math.floor(totalSeconds % SECONDS_PER_MINUTE)
 
   const timeParts = []
   if (days > 0) {
@@ -37,7 +44,7 @@ export const formatTimeFromSeconds = (totalSeconds?: number | null) => {
     timeParts.push(`${seconds}s`)
   }
 
-  if (timeParts.length === 0 && totalSeconds > 0) {
+  if (timeParts.length === 0) {
     return '<1s'
   }
 

--- a/src/shared/utils/dates.ts
+++ b/src/shared/utils/dates.ts
@@ -1,5 +1,9 @@
 import { formatDistanceToNow, fromUnixTime, parseISO } from 'date-fns'
 
+const SECONDS_PER_DAY = 86400
+const SECONDS_PER_HOUR = 3600
+const SECONDS_PER_MINUTE = 60
+
 export function formatTimeToNow(date?: string | number | null) {
   if (!date) return null
 
@@ -11,17 +15,9 @@ export function formatTimeToNow(date?: string | number | null) {
 }
 
 export const formatTimeFromSeconds = (totalSeconds?: number | null) => {
-  if (totalSeconds === 0) {
-    return '0s'
-  }
-
-  if (totalSeconds == null || totalSeconds < 0) {
-    return 'N/A'
-  }
-
-  const SECONDS_PER_DAY = 86400
-  const SECONDS_PER_HOUR = 3600
-  const SECONDS_PER_MINUTE = 60
+  if (totalSeconds == null || totalSeconds < 0) return 'N/A'
+  if (totalSeconds === 0) return '0s'
+  if (totalSeconds < 1) return '<1s'
 
   const days = Math.floor(totalSeconds / SECONDS_PER_DAY)
   const hours = Math.floor((totalSeconds % SECONDS_PER_DAY) / SECONDS_PER_HOUR)
@@ -42,10 +38,6 @@ export const formatTimeFromSeconds = (totalSeconds?: number | null) => {
   }
   if (seconds > 0) {
     timeParts.push(`${seconds}s`)
-  }
-
-  if (timeParts.length === 0) {
-    return '<1s'
   }
 
   return timeParts.join(' ')


### PR DESCRIPTION
The total test run time on https://app.codecov.io/github/getsentry/sentry/tests/master is bugged, this fixes that.