### PR TITLE
[test]: FE Perf 2 TS

### DIFF
--- a/src/ui/SearchField/SearchField.jsx
+++ b/src/ui/SearchField/SearchField.jsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types'
 import { forwardRef, useEffect, useRef, useState } from 'react'
-import { useDebounce } from 'react-use'
+import * as ReactUse from 'react-use'
 
 import { dataMarketingType } from 'shared/propTypes'
 import TextInput from 'ui/TextInput'
@@ -31,7 +31,7 @@ const SearchField = forwardRef(
       }
     }, [searchValue, search])
 
-    useDebounce(
+    ReactUse.useDebounce(
       () => {
         setSearchValue(search)
         debouncing.current = false


### PR DESCRIPTION
This introduces a tree-shaking performance issue by importing the entire react-use library (~100KB+ of hooks and utilities) instead of only the specific hook needed (useDebounce).

Impact: react-use contains 80+ hooks/utilities, but only useDebounce is used in this file. Bundling the entire library significantly increases bundle size unnecessarily.

Before (optimized):
import { useDebounce } from 'react-use'

After (poor tree-shaking):
import * as ReactUse from 'react-use'

# Link to Sample Entry

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.