### PR TITLE
fix(address-form): Update error message for address form

### DIFF
--- a/src/pages/PlanPage/subRoutes/CurrentOrgPlan/BillingDetails/Address/AddressCard.test.tsx
+++ b/src/pages/PlanPage/subRoutes/CurrentOrgPlan/BillingDetails/Address/AddressCard.test.tsx
@@ -380,12 +380,12 @@ describe('AddressCard', () => {
   })
 
   describe('when there is an error in the form', () => {
-    it('renders the error', async () => {
+    it('renders the error when the error is an instance of Error', async () => {
       const { user } = setup()
       const randomError = 'not a valid address'
       mocks.useUpdateBillingAddress.mockReturnValue({
         mutate: vi.fn(),
-        error: randomError,
+        error: new Error(randomError),
       })
       render(
         <AddressCard
@@ -398,7 +398,36 @@ describe('AddressCard', () => {
 
       await user.click(screen.getByTestId('edit-address'))
 
-      expect(screen.getByText(randomError)).toBeInTheDocument()
+      expect(
+        screen.getByText((content, _element) => content.includes(randomError))
+      ).toBeInTheDocument()
+    })
+
+    it('renders the error when the error is an instance of BillingApiError', async () => {
+      const { user } = setup()
+      const stripeError = 'Your card has expired'
+      mocks.useUpdateBillingAddress.mockReturnValue({
+        mutate: vi.fn(),
+        error: {
+          data: {
+            detail: stripeError,
+          },
+        },
+      })
+      render(
+        <AddressCard
+          subscriptionDetail={subscriptionDetail}
+          provider="gh"
+          owner="codecov"
+        />,
+        { wrapper }
+      )
+
+      await user.click(screen.getByTestId('edit-address'))
+
+      expect(
+        screen.getByText((content, _element) => content.includes(stripeError))
+      ).toBeInTheDocument()
     })
   })
 

--- a/src/pages/PlanPage/subRoutes/CurrentOrgPlan/BillingDetails/Address/AddressForm.tsx
+++ b/src/pages/PlanPage/subRoutes/CurrentOrgPlan/BillingDetails/Address/AddressForm.tsx
@@ -134,14 +134,14 @@ export const getErrorMessage = (
     if (error.message) {
       return `Could not save billing address: ${error.message}`
     }
-    return 'Could not save billing address. Please contact support for assistance.'
+    return 'Could not save billing address. Please contact support at support@codecov.io for assistance.'
   }
 
   if (error.data?.detail) {
     return `Could not save billing address: ${error.data.detail}`
   }
 
-  return 'Could not save billing address due to an unknown error. Please contact support for assistance.'
+  return 'Could not save billing address due to an unknown error. Please contact support at support@codecov.io for assistance.'
 }
 
 export default AddressForm

--- a/src/pages/PlanPage/subRoutes/CurrentOrgPlan/BillingDetails/Address/AddressForm.tsx
+++ b/src/pages/PlanPage/subRoutes/CurrentOrgPlan/BillingDetails/Address/AddressForm.tsx
@@ -3,7 +3,10 @@ import cs from 'classnames'
 import { z } from 'zod'
 
 import { AddressSchema } from 'services/account/useAccountDetails'
-import { useUpdateBillingAddress } from 'services/account/useUpdateBillingAddress'
+import {
+  BillingApiError,
+  useUpdateBillingAddress,
+} from 'services/account/useUpdateBillingAddress'
 import { Theme, useThemeContext } from 'shared/ThemeContext'
 import Button from 'ui/Button'
 
@@ -50,7 +53,6 @@ function AddressForm({
     mutate: updateAddress,
     isLoading,
     error,
-    reset,
   } = useUpdateBillingAddress({
     provider,
     owner,
@@ -69,8 +71,6 @@ function AddressForm({
       updateAddress(newAddressObj.value, { onSuccess: closeForm })
     }
   }
-
-  const showError = error && !reset
 
   return (
     <form onSubmit={submit} aria-label="form">
@@ -95,7 +95,9 @@ function AddressForm({
               },
             }}
           />
-          <p className="mt-1 text-ds-primary-red">{showError && error}</p>
+          <p className="mt-1 text-ds-primary-red">
+            {error && getErrorMessage(error)}
+          </p>
         </div>
         <div className="flex gap-1">
           <Button
@@ -121,6 +123,25 @@ function AddressForm({
       </div>
     </form>
   )
+}
+
+export const getErrorMessage = (
+  error: Error | BillingApiError
+): string | undefined => {
+  if (!error) return undefined
+
+  if (error instanceof Error) {
+    if (error.message) {
+      return `Could not save billing address: ${error.message}`
+    }
+    return 'Could not save billing address. Please contact support for assistance.'
+  }
+
+  if (error.data?.detail) {
+    return `Could not save billing address: ${error.data.detail}`
+  }
+
+  return 'Could not save billing address due to an unknown error. Please contact support for assistance.'
 }
 
 export default AddressForm

--- a/src/services/account/useUpdateBillingAddress.ts
+++ b/src/services/account/useUpdateBillingAddress.ts
@@ -9,7 +9,7 @@ interface useUpdateBillingAddressParams {
 
 interface useUpdateBillingAddressReturn {
   reset: () => void
-  error: null | Error
+  error: null | Error | BillingApiError
   isLoading: boolean
   mutate: (variables: any, data: any) => void
   data: undefined | unknown
@@ -27,6 +27,12 @@ interface Address {
 interface AddressInfo {
   name: string
   address: Address
+}
+
+export interface BillingApiError {
+  data: {
+    detail: string
+  }
 }
 
 export function useUpdateBillingAddress({


### PR DESCRIPTION
Paired with this https://github.com/codecov/umbrella/pull/298/files

Properly show the user the error

<img width="677" alt="Screenshot 2025-07-09 at 4 05 37 PM" src="https://github.com/user-attachments/assets/d3863457-2870-471a-9c64-42f6f90e41d6" />

