### PR TITLE
chore: Remove overwatch from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -337,51 +337,6 @@ jobs:
           # The head sha aligns with how the sha used in prod builds
           GAZEBO_SHA: ${{ github.event.pull_request.head.sha }}
 
-  overwatch:
-    name: Run Overwatch
-    runs-on: ubuntu-latest
-    needs: install
-    if: ${{ github.event_name == 'pull_request' }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20
-
-      - name: Cache node_modules
-        id: cache-node-modules
-        uses: actions/cache@v4
-        env:
-          cache-name: cache-gazebo-node-modules
-        with:
-          path: |
-            node_modules
-          key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ env.cache-name }}-
-
-      - name: Install Build Dependencies
-        run: |
-          sudo apt-get update
-          # Install libssl1.1 from Ubuntu 20.04 repositories
-          wget http://archive.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2_amd64.deb
-          sudo dpkg -i libssl1.1_1.1.1f-1ubuntu2_amd64.deb
-
-      - name: Install Overwatch CLI
-        run: |
-          curl -o overwatch-cli https://overwatch.codecov.io/linux/cli
-          chmod +x overwatch-cli
-
-      - name: Run Overwatch CLI
-        run: |
-          ./overwatch-cli \
-            --auth-token ${{ secrets.SENTRY_AUTH_TOKEN }} \
-            --organization-slug codecov \
-            typescript --package-manager yarn --eslint-pattern src
-
   storybook:
     name: Run storybook
     runs-on: ubuntu-latest

--- a/src/pages/RepoPage/ConfigTab/tabs/GeneralTab/DangerZone/EraseRepo/EraseRepoModal.jsx
+++ b/src/pages/RepoPage/ConfigTab/tabs/GeneralTab/DangerZone/EraseRepo/EraseRepoModal.jsx
@@ -12,10 +12,9 @@ const EraseRepoModal = ({ closeModal, eraseRepo, isLoading, showModal }) => {
       body={
         <p>
           This will erase the repository, including all of its contents. This
-          action is irreversible and if you proceed, you will permanently erase
-          any historical code coverage in Codecov for this repository. The
-          repository itself will be re-created when resync-ing the organization
-          contents.
+          action is irreversible and will permanently erase any historical code
+          coverage in Codecov for this repository. The repository will be
+          recreated when resyncing the organization.
         </p>
       }
       footer={


### PR DESCRIPTION
# Description

Overwatch CI no longer needed, just removing from Gazebo for cleanup

Relates to https://linear.app/getsentry/issue/PREVENT-260/clean-up-overwatch-cli

Also snuck in a copy update to tighten up some wording on the delete repo component

# Link to Sample Entry

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.