### PR TITLE
Use Owner.hasGithubApp instead of deprecated integrationId

### DIFF
--- a/src/pages/AccountSettings/tabs/Admin/GithubIntegrationSection/GithubIntegrationSection.jsx
+++ b/src/pages/AccountSettings/tabs/Admin/GithubIntegrationSection/GithubIntegrationSection.jsx
@@ -3,11 +3,11 @@ import { useParams } from 'react-router-dom'
 
 import config from 'config'
 
-import { useAccountDetails } from 'services/account/useAccountDetails'
+import { useOwner } from 'services/user'
 import A from 'ui/A'
 
-function GithubIntegrationCopy({ integrationId }) {
-  if (integrationId)
+function GithubIntegrationCopy({ hasGithubApp }) {
+  if (hasGithubApp)
     return (
       <p>
         This account is configured via the GitHub App. You can manage the apps
@@ -29,15 +29,14 @@ function GithubIntegrationCopy({ integrationId }) {
 }
 
 GithubIntegrationCopy.propTypes = {
-  integrationId: PropTypes.number,
+  hasGithubApp: PropTypes.bool,
 }
 
 function GithubIntegrationSection() {
   const { provider, owner } = useParams()
   const shouldRender = provider === 'gh' && !config.IS_SELF_HOSTED
-  const { data: accountDetails } = useAccountDetails({
-    provider,
-    owner,
+  const { data: ownerData } = useOwner({
+    username: owner,
     opts: {
       enabled: shouldRender,
     },
@@ -48,7 +47,7 @@ function GithubIntegrationSection() {
   return (
     <div className="flex flex-col gap-2">
       <h2 className="text-lg font-semibold">GitHub Integration</h2>
-      <GithubIntegrationCopy integrationId={accountDetails?.integrationId} />
+      <GithubIntegrationCopy hasGithubApp={!!ownerData?.hasGithubApp} />
     </div>
   )
 }

--- a/src/pages/AccountSettings/tabs/Admin/GithubIntegrationSection/GithubIntegrationSection.test.jsx
+++ b/src/pages/AccountSettings/tabs/Admin/GithubIntegrationSection/GithubIntegrationSection.test.jsx
@@ -1,12 +1,10 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { render, screen } from '@testing-library/react'
-import { http, HttpResponse } from 'msw'
+import { graphql, HttpResponse } from 'msw'
 import { setupServer } from 'msw/node'
 import { MemoryRouter, Route } from 'react-router-dom'
 
 import config from 'config'
-
-import { Plans } from 'shared/utils/billing'
 
 import GithubIntegrationSection from './GithubIntegrationSection'
 
@@ -45,8 +43,8 @@ afterAll(() => {
 
 describe('GithubIntegrationSection', () => {
   function setup(
-    { accountDetails, isSelfHosted } = {
-      accountDetails: {},
+    { hasGithubApp, isSelfHosted } = {
+      hasGithubApp: true,
       isSelfHosted: false,
     }
   ) {
@@ -54,19 +52,20 @@ describe('GithubIntegrationSection', () => {
     config.GH_APP = 'codecov'
 
     server.use(
-      http.get(`/internal/gh/codecov/account-details/`, () => {
+      graphql.query('DetailOwner', () => {
         return HttpResponse.json({
-          plan: {
-            marketingName: Plans.USERS_DEVELOPER,
-            baseUnitPrice: 12,
-            benefits: ['Configurable # of users', 'Unlimited repos'],
-            quantity: 5,
-            value: Plans.USERS_INAPPM,
+          data: {
+            owner: {
+              ownerid: 1,
+              username: 'codecov',
+              avatarUrl: 'http://127.0.0.1/avatar-url',
+              isCurrentUserPartOfOrg: true,
+              isAdmin: true,
+              isOnlyUsingSentryApp: false,
+              hasGithubApp,
+              externalId: 'external-id',
+            },
           },
-          activatedUserCount: 2,
-          inactiveUserCount: 1,
-          integrationId: 2,
-          ...accountDetails,
         })
       })
     )
@@ -88,7 +87,7 @@ describe('GithubIntegrationSection', () => {
 
   describe('when github user but enterprise', () => {
     beforeEach(() => {
-      setup({ isSelfHosted: true })
+      setup({ hasGithubApp: true, isSelfHosted: true })
     })
 
     it('renders nothing', () => {
@@ -102,7 +101,7 @@ describe('GithubIntegrationSection', () => {
 
   describe('when the user does not have the integration installed', () => {
     beforeEach(() => {
-      setup({ accountDetails: { integrationId: null } })
+      setup({ hasGithubApp: false, isSelfHosted: false })
     })
 
     it('renders the copy to explain the integration', async () => {

--- a/src/pages/CommitDetailPage/CommitCoverage/BotErrorBanner/BotErrorBanner.jsx
+++ b/src/pages/CommitDetailPage/CommitCoverage/BotErrorBanner/BotErrorBanner.jsx
@@ -1,7 +1,7 @@
 import PropType from 'prop-types'
 import { useParams } from 'react-router-dom'
 
-import { useAccountDetails } from 'services/account/useAccountDetails'
+import { useOwner } from 'services/user'
 import { providerToName } from 'shared/utils/provider'
 import A from 'ui/A'
 import Banner from 'ui/Banner'
@@ -16,17 +16,13 @@ export const ProvidersEnum = Object.freeze({
 
 function useProviderSetting() {
   const { owner, provider: paramProvider } = useParams()
-  const { data: accountDetails } = useAccountDetails({
-    provider: paramProvider,
-    owner,
-  })
+  const { data: ownerData } = useOwner({ username: owner })
 
   const provider = providerToName(paramProvider)
-  const ghWithApp =
-    accountDetails?.integrationId && provider === ProvidersEnum.Github
+  const hasGithubApp = !!ownerData?.hasGithubApp
+  const ghWithApp = hasGithubApp && provider === ProvidersEnum.Github
 
-  const ghWithNoApp =
-    !accountDetails?.integrationId && provider === ProvidersEnum.Github
+  const ghWithNoApp = !hasGithubApp && provider === ProvidersEnum.Github
 
   const bbProvider = provider === ProvidersEnum.Bitbucket
   const glProvider = provider === ProvidersEnum.Gitlab

--- a/src/pages/CommitDetailPage/CommitCoverage/BotErrorBanner/BotErrorBanner.test.jsx
+++ b/src/pages/CommitDetailPage/CommitCoverage/BotErrorBanner/BotErrorBanner.test.jsx
@@ -1,7 +1,7 @@
 import { render, screen } from 'custom-testing-library'
 
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { http, HttpResponse } from 'msw'
+import { graphql, HttpResponse } from 'msw'
 import { setupServer } from 'msw/node'
 import { MemoryRouter, Route } from 'react-router-dom'
 
@@ -42,17 +42,30 @@ afterAll(() => {
 })
 
 describe('BotErrorBanner', () => {
-  function setup({ integrationId } = { integrationId: null }) {
+  function setup({ hasGithubApp } = { hasGithubApp: false }) {
     server.use(
-      http.get('/internal/:provider/codecov/account-details/', () => {
-        return HttpResponse.json({ integrationId })
+      graphql.query('DetailOwner', () => {
+        return HttpResponse.json({
+          data: {
+            owner: {
+              ownerid: 1,
+              username: 'codecov',
+              avatarUrl: 'http://127.0.0.1/avatar-url',
+              isCurrentUserPartOfOrg: true,
+              isAdmin: true,
+              isOnlyUsingSentryApp: false,
+              hasGithubApp,
+              externalId: 'external-id',
+            },
+          },
+        })
       })
     )
   }
 
-  describe('when rendered with gh provider and integration id', () => {
+  describe('when rendered with gh provider and the app installed', () => {
     it('renders heading of banner', async () => {
-      setup({ integrationId: 2 })
+      setup({ hasGithubApp: true })
 
       render(<BotErrorBanner {...defaultProps} />, {
         wrapper: wrapper({ provider: 'gh' }),
@@ -65,7 +78,7 @@ describe('BotErrorBanner', () => {
     })
 
     it('renders content', async () => {
-      setup({ integrationId: 2 })
+      setup({ hasGithubApp: true })
 
       render(<BotErrorBanner {...defaultProps} />, {
         wrapper: wrapper({ provider: 'gh' }),
@@ -78,7 +91,11 @@ describe('BotErrorBanner', () => {
     })
   })
 
-  describe('when rendered with gh provider and no integration id', () => {
+  describe('when rendered with gh provider and no app installed', () => {
+    beforeEach(() => {
+      setup({ hasGithubApp: false })
+    })
+
     it('renders heading of banner', () => {
       render(<BotErrorBanner {...defaultProps} />, {
         wrapper: wrapper({ provider: 'gh' }),
@@ -107,6 +124,10 @@ describe('BotErrorBanner', () => {
   })
 
   describe('when rendered with gl provider', () => {
+    beforeEach(() => {
+      setup()
+    })
+
     it('renders heading of banner', () => {
       render(<BotErrorBanner {...defaultProps} />, {
         wrapper: wrapper({ provider: 'gl' }),
@@ -135,6 +156,10 @@ describe('BotErrorBanner', () => {
   })
 
   describe('when rendered with bb provider', () => {
+    beforeEach(() => {
+      setup()
+    })
+
     it('renders heading of banner', () => {
       render(<BotErrorBanner {...defaultProps} />, {
         wrapper: wrapper({ provider: 'bb' }),
@@ -163,6 +188,10 @@ describe('BotErrorBanner', () => {
   })
 
   describe('when rendered without errors', () => {
+    beforeEach(() => {
+      setup()
+    })
+
     it('renders empty dom', () => {
       const { container } = render(<BotErrorBanner botErrorsCount={0} />, {
         wrapper: wrapper({ provider: 'gh' }),

--- a/src/pages/OwnerPage/OwnerPage.jsx
+++ b/src/pages/OwnerPage/OwnerPage.jsx
@@ -4,7 +4,6 @@ import { useHistory, useParams } from 'react-router-dom'
 import SilentNetworkErrorWrapper from 'layouts/shared/SilentNetworkErrorWrapper'
 import NotFound from 'pages/NotFound'
 import { useOwnerPageData } from 'pages/OwnerPage/hooks'
-import { useAccountDetails } from 'services/account/useAccountDetails'
 import { useSentryToken } from 'services/account/useSentryToken'
 import { useLocationParams } from 'services/navigation/useLocationParams'
 import { renderToast } from 'services/toast/renderToast'
@@ -39,7 +38,7 @@ const useSentryTokenRedirect = ({ ownerData }) => {
 }
 
 function OwnerPage() {
-  const { owner, provider } = useParams()
+  const { provider } = useParams()
   const { data: ownerData } = useOwnerPageData()
   const { params } = useLocationParams({
     repoDisplay: 'All',
@@ -67,16 +66,7 @@ function OwnerPage() {
     }
   }, [userStartedTrial])
 
-  // TODO: refactor this to add a gql field for the integration id used to determine if the org has a GH app
-  const { data: accountDetails } = useAccountDetails({
-    provider,
-    owner,
-    opts: {
-      enabled: !!ownerData?.isCurrentUserPartOfOrg,
-    },
-  })
-
-  const hasGhApp = !!accountDetails?.integrationId
+  const hasGhApp = !!ownerData?.hasGithubApp
 
   if (!ownerData) {
     return <NotFound />

--- a/src/pages/OwnerPage/OwnerPage.test.jsx
+++ b/src/pages/OwnerPage/OwnerPage.test.jsx
@@ -1,6 +1,6 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { render, screen, waitFor } from '@testing-library/react'
-import { graphql, http, HttpResponse } from 'msw'
+import { graphql, HttpResponse } from 'msw'
 import { setupServer } from 'msw/node'
 import { MemoryRouter, Route } from 'react-router-dom'
 
@@ -21,7 +21,9 @@ vi.mock('services/toast/renderToast', async () => {
 
 vi.mock('./HeaderBanners', () => ({ default: () => 'HeaderBanners' }))
 vi.mock('./Tabs', () => ({ default: () => 'Tabs' }))
-vi.mock('shared/ListRepo', () => ({ default: () => 'ListRepo' }))
+vi.mock('shared/ListRepo', () => ({
+  default: ({ hasGhApp }) => `ListRepo hasGhApp:${String(hasGhApp)}`,
+}))
 
 const queryClient = new QueryClient({
   defaultOptions: { queries: { retry: false } },
@@ -59,10 +61,9 @@ afterAll(() => {
 
 describe('OwnerPage', () => {
   function setup(
-    { owner, successfulMutation = true, integrationId = 9 } = {
+    { owner, successfulMutation = true } = {
       owner: null,
       successfulMutation: true,
-      integrationId: 9,
     }
   ) {
     server.use(
@@ -86,9 +87,6 @@ describe('OwnerPage', () => {
         return HttpResponse.json({
           data: { saveSentryState: null },
         })
-      }),
-      http.get('/internal/gh/codecov/account-details/', () => {
-        return HttpResponse.json({ integrationId })
       })
     )
   }
@@ -132,6 +130,36 @@ describe('OwnerPage', () => {
       render(<OwnerPage />, { wrapper })
 
       const listRepo = await screen.findByText(/ListRepo/)
+      expect(listRepo).toBeInTheDocument()
+    })
+
+    it('passes along the GitHub app install state to ListRepo', async () => {
+      setup({
+        owner: {
+          username: 'codecov',
+          isCurrentUserPartOfOrg: true,
+          hasGithubApp: true,
+        },
+      })
+
+      render(<OwnerPage />, { wrapper })
+
+      const listRepo = await screen.findByText(/ListRepo hasGhApp:true/)
+      expect(listRepo).toBeInTheDocument()
+    })
+
+    it('tells ListRepo the app is missing when the owner has no install', async () => {
+      setup({
+        owner: {
+          username: 'codecov',
+          isCurrentUserPartOfOrg: true,
+          hasGithubApp: false,
+        },
+      })
+
+      render(<OwnerPage />, { wrapper })
+
+      const listRepo = await screen.findByText(/ListRepo hasGhApp:false/)
       expect(listRepo).toBeInTheDocument()
     })
 

--- a/src/pages/OwnerPage/hooks/useOwnerPageData.js
+++ b/src/pages/OwnerPage/hooks/useOwnerPageData.js
@@ -12,6 +12,7 @@ export function useOwnerPageData(opts = {}) {
           isCurrentUserPartOfOrg
           numberOfUploads
           avatarUrl
+          hasGithubApp
         }
       }
     `

--- a/src/pages/OwnerPage/hooks/useOwnerPageData.test.jsx
+++ b/src/pages/OwnerPage/hooks/useOwnerPageData.test.jsx
@@ -11,6 +11,7 @@ const mockOwner = {
   isCurrentUserPartOfOrg: true,
   numberOfUploads: 30,
   avatarUrl: 'cool-image-url',
+  hasGithubApp: true,
 }
 
 const queryClient = new QueryClient({

--- a/src/services/user/useOwner.ts
+++ b/src/services/user/useOwner.ts
@@ -13,6 +13,7 @@ const OwnerSchema = z.object({
   isCurrentUserPartOfOrg: z.boolean().nullish(),
   isAdmin: z.boolean().nullish(),
   isOnlyUsingSentryApp: z.boolean().nullish(),
+  hasGithubApp: z.boolean().nullish(),
   externalId: z.string().nullish(),
 })
 
@@ -43,6 +44,7 @@ const query = `
         isCurrentUserPartOfOrg
         isAdmin
         isOnlyUsingSentryApp
+        hasGithubApp
         externalId
       }
     }


### PR DESCRIPTION
## Summary
- Gates the GitHub app configure banner, Account Settings integration copy, and commit bot-error banner on `Owner.hasGithubApp` instead of deprecated `accountDetails.integrationId`
- Drops the OwnerPage `useAccountDetails` call that existed only to read `integrationId`
- Depends on companion API PR: https://github.com/codecov/umbrella/pull/1929 (must deploy first)

## Test plan
- [x] Vitest for OwnerPage, GithubIntegrationSection, BotErrorBanner, useOwner / useOwnerPageData (all passing under Node 22)
- [ ] With API deployed: open an org that has a `GithubAppInstallation` but null `integration_id` (e.g. `deployah-dev`) and confirm the configure-app banner is gone
- [ ] Confirm Account Settings → Admin shows "configured via the GitHub App" for that org
- [ ] Confirm an org with no install still sees the configure banner / install CTA
- [ ] On a commit with bot errors: installed app gets reinstall guidance; no app gets install CTA