### PR TITLE
fix(auth): remove isOnlyUsingSentryApp GraphQL field usage

### DIFF
--- a/src/services/user/useOwner.ts
+++ b/src/services/user/useOwner.ts
@@ -12,7 +12,6 @@ const OwnerSchema = z.object({
   avatarUrl: z.string().nullish(),
   isCurrentUserPartOfOrg: z.boolean().nullish(),
   isAdmin: z.boolean().nullish(),
-  isOnlyUsingSentryApp: z.boolean().nullish(),
 })
 
 export type Owner = z.infer<typeof OwnerSchema>
@@ -41,7 +40,6 @@ const query = `
         avatarUrl
         isCurrentUserPartOfOrg
         isAdmin
-        isOnlyUsingSentryApp
       }
     }
   `

--- a/src/shared/GlobalTopBanners/AnnouncementBanner/AnnouncementBanner.test.tsx
+++ b/src/shared/GlobalTopBanners/AnnouncementBanner/AnnouncementBanner.test.tsx
@@ -1,14 +1,7 @@
 import { render, screen } from '@testing-library/react'
 import { MemoryRouter, Route } from 'react-router'
-import { type Mock } from 'vitest'
-
-import { useOwner } from 'services/user/useOwner'
 
 import AnnouncementBanner from './AnnouncementBanner'
-
-vi.mock('services/user/useOwner')
-
-const mockedUseOwner = useOwner as Mock
 
 const wrapper: React.FC<React.PropsWithChildren> = ({ children }) => (
   <MemoryRouter initialEntries={['/gh/codecov']}>
@@ -17,73 +10,19 @@ const wrapper: React.FC<React.PropsWithChildren> = ({ children }) => (
 )
 
 describe('AnnouncementBanner', () => {
-  beforeEach(() => {
-    mockedUseOwner.mockReturnValue({
-      data: {
-        isOnlyUsingSentryApp: false,
-      },
-    })
+  it('renders banner text', async () => {
+    render(<AnnouncementBanner />, { wrapper })
+    const bannerText = await screen.findByText(/Codecov is joining Harness/)
+    expect(bannerText).toBeInTheDocument()
   })
 
-  describe('when rendered with default copy', () => {
-    it('renders banner text', async () => {
-      render(<AnnouncementBanner />, { wrapper })
-      const bannerText = await screen.findByText(/Codecov is joining Harness/)
-      expect(bannerText).toBeInTheDocument()
-    })
-
-    it('renders the announcement link', async () => {
-      render(<AnnouncementBanner />, { wrapper })
-      const bannerLink = await screen.findByRole('link', { name: 'here' })
-      expect(bannerLink).toBeInTheDocument()
-      expect(bannerLink).toHaveAttribute(
-        'href',
-        'https://about.codecov.io/blog/a-new-chapter-for-codecov/'
-      )
-    })
-  })
-
-  describe('when rendered for Sentry GitHub app users', () => {
-    beforeEach(() => {
-      mockedUseOwner.mockReturnValue({
-        data: {
-          isOnlyUsingSentryApp: true,
-        },
-      })
-    })
-
-    it('renders the migration banner text', async () => {
-      render(<AnnouncementBanner />, { wrapper })
-      const bannerText = await screen.findByText(
-        /You are currently using the Sentry GitHub app and need to migrate/
-      )
-      expect(bannerText).toBeInTheDocument()
-    })
-
-    it('renders the announcement link', async () => {
-      render(<AnnouncementBanner />, { wrapper })
-      const bannerLink = await screen.findByRole('link', {
-        name: /part of Harness/,
-      })
-
-      expect(bannerLink).toBeInTheDocument()
-      expect(bannerLink).toHaveAttribute(
-        'href',
-        'https://about.codecov.io/blog/a-new-chapter-for-codecov/'
-      )
-    })
-
-    it('renders the Codecov GitHub app link', async () => {
-      render(<AnnouncementBanner />, { wrapper })
-      const bannerLink = await screen.findByRole('link', {
-        name: /Codecov GitHub app/,
-      })
-
-      expect(bannerLink).toBeInTheDocument()
-      expect(bannerLink).toHaveAttribute(
-        'href',
-        'https://github.com/apps/codecov'
-      )
-    })
+  it('renders the announcement link', async () => {
+    render(<AnnouncementBanner />, { wrapper })
+    const bannerLink = await screen.findByRole('link', { name: 'here' })
+    expect(bannerLink).toBeInTheDocument()
+    expect(bannerLink).toHaveAttribute(
+      'href',
+      'https://about.codecov.io/blog/a-new-chapter-for-codecov/'
+    )
   })
 })

--- a/src/shared/GlobalTopBanners/AnnouncementBanner/AnnouncementBanner.tsx
+++ b/src/shared/GlobalTopBanners/AnnouncementBanner/AnnouncementBanner.tsx
@@ -1,47 +1,7 @@
-import { useParams } from 'react-router-dom'
-
-import { useOwner } from 'services/user/useOwner'
 import A from 'ui/A'
 import TopBanner from 'ui/TopBanner'
 
-interface URLParams {
-  owner: string
-}
-
 const AnnouncementBanner = () => {
-  const { owner } = useParams<URLParams>()
-  const { data: ownerData } = useOwner({ username: owner })
-  const isOnlyUsingSentryApp = !!ownerData?.isOnlyUsingSentryApp
-
-  if (isOnlyUsingSentryApp) {
-    return (
-      <TopBanner variant="importantAnnouncement">
-        <TopBanner.Start>
-          <p className="font-semibold text-white">
-            Codecov is now{' '}
-            <A
-              to={{ pageName: 'announcementBlog' }}
-              isExternal
-              hook="announcement-blog-link"
-            >
-              part of Harness
-            </A>
-            . You are currently using the Sentry GitHub app and need to migrate
-            to the{' '}
-            <A
-              to={{ pageName: 'codecovGitHubApp' }}
-              isExternal
-              hook="codecov-github-app-link"
-            >
-              Codecov GitHub app
-            </A>{' '}
-            to retain functionality.
-          </p>
-        </TopBanner.Start>
-      </TopBanner>
-    )
-  }
-
   return (
     <TopBanner variant="importantAnnouncement">
       <TopBanner.Start>


### PR DESCRIPTION
## Summary
- `codecov/umbrella` PR #1439 (COV-33) removed the `isOnlyUsingSentryApp` field from the `Owner` GraphQL type as part of the Sentry GitHub App removal.
- This frontend query in `useOwner.ts` was never updated to match, so every `useOwner()` call has been failing GraphQL schema validation in production since the #1439 deploy (`Cannot query field 'isOnlyUsingSentryApp' on type 'Owner'`).
- Fixes Sentry issue [API-E8B](https://codecov.sentry.io/issues/API-E8B) — 93+ occurrences, `handled: no`, still climbing.

## Changes
- Removed `isOnlyUsingSentryApp` from the `useOwner` query and schema.
- Removed the now-dead Sentry-GitHub-app migration banner branch from `AnnouncementBanner` (backend no longer distinguishes Sentry-app-only owners), leaving the default "Codecov is joining Harness" banner.
- Updated `AnnouncementBanner.test.tsx` to drop the removed Sentry-app-specific test cases and the now-unnecessary `useOwner` mock.

## Test plan
- [ ] CI green
- [ ] Confirm API-E8B stops recurring after this deploys