### PR TITLE
fix: Add sentry-merge to list of acceptable plan names

### DIFF
--- a/src/shared/utils/billing.ts
+++ b/src/shared/utils/billing.ts
@@ -17,7 +17,7 @@ export const Plans = {
   USERS_PR_INAPPY: 'users-pr-inappy',
   USERS_SENTRYM: 'users-sentrym',
   USERS_SENTRYY: 'users-sentryy',
-  USERS_SENTRYMERGE: 'users-sentry-merge',
+  USERS_SENTRYMERGE: 'sentry-merge',
   USERS_TEAMM: 'users-teamm',
   USERS_TEAMY: 'users-teamy',
   USERS_ENTERPRISEM: 'users-enterprisem',

--- a/src/shared/utils/billing.ts
+++ b/src/shared/utils/billing.ts
@@ -17,6 +17,7 @@ export const Plans = {
   USERS_PR_INAPPY: 'users-pr-inappy',
   USERS_SENTRYM: 'users-sentrym',
   USERS_SENTRYY: 'users-sentryy',
+  USERS_SENTRYMERGE: 'users-sentry-merge',
   USERS_TEAMM: 'users-teamm',
   USERS_TEAMY: 'users-teamy',
   USERS_ENTERPRISEM: 'users-enterprisem',


### PR DESCRIPTION
Fixes Plan page schema parsing fail on new plan name.

Fixes https://codecov.sentry.io/issues/6713090607/?project=5514400&query=is%3Aunresolved&referrer=issue-stream&stream_index=4