### PR TITLE
feat: surface owner support external ID in UI

### DIFF
--- a/src/layouts/Header/Header.test.tsx
+++ b/src/layouts/Header/Header.test.tsx
@@ -31,6 +31,9 @@ vi.mock('src/layouts/Header/components/SeatDetails', () => ({
 vi.mock('src/layouts/Header/components/ThemeToggle', () => ({
   default: () => 'Theme Toggle',
 }))
+vi.mock('src/layouts/Header/components/OwnerExternalId', () => ({
+  default: () => 'Owner External Id',
+}))
 
 vi.mock('services/impersonate/useImpersonate')
 const mockedUseImpersonate = useImpersonate as Mock

--- a/src/layouts/Header/Header.tsx
+++ b/src/layouts/Header/Header.tsx
@@ -10,6 +10,7 @@ import AdminLink from './components/AdminLink'
 import GuestHeader from './components/GuestHeader'
 import HelpDropdown from './components/HelpDropdown'
 import Navigator from './components/Navigator'
+import OwnerExternalId from './components/OwnerExternalId'
 import SeatDetails from './components/SeatDetails'
 import ThemeToggle from './components/ThemeToggle'
 import UserDropdown from './components/UserDropdown'
@@ -50,6 +51,9 @@ function Header({ hasRepoAccess }: HeaderProps) {
                 </Suspense>
               </div>
             ) : null}
+            <Suspense fallback={null}>
+              <OwnerExternalId />
+            </Suspense>
             <ThemeToggle />
             <HelpDropdown />
             <UserDropdown />

--- a/src/layouts/Header/components/Navigator/MyContextSwitcher.test.tsx
+++ b/src/layouts/Header/components/Navigator/MyContextSwitcher.test.tsx
@@ -147,16 +147,6 @@ describe('MyContextSwitcher', () => {
       })
       expect(button).toBeInTheDocument()
     })
-
-    it('renders the copyable external id', async () => {
-      setup()
-      render(<MyContextSwitcher pageName="owner" />, {
-        wrapper: wrapper('/gh/codecov'),
-      })
-
-      const externalId = await screen.findByText(/ID: ext-id-123/)
-      expect(externalId).toBeInTheDocument()
-    })
   })
 
   describe('user "scrolls" and fetches next page', () => {

--- a/src/layouts/Header/components/Navigator/MyContextSwitcher.test.tsx
+++ b/src/layouts/Header/components/Navigator/MyContextSwitcher.test.tsx
@@ -114,6 +114,7 @@ describe('MyContextSwitcher', () => {
           owner: {
             username: 'codecov',
             avatarUrl: 'http://127.0.0.1/avatar-url',
+            externalId: 'ext-id-123',
           },
         }
         return HttpResponse.json({ data: queryData })
@@ -145,6 +146,16 @@ describe('MyContextSwitcher', () => {
         name: /codecov/i,
       })
       expect(button).toBeInTheDocument()
+    })
+
+    it('renders the copyable external id', async () => {
+      setup()
+      render(<MyContextSwitcher pageName="owner" />, {
+        wrapper: wrapper('/gh/codecov'),
+      })
+
+      const externalId = await screen.findByText(/ID: ext-id-123/)
+      expect(externalId).toBeInTheDocument()
     })
   })
 

--- a/src/layouts/Header/components/Navigator/MyContextSwitcher.tsx
+++ b/src/layouts/Header/components/Navigator/MyContextSwitcher.tsx
@@ -3,6 +3,7 @@ import { useParams } from 'react-router-dom'
 import { useMyContexts, useOwner } from 'services/user'
 import { Provider } from 'shared/api/helpers'
 import ContextSwitcher from 'ui/ContextSwitcher'
+import ExternalId from 'ui/ExternalId'
 
 interface URLParams {
   provider: Provider
@@ -39,14 +40,17 @@ function MyContextSwitcher({ pageName }: MyContextSwitcherProps) {
   ]
 
   return (
-    <div className="max-w-[500px]">
-      <ContextSwitcher
-        activeContext={activeContext}
-        contexts={contexts}
-        currentUser={currentUser}
-        isLoading={isLoading}
-        onLoadMore={() => hasNextPage && fetchNextPage()}
-      />
+    <div className="flex items-center gap-3">
+      <div className="max-w-[500px]">
+        <ContextSwitcher
+          activeContext={activeContext}
+          contexts={contexts}
+          currentUser={currentUser}
+          isLoading={isLoading}
+          onLoadMore={() => hasNextPage && fetchNextPage()}
+        />
+      </div>
+      <ExternalId externalId={activeContext?.externalId} />
     </div>
   )
 }

