### PR TITLE
feat: Add personal org warnings to checkout flow

### DIFF
--- a/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/Controllers/ProPlanController/BillingOptions/BillingOptions.test.tsx
+++ b/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/Controllers/ProPlanController/BillingOptions/BillingOptions.test.tsx
@@ -153,15 +153,13 @@ describe('BillingOptions', () => {
           }
         )
 
-        const annualBtn = await screen.findByRole('button', { name: 'Annual' })
+        const annualBtn = await screen.findByTestId('radio-annual')
         expect(annualBtn).toBeInTheDocument()
-        await waitFor(() => expect(annualBtn).toHaveClass('bg-ds-primary-base'))
+        await waitFor(() => expect(annualBtn).toBeChecked())
 
-        const monthlyBtn = await screen.findByRole('button', {
-          name: 'Monthly',
-        })
+        const monthlyBtn = await screen.findByTestId('radio-monthly')
         expect(monthlyBtn).toBeInTheDocument()
-        expect(monthlyBtn).not.toHaveClass('bg-ds-primary-base')
+        expect(monthlyBtn).not.toBeChecked()
       })
 
       it('renders annual pricing scheme', async () => {
@@ -200,9 +198,7 @@ describe('BillingOptions', () => {
             }
           )
 
-          const monthlyBtn = await screen.findByRole('button', {
-            name: 'Monthly',
-          })
+          const monthlyBtn = await screen.findByTestId('radio-monthly')
           expect(monthlyBtn).toBeInTheDocument()
           await user.click(monthlyBtn)
 
@@ -230,15 +226,13 @@ describe('BillingOptions', () => {
           }
         )
 
-        const annualBtn = await screen.findByRole('button', { name: 'Annual' })
+        const annualBtn = await screen.findByTestId('radio-annual')
         expect(annualBtn).toBeInTheDocument()
-        expect(annualBtn).not.toHaveClass('bg-ds-primary-base')
+        expect(annualBtn).not.toBeChecked()
 
-        const monthlyBtn = await screen.findByRole('button', {
-          name: 'Monthly',
-        })
+        const monthlyBtn = await screen.findByTestId('radio-monthly')
         expect(monthlyBtn).toBeInTheDocument()
-        expect(monthlyBtn).toHaveClass('bg-ds-primary-base')
+        expect(monthlyBtn).toBeChecked()
       })
 
       it('renders correct pricing scheme', async () => {
@@ -277,9 +271,7 @@ describe('BillingOptions', () => {
             }
           )
 
-          const annualBtn = await screen.findByRole('button', {
-            name: 'Annual',
-          })
+          const annualBtn = await screen.findByTestId('radio-annual')
           expect(annualBtn).toBeInTheDocument()
           await user.click(annualBtn)
 

--- a/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/Controllers/ProPlanController/BillingOptions/BillingOptions.tsx
+++ b/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/Controllers/ProPlanController/BillingOptions/BillingOptions.tsx
@@ -78,10 +78,18 @@ const BillingControls: React.FC<BillingControlsProps> = ({
             setOption(value)
           }}
         >
-          <RadioTileGroup.Item value={TimePeriods.ANNUAL} className="w-32">
+          <RadioTileGroup.Item
+            value={TimePeriods.ANNUAL}
+            className="w-32"
+            data-testid="radio-annual"
+          >
             <RadioTileGroup.Label>{TimePeriods.ANNUAL}</RadioTileGroup.Label>
           </RadioTileGroup.Item>
-          <RadioTileGroup.Item value={TimePeriods.MONTHLY} className="w-32">
+          <RadioTileGroup.Item
+            value={TimePeriods.MONTHLY}
+            className="w-32"
+            data-testid="radio-monthly"
+          >
             <RadioTileGroup.Label>{TimePeriods.MONTHLY}</RadioTileGroup.Label>
           </RadioTileGroup.Item>
         </RadioTileGroup>

--- a/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/Controllers/ProPlanController/BillingOptions/BillingOptions.tsx
+++ b/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/Controllers/ProPlanController/BillingOptions/BillingOptions.tsx
@@ -8,7 +8,7 @@ import {
 } from 'services/account/useAvailablePlans'
 import { usePlanData } from 'services/account/usePlanData'
 import { BillingRate, findProPlans } from 'shared/utils/billing'
-import { OptionButton } from 'ui/OptionButton/OptionButton'
+import { RadioTileGroup } from 'ui/RadioTileGroup'
 
 import { OptionPeriod, TimePeriods } from '../../../constants'
 import { UpgradeFormFields } from '../../../UpgradeForm'
@@ -64,31 +64,27 @@ const BillingControls: React.FC<BillingControlsProps> = ({
 
   return (
     <div className="flex w-fit flex-col gap-2">
-      <h3 className="font-semibold">Choose a billing cycle</h3>
+      <h3 className="font-semibold">Step 2: Choose a billing cycle</h3>
       <div className="inline-flex items-center gap-2">
-        <OptionButton
-          type="button"
-          active={option}
-          onChange={({ text }) => {
-            if (text === TimePeriods.ANNUAL) {
+        <RadioTileGroup
+          value={option}
+          onValueChange={(value: OptionPeriod) => {
+            if (value === TimePeriods.ANNUAL) {
               setFormValue('newPlan', proPlanYear)
             } else {
               setFormValue('newPlan', proPlanMonth)
             }
 
-            setOption(text)
+            setOption(value)
           }}
-          options={
-            [
-              {
-                text: TimePeriods.ANNUAL,
-              },
-              {
-                text: TimePeriods.MONTHLY,
-              },
-            ] as const
-          }
-        />
+        >
+          <RadioTileGroup.Item value={TimePeriods.ANNUAL} className="w-32">
+            <RadioTileGroup.Label>{TimePeriods.ANNUAL}</RadioTileGroup.Label>
+          </RadioTileGroup.Item>
+          <RadioTileGroup.Item value={TimePeriods.MONTHLY} className="w-32">
+            <RadioTileGroup.Label>{TimePeriods.MONTHLY}</RadioTileGroup.Label>
+          </RadioTileGroup.Item>
+        </RadioTileGroup>
         <p>
           <span className="font-semibold">${baseUnitPrice}</span> per
           seat/month, billed {billingRate}

--- a/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/Controllers/ProPlanController/ProPlanController.test.tsx
+++ b/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/Controllers/ProPlanController/ProPlanController.test.tsx
@@ -278,7 +278,7 @@ describe('ProPlanController', () => {
         setup({ planValue: proPlanMonth })
         render(<ProPlanController {...props} />, { wrapper: wrapper() })
 
-        const optionBtn = await screen.findByRole('button', { name: 'Monthly' })
+        const optionBtn = await screen.findByTestId('radio-monthly')
         expect(optionBtn).toBeInTheDocument()
       })
 
@@ -286,7 +286,7 @@ describe('ProPlanController', () => {
         setup({ planValue: proPlanMonth })
         render(<ProPlanController {...props} />, { wrapper: wrapper() })
 
-        const optionBtn = await screen.findByRole('button', { name: 'Annual' })
+        const optionBtn = await screen.findByTestId('radio-annual')
         expect(optionBtn).toBeInTheDocument()
       })
 
@@ -294,9 +294,9 @@ describe('ProPlanController', () => {
         setup({ planValue: proPlanMonth })
         render(<ProPlanController {...props} />, { wrapper: wrapper() })
 
-        const optionBtn = await screen.findByRole('button', { name: 'Monthly' })
+        const optionBtn = await screen.findByTestId('radio-monthly')
         expect(optionBtn).toBeInTheDocument()
-        expect(optionBtn).toHaveClass('bg-ds-primary-base')
+        expect(optionBtn).toBeChecked()
       })
 
       it('has the price for the year', async () => {
@@ -321,7 +321,7 @@ describe('ProPlanController', () => {
         setup({ planValue: proPlanYear, monthlyPlan: false })
         render(<ProPlanController {...props} />, { wrapper: wrapper() })
 
-        const optionBtn = await screen.findByRole('button', { name: 'Monthly' })
+        const optionBtn = await screen.findByTestId('radio-monthly')
         expect(optionBtn).toBeInTheDocument()
       })
 
@@ -329,7 +329,7 @@ describe('ProPlanController', () => {
         setup({ planValue: proPlanYear, monthlyPlan: false })
         render(<ProPlanController {...props} />, { wrapper: wrapper() })
 
-        const optionBtn = await screen.findByRole('button', { name: 'Annual' })
+        const optionBtn = await screen.findByTestId('radio-annual')
         expect(optionBtn).toBeInTheDocument()
       })
 
@@ -337,9 +337,9 @@ describe('ProPlanController', () => {
         setup({ planValue: proPlanYear, monthlyPlan: false })
         render(<ProPlanController {...props} />, { wrapper: wrapper() })
 
-        const optionBtn = await screen.findByRole('button', { name: 'Annual' })
+        const optionBtn = await screen.findByTestId('radio-annual')
         expect(optionBtn).toBeInTheDocument()
-        expect(optionBtn).toHaveClass('bg-ds-primary-base')
+        expect(optionBtn).toBeChecked()
       })
 
       it('has the price for the year', async () => {

--- a/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/Controllers/ProPlanController/ProPlanController.tsx
+++ b/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/Controllers/ProPlanController/ProPlanController.tsx
@@ -2,6 +2,7 @@ import { UseFormRegister, UseFormSetValue } from 'react-hook-form'
 
 import { IndividualPlan } from 'services/account/useAvailablePlans'
 import { MIN_NB_SEATS_PRO } from 'shared/utils/upgradeForm'
+import { Card } from 'ui/Card'
 import TextInput from 'ui/TextInput'
 
 import BillingOptions from './BillingOptions'
@@ -32,34 +33,44 @@ const ProPlanController: React.FC<ProPlanControllerProps> = ({
 }) => {
   return (
     <>
-      <div className="flex flex-col gap-2">
-        <BillingOptions newPlan={newPlan} setFormValue={setFormValue} />
-      </div>
-      <div className="flex flex-col gap-2 xl:w-5/12">
-        <div className="w-1/2">
-          <TextInput
-            data-cy="seats"
-            dataMarketing="plan-pricing-seats"
-            {...register('seats')}
-            id="nb-seats"
-            size={20}
-            type="number"
-            label="Enter seat count"
-            min={MIN_NB_SEATS_PRO}
-          />
+      <Card.Content>
+        <div className="flex flex-col gap-2">
+          <BillingOptions newPlan={newPlan} setFormValue={setFormValue} />
         </div>
-        <UserCount />
-      </div>
-      <PriceCallout
-        seats={seats}
-        newPlan={newPlan}
-        setFormValue={setFormValue}
-      />
-      {errors?.seats && (
-        <p className="rounded-md bg-ds-error-quinary p-3 text-ds-error-nonary">
-          {errors?.seats?.message}
-        </p>
-      )}
+      </Card.Content>
+      <hr />
+      {/* if you're reading this, I'm sorry */}
+      <Card.Content>
+        <div className="flex flex-col gap-2 xl:w-5/12">
+          <label htmlFor="nb-seats" className="font-semibold">
+            Step 3: Enter seat count
+          </label>
+          <div className="w-1/4">
+            <TextInput
+              data-cy="seats"
+              dataMarketing="plan-pricing-seats"
+              {...register('seats')}
+              id="nb-seats"
+              size={20}
+              type="number"
+              min={MIN_NB_SEATS_PRO}
+            />
+          </div>
+          <UserCount />
+        </div>
+      </Card.Content>
+      <Card.Content>
+        <PriceCallout
+          seats={seats}
+          newPlan={newPlan}
+          setFormValue={setFormValue}
+        />
+        {errors?.seats && (
+          <p className="rounded-md bg-ds-error-quinary p-3 text-ds-error-nonary">
+            {errors?.seats?.message}
+          </p>
+        )}
+      </Card.Content>
     </>
   )
 }

--- a/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/Controllers/ProPlanController/UserCount/UserCount.tsx
+++ b/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/Controllers/ProPlanController/UserCount/UserCount.tsx
@@ -34,9 +34,11 @@ const UserText: React.FC<UserTextProps> = ({
   activatedUserCount,
   inactiveUserCount,
 }) => {
+  const hasOneMember = activatedUserCount + inactiveUserCount === 1
   return (
     <p>
-      Your organization has {activatedUserCount + inactiveUserCount} members.
+      Your organization has {activatedUserCount + inactiveUserCount} member
+      {hasOneMember ? '' : 's'}.
     </p>
   )
 }

--- a/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/Controllers/SentryPlanController/BillingOptions/BillingOptions.test.tsx
+++ b/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/Controllers/SentryPlanController/BillingOptions/BillingOptions.test.tsx
@@ -144,17 +144,13 @@ describe('BillingOptions', () => {
           }
         )
 
-        const annualBtn = await screen.findByRole('button', { name: 'Annual' })
+        const annualBtn = await screen.findByTestId('radio-annual')
         expect(annualBtn).toBeInTheDocument()
-        await waitFor(() => expect(annualBtn).toHaveClass('bg-ds-primary-base'))
+        await waitFor(() => expect(annualBtn).toBeChecked())
 
-        const monthlyBtn = await screen.findByRole('button', {
-          name: 'Monthly',
-        })
+        const monthlyBtn = await screen.findByTestId('radio-monthly')
         expect(monthlyBtn).toBeInTheDocument()
-        await waitFor(() =>
-          expect(monthlyBtn).not.toHaveClass('bg-ds-primary-base')
-        )
+        await waitFor(() => expect(monthlyBtn).not.toBeChecked())
       })
 
       it('renders annual pricing scheme', async () => {
@@ -193,9 +189,7 @@ describe('BillingOptions', () => {
             }
           )
 
-          const monthlyBtn = await screen.findByRole('button', {
-            name: 'Monthly',
-          })
+          const monthlyBtn = await screen.findByTestId('radio-monthly')
           expect(monthlyBtn).toBeInTheDocument()
           await user.click(monthlyBtn)
 
@@ -223,15 +217,13 @@ describe('BillingOptions', () => {
           }
         )
 
-        const annualBtn = await screen.findByRole('button', { name: 'Annual' })
+        const annualBtn = await screen.findByTestId('radio-annual')
         expect(annualBtn).toBeInTheDocument()
-        expect(annualBtn).not.toHaveClass('bg-ds-primary-base')
+        expect(annualBtn).not.toBeChecked()
 
-        const monthlyBtn = await screen.findByRole('button', {
-          name: 'Monthly',
-        })
+        const monthlyBtn = await screen.findByTestId('radio-monthly')
         expect(monthlyBtn).toBeInTheDocument()
-        expect(monthlyBtn).toHaveClass('bg-ds-primary-base')
+        expect(monthlyBtn).toBeChecked()
       })
 
       it('renders correct pricing scheme', async () => {
@@ -270,9 +262,7 @@ describe('BillingOptions', () => {
             }
           )
 
-          const annualBtn = await screen.findByRole('button', {
-            name: 'Annual',
-          })
+          const annualBtn = await screen.findByTestId('radio-annual')
           expect(annualBtn).toBeInTheDocument()
           await user.click(annualBtn)
 

--- a/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/Controllers/SentryPlanController/BillingOptions/BillingOptions.tsx
+++ b/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/Controllers/SentryPlanController/BillingOptions/BillingOptions.tsx
@@ -8,7 +8,7 @@ import {
 } from 'services/account/useAvailablePlans'
 import { usePlanData } from 'services/account/usePlanData'
 import { BillingRate, findSentryPlans } from 'shared/utils/billing'
-import { OptionButton } from 'ui/OptionButton/OptionButton'
+import { RadioTileGroup } from 'ui/RadioTileGroup'
 
 import { OptionPeriod, TimePeriods } from '../../../constants'
 import { UpgradeFormFields } from '../../../UpgradeForm'
@@ -65,31 +65,27 @@ const BillingControls: React.FC<BillingControlsProps> = ({
 
   return (
     <div className="flex w-fit flex-col gap-2">
-      <h3 className="font-semibold">Choose a billing cycle</h3>
+      <h3 className="font-semibold">Step 2: Choose a billing cycle</h3>
       <div className="inline-flex items-center gap-2">
-        <OptionButton
-          type="button"
-          active={option}
-          onChange={({ text }) => {
-            if (text === TimePeriods.ANNUAL) {
+        <RadioTileGroup
+          value={option}
+          onValueChange={(value: OptionPeriod) => {
+            if (value === TimePeriods.ANNUAL) {
               setFormValue('newPlan', sentryPlanYear)
             } else {
               setFormValue('newPlan', sentryPlanMonth)
             }
 
-            setOption(text)
+            setOption(value)
           }}
-          options={
-            [
-              {
-                text: TimePeriods.ANNUAL,
-              },
-              {
-                text: TimePeriods.MONTHLY,
-              },
-            ] as const
-          }
-        />
+        >
+          <RadioTileGroup.Item value={TimePeriods.ANNUAL} className="w-32">
+            <RadioTileGroup.Label>{TimePeriods.ANNUAL}</RadioTileGroup.Label>
+          </RadioTileGroup.Item>
+          <RadioTileGroup.Item value={TimePeriods.MONTHLY} className="w-32">
+            <RadioTileGroup.Label>{TimePeriods.MONTHLY}</RadioTileGroup.Label>
+          </RadioTileGroup.Item>
+        </RadioTileGroup>
         <p>
           <span className="font-semibold">${baseUnitPrice}</span> per
           seat/month, billed {billingRate}

--- a/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/Controllers/SentryPlanController/BillingOptions/BillingOptions.tsx
+++ b/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/Controllers/SentryPlanController/BillingOptions/BillingOptions.tsx
@@ -79,10 +79,18 @@ const BillingControls: React.FC<BillingControlsProps> = ({
             setOption(value)
           }}
         >
-          <RadioTileGroup.Item value={TimePeriods.ANNUAL} className="w-32">
+          <RadioTileGroup.Item
+            value={TimePeriods.ANNUAL}
+            className="w-32"
+            data-testid="radio-annual"
+          >
             <RadioTileGroup.Label>{TimePeriods.ANNUAL}</RadioTileGroup.Label>
           </RadioTileGroup.Item>
-          <RadioTileGroup.Item value={TimePeriods.MONTHLY} className="w-32">
+          <RadioTileGroup.Item
+            value={TimePeriods.MONTHLY}
+            className="w-32"
+            data-testid="radio-monthly"
+          >
             <RadioTileGroup.Label>{TimePeriods.MONTHLY}</RadioTileGroup.Label>
           </RadioTileGroup.Item>
         </RadioTileGroup>

--- a/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/Controllers/SentryPlanController/SentryPlanController.test.tsx
+++ b/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/Controllers/SentryPlanController/SentryPlanController.test.tsx
@@ -253,7 +253,7 @@ describe('SentryPlanController', () => {
         setup({ planValue: Plans.USERS_SENTRYM })
         render(<SentryPlanController {...props} />, { wrapper: wrapper() })
 
-        const optionBtn = await screen.findByRole('button', { name: 'Monthly' })
+        const optionBtn = await screen.findByTestId('radio-monthly')
         expect(optionBtn).toBeInTheDocument()
       })
 
@@ -261,7 +261,7 @@ describe('SentryPlanController', () => {
         setup({ planValue: Plans.USERS_SENTRYM })
         render(<SentryPlanController {...props} />, { wrapper: wrapper() })
 
-        const optionBtn = await screen.findByRole('button', { name: 'Annual' })
+        const optionBtn = await screen.findByTestId('radio-annual')
         expect(optionBtn).toBeInTheDocument()
       })
 
@@ -269,9 +269,9 @@ describe('SentryPlanController', () => {
         setup({ planValue: Plans.USERS_SENTRYM })
         render(<SentryPlanController {...props} />, { wrapper: wrapper() })
 
-        const optionBtn = await screen.findByRole('button', { name: 'Monthly' })
+        const optionBtn = await screen.findByTestId('radio-monthly')
         expect(optionBtn).toBeInTheDocument()
-        expect(optionBtn).toHaveClass('bg-ds-primary-base')
+        expect(optionBtn).toBeChecked()
       })
 
       it('has the monthly price for', async () => {
@@ -312,7 +312,7 @@ describe('SentryPlanController', () => {
         setup({ planValue: Plans.USERS_SENTRYY })
         render(<SentryPlanController {...props} />, { wrapper: wrapper() })
 
-        const optionBtn = await screen.findByRole('button', { name: 'Monthly' })
+        const optionBtn = await screen.findByTestId('radio-monthly')
         expect(optionBtn).toBeInTheDocument()
       })
 
@@ -320,7 +320,7 @@ describe('SentryPlanController', () => {
         setup({ planValue: Plans.USERS_SENTRYY })
         render(<SentryPlanController {...props} />, { wrapper: wrapper() })
 
-        const optionBtn = await screen.findByRole('button', { name: 'Annual' })
+        const optionBtn = await screen.findByTestId('radio-annual')
         expect(optionBtn).toBeInTheDocument()
       })
 
@@ -328,9 +328,9 @@ describe('SentryPlanController', () => {
         setup({ planValue: Plans.USERS_SENTRYY, monthlyPlan: false })
         render(<SentryPlanController {...props} />, { wrapper: wrapper() })
 
-        const optionBtn = await screen.findByRole('button', { name: 'Annual' })
+        const optionBtn = await screen.findByTestId('radio-annual')
         expect(optionBtn).toBeInTheDocument()
-        expect(optionBtn).toHaveClass('bg-ds-primary-base')
+        expect(optionBtn).toBeChecked()
       })
 
       it('has the price for the year', async () => {

--- a/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/Controllers/SentryPlanController/SentryPlanController.tsx
+++ b/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/Controllers/SentryPlanController/SentryPlanController.tsx
@@ -2,6 +2,7 @@ import { UseFormRegister, UseFormSetValue } from 'react-hook-form'
 
 import { IndividualPlan } from 'services/account/useAvailablePlans'
 import { MIN_SENTRY_SEATS } from 'shared/utils/upgradeForm'
+import { Card } from 'ui/Card'
 import TextInput from 'ui/TextInput'
 
 import BillingOptions from './BillingOptions'
@@ -31,34 +32,43 @@ const SentryPlanController: React.FC<SentryPlanControllerProps> = ({
 }) => {
   return (
     <>
-      <div className="flex flex-col gap-2">
-        <BillingOptions newPlan={newPlan} setFormValue={setFormValue} />
-      </div>
-      <div className="flex flex-col gap-2 xl:w-5/12">
-        <div className="w-1/2">
-          <TextInput
-            data-cy="seats"
-            dataMarketing="plan-pricing-seats"
-            {...register('seats')}
-            id="nb-seats"
-            size={20}
-            type="number"
-            label="Enter seat count"
-            min={MIN_SENTRY_SEATS}
-          />
+      <Card.Content>
+        <div className="flex flex-col gap-2">
+          <BillingOptions newPlan={newPlan} setFormValue={setFormValue} />
         </div>
-        <UserCount />
-      </div>
-      <PriceCallout
-        seats={seats}
-        newPlan={newPlan}
-        setFormValue={setFormValue}
-      />
-      {errors?.seats && (
-        <p className="rounded-md bg-ds-error-quinary p-3 text-ds-error-nonary">
-          {errors?.seats?.message}
-        </p>
-      )}
+      </Card.Content>
+      <hr />
+      <Card.Content>
+        <div className="flex flex-col gap-2 xl:w-5/12">
+          <label htmlFor="nb-seats" className="font-semibold">
+            Step 3: Enter seat count
+          </label>
+          <div className="w-1/4">
+            <TextInput
+              data-cy="seats"
+              dataMarketing="plan-pricing-seats"
+              {...register('seats')}
+              id="nb-seats"
+              size={20}
+              type="number"
+              min={MIN_SENTRY_SEATS}
+            />
+          </div>
+          <UserCount />
+        </div>
+      </Card.Content>
+      <Card.Content>
+        <PriceCallout
+          seats={seats}
+          newPlan={newPlan}
+          setFormValue={setFormValue}
+        />
+        {errors?.seats && (
+          <p className="rounded-md bg-ds-error-quinary p-3 text-ds-error-nonary">
+            {errors?.seats?.message}
+          </p>
+        )}
+      </Card.Content>
     </>
   )
 }

--- a/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/Controllers/TeamPlanController/BillingOptions/BillingOptions.test.tsx
+++ b/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/Controllers/TeamPlanController/BillingOptions/BillingOptions.test.tsx
@@ -136,15 +136,13 @@ describe('BillingOptions', () => {
           }
         )
 
-        const annualBtn = await screen.findByRole('button', { name: 'Annual' })
+        const annualBtn = await screen.findByTestId('radio-annual')
         expect(annualBtn).toBeInTheDocument()
-        await waitFor(() => expect(annualBtn).toHaveClass('bg-ds-primary-base'))
+        expect(annualBtn).toBeChecked()
 
-        const monthlyBtn = await screen.findByRole('button', {
-          name: 'Monthly',
-        })
+        const monthlyBtn = await screen.findByTestId('radio-monthly')
         expect(monthlyBtn).toBeInTheDocument()
-        expect(monthlyBtn).not.toHaveClass('bg-ds-primary-base')
+        expect(monthlyBtn).not.toBeChecked()
       })
 
       it('renders annual pricing scheme', async () => {
@@ -183,9 +181,7 @@ describe('BillingOptions', () => {
             }
           )
 
-          const monthlyBtn = await screen.findByRole('button', {
-            name: 'Monthly',
-          })
+          const monthlyBtn = await screen.findByTestId('radio-monthly')
           expect(monthlyBtn).toBeInTheDocument()
           await user.click(monthlyBtn)
 
@@ -213,15 +209,12 @@ describe('BillingOptions', () => {
           }
         )
 
-        const annualBtn = await screen.findByRole('button', { name: 'Annual' })
-        expect(annualBtn).toBeInTheDocument()
-        expect(annualBtn).not.toHaveClass('bg-ds-primary-base')
+        const annualBtn = await screen.findByTestId('radio-annual')
+        expect(annualBtn).not.toBeChecked()
 
-        const monthlyBtn = await screen.findByRole('button', {
-          name: 'Monthly',
-        })
+        const monthlyBtn = await screen.findByTestId('radio-monthly')
         expect(monthlyBtn).toBeInTheDocument()
-        expect(monthlyBtn).toHaveClass('bg-ds-primary-base')
+        expect(monthlyBtn).toBeChecked()
       })
 
       it('renders correct pricing scheme', async () => {
@@ -260,9 +253,7 @@ describe('BillingOptions', () => {
             }
           )
 
-          const annualBtn = await screen.findByRole('button', {
-            name: 'Annual',
-          })
+          const annualBtn = await screen.findByTestId('radio-annual')
           expect(annualBtn).toBeInTheDocument()
           await user.click(annualBtn)
 

--- a/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/Controllers/TeamPlanController/BillingOptions/BillingOptions.tsx
+++ b/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/Controllers/TeamPlanController/BillingOptions/BillingOptions.tsx
@@ -78,10 +78,18 @@ const BillingControls: React.FC<BillingControlsProps> = ({
             setOption(value)
           }}
         >
-          <RadioTileGroup.Item value={TimePeriods.ANNUAL} className="w-32">
+          <RadioTileGroup.Item
+            value={TimePeriods.ANNUAL}
+            className="w-32"
+            data-testid="radio-annual"
+          >
             <RadioTileGroup.Label>{TimePeriods.ANNUAL}</RadioTileGroup.Label>
           </RadioTileGroup.Item>
-          <RadioTileGroup.Item value={TimePeriods.MONTHLY} className="w-32">
+          <RadioTileGroup.Item
+            value={TimePeriods.MONTHLY}
+            className="w-32"
+            data-testid="radio-monthly"
+          >
             <RadioTileGroup.Label>{TimePeriods.MONTHLY}</RadioTileGroup.Label>
           </RadioTileGroup.Item>
         </RadioTileGroup>

--- a/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/Controllers/TeamPlanController/BillingOptions/BillingOptions.tsx
+++ b/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/Controllers/TeamPlanController/BillingOptions/BillingOptions.tsx
@@ -8,7 +8,7 @@ import {
 } from 'services/account/useAvailablePlans'
 import { usePlanData } from 'services/account/usePlanData'
 import { BillingRate, findTeamPlans } from 'shared/utils/billing'
-import { OptionButton } from 'ui/OptionButton/OptionButton'
+import { RadioTileGroup } from 'ui/RadioTileGroup'
 
 import { OptionPeriod, TimePeriods } from '../../../constants'
 import { UpgradeFormFields } from '../../../UpgradeForm'
@@ -64,31 +64,27 @@ const BillingControls: React.FC<BillingControlsProps> = ({
 
   return (
     <div className="flex w-fit flex-col gap-2">
-      <h3 className="font-semibold">Choose a billing cycle</h3>
+      <h3 className="font-semibold">Step 2: Choose a billing cycle</h3>
       <div className="inline-flex items-center gap-2">
-        <OptionButton
-          type="button"
-          active={option}
-          onChange={({ text }) => {
-            if (text === TimePeriods.ANNUAL) {
+        <RadioTileGroup
+          value={option}
+          onValueChange={(value: OptionPeriod) => {
+            if (value === TimePeriods.ANNUAL) {
               setFormValue('newPlan', teamPlanYear)
             } else {
               setFormValue('newPlan', teamPlanMonth)
             }
 
-            setOption(text)
+            setOption(value)
           }}
-          options={
-            [
-              {
-                text: TimePeriods.ANNUAL,
-              },
-              {
-                text: TimePeriods.MONTHLY,
-              },
-            ] as const
-          }
-        />
+        >
+          <RadioTileGroup.Item value={TimePeriods.ANNUAL} className="w-32">
+            <RadioTileGroup.Label>{TimePeriods.ANNUAL}</RadioTileGroup.Label>
+          </RadioTileGroup.Item>
+          <RadioTileGroup.Item value={TimePeriods.MONTHLY} className="w-32">
+            <RadioTileGroup.Label>{TimePeriods.MONTHLY}</RadioTileGroup.Label>
+          </RadioTileGroup.Item>
+        </RadioTileGroup>
         <p>
           <span className="font-semibold">${baseUnitPrice}</span> per
           seat/month, billed {billingRate}

--- a/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/Controllers/TeamPlanController/ErrorBanner/ErrorBanner.tsx
+++ b/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/Controllers/TeamPlanController/ErrorBanner/ErrorBanner.tsx
@@ -6,10 +6,12 @@ import {
   useAvailablePlans,
 } from 'services/account/useAvailablePlans'
 import { usePlanData } from 'services/account/usePlanData'
+import { useLocationParams } from 'services/navigation/useLocationParams'
 import {
   canApplySentryUpgrade,
   findProPlans,
   findSentryPlans,
+  TierNames,
 } from 'shared/utils/billing'
 import { UPGRADE_FORM_TOO_MANY_SEATS_MESSAGE } from 'shared/utils/upgradeForm'
 
@@ -33,6 +35,7 @@ export default function ErrorBanner({
   setSelectedPlan,
 }: ErrorBannerProps) {
   const { provider, owner } = useParams<{ provider: string; owner: string }>()
+  const { updateParams } = useLocationParams({ plan: null })
   const { data: plans } = useAvailablePlans({ provider, owner })
   const { data: planData } = usePlanData({ provider, owner })
   const { proPlanYear } = findProPlans({ plans })
@@ -57,6 +60,8 @@ export default function ErrorBanner({
             setFormValue('newPlan', yearlyProPlan, {
               shouldValidate: true,
             })
+            // without this line, the tier selector won't update
+            updateParams({ plan: TierNames.PRO })
           }}
         >
           Upgrade to Pro

--- a/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/Controllers/TeamPlanController/TeamPlanController.test.tsx
+++ b/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/Controllers/TeamPlanController/TeamPlanController.test.tsx
@@ -259,7 +259,7 @@ describe('TeamPlanController', () => {
         setup({ planValue: Plans.USERS_TEAMM })
         render(<TeamPlanController {...props} />, { wrapper: wrapper() })
 
-        const optionBtn = await screen.findByRole('button', { name: 'Monthly' })
+        const optionBtn = await screen.findByTestId('radio-monthly')
         expect(optionBtn).toBeInTheDocument()
       })
 
@@ -267,7 +267,7 @@ describe('TeamPlanController', () => {
         setup({ planValue: Plans.USERS_TEAMM })
         render(<TeamPlanController {...props} />, { wrapper: wrapper() })
 
-        const optionBtn = await screen.findByRole('button', { name: 'Annual' })
+        const optionBtn = await screen.findByTestId('radio-annual')
         expect(optionBtn).toBeInTheDocument()
       })
 
@@ -275,9 +275,9 @@ describe('TeamPlanController', () => {
         setup({ planValue: Plans.USERS_TEAMM })
         render(<TeamPlanController {...props} />, { wrapper: wrapper() })
 
-        const optionBtn = await screen.findByRole('button', { name: 'Monthly' })
+        const optionBtn = await screen.findByTestId('radio-monthly')
         expect(optionBtn).toBeInTheDocument()
-        expect(optionBtn).toHaveClass('bg-ds-primary-base')
+        expect(optionBtn).toBeChecked()
       })
 
       it('has the monthly price for', async () => {
@@ -377,7 +377,7 @@ describe('TeamPlanController', () => {
         setup({ planValue: Plans.USERS_TEAMY })
         render(<TeamPlanController {...props} />, { wrapper: wrapper() })
 
-        const optionBtn = await screen.findByRole('button', { name: 'Monthly' })
+        const optionBtn = await screen.findByTestId('radio-monthly')
         expect(optionBtn).toBeInTheDocument()
       })
 
@@ -385,7 +385,7 @@ describe('TeamPlanController', () => {
         setup({ planValue: Plans.USERS_TEAMY, monthlyPlan: false })
         render(<TeamPlanController {...props} />, { wrapper: wrapper() })
 
-        const optionBtn = await screen.findByRole('button', { name: 'Annual' })
+        const optionBtn = await screen.findByTestId('radio-annual')
         expect(optionBtn).toBeInTheDocument()
       })
 
@@ -393,9 +393,9 @@ describe('TeamPlanController', () => {
         setup({ planValue: Plans.USERS_TEAMY, monthlyPlan: false })
         render(<TeamPlanController {...props} />, { wrapper: wrapper() })
 
-        const optionBtn = await screen.findByRole('button', { name: 'Annual' })
+        const optionBtn = await screen.findByTestId('radio-annual')
         expect(optionBtn).toBeInTheDocument()
-        expect(optionBtn).toHaveClass('bg-ds-primary-base')
+        expect(optionBtn).toBeChecked()
       })
 
       it('has the price for the year', async () => {

--- a/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/Controllers/TeamPlanController/TeamPlanController.tsx
+++ b/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/Controllers/TeamPlanController/TeamPlanController.tsx
@@ -5,6 +5,7 @@ import {
   MIN_NB_SEATS_PRO,
   TEAM_PLAN_MAX_ACTIVE_USERS,
 } from 'shared/utils/upgradeForm'
+import { Card } from 'ui/Card'
 import TextInput from 'ui/TextInput'
 
 import BillingOptions from './BillingOptions'
@@ -39,37 +40,46 @@ const PlanController: React.FC<PlanControllerProps> = ({
 }) => {
   return (
     <>
-      <div className="flex flex-col gap-2">
-        <BillingOptions newPlan={newPlan} setFormValue={setFormValue} />
-      </div>
-      <div className="flex flex-col gap-2 xl:w-5/12">
-        <div className="w-1/2">
-          <TextInput
-            data-cy="seats"
-            dataMarketing="plan-pricing-seats"
-            {...register('seats')}
-            id="nb-seats"
-            size={20}
-            type="number"
-            label="Enter seat count"
-            min={MIN_NB_SEATS_PRO}
-            max={TEAM_PLAN_MAX_ACTIVE_USERS}
-          />
+      <Card.Content>
+        <div className="flex flex-col gap-2">
+          <BillingOptions newPlan={newPlan} setFormValue={setFormValue} />
         </div>
-        <UserCount />
-      </div>
-      <PriceCallout
-        seats={seats}
-        newPlan={newPlan}
-        setFormValue={setFormValue}
-      />
-      {errors?.seats?.message ? (
-        <ErrorBanner
-          errors={errors}
+      </Card.Content>
+      <hr />
+      <Card.Content>
+        <div className="flex flex-col gap-2 xl:w-5/12">
+          <label htmlFor="nb-seats" className="font-semibold">
+            Step 3: Enter seat count
+          </label>
+          <div className="w-1/4">
+            <TextInput
+              data-cy="seats"
+              dataMarketing="plan-pricing-seats"
+              {...register('seats')}
+              id="nb-seats"
+              size={20}
+              type="number"
+              min={MIN_NB_SEATS_PRO}
+              max={TEAM_PLAN_MAX_ACTIVE_USERS}
+            />
+          </div>
+          <UserCount />
+        </div>
+      </Card.Content>
+      <Card.Content>
+        <PriceCallout
+          seats={seats}
+          newPlan={newPlan}
           setFormValue={setFormValue}
-          setSelectedPlan={setSelectedPlan}
         />
-      ) : null}
+        {errors?.seats?.message ? (
+          <ErrorBanner
+            errors={errors}
+            setFormValue={setFormValue}
+            setSelectedPlan={setSelectedPlan}
+          />
+        ) : null}
+      </Card.Content>
     </>
   )
 }

--- a/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/Controllers/TeamPlanController/UserCount/UserCount.tsx
+++ b/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/Controllers/TeamPlanController/UserCount/UserCount.tsx
@@ -35,9 +35,11 @@ const UserText: React.FC<UserTextProps> = ({
   activatedUserCount,
   inactiveUserCount,
 }) => {
+  const hasOneMember = activatedUserCount + inactiveUserCount === 1
   return (
     <p>
-      Your organization has {activatedUserCount + inactiveUserCount} members.
+      Your organization has {activatedUserCount + inactiveUserCount} member
+      {hasOneMember ? '' : 's'}.
     </p>
   )
 }

--- a/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/PendingUpgradeModal.test.tsx
+++ b/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/PendingUpgradeModal.test.tsx
@@ -1,16 +1,16 @@
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 
-import UpgradeFormModal from './UpgradeFormModal'
+import PendingUpgradeModal from './PendingUpgradeModal'
 
-describe('UpgradeFormModal', () => {
+describe('PendingUpgradeModal', () => {
   const mockOnClose = vi.fn()
   const mockOnConfirm = vi.fn()
   const mockUrl = 'https://verify.stripe.com'
 
   const setup = (isUpgrading = false) => {
     return render(
-      <UpgradeFormModal
+      <PendingUpgradeModal
         isOpen={true}
         onClose={mockOnClose}
         onConfirm={mockOnConfirm}

--- a/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/PendingUpgradeModal.tsx
+++ b/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/PendingUpgradeModal.tsx
@@ -3,7 +3,7 @@ import Button from 'ui/Button'
 import Icon from 'ui/Icon'
 import Modal from 'ui/Modal'
 
-interface UpgradeModalProps {
+interface PendingUpgradeModalProps {
   isOpen: boolean
   onClose: () => void
   onConfirm: () => void
@@ -11,13 +11,13 @@ interface UpgradeModalProps {
   isUpgrading?: boolean
 }
 
-const UpgradeFormModal = ({
+const PendingUpgradeModal = ({
   isOpen,
   onClose,
   onConfirm,
   url,
   isUpgrading = false,
-}: UpgradeModalProps) => (
+}: PendingUpgradeModalProps) => (
   <Modal
     isOpen={isOpen}
     onClose={onClose}
@@ -60,6 +60,7 @@ const UpgradeFormModal = ({
         <Button
           hook="confirm-upgrade"
           variant="primary"
+          type="submit"
           onClick={onConfirm}
           disabled={isUpgrading}
         >
@@ -70,4 +71,4 @@ const UpgradeFormModal = ({
   />
 )
 
-export default UpgradeFormModal
+export default PendingUpgradeModal

--- a/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/PersonalOrgWarning.tsx
+++ b/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/PersonalOrgWarning.tsx
@@ -1,0 +1,31 @@
+import { useParams } from 'react-router'
+
+import { useUser } from 'services/user'
+import { Alert } from 'ui/Alert'
+
+interface URLParams {
+  owner: string
+}
+
+export function PersonalOrgWarning() {
+  const { owner } = useParams<URLParams>()
+  const { data } = useUser()
+  const username = data?.user.username
+
+  if (owner !== username) {
+    return null
+  }
+
+  return (
+    <Alert variant="info">
+      <Alert.Title>
+        You&apos;re about to upgrade your personal organization:{' '}
+        <span className="font-bold">{username}</span>
+      </Alert.Title>
+      <Alert.Description>
+        If you&apos;d like to upgrade a different organization, click on the
+        organization selector at the top left of the page.
+      </Alert.Description>
+    </Alert>
+  )
+}

--- a/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/PersonalOrgWarning.tsx
+++ b/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/PersonalOrgWarning.tsx
@@ -12,6 +12,9 @@ export function PersonalOrgWarning() {
   const { data } = useUser()
   const username = data?.user.username
 
+  console.log('owner', owner)
+  console.log('username', username)
+
   if (owner !== username) {
     return null
   }

--- a/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/PlanTypeOptions/PlanTypeOptions.test.tsx
+++ b/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/PlanTypeOptions/PlanTypeOptions.test.tsx
@@ -267,17 +267,13 @@ describe('PlanTypeOptions', () => {
           }
         )
 
-        const proBtn = await screen.findByRole('button', {
-          name: 'Pro',
-        })
+        const proBtn = await screen.findByTestId('radio-pro')
         expect(proBtn).toBeInTheDocument()
-        expect(proBtn).toHaveClass('bg-ds-primary-base')
+        expect(proBtn).toBeChecked()
 
-        const teamBtn = await screen.findByRole('button', {
-          name: 'Team',
-        })
+        const teamBtn = await screen.findByTestId('radio-team')
         expect(teamBtn).toBeInTheDocument()
-        expect(teamBtn).not.toHaveClass('bg-ds-primary-base')
+        expect(teamBtn).not.toBeChecked()
       })
 
       describe('plan param is set to team', () => {
@@ -299,17 +295,13 @@ describe('PlanTypeOptions', () => {
             }
           )
 
-          const proBtn = await screen.findByRole('button', {
-            name: 'Pro',
-          })
+          const proBtn = await screen.findByTestId('radio-pro')
           expect(proBtn).toBeInTheDocument()
-          expect(proBtn).not.toHaveClass('bg-ds-primary-base')
+          expect(proBtn).not.toBeChecked()
 
-          const teamBtn = await screen.findByRole('button', {
-            name: 'Team',
-          })
+          const teamBtn = await screen.findByTestId('radio-team')
           expect(teamBtn).toBeInTheDocument()
-          expect(teamBtn).toHaveClass('bg-ds-primary-base')
+          expect(teamBtn).toBeChecked()
         })
       })
 
@@ -332,9 +324,7 @@ describe('PlanTypeOptions', () => {
             }
           )
 
-          const teamBtn = await screen.findByRole('button', {
-            name: 'Team',
-          })
+          const teamBtn = await screen.findByTestId('radio-team')
           expect(teamBtn).toBeInTheDocument()
           await user.click(teamBtn)
 
@@ -367,83 +357,13 @@ describe('PlanTypeOptions', () => {
             }
           )
 
-          const teamBtn = await screen.findByRole('button', {
-            name: 'Team',
-          })
+          const teamBtn = await screen.findByTestId('radio-team')
           expect(teamBtn).toBeInTheDocument()
           await user.click(teamBtn)
 
           await waitFor(() =>
             expect(testLocation.search).toEqual(
               qs.stringify({ plan: 'team' }, { addQueryPrefix: true })
-            )
-          )
-        })
-      })
-
-      describe('user clicks Pro button', () => {
-        it('calls setValue and setSelectedPlan', async () => {
-          const { user, mockSetFormValue, mockSetSelectedPlan } = setup({
-            planValue: Plans.USERS_DEVELOPER,
-            hasSentryPlans: true,
-            hasTeamPlans: true,
-          })
-
-          render(
-            <PlanTypeOptions
-              setFormValue={mockSetFormValue}
-              setSelectedPlan={mockSetSelectedPlan}
-              newPlan={basicPlan}
-            />,
-            {
-              wrapper: wrapper(),
-            }
-          )
-
-          const proBtn = await screen.findByRole('button', {
-            name: 'Pro',
-          })
-          expect(proBtn).toBeInTheDocument()
-          await user.click(proBtn)
-
-          await waitFor(() =>
-            expect(mockSetFormValue).toHaveBeenCalledWith(
-              'newPlan',
-              sentryPlanYear
-            )
-          )
-          await waitFor(() =>
-            expect(mockSetSelectedPlan).toHaveBeenCalledWith(sentryPlanYear)
-          )
-        })
-
-        it('sets plan query param to pro', async () => {
-          const { user, mockSetFormValue, mockSetSelectedPlan } = setup({
-            planValue: Plans.USERS_DEVELOPER,
-            hasSentryPlans: true,
-            hasTeamPlans: true,
-          })
-
-          render(
-            <PlanTypeOptions
-              setFormValue={mockSetFormValue}
-              setSelectedPlan={mockSetSelectedPlan}
-              newPlan={basicPlan}
-            />,
-            {
-              wrapper: wrapper(),
-            }
-          )
-
-          const proBtn = await screen.findByRole('button', {
-            name: 'Pro',
-          })
-          expect(proBtn).toBeInTheDocument()
-          await user.click(proBtn)
-
-          await waitFor(() =>
-            expect(testLocation.search).toEqual(
-              qs.stringify({ plan: 'pro' }, { addQueryPrefix: true })
             )
           )
         })
@@ -469,17 +389,13 @@ describe('PlanTypeOptions', () => {
           }
         )
 
-        const proBtn = await screen.findByRole('button', {
-          name: 'Pro',
-        })
+        const proBtn = await screen.findByTestId('radio-pro')
         expect(proBtn).toBeInTheDocument()
-        expect(proBtn).toHaveClass('bg-ds-primary-base')
+        expect(proBtn).toBeChecked()
 
-        const teamBtn = await screen.findByRole('button', {
-          name: 'Team',
-        })
+        const teamBtn = await screen.findByTestId('radio-team')
         expect(teamBtn).toBeInTheDocument()
-        expect(teamBtn).not.toHaveClass('bg-ds-primary-base')
+        expect(teamBtn).not.toBeChecked()
       })
 
       describe('user clicks Team button', () => {
@@ -501,9 +417,7 @@ describe('PlanTypeOptions', () => {
             }
           )
 
-          const teamBtn = await screen.findByRole('button', {
-            name: 'Team',
-          })
+          const teamBtn = await screen.findByTestId('radio-team')
           expect(teamBtn).toBeInTheDocument()
           await user.click(teamBtn)
 
@@ -536,83 +450,13 @@ describe('PlanTypeOptions', () => {
             }
           )
 
-          const teamBtn = await screen.findByRole('button', {
-            name: 'Team',
-          })
+          const teamBtn = await screen.findByTestId('radio-team')
           expect(teamBtn).toBeInTheDocument()
           await user.click(teamBtn)
 
           await waitFor(() =>
             expect(testLocation.search).toEqual(
               qs.stringify({ plan: 'team' }, { addQueryPrefix: true })
-            )
-          )
-        })
-      })
-
-      describe('user clicks Pro button', () => {
-        it('calls setValue and setSelectedPlan', async () => {
-          const { user, mockSetFormValue, mockSetSelectedPlan } = setup({
-            planValue: Plans.USERS_SENTRYY,
-            hasSentryPlans: true,
-            hasTeamPlans: true,
-          })
-
-          render(
-            <PlanTypeOptions
-              setFormValue={mockSetFormValue}
-              setSelectedPlan={mockSetSelectedPlan}
-              newPlan={sentryPlanYear}
-            />,
-            {
-              wrapper: wrapper(),
-            }
-          )
-
-          const proBtn = await screen.findByRole('button', {
-            name: 'Pro',
-          })
-          expect(proBtn).toBeInTheDocument()
-          await user.click(proBtn)
-
-          await waitFor(() =>
-            expect(mockSetFormValue).toHaveBeenCalledWith(
-              'newPlan',
-              sentryPlanYear
-            )
-          )
-          await waitFor(() =>
-            expect(mockSetSelectedPlan).toHaveBeenCalledWith(sentryPlanYear)
-          )
-        })
-
-        it('sets plan query param to pro', async () => {
-          const { user, mockSetFormValue, mockSetSelectedPlan } = setup({
-            planValue: Plans.USERS_SENTRYY,
-            hasSentryPlans: true,
-            hasTeamPlans: true,
-          })
-
-          render(
-            <PlanTypeOptions
-              setFormValue={mockSetFormValue}
-              setSelectedPlan={mockSetSelectedPlan}
-              newPlan={sentryPlanYear}
-            />,
-            {
-              wrapper: wrapper(),
-            }
-          )
-
-          const proBtn = await screen.findByRole('button', {
-            name: 'Pro',
-          })
-          expect(proBtn).toBeInTheDocument()
-          await user.click(proBtn)
-
-          await waitFor(() =>
-            expect(testLocation.search).toEqual(
-              qs.stringify({ plan: 'pro' }, { addQueryPrefix: true })
             )
           )
         })
@@ -638,17 +482,13 @@ describe('PlanTypeOptions', () => {
           }
         )
 
-        const teamBtn = await screen.findByRole('button', {
-          name: 'Team',
-        })
-        expect(teamBtn).toBeInTheDocument()
-        expect(teamBtn).toHaveClass('bg-ds-primary-base')
-
-        const proBtn = await screen.findByRole('button', {
-          name: 'Pro',
-        })
+        const proBtn = await screen.findByTestId('radio-pro')
         expect(proBtn).toBeInTheDocument()
-        expect(proBtn).not.toHaveClass('bg-ds-primary-base')
+        expect(proBtn).toBeChecked()
+
+        const teamBtn = await screen.findByTestId('radio-team')
+        expect(teamBtn).toBeInTheDocument()
+        expect(teamBtn).not.toBeChecked()
       })
 
       describe('plan param is set to pro', () => {
@@ -670,17 +510,13 @@ describe('PlanTypeOptions', () => {
             }
           )
 
-          const proBtn = await screen.findByRole('button', {
-            name: 'Pro',
-          })
+          const proBtn = await screen.findByTestId('radio-pro')
           expect(proBtn).toBeInTheDocument()
-          expect(proBtn).not.toHaveClass('bg-ds-primary-base')
+          expect(proBtn).toBeChecked()
 
-          const teamBtn = await screen.findByRole('button', {
-            name: 'Team',
-          })
+          const teamBtn = await screen.findByTestId('radio-team')
           expect(teamBtn).toBeInTheDocument()
-          expect(teamBtn).toHaveClass('bg-ds-primary-base')
+          expect(teamBtn).not.toBeChecked()
         })
       })
 
@@ -703,9 +539,7 @@ describe('PlanTypeOptions', () => {
             }
           )
 
-          const teamBtn = await screen.findByRole('button', {
-            name: 'Team',
-          })
+          const teamBtn = await screen.findByTestId('radio-team')
           expect(teamBtn).toBeInTheDocument()
           await user.click(teamBtn)
 
@@ -738,83 +572,13 @@ describe('PlanTypeOptions', () => {
             }
           )
 
-          const teamBtn = await screen.findByRole('button', {
-            name: 'Team',
-          })
+          const teamBtn = await screen.findByTestId('radio-team')
           expect(teamBtn).toBeInTheDocument()
           await user.click(teamBtn)
 
           await waitFor(() =>
             expect(testLocation.search).toEqual(
               qs.stringify({ plan: 'team' }, { addQueryPrefix: true })
-            )
-          )
-        })
-      })
-
-      describe('user clicks Pro button', () => {
-        it('calls setValue and setSelectedPlan', async () => {
-          const { user, mockSetFormValue, mockSetSelectedPlan } = setup({
-            planValue: Plans.USERS_TEAMY,
-            hasSentryPlans: true,
-            hasTeamPlans: true,
-          })
-
-          render(
-            <PlanTypeOptions
-              setFormValue={mockSetFormValue}
-              setSelectedPlan={mockSetSelectedPlan}
-              newPlan={teamPlanYear}
-            />,
-            {
-              wrapper: wrapper(),
-            }
-          )
-
-          const proBtn = await screen.findByRole('button', {
-            name: 'Pro',
-          })
-          expect(proBtn).toBeInTheDocument()
-          await user.click(proBtn)
-
-          await waitFor(() =>
-            expect(mockSetFormValue).toHaveBeenCalledWith(
-              'newPlan',
-              sentryPlanYear
-            )
-          )
-          await waitFor(() =>
-            expect(mockSetSelectedPlan).toHaveBeenCalledWith(sentryPlanYear)
-          )
-        })
-
-        it('sets plan query param to pro', async () => {
-          const { user, mockSetFormValue, mockSetSelectedPlan } = setup({
-            planValue: Plans.USERS_TEAMY,
-            hasSentryPlans: true,
-            hasTeamPlans: true,
-          })
-
-          render(
-            <PlanTypeOptions
-              setFormValue={mockSetFormValue}
-              setSelectedPlan={mockSetSelectedPlan}
-              newPlan={teamPlanYear}
-            />,
-            {
-              wrapper: wrapper(),
-            }
-          )
-
-          const proBtn = await screen.findByRole('button', {
-            name: 'Pro',
-          })
-          expect(proBtn).toBeInTheDocument()
-          await user.click(proBtn)
-
-          await waitFor(() =>
-            expect(testLocation.search).toEqual(
-              qs.stringify({ plan: 'pro' }, { addQueryPrefix: true })
             )
           )
         })
@@ -840,17 +604,13 @@ describe('PlanTypeOptions', () => {
           }
         )
 
-        const proBtn = await screen.findByRole('button', {
-          name: 'Pro',
-        })
+        const proBtn = await screen.findByTestId('radio-pro')
         expect(proBtn).toBeInTheDocument()
-        expect(proBtn).toHaveClass('bg-ds-primary-base')
+        expect(proBtn).toBeChecked()
 
-        const teamBtn = await screen.findByRole('button', {
-          name: 'Team',
-        })
+        const teamBtn = await screen.findByTestId('radio-team')
         expect(teamBtn).toBeInTheDocument()
-        expect(teamBtn).not.toHaveClass('bg-ds-primary-base')
+        expect(teamBtn).not.toBeChecked()
       })
 
       describe('user clicks Team button', () => {
@@ -872,9 +632,7 @@ describe('PlanTypeOptions', () => {
             }
           )
 
-          const teamBtn = await screen.findByRole('button', {
-            name: 'Team',
-          })
+          const teamBtn = await screen.findByTestId('radio-team')
           expect(teamBtn).toBeInTheDocument()
           await user.click(teamBtn)
 
@@ -907,83 +665,13 @@ describe('PlanTypeOptions', () => {
             }
           )
 
-          const teamBtn = await screen.findByRole('button', {
-            name: 'Team',
-          })
+          const teamBtn = await screen.findByTestId('radio-team')
           expect(teamBtn).toBeInTheDocument()
           await user.click(teamBtn)
 
           await waitFor(() =>
             expect(testLocation.search).toEqual(
               qs.stringify({ plan: 'team' }, { addQueryPrefix: true })
-            )
-          )
-        })
-      })
-
-      describe('user clicks Pro button', () => {
-        it('calls setValue and setSelectedPlan', async () => {
-          const { user, mockSetFormValue, mockSetSelectedPlan } = setup({
-            planValue: Plans.USERS_TRIAL,
-            hasSentryPlans: true,
-            hasTeamPlans: true,
-          })
-
-          render(
-            <PlanTypeOptions
-              setFormValue={mockSetFormValue}
-              setSelectedPlan={mockSetSelectedPlan}
-              newPlan={trialPlan}
-            />,
-            {
-              wrapper: wrapper(),
-            }
-          )
-
-          const proBtn = await screen.findByRole('button', {
-            name: 'Pro',
-          })
-          expect(proBtn).toBeInTheDocument()
-          await user.click(proBtn)
-
-          await waitFor(() =>
-            expect(mockSetFormValue).toHaveBeenCalledWith(
-              'newPlan',
-              sentryPlanYear
-            )
-          )
-          await waitFor(() =>
-            expect(mockSetSelectedPlan).toHaveBeenCalledWith(sentryPlanYear)
-          )
-        })
-
-        it('sets plan query param to pro', async () => {
-          const { user, mockSetFormValue, mockSetSelectedPlan } = setup({
-            planValue: Plans.USERS_TRIAL,
-            hasSentryPlans: true,
-            hasTeamPlans: true,
-          })
-
-          render(
-            <PlanTypeOptions
-              setFormValue={mockSetFormValue}
-              setSelectedPlan={mockSetSelectedPlan}
-              newPlan={trialPlan}
-            />,
-            {
-              wrapper: wrapper(),
-            }
-          )
-
-          const proBtn = await screen.findByRole('button', {
-            name: 'Pro',
-          })
-          expect(proBtn).toBeInTheDocument()
-          await user.click(proBtn)
-
-          await waitFor(() =>
-            expect(testLocation.search).toEqual(
-              qs.stringify({ plan: 'pro' }, { addQueryPrefix: true })
             )
           )
         })
@@ -1011,17 +699,13 @@ describe('PlanTypeOptions', () => {
           }
         )
 
-        const proBtn = await screen.findByRole('button', {
-          name: 'Pro',
-        })
+        const proBtn = await screen.findByTestId('radio-pro')
         expect(proBtn).toBeInTheDocument()
-        expect(proBtn).toHaveClass('bg-ds-primary-base')
+        expect(proBtn).toBeChecked()
 
-        const teamBtn = await screen.findByRole('button', {
-          name: 'Team',
-        })
+        const teamBtn = await screen.findByTestId('radio-team')
         expect(teamBtn).toBeInTheDocument()
-        expect(teamBtn).not.toHaveClass('bg-ds-primary-base')
+        expect(teamBtn).not.toBeChecked()
       })
 
       describe('user clicks Team button', () => {
@@ -1043,9 +727,7 @@ describe('PlanTypeOptions', () => {
             }
           )
 
-          const teamBtn = await screen.findByRole('button', {
-            name: 'Team',
-          })
+          const teamBtn = await screen.findByTestId('radio-team')
           expect(teamBtn).toBeInTheDocument()
           await user.click(teamBtn)
 
@@ -1078,83 +760,13 @@ describe('PlanTypeOptions', () => {
             }
           )
 
-          const teamBtn = await screen.findByRole('button', {
-            name: 'Team',
-          })
+          const teamBtn = await screen.findByTestId('radio-team')
           expect(teamBtn).toBeInTheDocument()
           await user.click(teamBtn)
 
           await waitFor(() =>
             expect(testLocation.search).toEqual(
               qs.stringify({ plan: 'team' }, { addQueryPrefix: true })
-            )
-          )
-        })
-      })
-
-      describe('user clicks Pro button', () => {
-        it('calls setValue and setSelectedPlan', async () => {
-          const { user, mockSetFormValue, mockSetSelectedPlan } = setup({
-            planValue: Plans.USERS_DEVELOPER,
-            hasSentryPlans: false,
-            hasTeamPlans: true,
-          })
-
-          render(
-            <PlanTypeOptions
-              setFormValue={mockSetFormValue}
-              setSelectedPlan={mockSetSelectedPlan}
-              newPlan={basicPlan}
-            />,
-            {
-              wrapper: wrapper(),
-            }
-          )
-
-          const proBtn = await screen.findByRole('button', {
-            name: 'Pro',
-          })
-          expect(proBtn).toBeInTheDocument()
-          await user.click(proBtn)
-
-          await waitFor(() =>
-            expect(mockSetFormValue).toHaveBeenCalledWith(
-              'newPlan',
-              proPlanYear
-            )
-          )
-          await waitFor(() =>
-            expect(mockSetSelectedPlan).toHaveBeenCalledWith(proPlanYear)
-          )
-        })
-
-        it('sets plan query param to pro', async () => {
-          const { user, mockSetFormValue, mockSetSelectedPlan } = setup({
-            planValue: Plans.USERS_DEVELOPER,
-            hasSentryPlans: false,
-            hasTeamPlans: true,
-          })
-
-          render(
-            <PlanTypeOptions
-              setFormValue={mockSetFormValue}
-              setSelectedPlan={mockSetSelectedPlan}
-              newPlan={basicPlan}
-            />,
-            {
-              wrapper: wrapper(),
-            }
-          )
-
-          const proBtn = await screen.findByRole('button', {
-            name: 'Pro',
-          })
-          expect(proBtn).toBeInTheDocument()
-          await user.click(proBtn)
-
-          await waitFor(() =>
-            expect(testLocation.search).toEqual(
-              qs.stringify({ plan: 'pro' }, { addQueryPrefix: true })
             )
           )
         })
@@ -1180,17 +792,13 @@ describe('PlanTypeOptions', () => {
           }
         )
 
-        const proBtn = await screen.findByRole('button', {
-          name: 'Pro',
-        })
+        const proBtn = await screen.findByTestId('radio-pro')
         expect(proBtn).toBeInTheDocument()
-        expect(proBtn).toHaveClass('bg-ds-primary-base')
+        expect(proBtn).toBeChecked()
 
-        const teamBtn = await screen.findByRole('button', {
-          name: 'Team',
-        })
+        const teamBtn = await screen.findByTestId('radio-team')
         expect(teamBtn).toBeInTheDocument()
-        expect(teamBtn).not.toHaveClass('bg-ds-primary-base')
+        expect(teamBtn).not.toBeChecked()
       })
 
       describe('user clicks Team button', () => {
@@ -1212,9 +820,7 @@ describe('PlanTypeOptions', () => {
             }
           )
 
-          const teamBtn = await screen.findByRole('button', {
-            name: 'Team',
-          })
+          const teamBtn = await screen.findByTestId('radio-team')
           expect(teamBtn).toBeInTheDocument()
           await user.click(teamBtn)
 
@@ -1247,9 +853,7 @@ describe('PlanTypeOptions', () => {
             }
           )
 
-          const teamBtn = await screen.findByRole('button', {
-            name: 'Team',
-          })
+          const teamBtn = await screen.findByTestId('radio-team')
           expect(teamBtn).toBeInTheDocument()
           await user.click(teamBtn)
 
@@ -1260,78 +864,10 @@ describe('PlanTypeOptions', () => {
           )
         })
       })
-
-      describe('user clicks Pro button', () => {
-        it('calls setValue and setSelectedPlan', async () => {
-          const { user, mockSetFormValue, mockSetSelectedPlan } = setup({
-            planValue: Plans.USERS_PR_INAPPY,
-            hasSentryPlans: false,
-            hasTeamPlans: true,
-          })
-
-          render(
-            <PlanTypeOptions
-              setFormValue={mockSetFormValue}
-              setSelectedPlan={mockSetSelectedPlan}
-              newPlan={proPlanYear}
-            />,
-            {
-              wrapper: wrapper(),
-            }
-          )
-
-          const proBtn = await screen.findByRole('button', {
-            name: 'Pro',
-          })
-          expect(proBtn).toBeInTheDocument()
-          await user.click(proBtn)
-
-          await waitFor(() =>
-            expect(mockSetFormValue).toHaveBeenCalledWith(
-              'newPlan',
-              proPlanYear
-            )
-          )
-          await waitFor(() =>
-            expect(mockSetSelectedPlan).toHaveBeenCalledWith(proPlanYear)
-          )
-        })
-
-        it('sets plan query param to pro', async () => {
-          const { user, mockSetFormValue, mockSetSelectedPlan } = setup({
-            planValue: Plans.USERS_PR_INAPPY,
-            hasSentryPlans: false,
-            hasTeamPlans: true,
-          })
-
-          render(
-            <PlanTypeOptions
-              setFormValue={mockSetFormValue}
-              setSelectedPlan={mockSetSelectedPlan}
-              newPlan={proPlanYear}
-            />,
-            {
-              wrapper: wrapper(),
-            }
-          )
-
-          const proBtn = await screen.findByRole('button', {
-            name: 'Pro',
-          })
-          expect(proBtn).toBeInTheDocument()
-          await user.click(proBtn)
-
-          await waitFor(() =>
-            expect(testLocation.search).toEqual(
-              qs.stringify({ plan: 'pro' }, { addQueryPrefix: true })
-            )
-          )
-        })
-      })
     })
 
     describe('when plan is team yearly', () => {
-      it('renders Team button as "selected"', async () => {
+      it('renders Pro button as "selected"', async () => {
         const { mockSetFormValue, mockSetSelectedPlan } = setup({
           planValue: Plans.USERS_TEAMY,
           hasSentryPlans: false,
@@ -1349,17 +885,13 @@ describe('PlanTypeOptions', () => {
           }
         )
 
-        const proBtn = await screen.findByRole('button', {
-          name: 'Pro',
-        })
+        const proBtn = await screen.findByTestId('radio-pro')
         expect(proBtn).toBeInTheDocument()
-        expect(proBtn).not.toHaveClass('bg-ds-primary-base')
+        expect(proBtn).toBeChecked()
 
-        const teamBtn = await screen.findByRole('button', {
-          name: 'Team',
-        })
+        const teamBtn = await screen.findByTestId('radio-team')
         expect(teamBtn).toBeInTheDocument()
-        expect(teamBtn).toHaveClass('bg-ds-primary-base')
+        expect(teamBtn).not.toBeChecked()
       })
 
       describe('plan param is set to team', () => {
@@ -1381,17 +913,13 @@ describe('PlanTypeOptions', () => {
             }
           )
 
-          const proBtn = await screen.findByRole('button', {
-            name: 'Pro',
-          })
+          const proBtn = await screen.findByTestId('radio-pro')
           expect(proBtn).toBeInTheDocument()
-          expect(proBtn).not.toHaveClass('bg-ds-primary-base')
+          expect(proBtn).not.toBeChecked()
 
-          const teamBtn = await screen.findByRole('button', {
-            name: 'Team',
-          })
+          const teamBtn = await screen.findByTestId('radio-team')
           expect(teamBtn).toBeInTheDocument()
-          expect(teamBtn).toHaveClass('bg-ds-primary-base')
+          expect(teamBtn).toBeChecked()
         })
       })
 
@@ -1414,9 +942,7 @@ describe('PlanTypeOptions', () => {
             }
           )
 
-          const teamBtn = await screen.findByRole('button', {
-            name: 'Team',
-          })
+          const teamBtn = await screen.findByTestId('radio-team')
           expect(teamBtn).toBeInTheDocument()
           await user.click(teamBtn)
 
@@ -1449,83 +975,13 @@ describe('PlanTypeOptions', () => {
             }
           )
 
-          const teamBtn = await screen.findByRole('button', {
-            name: 'Team',
-          })
+          const teamBtn = await screen.findByTestId('radio-team')
           expect(teamBtn).toBeInTheDocument()
           await user.click(teamBtn)
 
           await waitFor(() =>
             expect(testLocation.search).toEqual(
               qs.stringify({ plan: 'team' }, { addQueryPrefix: true })
-            )
-          )
-        })
-      })
-
-      describe('user clicks Pro button', () => {
-        it('calls setValue and setSelectedPlan', async () => {
-          const { user, mockSetFormValue, mockSetSelectedPlan } = setup({
-            planValue: Plans.USERS_TEAMY,
-            hasSentryPlans: false,
-            hasTeamPlans: true,
-          })
-
-          render(
-            <PlanTypeOptions
-              setFormValue={mockSetFormValue}
-              setSelectedPlan={mockSetSelectedPlan}
-              newPlan={teamPlanYear}
-            />,
-            {
-              wrapper: wrapper(),
-            }
-          )
-
-          const proBtn = await screen.findByRole('button', {
-            name: 'Pro',
-          })
-          expect(proBtn).toBeInTheDocument()
-          await user.click(proBtn)
-
-          await waitFor(() =>
-            expect(mockSetFormValue).toHaveBeenCalledWith(
-              'newPlan',
-              proPlanYear
-            )
-          )
-          await waitFor(() =>
-            expect(mockSetSelectedPlan).toHaveBeenCalledWith(proPlanYear)
-          )
-        })
-
-        it('sets plan query param to pro', async () => {
-          const { user, mockSetFormValue, mockSetSelectedPlan } = setup({
-            planValue: Plans.USERS_TEAMY,
-            hasSentryPlans: false,
-            hasTeamPlans: true,
-          })
-
-          render(
-            <PlanTypeOptions
-              setFormValue={mockSetFormValue}
-              setSelectedPlan={mockSetSelectedPlan}
-              newPlan={teamPlanYear}
-            />,
-            {
-              wrapper: wrapper(),
-            }
-          )
-
-          const proBtn = await screen.findByRole('button', {
-            name: 'Pro',
-          })
-          expect(proBtn).toBeInTheDocument()
-          await user.click(proBtn)
-
-          await waitFor(() =>
-            expect(testLocation.search).toEqual(
-              qs.stringify({ plan: 'pro' }, { addQueryPrefix: true })
             )
           )
         })
@@ -1551,17 +1007,13 @@ describe('PlanTypeOptions', () => {
           }
         )
 
-        const proBtn = await screen.findByRole('button', {
-          name: 'Pro',
-        })
+        const proBtn = await screen.findByTestId('radio-pro')
         expect(proBtn).toBeInTheDocument()
-        expect(proBtn).toHaveClass('bg-ds-primary-base')
+        expect(proBtn).toBeChecked()
 
-        const teamBtn = await screen.findByRole('button', {
-          name: 'Team',
-        })
+        const teamBtn = await screen.findByTestId('radio-team')
         expect(teamBtn).toBeInTheDocument()
-        expect(teamBtn).not.toHaveClass('bg-ds-primary-base')
+        expect(teamBtn).not.toBeChecked()
       })
 
       describe('user clicks Team button', () => {
@@ -1583,9 +1035,7 @@ describe('PlanTypeOptions', () => {
             }
           )
 
-          const teamBtn = await screen.findByRole('button', {
-            name: 'Team',
-          })
+          const teamBtn = await screen.findByTestId('radio-team')
           expect(teamBtn).toBeInTheDocument()
           await user.click(teamBtn)
 
@@ -1618,9 +1068,7 @@ describe('PlanTypeOptions', () => {
             }
           )
 
-          const teamBtn = await screen.findByRole('button', {
-            name: 'Team',
-          })
+          const teamBtn = await screen.findByTestId('radio-team')
           expect(teamBtn).toBeInTheDocument()
           await user.click(teamBtn)
 
@@ -1631,78 +1079,10 @@ describe('PlanTypeOptions', () => {
           )
         })
       })
-
-      describe('user clicks Pro button', () => {
-        it('calls setValue and setSelectedPlan', async () => {
-          const { user, mockSetFormValue, mockSetSelectedPlan } = setup({
-            planValue: Plans.USERS_TRIAL,
-            hasSentryPlans: false,
-            hasTeamPlans: true,
-          })
-
-          render(
-            <PlanTypeOptions
-              setFormValue={mockSetFormValue}
-              setSelectedPlan={mockSetSelectedPlan}
-              newPlan={trialPlan}
-            />,
-            {
-              wrapper: wrapper(),
-            }
-          )
-
-          const proBtn = await screen.findByRole('button', {
-            name: 'Pro',
-          })
-          expect(proBtn).toBeInTheDocument()
-          await user.click(proBtn)
-
-          await waitFor(() =>
-            expect(mockSetFormValue).toHaveBeenCalledWith(
-              'newPlan',
-              proPlanYear
-            )
-          )
-          await waitFor(() =>
-            expect(mockSetSelectedPlan).toHaveBeenCalledWith(proPlanYear)
-          )
-        })
-
-        it('sets plan query param to pro', async () => {
-          const { user, mockSetFormValue, mockSetSelectedPlan } = setup({
-            planValue: Plans.USERS_TRIAL,
-            hasSentryPlans: false,
-            hasTeamPlans: true,
-          })
-
-          render(
-            <PlanTypeOptions
-              setFormValue={mockSetFormValue}
-              setSelectedPlan={mockSetSelectedPlan}
-              newPlan={trialPlan}
-            />,
-            {
-              wrapper: wrapper(),
-            }
-          )
-
-          const proBtn = await screen.findByRole('button', {
-            name: 'Pro',
-          })
-          expect(proBtn).toBeInTheDocument()
-          await user.click(proBtn)
-
-          await waitFor(() =>
-            expect(testLocation.search).toEqual(
-              qs.stringify({ plan: 'pro' }, { addQueryPrefix: true })
-            )
-          )
-        })
-      })
     })
   })
-  describe('when plan is team plan monthly', () => {
-    it('keeps monthly selection when updating to pro plan', async () => {
+  describe('when plan is monthly', () => {
+    it('keeps monthly selection when changing plans', async () => {
       const { user, mockSetFormValue, mockSetSelectedPlan } = setup({
         planValue: Plans.USERS_TEAMM,
         hasSentryPlans: false,
@@ -1720,17 +1100,15 @@ describe('PlanTypeOptions', () => {
         }
       )
 
-      const proBtn = await screen.findByRole('button', {
-        name: 'Pro',
-      })
+      const proBtn = await screen.findByTestId('radio-team')
       expect(proBtn).toBeInTheDocument()
       await user.click(proBtn)
 
       await waitFor(() =>
-        expect(mockSetFormValue).toHaveBeenCalledWith('newPlan', proPlanMonth)
+        expect(mockSetFormValue).toHaveBeenCalledWith('newPlan', teamPlanMonth)
       )
       await waitFor(() =>
-        expect(mockSetSelectedPlan).toHaveBeenCalledWith(proPlanMonth)
+        expect(mockSetSelectedPlan).toHaveBeenCalledWith(teamPlanMonth)
       )
     })
   })

--- a/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/PlanTypeOptions/PlanTypeOptions.tsx
+++ b/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/PlanTypeOptions/PlanTypeOptions.tsx
@@ -57,7 +57,7 @@ const PlanTypeOptions: React.FC<PlanTypeOptionsProps> = ({
   const monthlyPlan = newPlan?.billingRate === BillingRate.MONTHLY
 
   let planOption = null
-  if ((hasTeamPlans && planParam === TierNames.TEAM) || newPlan?.isTeamPlan) {
+  if (hasTeamPlans && planParam === TierNames.TEAM) {
     planOption = TierName.TEAM
   } else {
     planOption = TierName.PRO
@@ -94,10 +94,18 @@ const PlanTypeOptions: React.FC<PlanTypeOptionsProps> = ({
               }
             }}
           >
-            <RadioTileGroup.Item value={TierName.PRO} className="w-32">
+            <RadioTileGroup.Item
+              value={TierName.PRO}
+              className="w-32"
+              data-testid="radio-pro"
+            >
               <RadioTileGroup.Label>{TierName.PRO}</RadioTileGroup.Label>
             </RadioTileGroup.Item>
-            <RadioTileGroup.Item value={TierName.TEAM} className="w-32">
+            <RadioTileGroup.Item
+              value={TierName.TEAM}
+              className="w-32"
+              data-testid="radio-team"
+            >
               <RadioTileGroup.Label>{TierName.TEAM}</RadioTileGroup.Label>
             </RadioTileGroup.Item>
           </RadioTileGroup>

--- a/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/PlanTypeOptions/PlanTypeOptions.tsx
+++ b/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/PlanTypeOptions/PlanTypeOptions.tsx
@@ -17,7 +17,7 @@ import {
   TierNames,
 } from 'shared/utils/billing'
 import { TEAM_PLAN_MAX_ACTIVE_USERS } from 'shared/utils/upgradeForm'
-import { OptionButton } from 'ui/OptionButton/OptionButton'
+import { RadioTileGroup } from 'ui/RadioTileGroup'
 
 import { TierName } from '../constants'
 import { usePlanParams } from '../hooks/usePlanParams'
@@ -68,13 +68,12 @@ const PlanTypeOptions: React.FC<PlanTypeOptionsProps> = ({
   if (hasTeamPlans) {
     return (
       <div className="flex w-fit flex-col gap-2">
-        <h3 className="font-semibold">Choose a plan</h3>
+        <h3 className="font-semibold">Step 1: Choose a plan</h3>
         <div className="inline-flex items-center gap-2">
-          <OptionButton
-            type="button"
-            active={planOption}
-            onChange={({ text }) => {
-              if (text === TierName.PRO) {
+          <RadioTileGroup
+            value={planOption}
+            onValueChange={(value) => {
+              if (value === TierName.PRO) {
                 if (monthlyPlan) {
                   setSelectedPlan(monthlyProPlan)
                   setFormValue('newPlan', monthlyProPlan)
@@ -94,17 +93,14 @@ const PlanTypeOptions: React.FC<PlanTypeOptionsProps> = ({
                 updateParams({ plan: TierNames.TEAM })
               }
             }}
-            options={
-              [
-                {
-                  text: TierName.PRO,
-                },
-                {
-                  text: TierName.TEAM,
-                },
-              ] as const
-            }
-          />
+          >
+            <RadioTileGroup.Item value={TierName.PRO} className="w-32">
+              <RadioTileGroup.Label>{TierName.PRO}</RadioTileGroup.Label>
+            </RadioTileGroup.Item>
+            <RadioTileGroup.Item value={TierName.TEAM} className="w-32">
+              <RadioTileGroup.Label>{TierName.TEAM}</RadioTileGroup.Label>
+            </RadioTileGroup.Item>
+          </RadioTileGroup>
           {planOption === TierName.TEAM && (
             <p>Up to {TEAM_PLAN_MAX_ACTIVE_USERS} users</p>
           )}

--- a/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/UpdateBlurb/UpdateBlurb.tsx
+++ b/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/UpdateBlurb/UpdateBlurb.tsx
@@ -40,20 +40,21 @@ const UpdateBlurb = ({
 
   return (
     <div>
-      <h3 className="pb-2 font-semibold">Review your plan changes</h3>
-      {diffPlanType && (
-        <li className="pl-2">{`You are changing from the ${
-          currentIsFree ? 'Developer' : currentIsTeam ? 'Team' : 'Pro'
-        } plan to the [${selectedIsTeam ? 'Team' : 'Pro'} plan]`}</li>
-      )}
-      {diffSeats && (
-        <li className="pl-2">{`You are changing seats from ${currentPlan?.planUserCount} to [${seats}]`}</li>
-      )}
-      {diffBillingType && !currentIsFree && (
-        <li className="pl-2">{`You are changing your billing cycle from ${
-          currentIsAnnual ? 'Annual' : 'Monthly'
-        } to [${currentIsAnnual ? 'Monthly' : 'Annual'}]`}</li>
-      )}
+      <ul className="list-inside list-disc">
+        {diffPlanType && (
+          <li className="pl-2">{`You are changing from the ${
+            currentIsFree ? 'Developer' : currentIsTeam ? 'Team' : 'Pro'
+          } plan to the [${selectedIsTeam ? 'Team' : 'Pro'} plan]`}</li>
+        )}
+        {diffSeats && (
+          <li className="pl-2">{`You are changing seats from ${currentPlan?.planUserCount} to [${seats}]`}</li>
+        )}
+        {diffBillingType && !currentIsFree && (
+          <li className="pl-2">{`You are changing your billing cycle from ${
+            currentIsAnnual ? 'Annual' : 'Monthly'
+          } to [${currentIsAnnual ? 'Monthly' : 'Annual'}]`}</li>
+        )}
+      </ul>
       <br />
 
       <h3 className="font-medium">

--- a/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/UpdateButton/UpdateButton.test.tsx
+++ b/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/UpdateButton/UpdateButton.test.tsx
@@ -198,6 +198,8 @@ describe('UpdateButton', () => {
           isValid: true,
           newPlan: proPlanYearly,
           seats: 3,
+          onSubmit: () => {},
+          isLoading: false,
         }
 
         render(<UpdateButton {...props} />, {
@@ -218,6 +220,8 @@ describe('UpdateButton', () => {
           isValid: true,
           newPlan: proPlanYearly,
           seats: 27,
+          onSubmit: () => {},
+          isLoading: false,
         }
 
         render(<UpdateButton {...props} />, {
@@ -238,6 +242,8 @@ describe('UpdateButton', () => {
           isValid: false,
           newPlan: proPlanYearly,
           seats: 6,
+          onSubmit: () => {},
+          isLoading: false,
         }
 
         render(<UpdateButton {...props} />, {
@@ -258,6 +264,8 @@ describe('UpdateButton', () => {
           isValid: true,
           newPlan: proPlanMonthly,
           seats: 4,
+          onSubmit: () => {},
+          isLoading: false,
         }
 
         render(<UpdateButton {...props} />, {

--- a/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/UpdateButton/UpdateButton.test.tsx
+++ b/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/UpdateButton/UpdateButton.test.tsx
@@ -1,7 +1,7 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { graphql, HttpResponse } from 'msw'
+import { graphql, http, HttpResponse } from 'msw'
 import { setupServer } from 'msw/node'
 import { Suspense } from 'react'
 import { MemoryRouter, Route } from 'react-router-dom'
@@ -137,6 +137,24 @@ describe('UpdateButton', () => {
     }
   ) {
     server.use(
+      graphql.query('DetailOwner', () =>
+        HttpResponse.json({
+          data: {
+            owner: {
+              orgUploadToken: '9a9f1bb6-43e9-4766-b48b-aa16b449fbb1',
+              ownerid: 5537,
+              username: 'codecov',
+              avatarUrl:
+                'https://avatars0.githubusercontent.com/u/8226205?v=3&s=55',
+              isCurrentUserPartOfOrg: true,
+              isAdmin: true,
+            },
+          },
+        })
+      ),
+      http.get('/internal/gh/codecov/account-details/', () =>
+        HttpResponse.json({})
+      ),
       graphql.query(`GetPlanData`, () => {
         const planChunk = {
           trialStatus: TrialStatuses.NOT_STARTED,

--- a/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/UpdateButton/UpdateButton.tsx
+++ b/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/UpdateButton/UpdateButton.tsx
@@ -81,6 +81,7 @@ const UpdateButton: React.FC<BillingControlsProps> = ({
             <div className="flex items-center gap-2">
               <Checkbox
                 id="upgrade-confirmation-checkbox"
+                data-testid="upgrade-confirmation-checkbox"
                 checked={confirmationIsChecked}
                 onClick={() => setConfirmationIsChecked(!confirmationIsChecked)}
               />
@@ -111,8 +112,8 @@ const UpdateButton: React.FC<BillingControlsProps> = ({
                 variant="primary"
                 disabled={!confirmationIsChecked}
                 onClick={() => {
-                  onSubmit()
                   setShowConfirmationModal(false)
+                  onSubmit()
                 }}
               >
                 {planData?.plan?.isFreePlan ? 'Proceed to checkout' : 'Update'}

--- a/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/UpdateButton/UpdateButton.tsx
+++ b/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/UpdateButton/UpdateButton.tsx
@@ -9,6 +9,7 @@ import { Provider } from 'shared/api/helpers'
 import { getNextBillingDate } from 'shared/utils/billing'
 import Avatar from 'ui/Avatar'
 import Button from 'ui/Button'
+import Checkbox from 'ui/Checkbox'
 import Modal from 'ui/Modal'
 
 import { PersonalOrgWarning } from '../PersonalOrgWarning'
@@ -31,6 +32,7 @@ const UpdateButton: React.FC<BillingControlsProps> = ({
 }) => {
   const { provider, owner } = useParams<{ provider: Provider; owner: string }>()
   const [showConfirmationModal, setShowConfirmationModal] = useState(false)
+  const [confirmationIsChecked, setConfirmationIsChecked] = useState(false)
   const { data: ownerData } = useOwner({ username: owner })
   const { data: planData } = usePlanData({ provider, owner })
   const { data: accountDetails } = useAccountDetails({ provider, owner })
@@ -67,10 +69,7 @@ const UpdateButton: React.FC<BillingControlsProps> = ({
         body={
           <div className="flex flex-col gap-4 px-4 py-2">
             <div className="inline-flex items-center gap-1">
-              By proceeding, you are making the following changes to{' '}
-              <Avatar user={ownerData} className="size-4" />
-              <span className="font-bold text-ds-pink-default">{owner}</span>
-              &apos;s plan:
+              By proceeding, you are making the following changes to your plan:
             </div>
             <UpdateBlurb
               currentPlan={planData?.plan}
@@ -79,6 +78,24 @@ const UpdateButton: React.FC<BillingControlsProps> = ({
               nextBillingDate={getNextBillingDate(accountDetails)!}
             />
             <PersonalOrgWarning />
+            <div className="flex items-center gap-2">
+              <Checkbox
+                id="upgrade-confirmation-checkbox"
+                checked={confirmationIsChecked}
+                onClick={() => setConfirmationIsChecked(!confirmationIsChecked)}
+              />
+              <label
+                className="flex flex-wrap items-center"
+                htmlFor="upgrade-confirmation-checkbox"
+              >
+                I accept the changes to
+                <div className="flex items-center gap-1 pl-1">
+                  <Avatar user={ownerData} className="size-4" border="dark" />
+                  <span className="font-bold">{owner}</span>
+                </div>
+                &apos;s plan.
+              </label>
+            </div>
             <div className="flex justify-end gap-2">
               <Button
                 type="button"
@@ -92,6 +109,7 @@ const UpdateButton: React.FC<BillingControlsProps> = ({
                 type="submit"
                 hook="submit-upgrade"
                 variant="primary"
+                disabled={!confirmationIsChecked}
                 onClick={() => {
                   onSubmit()
                   setShowConfirmationModal(false)

--- a/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/UpdateButton/UpdateButton.tsx
+++ b/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/UpdateButton/UpdateButton.tsx
@@ -1,23 +1,39 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { useParams } from 'react-router-dom'
 
+import { useAccountDetails } from 'services/account/useAccountDetails'
 import { IndividualPlan } from 'services/account/useAvailablePlans'
 import { usePlanData } from 'services/account/usePlanData'
+import { useOwner } from 'services/user'
+import { Provider } from 'shared/api/helpers'
+import { getNextBillingDate } from 'shared/utils/billing'
+import Avatar from 'ui/Avatar'
 import Button from 'ui/Button'
+import Modal from 'ui/Modal'
+
+import { PersonalOrgWarning } from '../PersonalOrgWarning'
+import UpdateBlurb from '../UpdateBlurb'
 
 interface BillingControlsProps {
   seats: number
   isValid: boolean
   newPlan?: IndividualPlan
+  onSubmit: () => void
+  isLoading: boolean
 }
 
 const UpdateButton: React.FC<BillingControlsProps> = ({
   isValid,
   newPlan,
   seats,
+  onSubmit,
+  isLoading,
 }) => {
-  const { provider, owner } = useParams<{ provider: string; owner: string }>()
+  const { provider, owner } = useParams<{ provider: Provider; owner: string }>()
+  const [showConfirmationModal, setShowConfirmationModal] = useState(false)
+  const { data: ownerData } = useOwner({ username: owner })
   const { data: planData } = usePlanData({ provider, owner })
+  const { data: accountDetails } = useAccountDetails({ provider, owner })
 
   const currentPlanValue = planData?.plan?.value
   const currentPlanQuantity = planData?.plan?.planUserCount || 0
@@ -27,18 +43,68 @@ const UpdateButton: React.FC<BillingControlsProps> = ({
   const disabled = !isValid || (isSamePlan && noChangeInSeats)
 
   return (
-    <div className="inline-flex">
-      <Button
-        data-cy="plan-page-plan-update"
-        disabled={disabled}
-        type="submit"
-        variant="primary"
-        hook="submit-upgrade"
-        to={undefined}
-      >
-        {planData?.plan?.isFreePlan ? 'Proceed to checkout' : 'Update'}
-      </Button>
-    </div>
+    <>
+      <div className="inline-flex">
+        <Button
+          type="button"
+          data-cy="plan-page-plan-update"
+          disabled={disabled}
+          variant="primary"
+          hook="confirm-upgrade"
+          onClick={() => {
+            if (!disabled) {
+              setShowConfirmationModal(true)
+            }
+          }}
+          isLoading={isLoading}
+        >
+          {planData?.plan?.isFreePlan ? 'Proceed to checkout' : 'Update'}
+        </Button>
+      </div>
+      <Modal
+        isOpen={showConfirmationModal}
+        onClose={() => setShowConfirmationModal(false)}
+        body={
+          <div className="flex flex-col gap-4 px-4 py-2">
+            <div className="inline-flex items-center gap-1">
+              By proceeding, you are making the following changes to{' '}
+              <Avatar user={ownerData} className="size-4" />
+              <span className="font-bold text-ds-pink-default">{owner}</span>
+              &apos;s plan:
+            </div>
+            <UpdateBlurb
+              currentPlan={planData?.plan}
+              newPlan={newPlan}
+              seats={Number(seats)}
+              nextBillingDate={getNextBillingDate(accountDetails)!}
+            />
+            <PersonalOrgWarning />
+            <div className="flex justify-end gap-2">
+              <Button
+                type="button"
+                hook="cancel-upgrade"
+                variant="default"
+                onClick={() => setShowConfirmationModal(false)}
+              >
+                Go back
+              </Button>
+              <Button
+                type="submit"
+                hook="submit-upgrade"
+                variant="primary"
+                onClick={() => {
+                  onSubmit()
+                  setShowConfirmationModal(false)
+                }}
+              >
+                {planData?.plan?.isFreePlan ? 'Proceed to checkout' : 'Update'}
+              </Button>
+            </div>
+          </div>
+        }
+        title="Review plan changes"
+      />
+    </>
   )
 }
 

--- a/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/UpgradeForm.test.tsx
+++ b/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/UpgradeForm.test.tsx
@@ -2444,7 +2444,7 @@ describe('UpgradeForm', () => {
       })
     })
 
-    describe.only('user is upgrading personal org', () => {
+    describe('user is upgrading personal org', () => {
       const props = {
         setSelectedPlan: vi.fn(),
         selectedPlan: {
@@ -2467,7 +2467,7 @@ describe('UpgradeForm', () => {
       })
     })
 
-    describe.only('user is not upgrading personal org', () => {
+    describe('user is not upgrading personal org', () => {
       const props = {
         setSelectedPlan: vi.fn(),
         selectedPlan: {

--- a/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/UpgradeForm.test.tsx
+++ b/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/UpgradeForm.test.tsx
@@ -2443,5 +2443,53 @@ describe('UpgradeForm', () => {
         })
       })
     })
+
+    describe.only('user is upgrading personal org', () => {
+      const props = {
+        setSelectedPlan: vi.fn(),
+        selectedPlan: {
+          value: Plans.USERS_PR_INAPPY,
+        } as IndividualPlan,
+      }
+
+      it('shows personal org warning', async () => {
+        setup({
+          isPersonalOrg: true,
+        })
+        render(<UpgradeForm {...props} />, {
+          wrapper: wrapper(['/gh/janedoe']),
+        })
+
+        const personalOrgWarning = await screen.findByText(
+          /You're about to upgrade your personal organization/
+        )
+        expect(personalOrgWarning).toBeInTheDocument()
+      })
+    })
+
+    describe.only('user is not upgrading personal org', () => {
+      const props = {
+        setSelectedPlan: vi.fn(),
+        selectedPlan: {
+          value: Plans.USERS_PR_INAPPY,
+        } as IndividualPlan,
+      }
+
+      it('does not show personal org warning', async () => {
+        setup({
+          isPersonalOrg: false,
+        })
+        render(<UpgradeForm {...props} />, {
+          wrapper: wrapper(),
+        })
+
+        const _ = await screen.findByText(/codecov/)
+
+        const personalOrgWarning = screen.queryByText(
+          /You're about to upgrade your personal organization/
+        )
+        expect(personalOrgWarning).not.toBeInTheDocument()
+      })
+    })
   })
 })

--- a/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/UpgradeForm.test.tsx
+++ b/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/UpgradeForm.test.tsx
@@ -9,6 +9,7 @@ import { graphql, http, HttpResponse } from 'msw'
 import { setupServer } from 'msw/node'
 import { Suspense } from 'react'
 import { MemoryRouter, Route, useLocation } from 'react-router-dom'
+import ResizeObserver from 'resize-observer-polyfill'
 
 import { accountDetailsParsedObj } from 'services/account/mocks'
 import { IndividualPlan } from 'services/account/useAvailablePlans'
@@ -16,6 +17,8 @@ import { TrialStatuses } from 'services/account/usePlanData'
 import { BillingRate, Plans } from 'shared/utils/billing'
 
 import UpgradeForm from './UpgradeForm'
+
+global.ResizeObserver = ResizeObserver
 
 const mocks = vi.hoisted(() => ({
   useAddNotification: vi.fn(),
@@ -230,6 +233,49 @@ const mockPlanDataResponse = {
   isSentryPlan: false,
 }
 
+const mockUser = {
+  me: {
+    owner: {
+      defaultOrgUsername: 'codecov',
+    },
+    email: 'jane.doe@codecov.io',
+    privateAccess: true,
+    onboardingCompleted: true,
+    businessEmail: 'jane.doe@codecov.io',
+    termsAgreement: true,
+    user: {
+      name: 'Jane Doe',
+      username: 'janedoe',
+      avatarUrl: 'http://127.0.0.1/avatar-url',
+      avatar: 'http://127.0.0.1/avatar-url',
+      student: false,
+      studentCreatedAt: null,
+      studentUpdatedAt: null,
+    },
+    trackingMetadata: {
+      service: 'github',
+      ownerid: 123,
+      serviceId: '123',
+      plan: Plans.USERS_DEVELOPER,
+      staff: false,
+      hasYaml: false,
+      bot: null,
+      delinquent: null,
+      didTrial: null,
+      planProvider: null,
+      planUserCount: 1,
+      createdAt: 'timestamp',
+      updatedAt: 'timestamp',
+      profile: {
+        createdAt: 'timestamp',
+        otherGoal: null,
+        typeProjects: [],
+        goals: [],
+      },
+    },
+  },
+}
+
 const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
@@ -300,6 +346,7 @@ type SetupArgs = {
   planUserCount?: number
   hasUnverifiedPaymentMethods?: boolean
   subscriptionHasDefaultPaymentMethod?: boolean
+  isPersonalOrg?: boolean
 }
 
 describe('UpgradeForm', () => {
@@ -314,6 +361,7 @@ describe('UpgradeForm', () => {
     planUserCount = 1,
     hasUnverifiedPaymentMethods = false,
     subscriptionHasDefaultPaymentMethod = true,
+    isPersonalOrg = false,
   }: SetupArgs) {
     const addNotification = vi.fn()
     const user = userEvent.setup()
@@ -433,7 +481,27 @@ describe('UpgradeForm', () => {
             },
           },
         })
-      })
+      }),
+      graphql.query('CurrentUser', () =>
+        HttpResponse.json({
+          data: mockUser,
+        })
+      ),
+      graphql.query('DetailOwner', () =>
+        HttpResponse.json({
+          data: {
+            owner: {
+              orgUploadToken: '9a9f1bb6-43e9-4766-b48b-aa16b449fbb1',
+              ownerid: 5537,
+              username: isPersonalOrg ? 'janedoe' : 'codecov',
+              avatarUrl:
+                'https://avatars0.githubusercontent.com/u/8226205?v=3&s=55',
+              isCurrentUserPartOfOrg: true,
+              isAdmin: true,
+            },
+          },
+        })
+      )
     )
 
     return { addNotification, user, patchRequest }
@@ -446,7 +514,7 @@ describe('UpgradeForm', () => {
         selectedPlan: proPlanYear,
       }
 
-      it('shows modal when form is submitted', async () => {
+      it('shows unverified payment method modal when form is submitted', async () => {
         const { user } = setup({
           planValue: Plans.USERS_DEVELOPER,
           hasUnverifiedPaymentMethods: true,
@@ -458,6 +526,15 @@ describe('UpgradeForm', () => {
           name: /Proceed to checkout/,
         })
         await user.click(proceedToCheckoutButton)
+
+        const confirmCheckoutCheckbox = await screen.findByTestId(
+          'upgrade-confirmation-checkbox'
+        )
+        await user.click(confirmCheckoutCheckbox)
+
+        const confirmCheckoutButton =
+          await screen.findByTestId('submit-upgrade')
+        await user.click(confirmCheckoutButton)
 
         const modal = await screen.findByText(
           /Are you sure you want to abandon this upgrade and start a new one/,
@@ -482,7 +559,17 @@ describe('UpgradeForm', () => {
         const proceedToCheckoutButton = await screen.findByRole('button', {
           name: /Proceed to checkout/,
         })
+
         await user.click(proceedToCheckoutButton)
+
+        const confirmCheckoutCheckbox = await screen.findByTestId(
+          'upgrade-confirmation-checkbox'
+        )
+        await user.click(confirmCheckoutCheckbox)
+
+        const confirmCheckoutButton =
+          await screen.findByTestId('submit-upgrade')
+        await user.click(confirmCheckoutButton)
 
         const modal = screen.queryByText(
           /Are you sure you want to abandon this upgrade and start a new one/,
@@ -513,7 +600,7 @@ describe('UpgradeForm', () => {
         setup({ planValue: Plans.USERS_DEVELOPER })
         render(<UpgradeForm {...props} />, { wrapper: wrapper() })
 
-        const optionBtn = await screen.findByRole('button', { name: 'Monthly' })
+        const optionBtn = await screen.findByTestId('radio-monthly')
         expect(optionBtn).toBeInTheDocument()
       })
 
@@ -521,7 +608,7 @@ describe('UpgradeForm', () => {
         setup({ planValue: Plans.USERS_DEVELOPER })
         render(<UpgradeForm {...props} />, { wrapper: wrapper() })
 
-        const optionBtn = await screen.findByRole('button', { name: 'Annual' })
+        const optionBtn = await screen.findByTestId('radio-annual')
         expect(optionBtn).toBeInTheDocument()
       })
 
@@ -529,9 +616,9 @@ describe('UpgradeForm', () => {
         setup({ planValue: Plans.USERS_DEVELOPER, monthlyPlan: false })
         render(<UpgradeForm {...props} />, { wrapper: wrapper() })
 
-        const optionBtn = await screen.findByRole('button', { name: 'Annual' })
+        const optionBtn = await screen.findByTestId('radio-annual')
         expect(optionBtn).toBeInTheDocument()
-        expect(optionBtn).toHaveClass('bg-ds-primary-base')
+        expect(optionBtn).toBeChecked()
       })
 
       it('has the price for the year', async () => {
@@ -587,9 +674,9 @@ describe('UpgradeForm', () => {
           })
           render(<UpgradeForm {...props} />, { wrapper: wrapper() })
 
-          const optionBtn = await screen.findByRole('button', { name: 'Pro' })
+          const optionBtn = await screen.findByTestId('radio-pro')
           expect(optionBtn).toBeInTheDocument()
-          expect(optionBtn).toHaveClass('bg-ds-primary-base')
+          expect(optionBtn).toBeChecked()
         })
 
         it('renders team option button', async () => {
@@ -599,9 +686,7 @@ describe('UpgradeForm', () => {
           })
           render(<UpgradeForm {...props} />, { wrapper: wrapper() })
 
-          const optionBtn = await screen.findByRole('button', {
-            name: 'Team',
-          })
+          const optionBtn = await screen.findByTestId('radio-team')
           expect(optionBtn).toBeInTheDocument()
         })
 
@@ -613,9 +698,7 @@ describe('UpgradeForm', () => {
             })
             render(<UpgradeForm {...props} />, { wrapper: wrapper() })
 
-            const teamOption = await screen.findByRole('button', {
-              name: 'Team',
-            })
+            const teamOption = await screen.findByTestId('radio-team')
             await user.click(teamOption)
 
             const auxiliaryText = await screen.findByText(/Up to 10 users/)
@@ -629,9 +712,7 @@ describe('UpgradeForm', () => {
             })
             render(<UpgradeForm {...props} />, { wrapper: wrapper() })
 
-            const teamOption = await screen.findByRole('button', {
-              name: 'Team',
-            })
+            const teamOption = await screen.findByTestId('radio-team')
             await user.click(teamOption)
             expect(props.setSelectedPlan).toHaveBeenCalledWith(teamPlanYear)
           })
@@ -643,9 +724,7 @@ describe('UpgradeForm', () => {
           const { user } = setup({ planValue: Plans.USERS_DEVELOPER })
           render(<UpgradeForm {...props} />, { wrapper: wrapper() })
 
-          const monthOption = await screen.findByRole('button', {
-            name: 'Monthly',
-          })
+          const monthOption = await screen.findByTestId('radio-monthly')
           await user.click(monthOption)
 
           const price = screen.getByText(/\$48/)
@@ -668,7 +747,17 @@ describe('UpgradeForm', () => {
           const proceedToCheckoutButton = await screen.findByRole('button', {
             name: /Proceed to checkout/,
           })
+
           await user.click(proceedToCheckoutButton)
+
+          const confirmCheckoutCheckbox = await screen.findByTestId(
+            'upgrade-confirmation-checkbox'
+          )
+          await user.click(confirmCheckoutCheckbox)
+
+          const confirmCheckoutButton =
+            await screen.findByTestId('submit-upgrade')
+          await user.click(confirmCheckoutButton)
 
           await waitFor(() =>
             expect(patchRequest).toHaveBeenCalledWith({
@@ -691,15 +780,23 @@ describe('UpgradeForm', () => {
           await user.type(input, '{backspace}{backspace}{backspace}')
           await user.type(input, '20')
 
-          const optionBtn = await screen.findByRole('button', {
-            name: 'Monthly',
-          })
+          const optionBtn = await screen.findByTestId('radio-monthly')
           await user.click(optionBtn)
 
           const proceedToCheckoutButton = await screen.findByRole('button', {
             name: /Proceed to checkout/,
           })
+
           await user.click(proceedToCheckoutButton)
+
+          const confirmCheckoutCheckbox = await screen.findByTestId(
+            'upgrade-confirmation-checkbox'
+          )
+          await user.click(confirmCheckoutCheckbox)
+
+          const confirmCheckoutButton =
+            await screen.findByTestId('submit-upgrade')
+          await user.click(confirmCheckoutButton)
 
           await waitFor(() =>
             expect(patchRequest).toHaveBeenCalledWith({
@@ -725,7 +822,17 @@ describe('UpgradeForm', () => {
           const proceedToCheckoutButton = await screen.findByRole('button', {
             name: /Proceed to checkout/,
           })
+
           await user.click(proceedToCheckoutButton)
+
+          const confirmCheckoutCheckbox = await screen.findByTestId(
+            'upgrade-confirmation-checkbox'
+          )
+          await user.click(confirmCheckoutCheckbox)
+
+          const confirmCheckoutButton =
+            await screen.findByTestId('submit-upgrade')
+          await user.click(confirmCheckoutButton)
 
           await waitFor(() => queryClient.isMutating())
           await waitFor(() => !queryClient.isMutating())
@@ -753,7 +860,17 @@ describe('UpgradeForm', () => {
           const proceedToCheckoutButton = await screen.findByRole('button', {
             name: /Proceed to checkout/,
           })
+
           await user.click(proceedToCheckoutButton)
+
+          const confirmCheckoutCheckbox = await screen.findByTestId(
+            'upgrade-confirmation-checkbox'
+          )
+          await user.click(confirmCheckoutCheckbox)
+
+          const confirmCheckoutButton =
+            await screen.findByTestId('submit-upgrade')
+          await user.click(confirmCheckoutButton)
 
           await waitFor(() => queryClient.isMutating())
           await waitFor(() => queryClient.isFetching())
@@ -783,7 +900,17 @@ describe('UpgradeForm', () => {
           const proceedToCheckoutButton = await screen.findByRole('button', {
             name: /Proceed to checkout/,
           })
+
           await user.click(proceedToCheckoutButton)
+
+          const confirmCheckoutCheckbox = await screen.findByTestId(
+            'upgrade-confirmation-checkbox'
+          )
+          await user.click(confirmCheckoutCheckbox)
+
+          const confirmCheckoutButton =
+            await screen.findByTestId('submit-upgrade')
+          await user.click(confirmCheckoutButton)
 
           await waitFor(() => queryClient.isMutating())
           await waitFor(() => queryClient.isFetching())
@@ -819,7 +946,7 @@ describe('UpgradeForm', () => {
         setup({ planValue: Plans.USERS_PR_INAPPM })
         render(<UpgradeForm {...props} />, { wrapper: wrapper() })
 
-        const optionBtn = await screen.findByRole('button', { name: 'Monthly' })
+        const optionBtn = await screen.findByTestId('radio-monthly')
         expect(optionBtn).toBeInTheDocument()
       })
 
@@ -827,7 +954,7 @@ describe('UpgradeForm', () => {
         setup({ planValue: Plans.USERS_PR_INAPPM })
         render(<UpgradeForm {...props} />, { wrapper: wrapper() })
 
-        const optionBtn = await screen.findByRole('button', { name: 'Annual' })
+        const optionBtn = await screen.findByTestId('radio-annual')
         expect(optionBtn).toBeInTheDocument()
       })
 
@@ -835,9 +962,9 @@ describe('UpgradeForm', () => {
         setup({ planValue: Plans.USERS_PR_INAPPM })
         render(<UpgradeForm {...props} />, { wrapper: wrapper() })
 
-        const optionBtn = await screen.findByRole('button', { name: 'Monthly' })
+        const optionBtn = await screen.findByTestId('radio-monthly')
         expect(optionBtn).toBeInTheDocument()
-        expect(optionBtn).toHaveClass('bg-ds-primary-base')
+        expect(optionBtn).toBeChecked()
       })
 
       it('renders the seat input with 10 seats (existing subscription)', async () => {
@@ -912,9 +1039,7 @@ describe('UpgradeForm', () => {
           })
           render(<UpgradeForm {...props} />, { wrapper: wrapper() })
 
-          const annualOption = await screen.findByRole('button', {
-            name: 'Annual',
-          })
+          const annualOption = await screen.findByTestId('radio-annual')
           await user.click(annualOption)
 
           const price = screen.getByText(/\$100/)
@@ -930,9 +1055,9 @@ describe('UpgradeForm', () => {
           })
           render(<UpgradeForm {...props} />, { wrapper: wrapper() })
 
-          const optionBtn = await screen.findByRole('button', { name: 'Pro' })
+          const optionBtn = await screen.findByTestId('radio-pro')
           expect(optionBtn).toBeInTheDocument()
-          expect(optionBtn).toHaveClass('bg-ds-primary-base')
+          expect(optionBtn).toBeChecked()
         })
 
         it('renders team option button', async () => {
@@ -942,9 +1067,7 @@ describe('UpgradeForm', () => {
           })
           render(<UpgradeForm {...props} />, { wrapper: wrapper() })
 
-          const optionBtn = await screen.findByRole('button', {
-            name: 'Team',
-          })
+          const optionBtn = await screen.findByTestId('radio-team')
           expect(optionBtn).toBeInTheDocument()
         })
 
@@ -956,9 +1079,7 @@ describe('UpgradeForm', () => {
             })
             render(<UpgradeForm {...props} />, { wrapper: wrapper() })
 
-            const teamOption = await screen.findByRole('button', {
-              name: 'Team',
-            })
+            const teamOption = await screen.findByTestId('radio-team')
             await user.click(teamOption)
 
             const auxiliaryText = await screen.findByText(/Up to 10 users/)
@@ -972,9 +1093,7 @@ describe('UpgradeForm', () => {
             })
             render(<UpgradeForm {...props} />, { wrapper: wrapper() })
 
-            const teamOption = await screen.findByRole('button', {
-              name: 'Team',
-            })
+            const teamOption = await screen.findByTestId('radio-team')
             await user.click(teamOption)
             expect(props.setSelectedPlan).toHaveBeenCalledWith(teamPlanYear)
           })
@@ -998,6 +1117,15 @@ describe('UpgradeForm', () => {
           })
           await user.click(update)
 
+          const confirmCheckoutCheckbox = await screen.findByTestId(
+            'upgrade-confirmation-checkbox'
+          )
+          await user.click(confirmCheckoutCheckbox)
+
+          const confirmCheckoutButton =
+            await screen.findByTestId('submit-upgrade')
+          await user.click(confirmCheckoutButton)
+
           await waitFor(() =>
             expect(patchRequest).toHaveBeenCalledWith({
               plan: {
@@ -1019,15 +1147,22 @@ describe('UpgradeForm', () => {
           await user.type(input, '{backspace}{backspace}{backspace}')
           await user.type(input, '20')
 
-          const optionBtn = await screen.findByRole('button', {
-            name: 'Annual',
-          })
+          const optionBtn = await screen.findByTestId('radio-annual')
           await user.click(optionBtn)
 
           const update = await screen.findByRole('button', {
             name: /Update/,
           })
           await user.click(update)
+
+          const confirmCheckoutCheckbox = await screen.findByTestId(
+            'upgrade-confirmation-checkbox'
+          )
+          await user.click(confirmCheckoutCheckbox)
+
+          const confirmCheckoutButton =
+            await screen.findByTestId('submit-upgrade')
+          await user.click(confirmCheckoutButton)
 
           await waitFor(() =>
             expect(patchRequest).toHaveBeenCalledWith({
@@ -1059,6 +1194,15 @@ describe('UpgradeForm', () => {
           })
           await user.click(update)
 
+          const confirmCheckoutCheckbox = await screen.findByTestId(
+            'upgrade-confirmation-checkbox'
+          )
+          await user.click(confirmCheckoutCheckbox)
+
+          const confirmCheckoutButton =
+            await screen.findByTestId('submit-upgrade')
+          await user.click(confirmCheckoutButton)
+
           await waitFor(() => queryClient.isMutating())
           await waitFor(() => queryClient.isFetching())
           await waitFor(() => !queryClient.isMutating())
@@ -1088,6 +1232,15 @@ describe('UpgradeForm', () => {
             name: /Update/,
           })
           await user.click(update)
+
+          const confirmCheckoutCheckbox = await screen.findByTestId(
+            'upgrade-confirmation-checkbox'
+          )
+          await user.click(confirmCheckoutCheckbox)
+
+          const confirmCheckoutButton =
+            await screen.findByTestId('submit-upgrade')
+          await user.click(confirmCheckoutButton)
 
           await waitFor(() => queryClient.isMutating())
           await waitFor(() => queryClient.isFetching())
@@ -1123,7 +1276,7 @@ describe('UpgradeForm', () => {
         setup({ planValue: Plans.USERS_PR_INAPPY, monthlyPlan: false })
         render(<UpgradeForm {...props} />, { wrapper: wrapper() })
 
-        const optionBtn = await screen.findByRole('button', { name: 'Monthly' })
+        const optionBtn = await screen.findByTestId('radio-monthly')
         expect(optionBtn).toBeInTheDocument()
       })
 
@@ -1131,7 +1284,7 @@ describe('UpgradeForm', () => {
         setup({ planValue: Plans.USERS_PR_INAPPY, monthlyPlan: false })
         render(<UpgradeForm {...props} />, { wrapper: wrapper() })
 
-        const optionBtn = await screen.findByRole('button', { name: 'Annual' })
+        const optionBtn = await screen.findByTestId('radio-annual')
         expect(optionBtn).toBeInTheDocument()
       })
 
@@ -1139,9 +1292,9 @@ describe('UpgradeForm', () => {
         setup({ planValue: Plans.USERS_PR_INAPPY, monthlyPlan: false })
         render(<UpgradeForm {...props} />, { wrapper: wrapper() })
 
-        const optionBtn = await screen.findByRole('button', { name: 'Annual' })
+        const optionBtn = await screen.findByTestId('radio-annual')
         expect(optionBtn).toBeInTheDocument()
-        expect(optionBtn).toHaveClass('bg-ds-primary-base')
+        expect(optionBtn).toBeChecked()
       })
 
       it('renders the seat input with 13 seats (existing subscription)', async () => {
@@ -1231,9 +1384,7 @@ describe('UpgradeForm', () => {
           })
           render(<UpgradeForm {...props} />, { wrapper: wrapper() })
 
-          const monthlyOption = await screen.findByRole('button', {
-            name: 'Monthly',
-          })
+          const monthlyOption = await screen.findByTestId('radio-monthly')
           await user.click(monthlyOption)
 
           const price = screen.getByText(/\$156/)
@@ -1250,9 +1401,9 @@ describe('UpgradeForm', () => {
           })
           render(<UpgradeForm {...props} />, { wrapper: wrapper() })
 
-          const optionBtn = await screen.findByRole('button', { name: 'Pro' })
+          const optionBtn = await screen.findByTestId('radio-pro')
           expect(optionBtn).toBeInTheDocument()
-          expect(optionBtn).toHaveClass('bg-ds-primary-base')
+          expect(optionBtn).toBeChecked()
         })
 
         it('renders team option button', async () => {
@@ -1263,9 +1414,7 @@ describe('UpgradeForm', () => {
           })
           render(<UpgradeForm {...props} />, { wrapper: wrapper() })
 
-          const optionBtn = await screen.findByRole('button', {
-            name: 'Team',
-          })
+          const optionBtn = await screen.findByTestId('radio-team')
           expect(optionBtn).toBeInTheDocument()
         })
 
@@ -1278,9 +1427,7 @@ describe('UpgradeForm', () => {
             })
             render(<UpgradeForm {...props} />, { wrapper: wrapper() })
 
-            const teamOption = await screen.findByRole('button', {
-              name: 'Team',
-            })
+            const teamOption = await screen.findByTestId('radio-team')
             await user.click(teamOption)
 
             const auxiliaryText = await screen.findByText(/Up to 10 users/)
@@ -1294,9 +1441,7 @@ describe('UpgradeForm', () => {
             })
             render(<UpgradeForm {...props} />, { wrapper: wrapper() })
 
-            const teamOption = await screen.findByRole('button', {
-              name: 'Team',
-            })
+            const teamOption = await screen.findByTestId('radio-team')
             await user.click(teamOption)
             expect(props.setSelectedPlan).toHaveBeenCalledWith(teamPlanYear)
           })
@@ -1321,6 +1466,15 @@ describe('UpgradeForm', () => {
           })
           await user.click(update)
 
+          const confirmCheckoutCheckbox = await screen.findByTestId(
+            'upgrade-confirmation-checkbox'
+          )
+          await user.click(confirmCheckoutCheckbox)
+
+          const confirmCheckoutButton =
+            await screen.findByTestId('submit-upgrade')
+          await user.click(confirmCheckoutButton)
+
           await waitFor(() =>
             expect(patchRequest).toHaveBeenCalledWith({
               plan: {
@@ -1343,15 +1497,22 @@ describe('UpgradeForm', () => {
           await user.type(input, '{backspace}{backspace}{backspace}')
           await user.type(input, '20')
 
-          const optionBtn = await screen.findByRole('button', {
-            name: 'Monthly',
-          })
+          const optionBtn = await screen.findByTestId('radio-monthly')
           await user.click(optionBtn)
 
           const update = await screen.findByRole('button', {
             name: /Update/,
           })
           await user.click(update)
+
+          const confirmCheckoutCheckbox = await screen.findByTestId(
+            'upgrade-confirmation-checkbox'
+          )
+          await user.click(confirmCheckoutCheckbox)
+
+          const confirmCheckoutButton =
+            await screen.findByTestId('submit-upgrade')
+          await user.click(confirmCheckoutButton)
 
           await waitFor(() =>
             expect(patchRequest).toHaveBeenCalledWith({
@@ -1379,6 +1540,15 @@ describe('UpgradeForm', () => {
             name: /Update/,
           })
           await user.click(update)
+
+          const confirmCheckoutCheckbox = await screen.findByTestId(
+            'upgrade-confirmation-checkbox'
+          )
+          await user.click(confirmCheckoutCheckbox)
+
+          const confirmCheckoutButton =
+            await screen.findByTestId('submit-upgrade')
+          await user.click(confirmCheckoutButton)
 
           await waitFor(() => queryClient.isMutating())
           await waitFor(() => !queryClient.isMutating())
@@ -1408,6 +1578,15 @@ describe('UpgradeForm', () => {
             name: /Update/,
           })
           await user.click(update)
+
+          const confirmCheckoutCheckbox = await screen.findByTestId(
+            'upgrade-confirmation-checkbox'
+          )
+          await user.click(confirmCheckoutCheckbox)
+
+          const confirmCheckoutButton =
+            await screen.findByTestId('submit-upgrade')
+          await user.click(confirmCheckoutButton)
 
           await waitFor(() => queryClient.isMutating())
           await waitFor(() => queryClient.isFetching())
@@ -1439,6 +1618,15 @@ describe('UpgradeForm', () => {
             name: /Update/,
           })
           await user.click(update)
+
+          const confirmCheckoutCheckbox = await screen.findByTestId(
+            'upgrade-confirmation-checkbox'
+          )
+          await user.click(confirmCheckoutCheckbox)
+
+          const confirmCheckoutButton =
+            await screen.findByTestId('submit-upgrade')
+          await user.click(confirmCheckoutButton)
 
           await waitFor(() => queryClient.isMutating())
           await waitFor(() => queryClient.isFetching())
@@ -1496,7 +1684,7 @@ describe('UpgradeForm', () => {
         })
         render(<UpgradeForm {...props} />, { wrapper: wrapper() })
 
-        const optionBtn = await screen.findByRole('button', { name: 'Monthly' })
+        const optionBtn = await screen.findByTestId('radio-monthly')
         expect(optionBtn).toBeInTheDocument()
       })
 
@@ -1507,7 +1695,7 @@ describe('UpgradeForm', () => {
         })
         render(<UpgradeForm {...props} />, { wrapper: wrapper() })
 
-        const optionBtn = await screen.findByRole('button', { name: 'Annual' })
+        const optionBtn = await screen.findByTestId('radio-annual')
         expect(optionBtn).toBeInTheDocument()
       })
 
@@ -1519,9 +1707,9 @@ describe('UpgradeForm', () => {
         })
         render(<UpgradeForm {...props} />, { wrapper: wrapper() })
 
-        const optionBtn = await screen.findByRole('button', { name: 'Annual' })
+        const optionBtn = await screen.findByTestId('radio-annual')
         expect(optionBtn).toBeInTheDocument()
-        expect(optionBtn).toHaveClass('bg-ds-primary-base')
+        expect(optionBtn).toBeChecked()
       })
 
       it('renders the seat input with 21 seats (existing subscription)', async () => {
@@ -1620,9 +1808,7 @@ describe('UpgradeForm', () => {
           })
           render(<UpgradeForm {...props} />, { wrapper: wrapper() })
 
-          const monthlyOption = await screen.findByRole('button', {
-            name: 'Monthly',
-          })
+          const monthlyOption = await screen.findByTestId('radio-monthly')
           await user.click(monthlyOption)
 
           const price = screen.getByText(/\$221/)
@@ -1649,6 +1835,15 @@ describe('UpgradeForm', () => {
           })
           await user.click(update)
 
+          const confirmCheckoutCheckbox = await screen.findByTestId(
+            'upgrade-confirmation-checkbox'
+          )
+          await user.click(confirmCheckoutCheckbox)
+
+          const confirmCheckoutButton =
+            await screen.findByTestId('submit-upgrade')
+          await user.click(confirmCheckoutButton)
+
           await waitFor(() =>
             expect(patchRequest).toHaveBeenCalledWith({
               plan: {
@@ -1672,15 +1867,22 @@ describe('UpgradeForm', () => {
           await user.type(input, '{backspace}{backspace}{backspace}')
           await user.type(input, '7')
 
-          const optionBtn = await screen.findByRole('button', {
-            name: 'Monthly',
-          })
+          const optionBtn = await screen.findByTestId('radio-monthly')
           await user.click(optionBtn)
 
           const update = await screen.findByRole('button', {
             name: /Update/,
           })
           await user.click(update)
+
+          const confirmCheckoutCheckbox = await screen.findByTestId(
+            'upgrade-confirmation-checkbox'
+          )
+          await user.click(confirmCheckoutCheckbox)
+
+          const confirmCheckoutButton =
+            await screen.findByTestId('submit-upgrade')
+          await user.click(confirmCheckoutButton)
 
           await waitFor(() =>
             expect(patchRequest).toHaveBeenCalledWith({
@@ -1709,6 +1911,15 @@ describe('UpgradeForm', () => {
             name: /Update/,
           })
           await user.click(update)
+
+          const confirmCheckoutCheckbox = await screen.findByTestId(
+            'upgrade-confirmation-checkbox'
+          )
+          await user.click(confirmCheckoutCheckbox)
+
+          const confirmCheckoutButton =
+            await screen.findByTestId('submit-upgrade')
+          await user.click(confirmCheckoutButton)
 
           await waitFor(() => queryClient.isMutating())
           await waitFor(() => !queryClient.isMutating())
@@ -1739,6 +1950,15 @@ describe('UpgradeForm', () => {
             name: /Update/,
           })
           await user.click(update)
+
+          const confirmCheckoutCheckbox = await screen.findByTestId(
+            'upgrade-confirmation-checkbox'
+          )
+          await user.click(confirmCheckoutCheckbox)
+
+          const confirmCheckoutButton =
+            await screen.findByTestId('submit-upgrade')
+          await user.click(confirmCheckoutButton)
 
           await waitFor(() => queryClient.isMutating())
           await waitFor(() => queryClient.isFetching())
@@ -1771,6 +1991,15 @@ describe('UpgradeForm', () => {
             name: /Update/,
           })
           await user.click(update)
+
+          const confirmCheckoutCheckbox = await screen.findByTestId(
+            'upgrade-confirmation-checkbox'
+          )
+          await user.click(confirmCheckoutCheckbox)
+
+          const confirmCheckoutButton =
+            await screen.findByTestId('submit-upgrade')
+          await user.click(confirmCheckoutButton)
 
           await waitFor(() => queryClient.isMutating())
           await waitFor(() => queryClient.isFetching())
@@ -1814,9 +2043,7 @@ describe('UpgradeForm', () => {
         })
         render(<UpgradeForm {...props} />, { wrapper: wrapper() })
 
-        const teamOption = await screen.findByRole('button', {
-          name: 'Team',
-        })
+        const teamOption = await screen.findByTestId('radio-team')
         await user.click(teamOption)
 
         const auxiliaryText = await screen.findByText(/Up to 10 users/)
@@ -1831,7 +2058,7 @@ describe('UpgradeForm', () => {
         })
         render(<UpgradeForm {...props} />, { wrapper: wrapper() })
 
-        const optionBtn = await screen.findByRole('button', { name: 'Monthly' })
+        const optionBtn = await screen.findByTestId('radio-monthly')
         expect(optionBtn).toBeInTheDocument()
       })
 
@@ -1843,7 +2070,7 @@ describe('UpgradeForm', () => {
         })
         render(<UpgradeForm {...props} />, { wrapper: wrapper() })
 
-        const optionBtn = await screen.findByRole('button', { name: 'Annual' })
+        const optionBtn = await screen.findByTestId('radio-annual')
         expect(optionBtn).toBeInTheDocument()
       })
 
@@ -1855,9 +2082,9 @@ describe('UpgradeForm', () => {
         })
         render(<UpgradeForm {...props} />, { wrapper: wrapper() })
 
-        const optionBtn = await screen.findByRole('button', { name: 'Annual' })
+        const optionBtn = await screen.findByTestId('radio-annual')
         expect(optionBtn).toBeInTheDocument()
-        expect(optionBtn).toHaveClass('bg-ds-primary-base')
+        expect(optionBtn).toBeChecked()
       })
 
       it('renders the seat input with 5 seats (existing subscription)', async () => {
@@ -1972,9 +2199,7 @@ describe('UpgradeForm', () => {
           })
           render(<UpgradeForm {...props} />, { wrapper: wrapper() })
 
-          const monthlyOption = await screen.findByRole('button', {
-            name: 'Monthly',
-          })
+          const monthlyOption = await screen.findByTestId('radio-monthly')
           await user.click(monthlyOption)
 
           const price = screen.getByText(/\$10/)
@@ -1996,15 +2221,22 @@ describe('UpgradeForm', () => {
           await user.type(input, '{backspace}{backspace}{backspace}')
           await user.type(input, '8')
 
-          const teamOption = await screen.findByRole('button', {
-            name: 'Team',
-          })
+          const teamOption = await screen.findByTestId('radio-team')
           await user.click(teamOption)
 
           const update = await screen.findByRole('button', {
             name: /Update/,
           })
           await user.click(update)
+
+          const confirmCheckoutCheckbox = await screen.findByTestId(
+            'upgrade-confirmation-checkbox'
+          )
+          await user.click(confirmCheckoutCheckbox)
+
+          const confirmCheckoutButton =
+            await screen.findByTestId('submit-upgrade')
+          await user.click(confirmCheckoutButton)
 
           await waitFor(() =>
             expect(patchRequest).toHaveBeenCalledWith({
@@ -2029,15 +2261,22 @@ describe('UpgradeForm', () => {
           await user.type(input, '{backspace}{backspace}{backspace}')
           await user.type(input, '7')
 
-          const optionBtn = await screen.findByRole('button', {
-            name: 'Monthly',
-          })
+          const optionBtn = await screen.findByTestId('radio-monthly')
           await user.click(optionBtn)
 
           const update = await screen.findByRole('button', {
             name: /Update/,
           })
           await user.click(update)
+
+          const confirmCheckoutCheckbox = await screen.findByTestId(
+            'upgrade-confirmation-checkbox'
+          )
+          await user.click(confirmCheckoutCheckbox)
+
+          const confirmCheckoutButton =
+            await screen.findByTestId('submit-upgrade')
+          await user.click(confirmCheckoutButton)
 
           await waitFor(() =>
             expect(patchRequest).toHaveBeenCalledWith({
@@ -2066,6 +2305,15 @@ describe('UpgradeForm', () => {
             name: /Update/,
           })
           await user.click(update)
+
+          const confirmCheckoutCheckbox = await screen.findByTestId(
+            'upgrade-confirmation-checkbox'
+          )
+          await user.click(confirmCheckoutCheckbox)
+
+          const confirmCheckoutButton =
+            await screen.findByTestId('submit-upgrade')
+          await user.click(confirmCheckoutButton)
 
           await waitFor(() => queryClient.isMutating())
           await waitFor(() => !queryClient.isMutating())
@@ -2096,6 +2344,15 @@ describe('UpgradeForm', () => {
             name: /Update/,
           })
           await user.click(update)
+
+          const confirmCheckoutCheckbox = await screen.findByTestId(
+            'upgrade-confirmation-checkbox'
+          )
+          await user.click(confirmCheckoutCheckbox)
+
+          const confirmCheckoutButton =
+            await screen.findByTestId('submit-upgrade')
+          await user.click(confirmCheckoutButton)
 
           await waitFor(() => queryClient.isMutating())
           await waitFor(() => queryClient.isFetching())
@@ -2128,6 +2385,14 @@ describe('UpgradeForm', () => {
             name: /Update/,
           })
           await user.click(update)
+          const confirmCheckoutCheckbox = await screen.findByTestId(
+            'upgrade-confirmation-checkbox'
+          )
+          await user.click(confirmCheckoutCheckbox)
+
+          const confirmCheckoutButton =
+            await screen.findByTestId('submit-upgrade')
+          await user.click(confirmCheckoutButton)
 
           await waitFor(() => queryClient.isMutating())
           await waitFor(() => queryClient.isFetching())

--- a/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/UpgradeForm.tsx
+++ b/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/UpgradeForm.tsx
@@ -124,7 +124,7 @@ function UpgradeForm({ selectedPlan, setSelectedPlan }: UpgradeFormProps) {
           <h3 className="font-semibold">Organization</h3>
           <div className="flex items-center gap-2">
             <Avatar user={ownerData} border="dark" />
-            {owner}
+            <h4>{owner}</h4>
           </div>
         </div>
       </Card.Header>

--- a/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/UpgradeForm.tsx
+++ b/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/UpgradeForm.tsx
@@ -121,28 +121,31 @@ function UpgradeForm({ selectedPlan, setSelectedPlan }: UpgradeFormProps) {
     <Card className="flex-1 bg-transparent">
       <Card.Header>
         <div className="flex flex-col gap-1">
-          <h3 className="text-xl font-semibold">Organization</h3>
-          <div className="flex gap-2">
+          <h3 className="font-semibold">Organization</h3>
+          <div className="flex items-center gap-2">
             <Avatar user={ownerData} />
-            <span className="text-base">{owner}</span>
+            {owner}
           </div>
         </div>
       </Card.Header>
-      <Card.Content>
-        <form className="flex flex-col gap-6 text-ds-gray-default">
+      <form className="text-ds-gray-default">
+        <Card.Content>
           <PlanTypeOptions
             setFormValue={setFormValue}
             setSelectedPlan={setSelectedPlan}
             newPlan={newPlan}
           />
-          <Controller
-            setSelectedPlan={setSelectedPlan}
-            newPlan={newPlan}
-            seats={seats}
-            setFormValue={setFormValue}
-            register={register}
-            errors={errors}
-          />
+        </Card.Content>
+        <hr />
+        <Controller
+          setSelectedPlan={setSelectedPlan}
+          newPlan={newPlan}
+          seats={seats}
+          setFormValue={setFormValue}
+          register={register}
+          errors={errors}
+        />
+        <Card.Content className="flex flex-col gap-6 pb-6">
           <PersonalOrgWarning />
           <UpdateButton
             isValid={isValid}
@@ -163,8 +166,8 @@ function UpgradeForm({ selectedPlan, setSelectedPlan }: UpgradeFormProps) {
               isUpgrading={isUpgrading}
             />
           ) : null}
-        </form>
-      </Card.Content>
+        </Card.Content>
+      </form>
     </Card>
   )
 }

--- a/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/UpgradeForm.tsx
+++ b/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/UpgradeForm.tsx
@@ -123,7 +123,7 @@ function UpgradeForm({ selectedPlan, setSelectedPlan }: UpgradeFormProps) {
         <div className="flex flex-col gap-1">
           <h3 className="font-semibold">Organization</h3>
           <div className="flex items-center gap-2">
-            <Avatar user={ownerData} />
+            <Avatar user={ownerData} border="dark" />
             {owner}
           </div>
         </div>


### PR DESCRIPTION
Adds a few changes that draw attention to the org you are about to change the plan of. Most notably, this adds a confirmation modal to the checkout flow and adds a banner letting you know you're about to change the plan of your personal org. This is because we've had several issues caused by users upgrading their personal org by accident. There is another issue that fixes a more core issue, but these are certainly improvements regardless.

Closes https://github.com/codecov/feedback/issues/722
Closes https://github.com/codecov/feedback/issues/651

Related to https://github.com/codecov/engineering-team/issues/3587

![Recording 2025-06-19 at 14 46 22](https://github.com/user-attachments/assets/3fd918df-c4af-4962-8538-3291e03bdc01)
![Recording 2025-06-19 at 14 51 20](https://github.com/user-attachments/assets/28e78139-8cdf-4d8a-81dc-656aa5133d33)
