### PR TITLE
feat: Use names instead of id for component dropdown

### DIFF
--- a/src/pages/RepoPage/CoverageTab/ComponentsTab/Header/Header.tsx
+++ b/src/pages/RepoPage/CoverageTab/ComponentsTab/Header/Header.tsx
@@ -45,7 +45,7 @@ const Header = ({
   })
 
   const componentNames = componentsData?.components?.map(
-    (component) => component?.id
+    (component) => component?.name
   )
 
   const value = TimeOptions.find(


### PR DESCRIPTION
Closes https://linear.app/getsentry/issue/CCMRG-918/components-drop-down-in-components-tab-displays-the-list-of-component

Changes from id names to pretty names.

Before:
<img width="1723" height="748" alt="Screenshot 2025-11-24 at 4 56 39 PM" src="https://github.com/user-attachments/assets/0d5bcef1-c6a6-485a-9974-3331a45cffcb" />
After:
<img width="1724" height="729" alt="Screenshot 2025-11-24 at 4 56 24 PM" src="https://github.com/user-attachments/assets/20442866-0f5b-44ec-84a8-33de4db92115" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches ComponentsTab dropdown to display component names instead of IDs.
> 
> - **UI (ComponentsTab)**: In `src/pages/RepoPage/CoverageTab/ComponentsTab/Header/Header.tsx`, map dropdown items to `component.name` instead of `component.id` for the multi-select.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 61cca7a9977a20b1c12b5337defc7094e97acbca. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->