### PR TITLE
fix: add test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,6 +142,44 @@ jobs:
     uses: codecov/gha-workflows/.github/workflows/codecov-startup.yml@v1.2.14
     secrets: inherit
 
+  codecov-startup-test:
+    name: Codecov Startup
+    needs: install
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+          submodules: 'recursive'
+      - name: Install CLI
+        if: ${{ !github.event.pull_request.head.repo.fork && github.repository_owner == 'codecov' }}
+        run: |
+          make test_env.install_cli
+      - name: Run Startup
+        if: ${{ !github.event.pull_request.head.repo.fork && github.repository_owner == 'codecov' }}
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_ORG_TOKEN }}
+        run: |
+          codecovcli -u ${{ secrets.CODECOV_URL }} create-commit --fail-on-error
+          codecovcli -u ${{ secrets.CODECOV_URL }} create-report --fail-on-error
+      - name: Run Startup Staging
+        if: ${{ !github.event.pull_request.head.repo.fork && github.repository_owner == 'codecov' }}
+        run: |
+          codecovcli -v -u ${{ secrets.CODECOV_STAGING_URL }} create-commit -t ${{ secrets.CODECOV_ORG_TOKEN_STAGING }}
+          codecovcli -v -u ${{ secrets.CODECOV_STAGING_URL }} create-report -t ${{ secrets.CODECOV_ORG_TOKEN_STAGING }}
+      - name: Run Startup QA
+        if: ${{ !github.event.pull_request.head.repo.fork && github.repository_owner == 'codecov' }}
+        run: |
+          codecovcli -u ${{ secrets.CODECOV_QA_URL }} create-commit -t ${{ secrets.CODECOV_QA_TOKEN }} --fail-on-error
+          codecovcli -u ${{ secrets.CODECOV_QA_URL }} create-report -t ${{ secrets.CODECOV_QA_TOKEN }} --fail-on-error
+      - name: Run Startup Public QA
+        if: ${{ !github.event.pull_request.head.repo.fork && github.repository_owner == 'codecov' }}
+        run: |
+          codecovcli -u ${{ secrets.CODECOV_PUBLIC_QA_URL }} create-commit -t ${{ secrets.CODECOV_PUBLIC_QA_TOKEN }} --fail-on-error
+          codecovcli -u ${{ secrets.CODECOV_PUBLIC_QA_URL }} create-report -t ${{ secrets.CODECOV_PUBLIC_QA_TOKEN }} --fail-on-error
+    secrets: inherit
+
   runner-indexes-vitest:
     runs-on: ubuntu-latest
     name: Generate runner indexes Vitest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,35 +156,35 @@ jobs:
         if: ${{ !github.event.pull_request.head.repo.fork && github.repository_owner == 'codecov' }}
         run: |
           make test_env.install_cli
-			- name: Debug CODECOV_STAGING_URL network
-				run: |
-					URL='${{ secrets.CODECOV_STAGING_URL }}'
-					HOST="$(printf '%s' "$URL" | sed -E 's|^https?://||; s|[/:].*$||')"
-					echo "host = $HOST"
+      - name: Debug CODECOV_STAGING_URL network
+        run: |
+          URL='${{ secrets.CODECOV_STAGING_URL }}'
+          HOST="$(printf '%s' "$URL" | sed -E 's|^https?://||; s|[/:].*$||')"
+          echo "host = $HOST"
 
-					echo "=== getent (libc resolver) ==="
-					getent hosts "$HOST" || echo "getent: NXDOMAIN"
+          echo "=== getent (libc resolver) ==="
+          getent hosts "$HOST" || echo "getent: NXDOMAIN"
 
-					echo "=== dig system resolver ==="
-					dig +short "$HOST" || true
+          echo "=== dig system resolver ==="
+          dig +short "$HOST" || true
 
-					echo "=== dig @8.8.8.8 ==="
-					dig +short @8.8.8.8 "$HOST" || true
+          echo "=== dig @8.8.8.8 ==="
+          dig +short @8.8.8.8 "$HOST" || true
 
-					echo "=== TCP/TLS handshake ==="
-					timeout 5 openssl s_client -servername "$HOST" -connect "$HOST:443" </dev/null 2>&1 \
-						| grep -E 'CONNECTED|subject=|issuer=|Verify return|errno' | head
+          echo "=== TCP/TLS handshake ==="
+          timeout 5 openssl s_client -servername "$HOST" -connect "$HOST:443" </dev/null 2>&1 \
+            | grep -E 'CONNECTED|subject=|issuer=|Verify return|errno' | head
 
-					echo "=== HTTPS GET / ==="
-					curl -sS -o /dev/null \
-							 -w "HTTP=%{http_code} ip=%{remote_ip} dns=%{time_namelookup}s conn=%{time_connect}s total=%{time_total}s\n" \
-							 --max-time 10 "$URL/" || echo "curl exit=$?"
+          echo "=== HTTPS GET / ==="
+          curl -sS -o /dev/null \
+               -w "HTTP=%{http_code} ip=%{remote_ip} dns=%{time_namelookup}s conn=%{time_connect}s total=%{time_total}s\n" \
+               --max-time 10 "$URL/" || echo "curl exit=$?"
 
