### PR TITLE
fix: Use dynamic repo name for token step copy

### DIFF
--- a/src/pages/RepoPage/CoverageOnboarding/GitHubActions/TokenStep.tsx
+++ b/src/pages/RepoPage/CoverageOnboarding/GitHubActions/TokenStep.tsx
@@ -120,7 +120,7 @@ function OrgOrRepoTokenSelector({
   handleValueChange,
   hasOrgUploadToken,
 }: OrgOrRepoTokenSelectorProps) {
-  const { owner } = useParams<URLParams>()
+  const { owner, repo } = useParams<URLParams>()
   const isAdmin = useIsCurrentUserAnAdmin({ owner })
   const { regenerateToken, isLoading } = useGenerateOrgUploadToken()
 
@@ -147,7 +147,7 @@ function OrgOrRepoTokenSelector({
         >
           <RadioTileGroup.Label>Repository token</RadioTileGroup.Label>
           <RadioTileGroup.Description>
-            Use it for uploading coverage reports in the enigma repository.
+            Use it for uploading coverage reports in the {repo} repository.
           </RadioTileGroup.Description>
         </RadioTileGroup.Item>
       </RadioTileGroup>


### PR DESCRIPTION
Closes https://linear.app/getsentry/issue/CCMRG-676/remove-the-static-repo-name-or-make-it-dynamic

Replaces hardcoded repo name with the repo they are looking at

<img width="1006" height="253" alt="Screenshot 2025-08-27 at 1 06 53 PM" src="https://github.com/user-attachments/assets/6874e929-3164-4098-8577-dc26309dc750" />
