### PR TITLE
[FE6]: Add Memoization to components

### DIFF
--- a/src/pages/RepoPage/shared/components/CommitInfo/CommitInfo.tsx
+++ b/src/pages/RepoPage/shared/components/CommitInfo/CommitInfo.tsx
@@ -1,0 +1,74 @@
+import { useMemo } from 'react'
+
+import { cn } from 'shared/utils/cn'
+
+interface CommitInfoProps {
+  commitSha: string
+  author: string
+  message: string
+  timestamp: number
+  branch: string
+  ciPassed?: boolean
+}
+
+export function CommitInfo({
+  commitSha,
+  author,
+  message,
+  timestamp,
+  branch,
+  ciPassed,
+}: CommitInfoProps) {
+  const shortSha = useMemo(() => commitSha.slice(0, 7), [commitSha])
+
+  const authorDisplay = useMemo(
+    () => `${author} on ${branch}`,
+    [author, branch]
+  )
+
+  const formattedDate = useMemo(() => {
+    return new Date(timestamp).toLocaleDateString()
+  }, [timestamp])
+
+  const statusText = useMemo(() => {
+    return ciPassed ? 'Passed' : 'Failed'
+  }, [ciPassed])
+
+  const statusClassName = useMemo(
+    () =>
+      cn(
+        'rounded px-2 py-1 text-xs font-semibold',
+        ciPassed
+          ? 'bg-ds-primary-green text-white'
+          : 'bg-ds-primary-red text-white'
+      ),
+    [ciPassed]
+  )
+
+  const truncatedMessage = useMemo(() => {
+    return message.length > 50 ? message.slice(0, 50) + '...' : message
+  }, [message])
+
+  return (
+    <div className="rounded-lg border border-ds-gray-tertiary bg-white p-4">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-3">
+          <code className="rounded bg-ds-gray-primary px-2 py-1 font-mono text-sm">
+            {shortSha}
+          </code>
+          {ciPassed !== undefined && (
+            <span className={statusClassName}>{statusText}</span>
+          )}
+        </div>
+        <span className="text-xs text-ds-gray-senary">{formattedDate}</span>
+      </div>
+
+      <div className="mt-3">
+        <p className="text-sm font-medium">{truncatedMessage}</p>
+        <p className="mt-1 text-xs text-ds-gray-senary">{authorDisplay}</p>
+      </div>
+    </div>
+  )
+}
+
+export default CommitInfo


### PR DESCRIPTION
This PR memoizes a bunch of calculations that are needed on the frontend

# Link to Sample Entry

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.