--- a/src/layouts/Header/components/Navigator/MyContextSwitcher.tsx
+++ b/src/layouts/Header/components/Navigator/MyContextSwitcher.tsx
@@ -3,7 +3,6 @@ import { useParams } from 'react-router-dom'
 import { useMyContexts, useOwner } from 'services/user'
 import { Provider } from 'shared/api/helpers'
 import ContextSwitcher from 'ui/ContextSwitcher'
-import ExternalId from 'ui/ExternalId'
 
 interface URLParams {
   provider: Provider
@@ -40,17 +39,14 @@ function MyContextSwitcher({ pageName }: MyContextSwitcherProps) {
   ]
 
   return (
-    <div className="flex items-center gap-3">
-      <div className="max-w-[500px]">
-        <ContextSwitcher
-          activeContext={activeContext}
-          contexts={contexts}
-          currentUser={currentUser}
-          isLoading={isLoading}
-          onLoadMore={() => hasNextPage && fetchNextPage()}
-        />
-      </div>
-      <ExternalId externalId={activeContext?.externalId} />
+    <div className="max-w-[500px]">
+      <ContextSwitcher
+        activeContext={activeContext}
+        contexts={contexts}
+        currentUser={currentUser}
+        isLoading={isLoading}
+        onLoadMore={() => hasNextPage && fetchNextPage()}
+      />
     </div>
   )
 }

--- a/src/layouts/Header/components/OwnerExternalId/OwnerExternalId.test.tsx
+++ b/src/layouts/Header/components/OwnerExternalId/OwnerExternalId.test.tsx
@@ -1,0 +1,83 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { render, screen, waitFor } from '@testing-library/react'
+import { graphql, HttpResponse } from 'msw'
+import { setupServer } from 'msw/node'
+import { MemoryRouter, Route } from 'react-router-dom'
+
+import OwnerExternalId from './OwnerExternalId'
+
+const queryClient = new QueryClient({
+  defaultOptions: { queries: { retry: false } },
+})
+
+const wrapper: (initialEntries?: string) => React.FC<React.PropsWithChildren> =
+  (initialEntries = '/gh/codecov') =>
+  ({ children }) => (
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={[initialEntries]}>
+        <Route path="/:provider/:owner">{children}</Route>
+        <Route path="/:provider" exact>
+          {children}
+        </Route>
+      </MemoryRouter>
+    </QueryClientProvider>
+  )
+
+const server = setupServer()
+
+beforeAll(() => {
+  server.listen()
+})
+
+afterEach(() => {
+  queryClient.clear()
+  server.restoreHandlers()
+})
+
+afterAll(() => {
+  server.close()
+})
+
+describe('OwnerExternalId', () => {
+  function setup(externalId: string | null = 'ext-id-123') {
+    server.use(
+      graphql.query('DetailOwner', () =>
+        HttpResponse.json({
+          data: { owner: { username: 'codecov', externalId } },
+        })
+      )
+    )
+  }
+
+  describe('when there is an owner with an external id', () => {
+    it('renders the copyable external id', async () => {
+      setup()
+      render(<OwnerExternalId />, { wrapper: wrapper('/gh/codecov') })
+
+      const externalId = await screen.findByText(/Owner ID: ext-id-123/)
+      expect(externalId).toBeInTheDocument()
+    })
+  })
+
+  describe('when the owner has no external id', () => {
+    it('renders nothing', async () => {
+      setup(null)
+      const { container } = render(<OwnerExternalId />, {
+        wrapper: wrapper('/gh/codecov'),
+      })
+
+      await waitFor(() => expect(container).toBeEmptyDOMElement())
+    })
+  })
+
+  describe('when there is no owner in the route', () => {
+    it('renders nothing', async () => {
+      setup()
+      const { container } = render(<OwnerExternalId />, {
+        wrapper: wrapper('/gh'),
+      })
+
+      await waitFor(() => expect(container).toBeEmptyDOMElement())
+    })
+  })
+})