-					echo "=== HTTPS POST /upload/... ==="
-					curl -sS -o /dev/null \
-							 -w "HTTP=%{http_code} ip=%{remote_ip} dns=%{time_namelookup}s conn=%{time_connect}s total=%{time_total}s\n" \
-							 --max-time 10 -X POST "$URL/upload/github/codecov::::gazebo/commits" \
-							 -H 'Authorization: token abc' || echo "curl exit=$?"
+          echo "=== HTTPS POST /upload/... ==="
+          curl -sS -o /dev/null \
+               -w "HTTP=%{http_code} ip=%{remote_ip} dns=%{time_namelookup}s conn=%{time_connect}s total=%{time_total}s\n" \
+               --max-time 10 -X POST "$URL/upload/github/codecov::::gazebo/commits" \
+               -H 'Authorization: token abc' || echo "curl exit=$?"
       - name: Run Startup
         if: ${{ !github.event.pull_request.head.repo.fork && github.repository_owner == 'codecov' }}
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,11 +156,35 @@ jobs:
         if: ${{ !github.event.pull_request.head.repo.fork && github.repository_owner == 'codecov' }}
         run: |
           make test_env.install_cli
-      - name: Debug CODECOV_STAGING_URL
-        run: |
-          URL='${{ secrets.CODECOV_STAGING_URL }}'
-          printf 'len=%d\n' "${#URL}"
-          printf '%s' "$URL" | xxd
+			- name: Debug CODECOV_STAGING_URL network
+				run: |
+					URL='${{ secrets.CODECOV_STAGING_URL }}'
+					HOST="$(printf '%s' "$URL" | sed -E 's|^https?://||; s|[/:].*$||')"
+					echo "host = $HOST"
+
+					echo "=== getent (libc resolver) ==="
+					getent hosts "$HOST" || echo "getent: NXDOMAIN"
+
+					echo "=== dig system resolver ==="
+					dig +short "$HOST" || true
+
+					echo "=== dig @8.8.8.8 ==="
+					dig +short @8.8.8.8 "$HOST" || true
+
+					echo "=== TCP/TLS handshake ==="
+					timeout 5 openssl s_client -servername "$HOST" -connect "$HOST:443" </dev/null 2>&1 \
+						| grep -E 'CONNECTED|subject=|issuer=|Verify return|errno' | head
+
+					echo "=== HTTPS GET / ==="
+					curl -sS -o /dev/null \
+							 -w "HTTP=%{http_code} ip=%{remote_ip} dns=%{time_namelookup}s conn=%{time_connect}s total=%{time_total}s\n" \
+							 --max-time 10 "$URL/" || echo "curl exit=$?"
+
+					echo "=== HTTPS POST /upload/... ==="
+					curl -sS -o /dev/null \
+							 -w "HTTP=%{http_code} ip=%{remote_ip} dns=%{time_namelookup}s conn=%{time_connect}s total=%{time_total}s\n" \
+							 --max-time 10 -X POST "$URL/upload/github/codecov::::gazebo/commits" \
+							 -H 'Authorization: token abc' || echo "curl exit=$?"
       - name: Run Startup
         if: ${{ !github.event.pull_request.head.repo.fork && github.repository_owner == 'codecov' }}
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,7 +143,7 @@ jobs:
     secrets: inherit
 
   codecov-startup-test:
-    name: Codecov Startup
+    name: Codecov Startup - Test
     needs: install
     runs-on: ubuntu-latest
     steps:
@@ -156,6 +156,11 @@ jobs:
         if: ${{ !github.event.pull_request.head.repo.fork && github.repository_owner == 'codecov' }}
         run: |
           make test_env.install_cli
+      - name: Debug CODECOV_STAGING_URL
+        run: |
+          URL='${{ secrets.CODECOV_STAGING_URL }}'
+          printf 'len=%d\n' "${#URL}"
+          printf '%s' "$URL" | xxd
       - name: Run Startup
         if: ${{ !github.event.pull_request.head.repo.fork && github.repository_owner == 'codecov' }}
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,7 +178,6 @@ jobs:
         run: |
           codecovcli -u ${{ secrets.CODECOV_PUBLIC_QA_URL }} create-commit -t ${{ secrets.CODECOV_PUBLIC_QA_TOKEN }} --fail-on-error
           codecovcli -u ${{ secrets.CODECOV_PUBLIC_QA_URL }} create-report -t ${{ secrets.CODECOV_PUBLIC_QA_TOKEN }} --fail-on-error
-    secrets: inherit
 
   runner-indexes-vitest:
     runs-on: ubuntu-latest


### PR DESCRIPTION
# Description

# Code Example

# Notable Changes

# Screenshots

# Link to Sample Entry

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to GitHub Actions CI workflow, mainly adding a new diagnostic/startup job; primary impact is potential CI noise/time and exposure of basic network metadata in logs.
> 
> **Overview**
> Adds a new CI job, **`codecov-startup-test`**, to validate Codecov CLI “startup” calls across production/staging/QA/public-QA and to **debug connectivity to `CODECOV_STAGING_URL`** (DNS resolution, TLS handshake, and simple HTTP GET/POST timing).
> 
> The new job runs only for non-fork PRs under the `codecov` org and installs the CLI before executing `create-commit`/`create-report` against the configured endpoints.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 406d4abb4c20b1e808c90189ab06657dc3a005ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->