### PR TITLE
feat: Use new default-org on internal user for default org decision

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,7 +2,7 @@ import { ReactQueryDevtools } from '@tanstack/react-query-devtools'
 import qs from 'qs'
 import { lazy } from 'react'
 import { Toaster } from 'react-hot-toast'
-import { Redirect, Switch, useParams } from 'react-router-dom'
+import { Redirect, Switch } from 'react-router-dom'
 
 import config from 'config'
 
@@ -13,8 +13,7 @@ import EnterpriseLoginLayout from 'layouts/EnterpriseLoginLayout'
 import LoginLayout from 'layouts/LoginLayout'
 import { useLocationParams } from 'services/navigation/useLocationParams'
 import { ToastNotificationProvider } from 'services/toastNotification/context'
-import { useInternalUser, useUser } from 'services/user'
-import { isProvider } from 'shared/api/helpers'
+import { useInternalUser } from 'services/user'
 import 'ui/Table/Table.css'
 import 'ui/FileList/FileList.css'
 import { ThemeContextProvider } from 'shared/ThemeContext'
@@ -33,45 +32,29 @@ const PullRequestPage = lazy(() => import('./pages/PullRequestPage'))
 const RepoPage = lazy(() => import('./pages/RepoPage'))
 const SyncProviderPage = lazy(() => import('./pages/SyncProviderPage'))
 
-interface URLParams {
-  provider: string
-}
-
 const HomePageRedirect = () => {
-  const { provider } = useParams<URLParams>()
-  const { data: currentUser } = useUser()
   const { data: internalUser } = useInternalUser({})
   const { params } = useLocationParams()
   // @ts-expect-error useLocationParams needs to be typed
   const { setup_action: setupAction, to } = params
+  // create a query params object to be added to the redirect URL
+  const queryParams: Record<string, string> = {}
 
   let redirectURL = '/login'
 
   if (internalUser && internalUser.owners) {
     const service = internalUser.owners[0]?.service
-    const username = internalUser.owners[0]?.username
-    redirectURL = `/${service}/${username}`
-    if (to === 'plan') {
-      redirectURL = '/plan' + redirectURL
-    }
-  }
-
-  // create a query params object to be added to the redirect URL
-  const queryParams: Record<string, string> = {}
-
-  // only redirect if we have a provider and it's a valid provider and the user is logged in
-  if (provider && isProvider(provider) && currentUser) {
-    // set the redirect URL to the owner's default org or the user's username
-    const defaultOrg =
-      currentUser.owner?.defaultOrgUsername ?? currentUser.user?.username
-    redirectURL = `/${provider}/${defaultOrg}`
+    const defaultOrg = internalUser.defaultOrg
+    redirectURL = `/${service}/${defaultOrg ? defaultOrg : ''}`
 
     if (setupAction) {
       // eslint-disable-next-line camelcase
       queryParams.setup_action = setupAction
     }
-    // ensure that we only redirect if the user is not setting up the action and we don't want to redirect if we're already redirecting to the plan page
-    else if (to && to !== 'plan') {
+
+    if (to === 'plan') {
+      redirectURL = '/plan' + redirectURL
+    } else if (to) {
       redirectURL = to
     }
   }

--- a/src/layouts/BaseLayout/BaseLayout.test.tsx
+++ b/src/layouts/BaseLayout/BaseLayout.test.tsx
@@ -60,6 +60,7 @@ const mockUser = {
     },
   ],
   termsAgreement: true,
+  defaultOrg: 'cool-username',
 }
 
 const mockUserNoTermsAgreement = {
@@ -133,6 +134,7 @@ const internalUserNoSyncedProviders = {
   externalId: '123',
   termsAgreement: true,
   owners: [],
+  defaultOrg: null,
 }
 
 const internalUserHasSyncedProviders = {
@@ -150,6 +152,7 @@ const internalUserHasSyncedProviders = {
       service: 'github',
     },
   ],
+  defaultOrg: 'cool-username',
   termsAgreement: true,
 }
 

--- a/src/layouts/BaseLayout/hooks/useUserAccessGate.test.tsx
+++ b/src/layouts/BaseLayout/hooks/useUserAccessGate.test.tsx
@@ -155,6 +155,7 @@ const internalUserNoSyncedProviders = {
   externalId: '123',
   termsAgreement: null,
   owners: [],
+  defaultOrg: null,
 }
 
 const internalUserHasSyncedProviders = {
@@ -173,6 +174,7 @@ const internalUserHasSyncedProviders = {
       stats: null,
     },
   ],
+  defaultOrg: 'cool-owner',
 }
 
 const internalUserWithSignedTOS = {
@@ -190,6 +192,7 @@ const internalUserWithSignedTOS = {
       stats: null,
     },
   ],
+  defaultOrg: 'cool-owner',
   termsAgreement: true,
 }
 
@@ -208,6 +211,7 @@ const internalUserWithUnsignedTOS = {
       stats: null,
     },
   ],
+  defaultOrg: 'cool-owner',
   termsAgreement: false,
 }
 

--- a/src/pages/SyncProviderPage/SyncProviderPage.test.tsx
+++ b/src/pages/SyncProviderPage/SyncProviderPage.test.tsx
@@ -23,7 +23,8 @@ const createMockedInternalUser = (
   name: null,
   externalId: null,
   termsAgreement: false,
-  owners: owner !== undefined ? [owner] : [],
+  owners: owner != null ? [owner] : [],
+  defaultOrg: owner != null ? owner.username : null,
 })
 
 const server = setupServer()
