### PR TITLE
chore: update keybase GPG key URL to codecovsecops

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,7 +3,7 @@ FROM            alpine:3.22 as uploader
 USER            root
 WORKDIR         /tmp
 RUN             apk -U add gpg gpg-agent curl
-RUN             curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --import
+RUN             curl https://keybase.io/codecovsecops/pgp_keys.asc | gpg --import
 RUN             mkdir uploader && \
   mkdir uploader/linux && \
   mkdir uploader/macos && \

--- a/src/pages/RepoPage/CoverageOnboarding/OtherCI/TerminalInstructions/instructions.ts
+++ b/src/pages/RepoPage/CoverageOnboarding/OtherCI/TerminalInstructions/instructions.ts
@@ -1,5 +1,5 @@
 export const windowsSystemInstructions = `$ProgressPreference = 'SilentlyContinue'
-Invoke-WebRequest -Uri https://keybase.io/codecovsecurity/pgp_keys.asc -OutFile codecov.asc 
+Invoke-WebRequest -Uri https://keybase.io/codecovsecops/pgp_keys.asc -OutFile codecov.asc 
 gpg.exe --import codecov.asc
 
 Invoke-WebRequest -Uri https://cli.codecov.io/latest/windows/codecov.exe -Outfile codecov.exe
@@ -10,7 +10,7 @@ gpg.exe --verify codecov.exe.SHA256SUM.sig codecov.exe.SHA256SUM
 If ($(Compare-Object -ReferenceObject  $(($(certUtil -hashfile codecov.exe SHA256)[1], "codecov.exe") -join "  ") -DifferenceObject $(Get-Content codecov.exe.SHA256SUM)).length -eq 0) { echo "SHASUM verified" } Else {exit 1}
 `
 
-export const macOSSystemInstructions = `curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.gpg --import # One-time step  
+export const macOSSystemInstructions = `curl https://keybase.io/codecovsecops/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.gpg --import # One-time step  
 curl -Os https://cli.codecov.io/latest/macos/codecov
 curl -Os https://cli.codecov.io/latest/macos/codecov.SHA256SUM
 curl -Os https://cli.codecov.io/latest/macos/codecov.SHA256SUM.sig
@@ -21,7 +21,7 @@ sudo chmod +x codecov
 ./codecov --help
 `
 
-export const linuxSystemInstructions = `curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.gpg --import # One-time step  
+export const linuxSystemInstructions = `curl https://keybase.io/codecovsecops/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.gpg --import # One-time step  
 curl -Os https://cli.codecov.io/latest/linux/codecov
 curl -Os https://cli.codecov.io/latest/linux/codecov.SHA256SUM
 curl -Os https://cli.codecov.io/latest/linux/codecov.SHA256SUM.sig
@@ -32,7 +32,7 @@ sudo chmod +x codecov
 ./codecov --help
 `
 
-export const alpineLinuxSystemInstructions = `curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.gpg --import # One-time step  
+export const alpineLinuxSystemInstructions = `curl https://keybase.io/codecovsecops/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.gpg --import # One-time step  
 curl -Os https://cli.codecov.io/latest/alpine/codecov
 curl -Os https://cli.codecov.io/latest/alpine/codecov.SHA256SUM
 curl -Os https://cli.codecov.io/latest/alpine/codecov.SHA256SUM.sig
@@ -43,7 +43,7 @@ sudo chmod +x codecov
 ./codecov --help
 `
 
-export const linuxArm64SystemInstructions = `curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.gpg --import # One-time step  
+export const linuxArm64SystemInstructions = `curl https://keybase.io/codecovsecops/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.gpg --import # One-time step  
 curl -Os https://cli.codecov.io/latest/linux-arm64/codecov
 curl -Os https://cli.codecov.io/latest/linux-arm64/codecov.SHA256SUM
 curl -Os https://cli.codecov.io/latest/linux-arm64/codecov.SHA256SUM.sig
@@ -54,7 +54,7 @@ sudo chmod +x codecov
 ./codecov --help
 `
 
-export const alpineLinuxArm64Instructions = `curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.gpg --import # One-time step
+export const alpineLinuxArm64Instructions = `curl https://keybase.io/codecovsecops/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.gpg --import # One-time step
 curl -Os https://cli.codecov.io/latest/alpine-arm64/codecov
 curl -Os https://cli.codecov.io/latest/alpine-arm64/codecov.SHA256SUM
 curl -Os https://cli.codecov.io/latest/alpine-arm64/codecov.SHA256SUM.sig

--- a/src/ui/CodeSnippet/CodeSnippet.stories.tsx
+++ b/src/ui/CodeSnippet/CodeSnippet.stories.tsx
@@ -42,7 +42,7 @@ const overflow = `# download Codecov CLI
 curl -Os https://cli.codecov.io/latest/linux/codecov
 
 # integrity check
-curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.gpg --import # One-time step  
+curl https://keybase.io/codecovsecops/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.gpg --import # One-time step  
 curl -Os https://cli.codecov.io/latest/linux/codecov
 curl -Os https://cli.codecov.io/latest/linux/codecov.SHA256SUM
 curl -Os https://cli.codecov.io/latest/linux/codecov.SHA256SUM.sig


### PR DESCRIPTION
## Summary
- Replace the `codecovsecurity` keybase username with `codecovsecops` in the uploader integrity-check install instructions (`keybase.io/<user>/pgp_keys.asc`).
- Affects `CodeSnippet.stories.tsx` and the `OtherCI` terminal instructions (macOS, Linux, Alpine, arm64 variants).

## Test plan
- [ ] Confirm the displayed uploader install commands point to `keybase.io/codecovsecops/pgp_keys.asc`

Made with [Cursor](https://cursor.com)