### PR TITLE
feat: Add 'merged' upload state and log validation errors to Sentry

### DIFF
--- a/src/shared/api/rejectNetworkError.test.ts
+++ b/src/shared/api/rejectNetworkError.test.ts
@@ -12,6 +12,8 @@ const mocks = vi.hoisted(() => ({
   withScope: vi.fn(),
   addBreadcrumb: vi.fn(),
   captureMessage: vi.fn(),
+  captureException: vi.fn(),
+  setContext: vi.fn(),
   setFingerprint: vi.fn(),
   setTags: vi.fn(),
   setLevel: vi.fn(),
@@ -26,6 +28,8 @@ vi.mock('@sentry/react', async () => {
         addBreadcrumb: mocks.addBreadcrumb,
         setFingerprint: mocks.setFingerprint,
         captureMessage: mocks.captureMessage,
+        captureException: mocks.captureException,
+        setContext: mocks.setContext,
         setTags: mocks.setTags,
         setLevel: mocks.setLevel,
       })
@@ -110,9 +114,17 @@ describe('rejectNetworkError', () => {
       it('captures the error with Sentry', () => {
         rejectNetworkError(errorObject).catch((_e) => {})
 
-        expect(mocks.captureMessage).toHaveBeenCalledWith(
-          `${errorObject.errorDetails.callingFn} - ${errorObject.errorName}`
-        )
+        if (errorObject.errorName === 'Parsing Error') {
+          expect(mocks.captureException).toHaveBeenCalledWith(
+            errorObject.errorDetails.error
+          )
+          expect(mocks.captureMessage).not.toHaveBeenCalled()
+        } else {
+          expect(mocks.captureMessage).toHaveBeenCalledWith(
+            `${errorObject.errorDetails.callingFn} - ${errorObject.errorName}`
+          )
+          expect(mocks.captureException).not.toHaveBeenCalled()
+        }
       })
 
       it('returns a rejected promise', () => {

--- a/src/shared/api/rejectNetworkError.ts
+++ b/src/shared/api/rejectNetworkError.ts
@@ -72,12 +72,14 @@ export function rejectNetworkError(error: NetworkErrorObject) {
 
   Sentry.withScope((scope) => {
     const level = determineSentryLevel(errorName)
+    const err =
+      'error' in error.errorDetails ? error.errorDetails.error : undefined
+
     scope.addBreadcrumb({
       category: 'network.error',
       level: level,
       message: devMsg,
-      data:
-        'error' in error.errorDetails ? error.errorDetails.error : undefined,
+      data: err,
     })
 
     scope.setTags({
@@ -87,7 +89,20 @@ export function rejectNetworkError(error: NetworkErrorObject) {
 
     scope.setLevel(level)
     scope.setFingerprint([devMsg])
-    scope.captureMessage(devMsg)
+
+    // logm zod validation errors with full context
+    if (errorName === 'Parsing Error' && err) {
+      scope.captureException(err)
+      const errObj = err as { issues?: unknown[]; message?: string }
+      if (Array.isArray(errObj.issues)) {
+        scope.setContext('zod_validation', {
+          issues: errObj.issues,
+          message: errObj.message ?? err.message,
+        })
+      }
+    } else {
+      scope.captureMessage(devMsg)
+    }
   })
 
   const status = determineStatusCode(errorName)

--- a/src/shared/api/rejectNetworkError.ts
+++ b/src/shared/api/rejectNetworkError.ts
@@ -92,7 +92,6 @@ export function rejectNetworkError(error: NetworkErrorObject) {
 
     // logm zod validation errors with full context
     if (errorName === 'Parsing Error' && err) {
-      scope.captureException(err)
       const errObj = err as { issues?: unknown[]; message?: string }
       if (Array.isArray(errObj.issues)) {
         scope.setContext('zod_validation', {
@@ -100,6 +99,7 @@ export function rejectNetworkError(error: NetworkErrorObject) {
           message: errObj.message ?? err.message,
         })
       }
+      scope.captureException(err)
     } else {
       scope.captureMessage(devMsg)
     }

--- a/src/shared/utils/commit.ts
+++ b/src/shared/utils/commit.ts
@@ -4,6 +4,7 @@ export const UploadStateEnum = {
   complete: 'COMPLETE',
   error: 'ERROR',
   processed: 'PROCESSED',
+  merged: 'MERGED',
 } as const
 
 export const UploadErrorStates = Object.values(UploadStateEnum)

--- a/src/shared/utils/extractUploads.test.ts
+++ b/src/shared/utils/extractUploads.test.ts
@@ -37,6 +37,22 @@ const travisObject2 = {
   uploadType: UploadTypeEnum.UPLOADED,
   errors: [],
 }
+const travisObject3 = {
+  id: 5,
+  jobCode: 'blah',
+  buildCode: 'ok',
+  name: 'merged-upload',
+  state: UploadStateEnum.merged,
+  provider: 'travis',
+  createdAt: '2020-08-25T16:36:25.820340+00:00',
+  updatedAt: '2020-08-25T16:36:25.859889+00:00',
+  flags: ['flag1', 'flag2'],
+  downloadUrl:
+    '/api/gh/febg/repo-test/download/build?path=v4/raw/2020-08-25/F84D6D9A7F883055E40E3B380280BC44/f00162848a3cebc0728d915763c2fd9e92132408/18b19f8d-5df6-48bd-90eb-50578ed8812f.txt',
+  ciUrl: 'https://travis-ci.com/febg/repo-test/jobs/721065763',
+  uploadType: UploadTypeEnum.UPLOADED,
+  errors: [],
+}
 const circleciObject = {
   id: 1,
   jobCode: 'blah',
@@ -121,6 +137,7 @@ const noProviderObject3 = {
 const mockUploads: Upload[] = [
   travisObject,
   travisObject2,
+  travisObject3,
   circleciObject,
   circleciObject2,
   noProviderObject,
@@ -136,7 +153,7 @@ describe('extractUploads', () => {
       })
 
       expect(groupedUploads).toStrictEqual({
-        travis: [travisObject2, travisObject],
+        travis: [travisObject3, travisObject2, travisObject],
         circleci: [circleciObject2, circleciObject],
         none: [noProviderObject3, noProviderObject2, noProviderObject],
       })
@@ -156,8 +173,17 @@ describe('extractUploads', () => {
       })
 
       expect(uploadsOverview).toEqual(
-        '2 uploaded, 1 started, 3 errored, 1 successful'
+        '2 uploaded, 1 started, 3 errored, 1 successful, 1 merged'
       )
+    })
+
+    it('includes merged state in overview when uploads have merged state', () => {
+      const { uploadsOverview } = extractUploads({
+        unfilteredUploads: [...mockUploads, travisObject3],
+      })
+
+      expect(uploadsOverview).toContain('merged')
+      expect(uploadsOverview).toMatch(/\d+ merged/)
     })
 
     it('returns hasNoUploads', () => {
@@ -185,7 +211,7 @@ describe('extractUploads', () => {
       })
 
       expect(flagErrorUploads).toStrictEqual({
-        travis: [travisObject2, travisObject],
+        travis: [travisObject3, travisObject2, travisObject],
         none: [noProviderObject],
       })
     })
@@ -223,7 +249,7 @@ describe('extractUploads', () => {
       })
 
       expect(groupedUploads).toStrictEqual({
-        travis: [travisObject2, travisObject],
+        travis: [travisObject3, travisObject2, travisObject],
         none: [noProviderObject],
       })
     })

--- a/src/shared/utils/extractUploads.ts
+++ b/src/shared/utils/extractUploads.ts
@@ -46,6 +46,8 @@ function humanReadableOverview(state: (typeof UploadErrorStates)[number]) {
       return 'carried forward'
     case UploadStateEnum.started:
       return 'started'
+    case UploadStateEnum.merged:
+      return 'merged'
   }
 }
 


### PR DESCRIPTION
- Add "Merged" upload state to accommodate the changes at https://github.com/codecov/umbrella/pull/741
- Add more context to the logging for zod validation schema errors to show up in Sentry so it is easier to identify and diagnose.

Clients are receiving 400 bad request errors ("useCommitCoverageDropdownSummary - Parsing Error") on the FE for the commit page due to zod validation schema errors. This was the existing log for this problem and it was super hard for me to find https://codecov.sentry.io/issues/7333666981/?project=5514400&query=is%3Aunresolved%20useCommitCoverageDropdownSummary%20-%20Parsing%20Error&referrer=issue-stream

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to adding a new upload state label in upload summaries and adjusting Sentry reporting for a specific parsing error case, with tests updated accordingly.
> 
> **Overview**
> **Adds support for a new upload lifecycle state.** `UploadStateEnum` now includes `MERGED`, and upload overview/grouping logic in `extractUploads` renders this state as "merged" and includes it in the summary string.
> 
> **Improves Sentry diagnostics for validation/parsing failures.** `rejectNetworkError` now sends `Parsing Error` cases via `captureException` (instead of `captureMessage`) and attaches Zod-style `issues` details via `setContext`, with unit tests updated to assert the new logging behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 18ab2ced77df83ba83fac0d7e0ca614ab4eec223. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->