### PR TITLE
Rebrand ownership references from Functional Software/Sentry to Harness

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -4,11 +4,10 @@ about: Create a report to help us improve
 title: ''
 labels: ''
 assignees: ''
-
 ---
 
 <!--
-  Sentry/Codecov employees and contractors can delete or ignore the following.
+  Harness/Codecov employees and contractors can delete or ignore the following.
 -->
 
 # 📣 Feedback / 🐛 Bugs

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -4,11 +4,10 @@ about: Suggest an idea for this project
 title: ''
 labels: ''
 assignees: ''
-
 ---
 
 <!--
-  Sentry/Codecov employees and contractors can delete or ignore the following.
+  Harness/Codecov employees and contractors can delete or ignore the following.
 -->
 
 # 📣 Feedback / 🐛 Bugs

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,9 +9,9 @@
 # Link to Sample Entry
 
 <!--
-  Sentry/Codecov employees and contractors can delete or ignore the following.
+  Harness/Codecov employees and contractors can delete or ignore the following.
 -->
 
 # Legal Boilerplate
 
-Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
+Look, I get it. The entity doing business as "Codecov" is owned by Harness, Inc. In 2026 Harness acquired Codecov and as a result Harness is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Harness can use, modify, copy, and redistribute my contributions, under Harness's choice of terms.

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -6,7 +6,7 @@ FSL-1.1-Apache-2.0
 
 ## Notice
 
-Copyright 2020-2024 Functional Software, Inc. dba Sentry
+Copyright 2020-2026 Harness, Inc.
 
 ## Terms and Conditions
 

--- a/src/pages/PlanPage/subRoutes/InvoiceDetailsPage/InvoiceDetail.test.tsx
+++ b/src/pages/PlanPage/subRoutes/InvoiceDetailsPage/InvoiceDetail.test.tsx
@@ -135,11 +135,11 @@ describe('InvoiceDetail', () => {
   describe('when rendering', () => {
     it('renders the Codecov address', () => {
       setup()
+      expect(screen.getByText(/Harness, Inc./i)).toBeInTheDocument()
       expect(
-        screen.getByText(/Functional Software, dba Sentry/i)
+        screen.getByText(/55 Stockton Street, Floor 8/i)
       ).toBeInTheDocument()
-      expect(screen.getByText(/45 Fremont St. 8th Floor/i)).toBeInTheDocument()
-      expect(screen.getByText(/San Francisco, CA 94105/i)).toBeInTheDocument()
+      expect(screen.getByText(/San Francisco, CA 94108/i)).toBeInTheDocument()
       expect(screen.getByText(/United States/i)).toBeInTheDocument()
       expect(screen.getByText(/support@codecov.io/i)).toBeInTheDocument()
     })

--- a/src/pages/PlanPage/subRoutes/InvoiceDetailsPage/sections/InvoiceHeader.test.tsx
+++ b/src/pages/PlanPage/subRoutes/InvoiceDetailsPage/sections/InvoiceHeader.test.tsx
@@ -153,7 +153,7 @@ describe('Invoice Header', () => {
       const paymentMethod = screen.getByText(/Payment method/)
       expect(paymentMethod).toBeInTheDocument()
 
-      const address = screen.getByText(/San Francisco, CA 94105/)
+      const address = screen.getByText(/San Francisco, CA 94108/)
       expect(address).toBeInTheDocument()
 
       const paidOn = screen.getByText(/December 30th 2020/)

--- a/src/pages/PlanPage/subRoutes/InvoiceDetailsPage/sections/InvoiceHeader.tsx
+++ b/src/pages/PlanPage/subRoutes/InvoiceDetailsPage/sections/InvoiceHeader.tsx
@@ -41,11 +41,11 @@ function InvoiceHeader({ invoice, accountDetails }: InvoiceHeaderProps) {
         <div>
           <p className="font-semibold">Codecov</p>
           <address className="not-italic text-ds-gray-octonary">
-            Functional Software, dba Sentry
+            Harness, Inc.
             <br />
-            45 Fremont St. 8th Floor
+            55 Stockton Street, Floor 8
             <br />
-            San Francisco, CA 94105
+            San Francisco, CA 94108
             <br />
             United States
           </address>


### PR DESCRIPTION
## Summary
Codecov is now owned by **Harness, Inc.** following the 2026 acquisition. This updates user-facing ownership/branding references that previously named Sentry's legal entity ("Functional Software, Inc. dba Sentry").

- **Billing invoice header** (`InvoiceHeader.tsx`): entity → `Harness, Inc.`, address → `55 Stockton Street, Floor 8, San Francisco, CA 94108`
- **LICENSE.md** copyright notice → `Harness, Inc.`
- **PR template** legal boilerplate → Harness
- Updated corresponding tests (`InvoiceDetail.test.tsx`, `InvoiceHeader.test.tsx`)

## Out of scope (intentionally unchanged)
Legitimate Sentry-product references — the Sentry login provider, the "Sentry plan" billing tier, and the `@sentry/*` error-monitoring SDK — are **not** ownership branding and are left as-is.

## Test plan
- [ ] `InvoiceDetail` / `InvoiceHeader` unit tests pass with new entity + address

Made with [Cursor](https://cursor.com)