### PR TITLE
feat: Add sentry login deprecation banner

### DIFF
--- a/src/layouts/BaseLayout/BaseLayout.test.tsx
+++ b/src/layouts/BaseLayout/BaseLayout.test.tsx
@@ -99,6 +99,7 @@ const mockMe = {
   onboardingCompleted: true,
   businessEmail: 'jane.doe@codecov.io',
   termsAgreement: true,
+  hasLinkedSentryLogin: null,
   user: mockUser,
   trackingMetadata: mockTrackingMetadata,
 }

--- a/src/layouts/BaseLayout/hooks/useUserAccessGate.test.tsx
+++ b/src/layouts/BaseLayout/hooks/useUserAccessGate.test.tsx
@@ -100,6 +100,7 @@ const mockMe = {
   onboardingCompleted: true,
   businessEmail: 'jane.doe@codecov.io',
   termsAgreement: true,
+  hasLinkedSentryLogin: null,
   user: mockUser,
   trackingMetadata: mockTrackingMetadata,
 }

--- a/src/layouts/Header/Header.test.tsx
+++ b/src/layouts/Header/Header.test.tsx
@@ -45,6 +45,7 @@ const mockUser = {
     onboardingCompleted: true,
     businessEmail: 'jane.doe@codecov.io',
     termsAgreement: true,
+    hasLinkedSentryLogin: null,
     user: {
       name: 'Jane Doe',
       username: 'janedoe',

--- a/src/layouts/Header/components/Navigator/Navigator.test.tsx
+++ b/src/layouts/Header/components/Navigator/Navigator.test.tsx
@@ -60,6 +60,7 @@ const mockUser = {
   onboardingCompleted: true,
   businessEmail: 'jane.doe@codecov.io',
   termsAgreement: true,
+  hasLinkedSentryLogin: true,
   user: {
     name: 'Jane Doe',
     username: 'janedoe',

--- a/src/layouts/Header/components/UserDropdown/UserDropdown.test.tsx
+++ b/src/layouts/Header/components/UserDropdown/UserDropdown.test.tsx
@@ -29,6 +29,7 @@ const mockUser = {
     onboardingCompleted: true,
     businessEmail: 'jane.doe@codecov.io',
     termsAgreement: true,
+    hasLinkedSentryLogin: null,
     user: {
       name: 'Jane Doe',
       username: 'janedoe',

--- a/src/layouts/shared/NetworkErrorBoundary/NetworkErrorBoundary.test.jsx
+++ b/src/layouts/shared/NetworkErrorBoundary/NetworkErrorBoundary.test.jsx
@@ -26,6 +26,7 @@ const mockUser = {
     onboardingCompleted: true,
     businessEmail: 'jane.doe@codecov.io',
     termsAgreement: true,
+    hasLinkedSentryLogin: null,
     user: {
       name: 'Jane Doe',
       username: 'janedoe',

--- a/src/pages/AccountSettings/AccountSettings.test.jsx
+++ b/src/pages/AccountSettings/AccountSettings.test.jsx
@@ -52,6 +52,7 @@ const mockCurrentUser = (username) => ({
     onboardingCompleted: true,
     businessEmail: 'jane.doe@codecov.io',
     termsAgreement: true,
+    hasLinkedSentryLogin: null,
     user: {
       name: 'Jane Doe',
       username,

--- a/src/pages/AccountSettings/AccountSettingsSideMenu.test.jsx
+++ b/src/pages/AccountSettings/AccountSettingsSideMenu.test.jsx
@@ -40,6 +40,7 @@ const mockCurrentUser = (username) => ({
     onboardingCompleted: true,
     businessEmail: 'jane.doe@codecov.io',
     termsAgreement: true,
+    hasLinkedSentryLogin: null,
     user: {
       name: 'Jane Doe',
       username,

--- a/src/pages/AccountSettings/tabs/Access/Access.test.tsx
+++ b/src/pages/AccountSettings/tabs/Access/Access.test.tsx
@@ -27,6 +27,7 @@ const mockSignedInUser = {
     onboardingCompleted: true,
     businessEmail: 'jane.doe@codecov.io',
     termsAgreement: true,
+    hasLinkedSentryLogin: null,
     user: {
       name: 'Jane Doe',
       username: 'janedoe',

--- a/src/pages/AccountSettings/tabs/Admin/Admin.test.jsx
+++ b/src/pages/AccountSettings/tabs/Admin/Admin.test.jsx
@@ -27,6 +27,7 @@ const user = {
     onboardingCompleted: true,
     businessEmail: 'jane.doe@codecov.io',
     termsAgreement: true,
+    hasLinkedSentryLogin: null,
     user: {
       name: 'Jane Doe',
       username: 'janedoe',
@@ -104,36 +105,33 @@ describe('AdminTab', () => {
     it('renders the DetailsSection', async () => {
       render(<Admin />, { wrapper })
 
-      const card = await screen.findByText(/DetailsSection/)
-      expect(card).toBeInTheDocument()
+      expect(await screen.findByText(/DetailsSection/)).toBeInTheDocument()
     })
 
     it('renders the StudentSection', async () => {
       render(<Admin />, { wrapper })
 
-      const card = await screen.findByText(/StudentSection/)
-      expect(card).toBeInTheDocument()
+      expect(await screen.findByText(/StudentSection/)).toBeInTheDocument()
     })
 
     it('renders the SupportPinCard', async () => {
       render(<Admin />, { wrapper })
 
-      const card = await screen.findByText(/SupportPinCard/)
-      expect(card).toBeInTheDocument()
+      expect(await screen.findByText(/SupportPinCard/)).toBeInTheDocument()
     })
 
     it('renders the GithubIntegrationSection', async () => {
       render(<Admin />, { wrapper })
 
-      const card = await screen.findByText(/GithubIntegrationSection/)
-      expect(card).toBeInTheDocument()
+      expect(
+        await screen.findByText(/GithubIntegrationSection/)
+      ).toBeInTheDocument()
     })
 
     it('renders the DeletionCard', async () => {
       render(<Admin />, { wrapper })
 
-      const card = await screen.findByText(/DeletionCard/)
-      expect(card).toBeInTheDocument()
+      expect(await screen.findByText(/DeletionCard/)).toBeInTheDocument()
     })
   })
 
@@ -145,29 +143,28 @@ describe('AdminTab', () => {
     it('renders the ManageAdminCard', async () => {
       render(<Admin />, { wrapper })
 
-      const card = await screen.findByText(/ManageAdminCard/)
-      expect(card).toBeInTheDocument()
+      expect(await screen.findByText(/ManageAdminCard/)).toBeInTheDocument()
     })
 
     it('does not render the SupportPinCard', async () => {
       render(<Admin />, { wrapper })
 
-      await screen.findByText(/ManageAdminCard/)
+      expect(await screen.findByText(/ManageAdminCard/)).toBeInTheDocument()
       expect(screen.queryByText(/SupportPinCard/)).not.toBeInTheDocument()
     })
 
     it('renders the GithubIntegrationSection', async () => {
       render(<Admin />, { wrapper })
 
-      const card = await screen.findByText(/GithubIntegrationSection/)
-      expect(card).toBeInTheDocument()
+      expect(
+        await screen.findByText(/GithubIntegrationSection/)
+      ).toBeInTheDocument()
     })
 
     it('renders the DeletionCard', async () => {
       render(<Admin />, { wrapper })
 
-      const card = await screen.findByText(/DeletionCard/)
-      expect(card).toBeInTheDocument()
+      expect(await screen.findByText(/DeletionCard/)).toBeInTheDocument()
     })
   })
 })

--- a/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/UpgradeForm.test.tsx
+++ b/src/pages/PlanPage/subRoutes/UpgradePlanPage/UpgradeForm/UpgradeForm.test.tsx
@@ -245,6 +245,7 @@ const mockUser = {
     onboardingCompleted: true,
     businessEmail: 'jane.doe@codecov.io',
     termsAgreement: true,
+    hasLinkedSentryLogin: null,
     user: {
       name: 'Jane Doe',
       username: 'janedoe',

--- a/src/pages/RepoPage/CoverageOnboarding/GitHubActions/GitHubActions.test.tsx
+++ b/src/pages/RepoPage/CoverageOnboarding/GitHubActions/GitHubActions.test.tsx
@@ -85,6 +85,7 @@ const mockCurrentUser = {
     onboardingCompleted: true,
     businessEmail: 'jane.doe@codecov.io',
     termsAgreement: true,
+    hasLinkedSentryLogin: null,
     user: {
       name: 'Jane Doe',
       username: 'janedoe',

--- a/src/pages/RepoPage/RepoPage.test.tsx
+++ b/src/pages/RepoPage/RepoPage.test.tsx
@@ -97,6 +97,7 @@ const mockUser = {
     onboardingCompleted: true,
     businessEmail: 'jane.doe@codecov.io',
     termsAgreement: true,
+    hasLinkedSentryLogin: null,
     user: {
       name: 'Jane Doe',
       username: 'janedoe',

--- a/src/pages/RepoPage/hooks/useJSorTSPendoTracking.test.tsx
+++ b/src/pages/RepoPage/hooks/useJSorTSPendoTracking.test.tsx
@@ -17,6 +17,7 @@ const mockUser = {
     onboardingCompleted: true,
     businessEmail: 'jane.doe@codecov.io',
     termsAgreement: true,
+    hasLinkedSentryLogin: null,
     user: {
       name: 'Jane Doe',
       username: 'janedoe',

--- a/src/services/tracking/useTracking.test.jsx
+++ b/src/services/tracking/useTracking.test.jsx
@@ -68,6 +68,7 @@ describe('useTracking', () => {
       onboardingCompleted: true,
       businessEmail: 'fake@test.com',
       termsAgreement: true,
+      hasLinkedSentryLogin: null,
       user: {
         name: 'Eugene Onegin',
         username: 'eugene_onegin',
@@ -136,6 +137,7 @@ describe('useTracking', () => {
       onboardingCompleted: true,
       businessEmail: null,
       termsAgreement: null,
+      hasLinkedSentryLogin: null,
       user: {
         name: null,
         username: 'eugene_onegin',

--- a/src/services/user/useUser.test.tsx
+++ b/src/services/user/useUser.test.tsx
@@ -17,6 +17,7 @@ const user = {
     onboardingCompleted: true,
     businessEmail: 'jane.doe@codecov.io',
     termsAgreement: true,
+    hasLinkedSentryLogin: null,
     user: {
       name: 'Jane Doe',
       username: 'janedoe',

--- a/src/services/user/useUser.ts
+++ b/src/services/user/useUser.ts
@@ -36,6 +36,7 @@ const MeSchema = z.object({
   businessEmail: z.string().nullable(),
   termsAgreement: z.boolean().nullable(),
   supportPin: z.string().nullish(),
+  hasLinkedSentryLogin: z.boolean().nullable(),
   user: z.object({
     name: z.string().nullable(),
     username: z.string(),
@@ -82,7 +83,6 @@ const currentUserFragment = `
 fragment CurrentUserFragment on Me {
   owner {
     defaultOrgUsername
-    isOnlyUsingSentryApp
   }
   email
   privateAccess
@@ -90,6 +90,7 @@ fragment CurrentUserFragment on Me {
   businessEmail
   termsAgreement
   supportPin
+  hasLinkedSentryLogin
   user {
     name
     username

--- a/src/shared/GlobalTopBanners/GlobalTopBanners.test.tsx
+++ b/src/shared/GlobalTopBanners/GlobalTopBanners.test.tsx
@@ -73,4 +73,11 @@ describe('GlobalTopBanners', () => {
     const banner = await screen.findByText(/AnnouncementBanner/)
     expect(banner).toBeInTheDocument()
   })
+
+  it('renders sentry login deprecation banner', async () => {
+    render(<GlobalTopBanners />)
+
+    const banner = await screen.findByText(/SentryLoginDeprecationBanner/)
+    expect(banner).toBeInTheDocument()
+  })
 })

--- a/src/shared/GlobalTopBanners/GlobalTopBanners.test.tsx
+++ b/src/shared/GlobalTopBanners/GlobalTopBanners.test.tsx
@@ -23,6 +23,9 @@ vi.mock('./TokenlessBanner', () => ({
 vi.mock('./AnnouncementBanner', () => ({
   default: () => 'AnnouncementBanner',
 }))
+vi.mock('./SentryLoginDeprecationBanner', () => ({
+  default: () => 'SentryLoginDeprecationBanner',
+}))
 
 describe('GlobalTopBanners', () => {
   it('renders sentry trial banner', async () => {

--- a/src/shared/GlobalTopBanners/GlobalTopBanners.tsx
+++ b/src/shared/GlobalTopBanners/GlobalTopBanners.tsx
@@ -4,6 +4,7 @@ import AnnouncementBanner from './AnnouncementBanner'
 import BundleFeedbackBanner from './BundleFeedbackBanner'
 import OktaBanners from './OktaBanners'
 import ProPlanFeedbackBanner from './ProPlanFeedbackBanner'
+import SentryLoginDeprecationBanner from './SentryLoginDeprecationBanner'
 import TeamPlanFeedbackBanner from './TeamPlanFeedbackBanner'
 import TokenlessBanner from './TokenlessBanner'
 import TrialBanner from './TrialBanner'
@@ -14,6 +15,10 @@ const GlobalTopBanners: React.FC = () => {
       <div className="[&>*:last-child]:block">
         <SilentNetworkErrorWrapper>
           <AnnouncementBanner />
+        </SilentNetworkErrorWrapper>
+
+        <SilentNetworkErrorWrapper>
+          <SentryLoginDeprecationBanner />
         </SilentNetworkErrorWrapper>
 
         <SilentNetworkErrorWrapper>

--- a/src/shared/GlobalTopBanners/SentryLoginDeprecationBanner/SentryLoginDeprecationBanner.test.tsx
+++ b/src/shared/GlobalTopBanners/SentryLoginDeprecationBanner/SentryLoginDeprecationBanner.test.tsx
@@ -1,0 +1,60 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { type Mock } from 'vitest'
+
+import { useUser } from 'services/user/useUser'
+
+import SentryLoginDeprecationBanner from './SentryLoginDeprecationBanner'
+
+vi.mock('services/user/useUser')
+
+const mockedUseUser = useUser as Mock
+
+describe('SentryLoginDeprecationBanner', () => {
+  it('renders the deprecation banner when the user has linked Sentry login', async () => {
+    mockedUseUser.mockReturnValue({
+      data: {
+        hasLinkedSentryLogin: true,
+      },
+    })
+
+    render(<SentryLoginDeprecationBanner />)
+
+    const bannerText = await screen.findByText(
+      /Logging in through Sentry will no longer be supported starting July 8th, 2026/i
+    )
+    expect(bannerText).toBeInTheDocument()
+  })
+
+  it('dismisses the banner when the user clicks Dismiss', async () => {
+    mockedUseUser.mockReturnValue({
+      data: {
+        hasLinkedSentryLogin: true,
+      },
+    })
+
+    localStorage.clear()
+
+    const user = userEvent.setup()
+
+    const { container } = render(<SentryLoginDeprecationBanner />)
+
+    const dismissBtn = await screen.findByRole('button', { name: /dismiss/i })
+    expect(dismissBtn).toBeInTheDocument()
+
+    await user.click(dismissBtn)
+
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('renders nothing when the user has not linked Sentry login', () => {
+    mockedUseUser.mockReturnValue({
+      data: {
+        hasLinkedSentryLogin: false,
+      },
+    })
+
+    const { container } = render(<SentryLoginDeprecationBanner />)
+    expect(container).toBeEmptyDOMElement()
+  })
+})

--- a/src/shared/GlobalTopBanners/SentryLoginDeprecationBanner/SentryLoginDeprecationBanner.tsx
+++ b/src/shared/GlobalTopBanners/SentryLoginDeprecationBanner/SentryLoginDeprecationBanner.tsx
@@ -1,0 +1,35 @@
+import { useUser } from 'services/user/useUser'
+import TopBanner from 'ui/TopBanner'
+
+const SENTRY_LOGIN_DEPRECATION_BANNER_KEY = 'sentry-login-deprecation-banner'
+
+const SentryLoginDeprecationBanner = () => {
+  const { data: userData } = useUser()
+  const hasLinkedSentryLogin = userData?.hasLinkedSentryLogin
+
+  if (hasLinkedSentryLogin) {
+    return (
+      <TopBanner
+        localStorageKey={SENTRY_LOGIN_DEPRECATION_BANNER_KEY}
+        variant="importantAnnouncement"
+      >
+        <TopBanner.Start>
+          <p className="font-semibold text-white">
+            Logging in through Sentry will no longer be supported starting July
+            8th, 2026. Please continue logging in through your Source Code
+            Management platform instead.
+          </p>
+        </TopBanner.Start>
+        <TopBanner.End>
+          <TopBanner.DismissButton>
+            <span className="text-white opacity-100"> Dismiss </span>
+          </TopBanner.DismissButton>
+        </TopBanner.End>
+      </TopBanner>
+    )
+  }
+
+  return null
+}
+
+export default SentryLoginDeprecationBanner

--- a/src/shared/GlobalTopBanners/SentryLoginDeprecationBanner/index.ts
+++ b/src/shared/GlobalTopBanners/SentryLoginDeprecationBanner/index.ts
@@ -1,0 +1,1 @@
+export { default } from './SentryLoginDeprecationBanner'

--- a/src/shared/GlobalTopBanners/TokenlessBanner/TokenlessBanner.test.tsx
+++ b/src/shared/GlobalTopBanners/TokenlessBanner/TokenlessBanner.test.tsx
@@ -62,6 +62,7 @@ const mockSignedInUser = {
     onboardingCompleted: true,
     businessEmail: 'jane.doe@codecov.io',
     termsAgreement: true,
+    hasLinkedSentryLogin: null,
     user: {
       name: 'Jane Doe',
       username: 'janedoe',

--- a/src/shared/ListRepo/ListRepo.test.tsx
+++ b/src/shared/ListRepo/ListRepo.test.tsx
@@ -38,6 +38,7 @@ const mockUser = {
     onboardingCompleted: true,
     businessEmail: 'jane.doe@codecov.io',
     termsAgreement: true,
+    hasLinkedSentryLogin: null,
     user: {
       name: 'Jane Doe',
       username: 'janedoe',

--- a/src/shared/ListRepo/ReposTable/ReposTable.test.tsx
+++ b/src/shared/ListRepo/ReposTable/ReposTable.test.tsx
@@ -187,6 +187,7 @@ const mockUser = {
     onboardingCompleted: true,
     businessEmail: 'jane.doe@codecov.io',
     termsAgreement: true,
+    hasLinkedSentryLogin: null,
     user: {
       name: 'Jane Doe',
       username: 'owner1',


### PR DESCRIPTION
Add banner to notify Sentry login users that the option is going to be deprecated soon.

<img width="1728" height="103" alt="Screenshot 2026-06-18 at 3 35 46 PM" src="https://github.com/user-attachments/assets/eff027f0-0870-4f26-904b-d23eb6fb6aac" />
