### PR TITLE
fix: Default to owner username when no default org received

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -45,7 +45,7 @@ const HomePageRedirect = () => {
   if (internalUser && internalUser.owners) {
     const service = internalUser.owners[0]?.service
     const defaultOrg = internalUser.defaultOrg
-    redirectURL = `/${service}/${defaultOrg ? defaultOrg : ''}`
+    redirectURL = `/${service}/${defaultOrg ? defaultOrg : internalUser.owners[0]?.username}`
 
     if (setupAction) {
       // eslint-disable-next-line camelcase


### PR DESCRIPTION
When no default org exists currently, users are shown an empty page. This change fixes that behaviour to show the user’s personal org instead.