### PR TITLE
adjust secret link for personal orgs

### DIFF
--- a/src/pages/RepoPage/CoverageOnboarding/GitHubActions/GitHubActions.test.tsx
+++ b/src/pages/RepoPage/CoverageOnboarding/GitHubActions/GitHubActions.test.tsx
@@ -8,6 +8,7 @@ import { MemoryRouter, Route } from 'react-router-dom'
 
 import { eventTracker } from 'services/events/events'
 import { ThemeContextProvider } from 'shared/ThemeContext'
+import { Plans } from 'shared/utils/billing'
 
 import GitHubActions from './GitHubActions'
 
@@ -74,6 +75,49 @@ const mockRegenerateOrgUploadToken = {
   },
 }
 
+const mockCurrentUser = {
+  me: {
+    owner: {
+      defaultOrgUsername: 'codecov',
+    },
+    email: 'jane.doe@codecov.io',
+    privateAccess: true,
+    onboardingCompleted: true,
+    businessEmail: 'jane.doe@codecov.io',
+    termsAgreement: true,
+    user: {
+      name: 'Jane Doe',
+      username: 'janedoe',
+      avatarUrl: 'http://127.0.0.1/avatar-url',
+      avatar: 'http://127.0.0.1/avatar-url',
+      student: false,
+      studentCreatedAt: null,
+      studentUpdatedAt: null,
+    },
+    trackingMetadata: {
+      service: 'github',
+      ownerid: 123,
+      serviceId: '123',
+      plan: Plans.USERS_DEVELOPER,
+      staff: false,
+      hasYaml: false,
+      bot: null,
+      delinquent: null,
+      didTrial: null,
+      planProvider: null,
+      planUserCount: 1,
+      createdAt: 'timestamp',
+      updatedAt: 'timestamp',
+      profile: {
+        createdAt: 'timestamp',
+        otherGoal: null,
+        typeProjects: [],
+        goals: [],
+      },
+    },
+  },
+}
+
 const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