@@ -202,7 +203,17 @@ describe('SyncProviderPage', () => {
 
     describe('user does not have a service', () => {
       it('redirects user to /', async () => {
-        setup({ user: createMockedInternalUser(null) })
+        setup({
+          user: createMockedInternalUser({
+            name: 'noservice',
+            service: '',
+            username: 'noservice',
+            avatarUrl: 'http://127.0.0.1/cool-user-avatar',
+            integrationId: null,
+            ownerid: 123,
+            stats: null,
+          }),
+        })
 
         render(<SyncProviderPage />, { wrapper })
 

--- a/src/pages/TermsOfService/TermsOfService.test.tsx
+++ b/src/pages/TermsOfService/TermsOfService.test.tsx
@@ -164,6 +164,7 @@ describe('TermsOfService', () => {
           externalId: '',
           owners: null,
           termsAgreement: false,
+          defaultOrg: null,
         },
       })
     )
@@ -239,6 +240,7 @@ describe('TermsOfService', () => {
           externalId: '1234',
           owners: null,
           termsAgreement: false,
+          defaultOrg: null,
         },
       })
 
@@ -313,6 +315,7 @@ describe('TermsOfService', () => {
           externalId: '1234',
           owners: null,
           name: 'Chetney',
+          defaultOrg: null,
         },
       },
       [expectPageIsReady],
@@ -332,6 +335,7 @@ describe('TermsOfService', () => {
           name: 'Chetney',
           externalId: '1234',
           owners: null,
+          defaultOrg: null,
         },
       },
       [expectPageIsReady],
@@ -353,6 +357,7 @@ describe('TermsOfService', () => {
           name: 'Chetney',
           externalId: '1234',
           owners: null,
+          defaultOrg: null,
         },
       },
       [expectPageIsReady],
@@ -375,6 +380,7 @@ describe('TermsOfService', () => {
           externalId: '1234',
           owners: null,
           email: '',
+          defaultOrg: null,
         },
       },
       [expectPageIsReady],
@@ -402,6 +408,7 @@ describe('TermsOfService', () => {
           name: 'Chetney',
           externalId: '1234',
           owners: null,
+          defaultOrg: null,
         },
       },
       [expectPageIsReady],
@@ -420,6 +427,7 @@ describe('TermsOfService', () => {
           name: '',
           externalId: '1234',
           owners: null,
+          defaultOrg: null,
         },
       },
       [expectPageIsReady],
@@ -452,6 +460,7 @@ describe('TermsOfService', () => {
           name: '',
           externalId: '1234',
           owners: null,
+          defaultOrg: null,
         },
       },
       [expectPageIsReady],
@@ -479,6 +488,7 @@ describe('TermsOfService', () => {
           name: '',
           externalId: '1234',
           owners: null,
+          defaultOrg: null,
         },
       },
       [expectPageIsReady],
@@ -510,6 +520,7 @@ describe('TermsOfService', () => {
               username: 'chetney',
             },
           ],
+          defaultOrg: 'chetney',
         },
       },
       [expectRedirectTo, '/gh/codecov/cool-repo'],
@@ -570,6 +581,7 @@ describe('TermsOfService', () => {
             externalId: '',
             owners: null,
             termsAgreement: false,
+            defaultOrg: null,
           },
         })
         const removeFromDom = vi.fn()
@@ -596,6 +608,7 @@ describe('TermsOfService', () => {
             externalId: '',
             owners: null,
             termsAgreement: false,
+            defaultOrg: null,
           },
         })
         config.SENTRY_DSN = 'dsn'
@@ -622,6 +635,7 @@ describe('TermsOfService', () => {
               externalId: '',
               owners: null,
               termsAgreement: false,
+              defaultOrg: null,
             },
           })
           config.SENTRY_DSN = 'dsn'

--- a/src/pages/TermsOfService/TermsOfService.test.tsx
+++ b/src/pages/TermsOfService/TermsOfService.test.tsx
@@ -68,6 +68,7 @@ const mockedUserData = {
   externalId: null,
   owners: null,
   termsAgreement: false,
+  defaultOrg: null,
 }
 
 const mocks = vi.hoisted(() => ({

--- a/src/services/user/useInternalUser.test.tsx
+++ b/src/services/user/useInternalUser.test.tsx
@@ -47,6 +47,7 @@ describe('useInternalUser', () => {
           externalId: '1234',
           termsAgreement: false,
           owners: [],
+          defaultOrg: null,
         })
       })
     )
@@ -64,6 +65,7 @@ describe('useInternalUser', () => {
           externalId: '1234',
           owners: [],
           termsAgreement: false,
+          defaultOrg: null,
         })
       )
     })

--- a/src/services/user/useInternalUser.ts
+++ b/src/services/user/useInternalUser.ts
@@ -29,6 +29,7 @@ const InternalUserSchema = z
     externalId: z.string().nullable(),
     owners: z.array(OwnerSchema).nullable(),
     termsAgreement: z.boolean().nullable(),
+    defaultOrg: z.string().nullable(),
   })
   .nullable()
 


### PR DESCRIPTION
Main motivation for this is plan page troubles faced by users. A common flow we're trying to fix is: User clicks Learn more on plans page which takes them to our marketing site. They they click Get started from the marketing site, which takes them back to the app, but the default org logic fails and they end up on their personal org instead of the org they started with. We have had several instances of users upgrading the plan of their personal org instead of the desired org from this flow. We made some other improvements to the checkout page in a previous PR, but we also want to get this part fixed as it's likely the primary problem.