--- a/src/layouts/Header/components/OwnerExternalId/OwnerExternalId.tsx
+++ b/src/layouts/Header/components/OwnerExternalId/OwnerExternalId.tsx
@@ -1,0 +1,22 @@
+import { useParams } from 'react-router-dom'
+
+import { useOwner } from 'services/user'
+import { Provider } from 'shared/api/helpers'
+import ExternalId from 'ui/ExternalId'
+
+interface URLParams {
+  provider: Provider
+  owner: string
+}
+
+// Shows the active owner's support external ID in the header, next to the
+// theme toggle. `useOwner` is disabled when there's no `owner` route param,
+// so this renders nothing on pages without an owner context.
+function OwnerExternalId() {
+  const { owner } = useParams<URLParams>()
+  const { data: activeContext } = useOwner({ username: owner })
+
+  return <ExternalId externalId={activeContext?.externalId} label="Owner ID" />
+}
+
+export default OwnerExternalId

--- a/src/layouts/Header/components/OwnerExternalId/index.ts
+++ b/src/layouts/Header/components/OwnerExternalId/index.ts
@@ -1,0 +1,1 @@
+export { default } from './OwnerExternalId'

--- a/src/pages/AccountSettings/tabs/DeletionCard/DeletionCard.test.tsx
+++ b/src/pages/AccountSettings/tabs/DeletionCard/DeletionCard.test.tsx
@@ -89,12 +89,12 @@ describe('DeletionCard', () => {
   })
 
   describe('when the owner has an external id', () => {
-    it('renders the support id', async () => {
+    it('renders the owner id', async () => {
       setup({ externalId: 'ext-id-123' })
       render(<DeletionCard isPersonalSettings={true} />, { wrapper })
 
-      const supportId = await screen.findByText(/Support ID: ext-id-123/)
-      expect(supportId).toBeInTheDocument()
+      const ownerId = await screen.findByText(/Owner ID: ext-id-123/)
+      expect(ownerId).toBeInTheDocument()
     })
   })
 })

--- a/src/pages/AccountSettings/tabs/DeletionCard/DeletionCard.test.tsx
+++ b/src/pages/AccountSettings/tabs/DeletionCard/DeletionCard.test.tsx
@@ -1,16 +1,63 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { render, screen } from '@testing-library/react'
+import { graphql, HttpResponse } from 'msw'
+import { setupServer } from 'msw/node'
 import { MemoryRouter, Route } from 'react-router-dom'
 
 import DeletionCard from './DeletionCard'
 
+vi.mock('copy-to-clipboard', () => ({ default: () => true }))
+
+const queryClient = new QueryClient({
+  defaultOptions: { queries: { retry: false } },
+})
+
 const wrapper: React.FC<React.PropsWithChildren> = ({ children }) => (
-  <MemoryRouter initialEntries={['/account/gh/test-user']}>
-    <Route path="/account/:provider/:owner">{children}</Route>
-  </MemoryRouter>
+  <QueryClientProvider client={queryClient}>
+    <MemoryRouter initialEntries={['/account/gh/test-user']}>
+      <Route path="/account/:provider/:owner">{children}</Route>
+    </MemoryRouter>
+  </QueryClientProvider>
 )
 