@@ -133,6 +177,9 @@ describe('GitHubActions', () => {
       }),
       graphql.query('DetailOwner', () => {
         return HttpResponse.json({ data: mockDetailOwner })
+      }),
+      graphql.query('CurrentUser', () => {
+        return HttpResponse.json({ data: mockCurrentUser })
       }),
       graphql.mutation('regenerateOrgUploadToken', () => {
         return HttpResponse.json({ data: mockRegenerateOrgUploadToken })

--- a/src/pages/RepoPage/CoverageOnboarding/GitHubActions/GitHubActions.tsx
+++ b/src/pages/RepoPage/CoverageOnboarding/GitHubActions/GitHubActions.tsx
@@ -1,9 +1,10 @@
-import { useRef, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { useParams } from 'react-router-dom'
 
 import { useOrgUploadToken } from 'services/orgUploadToken/useOrgUploadToken'
 import { useRepo } from 'services/repo'
 import { useUploadTokenRequired } from 'services/uploadTokenRequired'
+import { useUser } from 'services/user'
 import { Provider } from 'shared/api/helpers'
 import A from 'ui/A'
 import { Card } from 'ui/Card'
@@ -31,8 +32,17 @@ function GitHubActions() {
     provider,
     owner,
   })
+  const { data: currentUser } = useUser()
+  const isCurrentUser = currentUser?.user.username === owner
 
   const [isUsingGlobalToken, setIsUsingGlobalToken] = useState<boolean>(true)
+
+  // Update token selection based on user ownership when currentUser data loads
+  useEffect(() => {
+    if (currentUser) {
+      setIsUsingGlobalToken(!isCurrentUser)
+    }
+  }, [currentUser, isCurrentUser])
   const { data: repoData } = useRepo({ provider, owner, repo })
   const repoUploadToken = repoData?.repository?.uploadToken ?? ''
   const previouslyGeneratedOrgToken = useRef<string | null | undefined>()
@@ -79,6 +89,7 @@ function GitHubActions() {
         showAddTokenStep={showAddTokenStep}
         showTokenSelector={showTokenSelector}
         framework={framework}
+        isCurrentUser={isCurrentUser}
       />
       <WorkflowYMLStep
         framework={framework}

--- a/src/pages/RepoPage/CoverageOnboarding/GitHubActions/TokenStep.test.tsx
+++ b/src/pages/RepoPage/CoverageOnboarding/GitHubActions/TokenStep.test.tsx
@@ -114,6 +114,7 @@ describe('TokenStepSection', () => {
         isUsingGlobalToken={false}
         setIsUsingGlobalToken={vi.fn()}
         framework="Jest"
+        isCurrentUser={false}
       />,
       {
         wrapper: wrapper(),
@@ -134,6 +135,7 @@ describe('TokenStepSection', () => {
         isUsingGlobalToken={true}
         setIsUsingGlobalToken={vi.fn()}
         framework="Jest"
+        isCurrentUser={true}
       />,
       {
         wrapper: wrapper(),
@@ -153,6 +155,7 @@ describe('TokenStepSection', () => {
         isUsingGlobalToken={false}
         setIsUsingGlobalToken={vi.fn()}
         framework="Jest"
+        isCurrentUser={true}
       />,
       {
         wrapper: wrapper(),
@@ -172,6 +175,7 @@ describe('TokenStepSection', () => {
         isUsingGlobalToken={false}
         setIsUsingGlobalToken={vi.fn()}
         framework="Jest"
+        isCurrentUser={true}
       />,
       {
         wrapper: wrapper(),
@@ -190,6 +194,7 @@ describe('TokenStepSection', () => {
         isUsingGlobalToken={true}
         setIsUsingGlobalToken={vi.fn()}
         framework="Jest"
+        isCurrentUser={false}
       />,
       {
         wrapper: wrapper(),
@@ -211,6 +216,7 @@ describe('TokenStepSection', () => {
         isUsingGlobalToken={false}
         setIsUsingGlobalToken={vi.fn()}
         framework="Jest"
+        isCurrentUser={true}
       />,
       {
         wrapper: wrapper(),
@@ -236,6 +242,7 @@ describe('TokenStepSection', () => {
         isUsingGlobalToken={true}
         setIsUsingGlobalToken={vi.fn()}
         framework="Jest"
+        isCurrentUser={false}
       />,
       {
         wrapper: wrapper(),
@@ -255,6 +262,7 @@ describe('TokenStepSection', () => {
         isUsingGlobalToken={true}
         setIsUsingGlobalToken={vi.fn()}
         framework="Jest"
+        isCurrentUser={true}
       />,
       {
         wrapper: wrapper(),
@@ -278,6 +286,7 @@ describe('TokenStepSection', () => {
         isUsingGlobalToken={true}
         setIsUsingGlobalToken={vi.fn()}
         framework="Jest"
+        isCurrentUser={true}
       />,
       {
         wrapper: wrapper(),
@@ -299,6 +308,7 @@ describe('TokenStepSection', () => {
         isUsingGlobalToken={true}
         setIsUsingGlobalToken={vi.fn()}
         framework="Jest"
+        isCurrentUser={true}
       />,
       {
         wrapper: wrapper(),
@@ -319,6 +329,7 @@ describe('TokenStepSection', () => {
         isUsingGlobalToken={true}
         setIsUsingGlobalToken={vi.fn()}
         framework="Jest"
+        isCurrentUser={true}
       />,
       {
         wrapper: wrapper(),
@@ -341,6 +352,7 @@ describe('TokenStepSection', () => {
         isUsingGlobalToken={false}
         setIsUsingGlobalToken={vi.fn()}
         framework="Jest"
+        isCurrentUser={true}
       />,
       {
         wrapper: wrapper(),
@@ -364,6 +376,7 @@ describe('TokenStepSection', () => {
           isUsingGlobalToken={true}
           setIsUsingGlobalToken={vi.fn()}
           framework="Jest"
+          isCurrentUser={true}
         />,
         {
           wrapper: wrapper(),
@@ -385,6 +398,7 @@ describe('TokenStepSection', () => {
           isUsingGlobalToken={false}
           setIsUsingGlobalToken={vi.fn()}
           framework="Jest"
+          isCurrentUser={true}
         />,
         {
           wrapper: wrapper(),

--- a/src/pages/RepoPage/CoverageOnboarding/GitHubActions/TokenStep.tsx
+++ b/src/pages/RepoPage/CoverageOnboarding/GitHubActions/TokenStep.tsx
@@ -113,12 +113,14 @@ interface OrgOrRepoTokenSelectorProps {
   isUsingGlobalToken: boolean
   handleValueChange: (value: string) => void
   hasOrgUploadToken: boolean
+  isCurrentUser: boolean
 }
 
 function OrgOrRepoTokenSelector({
   isUsingGlobalToken,
   handleValueChange,
   hasOrgUploadToken,
+  isCurrentUser,
 }: OrgOrRepoTokenSelectorProps) {
   const { owner } = useParams<URLParams>()
   const isAdmin = useIsCurrentUserAnAdmin({ owner })
@@ -131,16 +133,18 @@ function OrgOrRepoTokenSelector({
         name="token-selection"
         onValueChange={handleValueChange}
       >
-        <RadioTileGroup.Item
-          value={TOKEN_OPTIONS.GLOBAL}
-          data-testid="global-token-radio"
-        >
-          <RadioTileGroup.Label>Global upload token</RadioTileGroup.Label>
-          <RadioTileGroup.Description>
-            Use it for uploading coverage reports across all your
-            organization&apos;s repositories.
-          </RadioTileGroup.Description>
-        </RadioTileGroup.Item>
+        {!isCurrentUser && (
+          <RadioTileGroup.Item
+            value={TOKEN_OPTIONS.GLOBAL}
+            data-testid="global-token-radio"
+          >
+            <RadioTileGroup.Label>Global upload token</RadioTileGroup.Label>
+            <RadioTileGroup.Description>
+              Use it for uploading coverage reports across all your
+              organization&apos;s repositories.
+            </RadioTileGroup.Description>
+          </RadioTileGroup.Item>
+        )}
         <RadioTileGroup.Item
           value={TOKEN_OPTIONS.REPO}
           data-testid="repo-token-radio"
@@ -151,7 +155,7 @@ function OrgOrRepoTokenSelector({
           </RadioTileGroup.Description>
         </RadioTileGroup.Item>
       </RadioTileGroup>
-      {isUsingGlobalToken && !hasOrgUploadToken && (
+      {isUsingGlobalToken && !hasOrgUploadToken && !isCurrentUser && (
         <>
           <div className="flex items-center justify-between pb-3.5 pt-7">
             <p className="font-semibold">Generate a global upload token</p>
@@ -237,6 +241,7 @@ interface TokenStepSectionProps {
   showAddTokenStep: boolean
   showTokenSelector: boolean
   framework: Framework
+  isCurrentUser: boolean
 }
 
 function TokenStepSection({
@@ -245,6 +250,7 @@ function TokenStepSection({
   showAddTokenStep,
   showTokenSelector,
   framework,
+  isCurrentUser,
 }: TokenStepSectionProps) {
   const { provider, owner } = useParams<URLParams>()
   const { data: uploadTokenRequiredData } = useUploadTokenRequired({
@@ -280,6 +286,7 @@ function TokenStepSection({
               isUsingGlobalToken={isUsingGlobalToken}
               handleValueChange={handleValueChange}
               hasOrgUploadToken={!!orgUploadToken}
+              isCurrentUser={isCurrentUser}
             />
           </Card.Content>
         </Card>


### PR DESCRIPTION
# Description
This PR adds changes to ensure personal orgs can only access repo tokens and not global upload tokens. 

# Notable Changes
- Added logic to determine if current use is the same as the chosen org and spread the logic where needed
- Added tests to these changes