### PR TITLE
fix: Only report invalid line hashes in virtual file renderer

### DIFF
--- a/src/ui/VirtualRenderers/VirtualFileRenderer.test.tsx
+++ b/src/ui/VirtualRenderers/VirtualFileRenderer.test.tsx
@@ -455,15 +455,51 @@ describe('VirtualFileRenderer', () => {
             coverage={coverageData}
             fileName="tsx"
           />,
-          { wrapper: wrapper('/#RandomNumber') }
+          { wrapper: wrapper('/#L99999') }
         )
 
         await waitFor(() => {
           expect(Sentry.captureMessage).toHaveBeenCalledWith(
-            'Invalid line number in file renderer hash: #RandomNumber',
+            'Invalid line number in file renderer hash: #L99999',
             { fingerprint: ['file-renderer-invalid-line-number'] }
           )
         })
+      })
+    })
+
+    describe('hash is not a line anchor', () => {
+      it('does not capture message to sentry', async () => {
+        render(
+          <VirtualFileRenderer
+            code={code}
+            coverage={coverageData}
+            fileName="tsx"
+          />,
+          { wrapper: wrapper('/#RandomNumber') }
+        )
+
+        expect(
+          await screen.findByTestId('virtual-file-renderer-text-area')
+        ).toBeInTheDocument()
+        expect(Sentry.captureMessage).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('no hash present', () => {
+      it('does not capture message to sentry', async () => {
+        render(
+          <VirtualFileRenderer
+            code={code}
+            coverage={coverageData}
+            fileName="tsx"
+          />,
+          { wrapper: wrapper('/') }
+        )
+
+        expect(
+          await screen.findByTestId('virtual-file-renderer-text-area')
+        ).toBeInTheDocument()
+        expect(Sentry.captureMessage).not.toHaveBeenCalled()
       })
     })
   })

--- a/src/ui/VirtualRenderers/VirtualFileRenderer.tsx
+++ b/src/ui/VirtualRenderers/VirtualFileRenderer.tsx
@@ -95,8 +95,6 @@ const CodeBody = ({
       // need to adjust from line number back to array index
       virtualizer.scrollToIndex(index - 1, { align: 'start' })
     } else if (location.hash.startsWith('#L')) {
-      // only report genuinely malformed line anchors (e.g. #L0, #Labc, out of range).
-      // the common case of no hash at all is expected navigation and must not be logged.
       Sentry.captureMessage(
         `Invalid line number in file renderer hash: ${location.hash}`,
         { fingerprint: ['file-renderer-invalid-line-number'] }

--- a/src/ui/VirtualRenderers/VirtualFileRenderer.tsx
+++ b/src/ui/VirtualRenderers/VirtualFileRenderer.tsx
@@ -94,7 +94,9 @@ const CodeBody = ({
     if (!isNaN(index) && index > 0 && index <= tokens.length) {
       // need to adjust from line number back to array index
       virtualizer.scrollToIndex(index - 1, { align: 'start' })
-    } else {
+    } else if (location.hash.startsWith('#L')) {
+      // only report genuinely malformed line anchors (e.g. #L0, #Labc, out of range).
+      // the common case of no hash at all is expected navigation and must not be logged.
       Sentry.captureMessage(
         `Invalid line number in file renderer hash: ${location.hash}`,
         { fingerprint: ['file-renderer-invalid-line-number'] }


### PR DESCRIPTION
## Summary

Fixes the runaway Sentry issue [`GAZEBO-15FS`](https://codecov.sentry.io/issues/5695810305/) — "Invalid line number in file renderer hash".

The `VirtualFileRenderer` captured a Sentry message on initial render whenever the URL hash did not resolve to a valid line number. Critically, the `else` branch also fired for the extremely common case of **no hash at all**: `location.hash === ''` → `''.slice(2)` → `parseInt('')` → `NaN` → fell through to `captureMessage`. This meant essentially every `/blob/` file-page load without a `#L<n>` anchor logged an error.

The logger has existed since the component was introduced (Aug 2024), so this is not a new regression — but a recent surge in file-page traffic (a crawler fanning out across many public repos' blob pages) amplified it into hundreds of thousands of events (~108k in the last 7 days), impacting 15k+ "users". Volume has since dropped back to baseline.

## Fix

Only call `captureMessage` when the hash actually looks like a line anchor (`#L…`) but resolves to an invalid line (e.g. `#L0`, `#Labc`, out of range). The common no-hash / non-line-anchor navigation case is no longer reported.

## Test plan

- [x] Updated the existing "invalid line number" test to use a malformed anchor (`#L99999`), which is still reported.
- [x] Added a test that a non-line-anchor hash (`#RandomNumber`) does not report.
- [x] Added a test that no hash present (`/`) does not report.
- [x] `VirtualFileRenderer.test.tsx` — 21/21 passing.