### PR TITLE
fix: remove fossa restriction on forks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -375,7 +375,7 @@ jobs:
     name: Run Fossa
     runs-on: ubuntu-latest
     needs: install
-    if: ${{ !github.event.pull_request.head.repo.fork && github.repository_owner == 'codecov' }}
+    if: ${{ github.repository_owner == 'codecov' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
# Description

Remove the restriction on FOSSA on forks, we should still run it if it's incoming into `codecov`. Note that a Codecov eng will still need to run by pushing up an empty commit `git commit --allow-empty`

# Code Example

# Notable Changes

# Screenshots

# Link to Sample Entry

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Allows the `fossa` job in `.github/workflows/ci.yml` to run whenever `github.repository_owner == 'codecov'` by removing the fork check.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cbced96861b205731a685f177daaea5da33cfa84. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->