+const server = setupServer()
+
+beforeAll(() => {
+  server.listen()
+})
+
+afterEach(() => {
+  queryClient.clear()
+  server.restoreHandlers()
+})
+
+afterAll(() => {
+  server.close()
+})
+
 describe('DeletionCard', () => {
+  function setup({ externalId = 'ext-id-123' }: { externalId?: string } = {}) {
+    server.use(
+      graphql.query('DetailOwner', () =>
+        HttpResponse.json({
+          data: {
+            owner: {
+              ownerid: 1,
+              username: 'test-user',
+              avatarUrl: 'http://127.0.0.1/avatar-url',
+              isCurrentUserPartOfOrg: true,
+              isAdmin: true,
+              isOnlyUsingSentryApp: false,
+              externalId,
+            },
+          },
+        })
+      )
+    )
+  }
+
   it('renders header', () => {
+    setup()
     render(<DeletionCard isPersonalSettings={true} />, { wrapper })
 
     const header = screen.getByRole('heading', { name: 'Delete account' })
@@ -19,6 +66,7 @@ describe('DeletionCard', () => {
 
   describe('when isPersonalSettings is true', () => {
     it('renders account deletion message', () => {
+      setup()
       render(<DeletionCard isPersonalSettings={true} />, { wrapper })
 
       const message = screen.getByText(
@@ -30,12 +78,23 @@ describe('DeletionCard', () => {
 
   describe('when isPersonalSettings is false', () => {
     it('renders organization deletion message', () => {
+      setup()
       render(<DeletionCard isPersonalSettings={false} />, { wrapper })
 
       const message = screen.getByText(
         /Erase organization and all its repositories./
       )
       expect(message).toBeInTheDocument()
+    })
+  })
+
+  describe('when the owner has an external id', () => {
+    it('renders the support id', async () => {
+      setup({ externalId: 'ext-id-123' })
+      render(<DeletionCard isPersonalSettings={true} />, { wrapper })
+
+      const supportId = await screen.findByText(/Support ID: ext-id-123/)
+      expect(supportId).toBeInTheDocument()
     })
   })
 })

--- a/src/pages/AccountSettings/tabs/DeletionCard/DeletionCard.tsx
+++ b/src/pages/AccountSettings/tabs/DeletionCard/DeletionCard.tsx
@@ -38,7 +38,7 @@ function DeletionCard({ isPersonalSettings }: DeletionCardProps) {
               Contact support
             </A>
           </p>
-          <ExternalId externalId={ownerData?.externalId} label="Support ID" />
+          <ExternalId externalId={ownerData?.externalId} label="Owner ID" />
         </div>
       </Card>
     </div>

--- a/src/pages/AccountSettings/tabs/DeletionCard/DeletionCard.tsx
+++ b/src/pages/AccountSettings/tabs/DeletionCard/DeletionCard.tsx
@@ -1,29 +1,45 @@
+import { useParams } from 'react-router-dom'
+
 import Card from 'old_ui/Card'
+import { useOwner } from 'services/user'
+import { Provider } from 'shared/api/helpers'
 import A from 'ui/A'
+import ExternalId from 'ui/ExternalId'
 
 interface DeletionCardProps {
   isPersonalSettings: boolean
 }
 
+interface URLParams {
+  provider: Provider
+  owner: string
+}
+
 function DeletionCard({ isPersonalSettings }: DeletionCardProps) {
+  const { owner } = useParams<URLParams>()
+  const { data: ownerData } = useOwner({ username: owner })
+
   return (
     <div className="flex flex-col gap-4">
       <h2 className="text-lg font-semibold">
         {isPersonalSettings ? 'Delete account' : 'Delete organization'}
       </h2>
       <Card>
-        <p>
-          {isPersonalSettings
-            ? 'Erase my personal account and all my repositories. '
-            : 'Erase organization and all its repositories. '}
-          <A
-            to={{ pageName: 'support' }}
-            hook="contact-support-link"
-            isExternal
-          >
-            Contact support
-          </A>
-        </p>
+        <div className="flex flex-col gap-4">
+          <p>
+            {isPersonalSettings
+              ? 'Erase my personal account and all my repositories. '
+              : 'Erase organization and all its repositories. '}
+            <A
+              to={{ pageName: 'support' }}
+              hook="contact-support-link"
+              isExternal
+            >
+              Contact support
+            </A>
+          </p>
+          <ExternalId externalId={ownerData?.externalId} label="Support ID" />
+        </div>
       </Card>
     </div>
   )

--- a/src/services/user/useOwner.ts
+++ b/src/services/user/useOwner.ts
@@ -13,6 +13,7 @@ const OwnerSchema = z.object({
   isCurrentUserPartOfOrg: z.boolean().nullish(),
   isAdmin: z.boolean().nullish(),
   isOnlyUsingSentryApp: z.boolean().nullish(),
+  externalId: z.string().nullish(),
 })
 
 export type Owner = z.infer<typeof OwnerSchema>
@@ -42,6 +43,7 @@ const query = `
         isCurrentUserPartOfOrg
         isAdmin
         isOnlyUsingSentryApp
+        externalId
       }
     }
   `

--- a/src/ui/ExternalId/ExternalId.test.tsx
+++ b/src/ui/ExternalId/ExternalId.test.tsx
@@ -1,0 +1,84 @@
+import { act, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+import ExternalId from './ExternalId'
+
+const mocks = vi.hoisted(() => ({
+  copy: vi.fn(() => true),
+}))
+
+vi.mock('copy-to-clipboard', () => ({ default: mocks.copy }))
+
+describe('ExternalId', () => {
+  beforeAll(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    mocks.copy.mockClear()
+  })
+
+  afterAll(() => {
+    vi.restoreAllMocks()
+  })
+
+  function setup() {
+    const user = userEvent.setup({
+      advanceTimers: vi.advanceTimersByTime,
+    })
+
+    return { user }
+  }
+
+  describe('when no externalId is passed', () => {
+    it('renders nothing', () => {
+      const { container } = render(<ExternalId externalId={null} />)
+
+      expect(container).toBeEmptyDOMElement()
+    })
+  })
+
+  describe('when an externalId is passed', () => {
+    it('renders the id with the default label', () => {
+      render(<ExternalId externalId="abc-123" />)
+
+      const text = screen.getByText(/ID: abc-123/)
+      expect(text).toBeInTheDocument()
+    })
+
+    it('renders a custom label when provided', () => {
+      render(<ExternalId externalId="abc-123" label="Support ID" />)
+
+      const text = screen.getByText(/Support ID: abc-123/)
+      expect(text).toBeInTheDocument()
+    })
+  })
+
+  describe('when the user clicks the value', () => {
+    it('copies the full external id', async () => {
+      const { user } = setup()
+      render(<ExternalId externalId="abc-123" />)
+
+      const button = screen.getByRole('button', { name: /Copy ID abc-123/ })
+      await user.click(button)
+
+      expect(mocks.copy).toHaveBeenCalledWith('abc-123')
+    })
+
+    it('shows a success icon that reverts after the delay', async () => {
+      const { user } = setup()
+      render(<ExternalId externalId="abc-123" />)
+
+      const button = screen.getByRole('button', { name: /Copy ID abc-123/ })
+      await user.click(button)
+
+      const success = await screen.findByTestId('copied')
+      expect(success).toBeInTheDocument()
+
+      act(() => vi.advanceTimersByTime(1500))
+
+      const clipboard = await screen.findByTestId('copy')
+      expect(clipboard).toBeInTheDocument()
+    })
+  })
+})

--- a/src/ui/ExternalId/ExternalId.tsx
+++ b/src/ui/ExternalId/ExternalId.tsx
@@ -1,0 +1,51 @@
+import copy from 'copy-to-clipboard'
+import { useState } from 'react'
+
+import { cn } from 'shared/utils/cn'
+import Icon from 'ui/Icon'
+
+interface ExternalIdProps {
+  externalId?: string | null
+  label?: string
+  className?: string
+}
+
+// Renders an owner's support external ID as a single click-to-copy control.
+// The clipboard icon (which flips to a checkmark for ~1.5s after a copy) makes
+// it obvious the value is meant to be copied for easy copy + paste.
+function ExternalId({ externalId, label = 'ID', className }: ExternalIdProps) {
+  const [copied, setCopied] = useState(false)
+
+  if (!externalId) return null
+
+  const handleCopy = () => {
+    copy(externalId)
+    setCopied(true)
+    setTimeout(() => setCopied(false), 1500)
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={handleCopy}
+      title="Click to copy"
+      aria-label={`Copy ${label} ${externalId}`}
+      data-testid="owner-external-id"
+      className={cn(
+        'flex items-center gap-1 font-mono text-xs text-ds-gray-quinary hover:text-ds-gray-octonary hover:underline',
+        className
+      )}
+    >
+      <span>
+        {label}: {externalId}
+      </span>
+      {copied ? (
+        <Icon name="check" size="sm" label="copied" />
+      ) : (
+        <Icon name="clipboardCopy" size="sm" label="copy" />
+      )}
+    </button>
+  )
+}
+
+export default ExternalId

--- a/src/ui/ExternalId/index.ts
+++ b/src/ui/ExternalId/index.ts
@@ -1,0 +1,1 @@
+export { default } from './ExternalId'


### PR DESCRIPTION
## Summary
- Add a small, click-to-copy `ExternalId` control (`ui/ExternalId`) that displays the owner's support external ID with a clipboard icon that flips to a checkmark on copy.
- Show it next to the organization name in the header (`MyContextSwitcher`) in much smaller print, and again in the account deletion card (`DeletionCard`) labeled "Support ID".
- Fetch `externalId` via the `DetailOwner` query (`useOwner`).
<img width="1291" height="806" alt="image" src="https://github.com/user-attachments/assets/23faceac-0a69-49fd-9f33-130db5edf869" />
(this is on local, not a real UUID)

## Depends on
Backend: codecov/umbrella#1462 (adds the `externalId` GraphQL field).

## Test plan
- [ ] `ExternalId` renders nothing when id is absent; copies value on click; toggles success icon.
- [ ] `MyContextSwitcher` shows the id next to the org name.
- [ ] `DeletionCard` shows the Support ID.

Made with [Cursor](https://cursor.com)