### PR TITLE
fix: Use new scheduled phase data for next bill price

### DIFF
--- a/src/pages/PlanPage/subRoutes/CurrentOrgPlan/BillingDetails/PaymentCard/PaymentCard.test.jsx
+++ b/src/pages/PlanPage/subRoutes/CurrentOrgPlan/BillingDetails/PaymentCard/PaymentCard.test.jsx
@@ -110,6 +110,76 @@ const accountDetails = {
   activatedUserCount: 1,
 }
 
+const scheduledPhaseProYToTeamMAccountDetails = {
+  subscriptionDetail,
+  activatedUserCount: 1,
+  scheduleDetail: {
+    scheduledPhase: {
+      plan: 'Team',
+      baseUnitPrice: 6,
+      billingRate: BillingRate.MONTHLY,
+      quantity: 10,
+      startDate: 1764258944,
+    },
+  },
+}
+
+const scheduledPhaseTeamYToProMAccountDetails = {
+  subscriptionDetail: {
+    defaultPaymentMethod: {
+      card: {
+        brand: 'visa',
+        expMonth: 12,
+        expYear: 2021,
+        last4: '1234',
+      },
+    },
+    plan: {
+      value: Plans.USERS_TEAMY,
+    },
+    currentPeriodEnd: 1606851492,
+    cancelAtPeriodEnd: false,
+  },
+  activatedUserCount: 1,
+  scheduleDetail: {
+    scheduledPhase: {
+      plan: 'Pro',
+      baseUnitPrice: 12,
+      billingRate: BillingRate.MONTHLY,
+      quantity: 7,
+      startDate: 1764258944,
+    },
+  },
+}
+
+const scheduledPhaseTeamYToSentryProMAccountDetails = {
+  subscriptionDetail: {
+    defaultPaymentMethod: {
+      card: {
+        brand: 'visa',
+        expMonth: 12,
+        expYear: 2021,
+        last4: '1234',
+      },
+    },
+    plan: {
+      value: Plans.USERS_TEAMY,
+    },
+    currentPeriodEnd: 1606851492,
+    cancelAtPeriodEnd: false,
+  },
+  activatedUserCount: 1,
+  scheduleDetail: {
+    scheduledPhase: {
+      plan: 'Sentry Pro',
+      baseUnitPrice: 12,
+      billingRate: BillingRate.MONTHLY,
+      quantity: 9,
+      startDate: 1764258944,
+    },
+  },
+}
+
 const usBankSubscriptionDetail = {
   defaultPaymentMethod: {
     usBankAccount: {
@@ -629,6 +699,58 @@ describe('PaymentCard', () => {
 
         await waitFor(() => {
           expect(screen.getByText(/for \$588.00/)).toBeInTheDocument()
+        })
+      })
+    })
+    describe('Scheduled phase pricing', () => {
+      it('calculates the next billing price correctly when switching from Pro to Team', async () => {
+        // Upcoming team monthly plan: baseUnitPrice 6, 10 paid seats = $60.00
+        setup({})
+        render(
+          <PaymentCard
+            accountDetails={scheduledPhaseProYToTeamMAccountDetails}
+            provider="gh"
+            owner="codecov"
+          />,
+          { wrapper }
+        )
+
+        await waitFor(() => {
+          expect(screen.getByText(/for \$60.00/)).toBeInTheDocument()
+        })
+      })
+
+      it('calculates the next billing price correctly when switching from Team to Pro', async () => {
+        // Upcoming pro monthly plan: baseUnitPrice 12, 7 paid seats = $84.00
+        setup({})
+        render(
+          <PaymentCard
+            accountDetails={scheduledPhaseTeamYToProMAccountDetails}
+            provider="gh"
+            owner="codecov"
+          />,
+          { wrapper }
+        )
+
+        await waitFor(() => {
+          expect(screen.getByText(/for \$84.00/)).toBeInTheDocument()
+        })
+      })
+
+      it('calculates the next billing price correctly when switching from Team to Sentry Pro', async () => {
+        // Upcoming Sentry Pro monthly plan: baseUnitPrice 12, 9 paid seats = $29 + 4 seats x $12 = $77.00
+        setup({})
+        render(
+          <PaymentCard
+            accountDetails={scheduledPhaseTeamYToSentryProMAccountDetails}
+            provider="gh"
+            owner="codecov"
+          />,
+          { wrapper }
+        )
+
+        await waitFor(() => {
+          expect(screen.getByText(/for \$77.00/)).toBeInTheDocument()
         })
       })
     })

--- a/src/services/account/useAccountDetails.ts
+++ b/src/services/account/useAccountDetails.ts
@@ -146,6 +146,8 @@ export const AccountDetailsSchema = z
             quantity: z.number(),
             plan: z.string(),
             startDate: z.number(),
+            billingRate: z.string().nullable(),
+            baseUnitPrice: z.number().nullable(),
           })
           .nullable(),
       })

--- a/src/shared/utils/billing.ts
+++ b/src/shared/utils/billing.ts
@@ -34,6 +34,13 @@ export const TierNames = {
   ENTERPRISE: 'enterprise',
 } as const
 
+export const PlanMarketingNames = {
+  DEVELOPER: 'Developer',
+  PRO: 'Pro',
+  SENTRY: 'Sentry Pro',
+  TEAM: 'Team',
+} as const
+
 export const BillingRate = {
   MONTHLY: 'monthly',
   /** @deprecated no longer offering new annual plans */


### PR DESCRIPTION
FE followup to https://github.com/codecov/umbrella/pull/569 to close https://linear.app/getsentry/issue/CCMRG-1859/billing-display-mismatch to use new GQL fields in the scheduledPhase object for more accurate upcoming bill price calculation if the customer has an upcoming plan that is different.




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Compute next bill price using upcoming `scheduledPhase` fields, with schema/util additions and comprehensive tests.
> 
> - **Billing UI**:
>   - Refactor `PaymentCard.jsx` to calculate next bill via new helper `calculateNextBillPrice`, prioritizing `accountDetails.scheduleDetail.scheduledPhase` (uses `billingRate`, `baseUnitPrice`, `plan`, `quantity`), with fallback to current plan data.
>   - Update `useMemo` dependencies to include `scheduledPhase`.
> - **Schema/Types**:
>   - Extend `AccountDetailsSchema` to include `scheduledPhase.billingRate` and `scheduledPhase.baseUnitPrice`.
> - **Utils**:
>   - Add `PlanMarketingNames` to `shared/utils/billing` for plan name matching.
> - **Tests**:
>   - Expand `PaymentCard.test.jsx` with cases covering scheduled phase transitions (Pro → Team, Team → Pro, Team → Sentry Pro) and various plan/billing scenarios (monthly/annual; Pro/Team/Sentry).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 89abd443889c3c535ff5bf50d25915e9b1572139. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

Some examples
<img width="1009" height="651" alt="Screenshot 2025-12-19 at 9 57 36 AM" src="https://github.com/user-attachments/assets/f9f70f0d-288c-4d26-a4cf-d9127389c51f" />
<img width="1030" height="663" alt="Screenshot 2025-12-19 at 9 56 40 AM" src="https://github.com/user-attachments/assets/73cb56c6-64f5-4fca-9bfb-5f84401cd5e4" />
<img width="1022" height="649" alt="Screenshot 2025-12-19 at 9 53 05 AM" src="https://github.com/user-attachments/assets/3f5ff455-a2b5-46b0-9f7a-4da8b0ea9965" />
