### PR TITLE
feat: Add sentry app deprecation banner

### DIFF
--- a/src/pages/AccountSettings/tabs/Admin/GithubIntegrationSection/GithubIntegrationSection.jsx
+++ b/src/pages/AccountSettings/tabs/Admin/GithubIntegrationSection/GithubIntegrationSection.jsx
@@ -21,7 +21,7 @@ function GithubIntegrationCopy({ integrationId }) {
       <br />
       This will replace the team bot account and post pull request comments on
       behalf of Codecov.{' '}
-      <A to={{ pageName: 'codecovGithubAppSelectTarget' }}>
+      <A to={{ pageName: 'codecovGitHubAppSelectTarget' }}>
         View the Codecov App on GitHub
       </A>
     </p>

--- a/src/pages/CommitDetailPage/CommitCoverage/BotErrorBanner/BotErrorBanner.jsx
+++ b/src/pages/CommitDetailPage/CommitCoverage/BotErrorBanner/BotErrorBanner.jsx
@@ -44,7 +44,7 @@ const BotErrorContent = () => {
         The bot posts the coverage report comment on pull requests. If
         you&apos;re using GitHub, the best way to integrate with Codecov.io is
         to Install{' '}
-        <A to={{ pageName: 'codecovGithubAppSelectTarget' }}>
+        <A to={{ pageName: 'codecovGitHubAppSelectTarget' }}>
           Codecov&apos;s GitHub App.
         </A>
       </p>

--- a/src/pages/OwnerPage/HeaderBanners/GithubConfigBanner/GithubConfigBanner.jsx
+++ b/src/pages/OwnerPage/HeaderBanners/GithubConfigBanner/GithubConfigBanner.jsx
@@ -20,8 +20,8 @@ const GithubConfigBanner = () => {
           <h2 className="flex justify-center gap-2 font-semibold">
             Configure{' '}
             <A
-              data-testid="codecovGithubApp-link"
-              to={{ pageName: 'codecovGithubAppSelectTarget' }}
+              data-testid="codecovGitHubApp-link"
+              to={{ pageName: 'codecovGitHubAppSelectTarget' }}
               onClick={() =>
                 eventTracker().track({
                   type: 'Button Clicked',

--- a/src/pages/OwnerPage/OwnerPage.jsx
+++ b/src/pages/OwnerPage/OwnerPage.jsx
@@ -78,8 +78,6 @@ function OwnerPage() {
 
   const hasGhApp = !!accountDetails?.integrationId
 
-  console.log('ownerPage')
-
   if (!ownerData) {
     return <NotFound />
   }

--- a/src/services/navigation/useStaticNavLinks.test.tsx
+++ b/src/services/navigation/useStaticNavLinks.test.tsx
@@ -59,8 +59,8 @@ describe('useStaticNavLinks', () => {
       ${links.uploader}                      | ${'https://docs.codecov.com/docs/codecov-uploader'}
       ${links.uploaderCLI}                   | ${'https://docs.codecov.com/docs/codecov-uploader#using-the-cli-to-upload-reports-with-codecovio-cloud'}
       ${links.integrityCheck}                | ${'https://docs.codecov.com/docs/codecov-uploader#integrity-checking-the-uploader'}
-      ${links.codecovGithubApp}              | ${`https://github.com/apps/${config.GH_APP}`}
-      ${links.codecovGithubAppSelectTarget}  | ${`https://github.com/apps/${config.GH_APP}/installations/select_target`}
+      ${links.codecovGitHubApp}              | ${`https://github.com/apps/${config.GH_APP}`}
+      ${links.codecovGitHubAppSelectTarget}  | ${`https://github.com/apps/${config.GH_APP}/installations/select_target`}
       ${links.teamBot}                       | ${'https://docs.codecov.com/docs/team-bot'}
       ${links.runtimeInsights}               | ${'https://docs.codecov.com/docs/runtime-insights'}
       ${links.graphAuthorization}            | ${'https://docs.codecov.com/reference/authorization#about-graphs'}

--- a/src/services/navigation/useStaticNavLinks.ts
+++ b/src/services/navigation/useStaticNavLinks.ts
@@ -193,13 +193,13 @@ export function useStaticNavLinks() {
       text: 'Uploader Integrity Check',
       openNewTab: true,
     },
-    codecovGithubApp: {
+    codecovGitHubApp: {
       path: () => `https://github.com/apps/${config.GH_APP}`,
       isExternalLink: true,
       text: 'Codecov GitHub App',
       openNewTab: true,
     },
-    codecovGithubAppSelectTarget: {
+    codecovGitHubAppSelectTarget: {
       path: () =>
         `https://github.com/apps/${config.GH_APP}/installations/select_target`,
       isExternalLink: true,

--- a/src/services/user/useOwner.ts
+++ b/src/services/user/useOwner.ts
@@ -12,6 +12,7 @@ const OwnerSchema = z.object({
   avatarUrl: z.string().nullish(),
   isCurrentUserPartOfOrg: z.boolean().nullish(),
   isAdmin: z.boolean().nullish(),
+  isOnlyUsingSentryApp: z.boolean().nullish(),
 })
 
 export type Owner = z.infer<typeof OwnerSchema>
@@ -40,6 +41,7 @@ const query = `
         avatarUrl
         isCurrentUserPartOfOrg
         isAdmin
+        isOnlyUsingSentryApp
       }
     }
   `

--- a/src/services/user/useUser.ts
+++ b/src/services/user/useUser.ts
@@ -81,6 +81,7 @@ const currentUserFragment = `
 fragment CurrentUserFragment on Me {
   owner {
     defaultOrgUsername
+    isOnlyUsingSentryApp
   }
   email
   privateAccess

--- a/src/shared/GlobalBanners/GitHubRateLimitExceeded/GitHubRateLimitExceededBanner.tsx
+++ b/src/shared/GlobalBanners/GitHubRateLimitExceeded/GitHubRateLimitExceededBanner.tsx
@@ -23,7 +23,7 @@ const GitHubRateLimitExceededBanner = () => {
           Unable to calculate coverage due to GitHub rate limit exceeded. Please
           retry later. More info on rate limits:{' '}
           <A
-            data-testid="codecovGithubApp-link"
+            data-testid="codecovGitHubApp-link"
             to={{ pageName: 'githubRateLimitExceeded' }}
             hook={undefined}
             isExternal={true}

--- a/src/shared/GlobalTopBanners/AnnouncementBanner/AnnouncementBanner.test.tsx
+++ b/src/shared/GlobalTopBanners/AnnouncementBanner/AnnouncementBanner.test.tsx
@@ -1,7 +1,14 @@
 import { render, screen } from '@testing-library/react'
 import { MemoryRouter, Route } from 'react-router'
+import { type Mock } from 'vitest'
+
+import { useOwner } from 'services/user/useOwner'
 
 import AnnouncementBanner from './AnnouncementBanner'
+
+vi.mock('services/user/useOwner')
+
+const mockedUseOwner = useOwner as Mock
 
 const wrapper: React.FC<React.PropsWithChildren> = ({ children }) => (
   <MemoryRouter initialEntries={['/gh/codecov']}>
@@ -10,16 +17,73 @@ const wrapper: React.FC<React.PropsWithChildren> = ({ children }) => (
 )
 
 describe('AnnouncementBanner', () => {
-  describe('when rendered', () => {
+  beforeEach(() => {
+    mockedUseOwner.mockReturnValue({
+      data: {
+        isOnlyUsingSentryApp: false,
+      },
+    })
+  })
+
+  describe('when rendered with default copy', () => {
     it('renders banner text', async () => {
       render(<AnnouncementBanner />, { wrapper })
       const bannerText = await screen.findByText(/Codecov is joining Harness/)
       expect(bannerText).toBeInTheDocument()
     })
-    it('renders the correct link', async () => {
+
+    it('renders the announcement link', async () => {
       render(<AnnouncementBanner />, { wrapper })
       const bannerLink = await screen.findByRole('link', { name: 'here' })
       expect(bannerLink).toBeInTheDocument()
+      expect(bannerLink).toHaveAttribute(
+        'href',
+        'https://about.codecov.io/blog/a-new-chapter-for-codecov/'
+      )
+    })
+  })
+
+  describe('when rendered for Sentry GitHub app users', () => {
+    beforeEach(() => {
+      mockedUseOwner.mockReturnValue({
+        data: {
+          isOnlyUsingSentryApp: true,
+        },
+      })
+    })
+
+    it('renders the migration banner text', async () => {
+      render(<AnnouncementBanner />, { wrapper })
+      const bannerText = await screen.findByText(
+        /You are currently using the Sentry GitHub app and need to migrate/
+      )
+      expect(bannerText).toBeInTheDocument()
+    })
+
+    it('renders the announcement link', async () => {
+      render(<AnnouncementBanner />, { wrapper })
+      const bannerLink = await screen.findByRole('link', {
+        name: /part of Harness/,
+      })
+
+      expect(bannerLink).toBeInTheDocument()
+      expect(bannerLink).toHaveAttribute(
+        'href',
+        'https://about.codecov.io/blog/a-new-chapter-for-codecov/'
+      )
+    })
+
+    it('renders the Codecov GitHub app link', async () => {
+      render(<AnnouncementBanner />, { wrapper })
+      const bannerLink = await screen.findByRole('link', {
+        name: /Codecov GitHub app/,
+      })
+
+      expect(bannerLink).toBeInTheDocument()
+      expect(bannerLink).toHaveAttribute(
+        'href',
+        'https://github.com/apps/codecov'
+      )
     })
   })
 })

--- a/src/shared/GlobalTopBanners/AnnouncementBanner/AnnouncementBanner.tsx
+++ b/src/shared/GlobalTopBanners/AnnouncementBanner/AnnouncementBanner.tsx
@@ -1,7 +1,47 @@
+import { useParams } from 'react-router-dom'
+
+import { useOwner } from 'services/user/useOwner'
 import A from 'ui/A'
 import TopBanner from 'ui/TopBanner'
 
+interface URLParams {
+  owner: string
+}
+
 const AnnouncementBanner = () => {
+  const { owner } = useParams<URLParams>()
+  const { data: ownerData } = useOwner({ username: owner })
+  const isOnlyUsingSentryApp = !!ownerData?.isOnlyUsingSentryApp
+
+  if (isOnlyUsingSentryApp) {
+    return (
+      <TopBanner variant="importantAnnouncement">
+        <TopBanner.Start>
+          <p className="font-semibold text-white">
+            Codecov is now{' '}
+            <A
+              to={{ pageName: 'announcementBlog' }}
+              isExternal
+              hook="announcement-blog-link"
+            >
+              part of Harness
+            </A>
+            . You are currently using the Sentry GitHub app and need to migrate
+            to the{' '}
+            <A
+              to={{ pageName: 'codecovGitHubApp' }}
+              isExternal
+              hook="codecov-github-app-link"
+            >
+              Codecov GitHub app
+            </A>{' '}
+            to retain functionality.
+          </p>
+        </TopBanner.Start>
+      </TopBanner>
+    )
+  }
+
   return (
     <TopBanner variant="importantAnnouncement">
       <TopBanner.Start>


### PR DESCRIPTION
Adds banner notice for future sentry GitHub app deprecation

Side change:
- updating "Github" to "GitHub" for variable names

<img width="641" height="127" alt="Screenshot 2026-06-10 at 11 28 48 PM" src="https://github.com/user-attachments/assets/41b594fa-f3f7-4e27-8071-d34f278f8218" />
<img width="1260" height="77" alt="Screenshot 2026-06-11 at 12 11 15 AM" src="https://github.com/user-attachments/assets/57b0323e-4d4e-479a-bbff-f8c06d4ba669" />
